### PR TITLE
Bump go from 1.19 to 1.20 (workflow)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
## Description
Bump go from 1.19 to 1.20 (workflow)

## Type of change
<!--- Select type of change and remove irrelevant options. -->
* [x] New features

## Motivation and Context
* Bump go from 1.19 to 1.20 in GoReleaser workflow
