### PR TITLE
Bump go from 1.19 to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nttcom/pola
 
-go 1.19
+go 1.20
 
 require (
 	github.com/golang/protobuf v1.5.2


### PR DESCRIPTION
## Description
Bump go from 1.19 to 1.20
Check go.mod/go.sum/CREDITS (There was no update.)

## Type of change
* Bump up