### PR TITLE
Use go 1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nttcom/pola
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-yaml/yaml v2.1.0+incompatible


### PR DESCRIPTION
- Update go.mod using command `go mod tidy -go=1.19`
- Update release workflow for go 1.19