### PR TITLE
Revise struct and methods of SR Policy 

### DIFF
--- a/internal/pkg/table/sr_policy.go
+++ b/internal/pkg/table/sr_policy.go
@@ -19,6 +19,7 @@ type SRPolicy struct {
 	DstAddr     netip.Addr
 	Color       uint32
 	Preference  uint32
+	LspID       uint16
 }
 
 type Segment interface {

--- a/internal/pkg/table/sr_policy.go
+++ b/internal/pkg/table/sr_policy.go
@@ -33,6 +33,59 @@ type SRPolicy struct {
 	State       PolicyState
 }
 
+func NewSRPolicy(
+	plspId uint32,
+	name string,
+	segmentList []Segment,
+	srcAddr netip.Addr,
+	dstAddr netip.Addr,
+	color uint32,
+	preference uint32,
+	lspID uint16,
+	state PolicyState,
+) *SRPolicy {
+	p := &SRPolicy{
+		PlspID:      plspId,
+		Name:        name,
+		SegmentList: segmentList,
+		SrcAddr:     srcAddr,
+		DstAddr:     dstAddr,
+		Color:       color,
+		Preference:  preference,
+		LspID:       lspID,
+		State:       state,
+	}
+
+	return p
+}
+
+// SR Policy parameter that can be changed
+type PolicyDiff struct {
+	Name        *string
+	Color       *uint32
+	Preference  *uint32
+	SegmentList []Segment
+	LspID       uint16
+	State       PolicyState
+}
+
+func (p *SRPolicy) Update(df PolicyDiff) {
+	p.State = df.State
+	p.LspID = df.LspID
+	if df.Name != nil {
+		p.Name = *df.Name
+	}
+	if df.Color != nil {
+		p.Color = *df.Color
+	}
+	if df.Preference != nil {
+		p.Preference = *df.Preference
+	}
+	if df.SegmentList != nil {
+		p.SegmentList = df.SegmentList
+	}
+}
+
 type Segment interface {
 	SidString() string
 }

--- a/internal/pkg/table/sr_policy.go
+++ b/internal/pkg/table/sr_policy.go
@@ -11,6 +11,16 @@ import (
 	"strconv"
 )
 
+// sr-policy state
+type PolicyState string
+
+const (
+	POLICY_DOWN    = PolicyState("down")
+	POLICY_UP      = PolicyState("up")
+	POLICY_ACTIVE  = PolicyState("active")
+	POLICY_UNKNOWN = PolicyState("unknown")
+)
+
 type SRPolicy struct {
 	PlspID      uint32
 	Name        string
@@ -20,6 +30,7 @@ type SRPolicy struct {
 	Color       uint32
 	Preference  uint32
 	LspID       uint16
+	State       PolicyState
 }
 
 type Segment interface {

--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -287,27 +287,6 @@ func (r *StateReport) decodeVendorInformationObject(objectType uint8, objectBody
 	return r.VendorInformationObject.DecodeFromBytes(objectType, objectBody)
 }
 
-func (r *StateReport) ToSRPolicy(pcc PccType) table.SRPolicy {
-	srPolicy := table.SRPolicy{
-		PlspID:      r.LspObject.PlspID,
-		Name:        r.LspObject.Name,
-		SegmentList: []table.Segment{},
-		SrcAddr:     r.LspObject.SrcAddr,
-		DstAddr:     r.LspObject.DstAddr,
-	}
-	if pcc == CISCO_LEGACY {
-		srPolicy.Color = r.VendorInformationObject.Color()
-		srPolicy.Preference = r.VendorInformationObject.Preference()
-	} else {
-		srPolicy.Color = r.AssociationObject.Color()
-		srPolicy.Preference = r.AssociationObject.Preference()
-	}
-
-	srPolicy.SegmentList = r.EroObject.ToSegmentList()
-
-	return srPolicy
-}
-
 // PCRpt Message
 type PCRptMessage struct {
 	StateReports []*StateReport

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -482,6 +482,7 @@ type LspObject struct {
 	SrcAddr    netip.Addr
 	DstAddr    netip.Addr
 	PlspID     uint32
+	LspID      uint16
 	OFlag      uint8
 	AFlag      bool
 	RFlag      bool
@@ -513,10 +514,12 @@ func (o *LspObject) DecodeFromBytes(typ uint8, objectBody []uint8) error {
 			if t, ok := tlv.(*IPv4LspIdentifiers); ok {
 				o.SrcAddr = t.IPv4TunnelSenderAddress
 				o.DstAddr = t.IPv4TunnelEndpointAddress
+				o.LspID = t.LspID
 			}
 			if t, ok := tlv.(*IPv6LspIdentifiers); ok {
 				o.SrcAddr = t.IPv6TunnelSenderAddress
 				o.DstAddr = t.IPv6TunnelEndpointAddress
+				o.LspID = t.LspID
 			}
 		}
 	}

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -214,6 +214,8 @@ func (tlv *SymbolicPathName) Len() uint16 {
 type IPv4LspIdentifiers struct {
 	IPv4TunnelSenderAddress   netip.Addr
 	IPv4TunnelEndpointAddress netip.Addr
+	LspID                     uint16
+	TunnelID                  uint16
 }
 
 func (tlv *IPv4LspIdentifiers) DecodeFromBytes(data []uint8) error {
@@ -221,6 +223,8 @@ func (tlv *IPv4LspIdentifiers) DecodeFromBytes(data []uint8) error {
 	if tlv.IPv4TunnelSenderAddress, ok = netip.AddrFromSlice(data[12:16]); !ok {
 		tlv.IPv4TunnelSenderAddress, _ = netip.AddrFromSlice(data[4:8])
 	}
+	tlv.LspID = binary.BigEndian.Uint16(data[8:10])
+	tlv.TunnelID = binary.BigEndian.Uint16(data[10:12])
 	tlv.IPv4TunnelEndpointAddress, _ = netip.AddrFromSlice(data[16:20])
 	return nil
 }
@@ -244,10 +248,14 @@ func (tlv *IPv4LspIdentifiers) Len() uint16 {
 type IPv6LspIdentifiers struct {
 	IPv6TunnelSenderAddress   netip.Addr
 	IPv6TunnelEndpointAddress netip.Addr
+	LspID                     uint16
+	TunnelID                  uint16
 }
 
 func (tlv *IPv6LspIdentifiers) DecodeFromBytes(data []uint8) error {
 	tlv.IPv6TunnelSenderAddress, _ = netip.AddrFromSlice(data[4:20])
+	tlv.LspID = binary.BigEndian.Uint16(data[20:22])
+	tlv.TunnelID = binary.BigEndian.Uint16(data[22:24])
 	tlv.IPv6TunnelEndpointAddress, _ = netip.AddrFromSlice(data[40:56])
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,8 +133,8 @@ func (s *Server) SearchSession(peerAddr netip.Addr) *Session {
 }
 
 // SRPolicies returns a map of registered SR Policy with key sessionAddr
-func (s *Server) SRPolicies() map[netip.Addr][]table.SRPolicy {
-	srPolicies := make(map[netip.Addr][]table.SRPolicy)
+func (s *Server) SRPolicies() map[netip.Addr][]*table.SRPolicy {
+	srPolicies := make(map[netip.Addr][]*table.SRPolicy)
 	for _, ss := range s.sessionList {
 		if ss.isSynced {
 			srPolicies[ss.peerAddr] = ss.srPolicies

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -314,9 +314,11 @@ func (ss *Session) RegisterSRPolicy(srPolicy table.SRPolicy) {
 	ss.srPolicies = append(ss.srPolicies, srPolicy)
 }
 
-func (ss *Session) DeleteSRPolicy(plspID uint32) {
+func (ss *Session) DeleteSRPolicy(sr pcep.StateReport) {
+	lspID := sr.LspObject.LspID
 	for i, v := range ss.srPolicies {
-		if v.PlspID == plspID {
+		// If the LSP ID is old, it is not the latest data update.
+		if v.PlspID == sr.LspObject.PlspID && v.LspID <= lspID {
 			ss.srPolicies[i] = ss.srPolicies[len(ss.srPolicies)-1]
 			ss.srPolicies = ss.srPolicies[:len(ss.srPolicies)-1]
 			break

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -23,7 +23,7 @@ type Session struct {
 	tcpConn         *net.TCPConn
 	isSynced        bool
 	srpIDHead       uint32 // 0x00000000 and 0xFFFFFFFF are reserved.
-	srPolicies      []table.SRPolicy
+	srPolicies      []*table.SRPolicy
 	logger          *zap.Logger
 	keepAlive       uint8
 	pccType         pcep.PccType
@@ -263,25 +263,34 @@ func (ss *Session) handlePCRpt(length uint16) error {
 	}
 
 	for _, sr := range message.StateReports {
+		// synchronization
 		if sr.LspObject.SFlag {
-			srPolicy := sr.ToSRPolicy(ss.pccType)
-			ss.logger.Info("Synchronize SR Policy information", zap.String("session", ss.peerAddr.String()), zap.Any("SRPolicy", srPolicy), zap.Any("Message", message))
-			go ss.RegisterSRPolicy(srPolicy)
+			ss.logger.Info("Synchronize SR Policy information", zap.String("session", ss.peerAddr.String()), zap.Any("Message", message))
+			ss.RegisterSRPolicy(*sr)
 		} else if !sr.LspObject.SFlag {
 			switch {
+			// finish synchronization
 			case sr.LspObject.PlspID == 0:
 				ss.logger.Info("Finish PCRpt state synchronization", zap.String("session", ss.peerAddr.String()))
 				ss.isSynced = true
+			// response to request from PCE
 			case sr.SrpObject.SrpID != 0:
-				srPolicy := sr.ToSRPolicy(ss.pccType)
 				ss.logger.Info("Finish Stateful PCE request", zap.String("session", ss.peerAddr.String()), zap.Uint32("srpID", sr.SrpObject.SrpID))
-				go ss.RegisterSRPolicy(srPolicy)
+				if sr.LspObject.RFlag {
+					ss.DeleteSRPolicy(*sr)
+				} else {
+					ss.RegisterSRPolicy(*sr)
+				}
+
 			default:
-				// TODO: Need to implementation of PCUpdate for Passive stateful PCE
+				if sr.LspObject.RFlag {
+					ss.DeleteSRPolicy(*sr)
+				} else {
+					ss.RegisterSRPolicy(*sr)
+				}
 			}
 		}
 	}
-
 	return nil
 }
 
@@ -309,9 +318,61 @@ func (ss *Session) SendPCUpdate(srPolicy table.SRPolicy) error {
 	return err
 }
 
-func (ss *Session) RegisterSRPolicy(srPolicy table.SRPolicy) {
-	ss.DeleteSRPolicy(srPolicy.PlspID)
-	ss.srPolicies = append(ss.srPolicies, srPolicy)
+func (ss *Session) RegisterSRPolicy(sr pcep.StateReport) {
+	var color, preference uint32
+
+	if ss.pccType == pcep.CISCO_LEGACY {
+		color = sr.VendorInformationObject.Color()
+		preference = sr.VendorInformationObject.Preference()
+	} else {
+		color = sr.AssociationObject.Color()
+		preference = sr.AssociationObject.Preference()
+	}
+
+	lspID := sr.LspObject.LspID
+
+	var state table.PolicyState
+	switch sr.LspObject.OFlag {
+	case uint8(0x00):
+		state = table.POLICY_DOWN
+	case uint8(0x01):
+		state = table.POLICY_UP
+	case uint8(0x02):
+		state = table.POLICY_ACTIVE
+	default:
+		state = table.POLICY_UNKNOWN
+	}
+
+	if p, ok := ss.SearchSRPolicy(sr.LspObject.PlspID); ok {
+		// update
+		// If the LSP ID is old, it is not the latest data update.
+		if p.LspID <= lspID {
+			p.Update(
+				table.PolicyDiff{
+					Name:        &sr.LspObject.Name,
+					Color:       &color,
+					Preference:  &preference,
+					SegmentList: sr.EroObject.ToSegmentList(),
+					LspID:       lspID,
+					State:       state,
+				},
+			)
+		}
+	} else {
+		// create
+		p := table.NewSRPolicy(
+			sr.LspObject.PlspID,
+			sr.LspObject.Name,
+			sr.EroObject.ToSegmentList(),
+			sr.LspObject.SrcAddr,
+			sr.LspObject.DstAddr,
+			color,
+			preference,
+			lspID,
+			state,
+		)
+		ss.srPolicies = append(ss.srPolicies, p)
+	}
 }
 
 func (ss *Session) DeleteSRPolicy(sr pcep.StateReport) {
@@ -324,6 +385,15 @@ func (ss *Session) DeleteSRPolicy(sr pcep.StateReport) {
 			break
 		}
 	}
+}
+
+func (ss *Session) SearchSRPolicy(plspID uint32) (*table.SRPolicy, bool) {
+	for _, v := range ss.srPolicies {
+		if v.PlspID == plspID {
+			return v, true
+		}
+	}
+	return nil, false
 }
 
 // SearchSRPolicyPlspID returns the PLSP-ID of a registered SR Policy, along with a boolean value indicating if it was found.


### PR DESCRIPTION
## Description

* Add the following elements to the SR Policy
  * SR Policy status
  * LSP ID
* Enable to get the above elements from PCEP's LSP object
* Improved handling of PCRpt messages and implemented delete processing

The functions to execute a request for deletion from a PCE will be addressed in a separate PR.

## Type of change
<!--- Select type of change and remove irrelevant options. -->
* [x] Refactoring

## Motivation and Context

* SR Policy state information was not stored in the PCE
* Preparation to implement the deletion request function of SR Policy

## Other Information
