### PR TITLE
Improve YAML Error Handling and Refactor Variable Names (#97)

### DIFF
--- a/cmd/pola/sr_policy_add.go
+++ b/cmd/pola/sr_policy_add.go
@@ -128,12 +128,12 @@ func addSRPolicyNoLinkState(input InputFormat) error {
 	}
 
 	segmentList := []*pb.Segment{}
-	for _, seg := range input.SRPolicy.SegmentList {
+	for _, segment := range input.SRPolicy.SegmentList {
 		pbSeg := &pb.Segment{
-			Sid:          seg.Sid,
-			LocalAddr:    seg.LocalAddr,
-			RemoteAddr:   seg.RemoteAddr,
-			SidStructure: seg.SidStructure,
+			Sid:          segment.Sid,
+			LocalAddr:    segment.LocalAddr,
+			RemoteAddr:   segment.RemoteAddr,
+			SidStructure: segment.SidStructure,
 		}
 		segmentList = append(segmentList, pbSeg)
 	}
@@ -201,8 +201,8 @@ func addSRPolicyLinkState(input InputFormat) error {
 			return errors.New(errMsg)
 		}
 		srPolicyType = pb.SRPolicyType_EXPLICIT
-		for _, seg := range input.SRPolicy.SegmentList {
-			segmentList = append(segmentList, &pb.Segment{Sid: seg.Sid})
+		for _, segment := range input.SRPolicy.SegmentList {
+			segmentList = append(segmentList, &pb.Segment{Sid: segment.Sid})
 		}
 	case "dynamic":
 		if input.SRPolicy.Metric == "" {

--- a/cmd/pola/sr_policy_add.go
+++ b/cmd/pola/sr_policy_add.go
@@ -45,9 +45,9 @@ func newSRPolicyAddCmd() *cobra.Command {
 				}
 			}()
 
-			var inputData InputFormat
+			inputData := InputFormat{}
 			if err := yaml.NewDecoder(f).Decode(&inputData); err != nil {
-				return fmt.Errorf("failed to decode file \"%s\": %v", filepath, err)
+				return fmt.Errorf("YAML syntax error in file \"%s\": %v", filepath, err)
 			}
 
 			if err := addSRPolicy(inputData, jsonFmt, noLinkStateFlag); err != nil {

--- a/cmd/pola/sr_policy_delete.go
+++ b/cmd/pola/sr_policy_delete.go
@@ -41,7 +41,7 @@ func newSRPolicyDeleteCmd() *cobra.Command {
 
 			var inputData InputFormat
 			if err := yaml.NewDecoder(f).Decode(&inputData); err != nil {
-				return fmt.Errorf("failed to decode file \"%s\": %v", filepath, err)
+				return fmt.Errorf("YAML syntax error in file \"%s\": %v", filepath, err)
 			}
 
 			if err := deleteSRPolicy(inputData, jsonFmt); err != nil {
@@ -64,9 +64,8 @@ func deleteSRPolicy(input InputFormat, jsonFlag bool) error {
 			"  color: 100\n" +
 			"  name: name\n"
 		errMsg := "invalid input\n" +
-			"input example is below\n\n" +
+			"Input example is below:\n\n" +
 			sampleInput
-
 		return errors.New(errMsg)
 	}
 

--- a/cmd/pola/sr_policy_list.go
+++ b/cmd/pola/sr_policy_list.go
@@ -24,50 +24,50 @@ func newSRPolicyListCmd() *cobra.Command {
 func showSRPolicyList(cmd *cobra.Command, args []string) error {
 	jsonFlag, err := cmd.Flags().GetBool("json")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to retrieve 'json' flag: %v", err)
 	}
 
 	srPolicies, err := grpc.GetSRPolicyList(client)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to retrieve SR policy list: %v", err)
 	}
 
 	if jsonFlag {
-		// Output JSON format
+		// Output in JSON format
 		outputJSON, err := json.Marshal(srPolicies)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to marshal SR policy list to JSON: %v", err)
 		}
 		fmt.Println(string(outputJSON))
 	} else {
-		// Output user-friendly format
+		// Output in user-friendly format
 		if len(srPolicies) == 0 {
-			fmt.Println("no SR Policies")
+			fmt.Println("No SR Policies found.")
 		} else {
-			for ssID, pols := range srPolicies {
-				fmt.Printf("Session: %s\n", ssID)
-				for _, pol := range pols {
-					fmt.Printf("  PolicyName: %s\n", pol.Name)
-					fmt.Printf("    SrcAddr: %s\n", pol.SrcAddr)
-					fmt.Printf("    DstAddr: %s\n", pol.DstAddr)
-					fmt.Printf("    Color: %d\n", pol.Color)
-					fmt.Printf("    Preference: %d\n", pol.Preference)
+			for sessionID, policies := range srPolicies {
+				fmt.Printf("Session: %s\n", sessionID)
+				for _, policy := range policies {
+					fmt.Printf("  PolicyName: %s\n", policy.Name)
+					fmt.Printf("    SrcAddr: %s\n", policy.SrcAddr)
+					fmt.Printf("    DstAddr: %s\n", policy.DstAddr)
+					fmt.Printf("    Color: %d\n", policy.Color)
+					fmt.Printf("    Preference: %d\n", policy.Preference)
 					fmt.Printf("    SegmentList: ")
 
-					if len(pol.SegmentList) == 0 {
-						fmt.Printf("None \n")
+					if len(policy.SegmentList) == 0 {
+						fmt.Println("None")
 					} else {
-						for j, seg := range pol.SegmentList {
-							fmt.Printf("%s", seg.SidString())
-							if j == len(pol.SegmentList)-1 {
-								fmt.Printf("\n")
+						for j, segment := range policy.SegmentList {
+							fmt.Print(segment.SidString())
+							if j == len(policy.SegmentList)-1 {
+								fmt.Println()
 							} else {
-								fmt.Printf(" -> ")
+								fmt.Print(" -> ")
 							}
 						}
 					}
 				}
-				fmt.Printf("\n")
+				fmt.Println()
 			}
 		}
 	}

--- a/examples/tinet/sr-mpls_te_l3vpn/spec.yaml
+++ b/examples/tinet/sr-mpls_te_l3vpn/spec.yaml
@@ -69,7 +69,7 @@ node_configs:
   - name: pola
     cmds:
       - cmd: 'ip a add 10.0.255.254/24 dev net0'
-      - cmd: '/usr/local/go/bin/polad -f config.yaml > /dev/null 2>&1 &'
+      - cmd: '/go/bin/polad -f /config.yaml > /dev/null 2>&1 &'
   - name: pe01
     cmds:
       - cmd: sysctl -w net.ipv4.ip_forward=1
@@ -132,6 +132,7 @@ node_configs:
           -c '  import vpn'
           -c ' exit-address-family'
           -c 'exit'
+          -c '!'
           -c 'route-map color1 permit 1'
           -c ' set sr-te color 1'
           -c 'exit'

--- a/pkg/packet/pcep/capability.go
+++ b/pkg/packet/pcep/capability.go
@@ -16,12 +16,20 @@ func PolaCapability(caps []CapabilityInterface) []CapabilityInterface {
 		switch tlv := cap.(type) {
 		case *StatefulPceCapability:
 			tlv = &StatefulPceCapability{
-				LspUpdateCapability:        true,
-				IncludeDBVersion:           false,
-				LspInstantiationCapability: true,
-				TriggeredResync:            false,
-				DeltaLspSyncCapability:     false,
-				TriggeredInitialSync:       false,
+				LspUpdateCapability:            true,
+				IncludeDBVersion:               false,
+				LspInstantiationCapability:     true,
+				TriggeredResync:                false,
+				DeltaLspSyncCapability:         false,
+				TriggeredInitialSync:           false,
+				P2mpCapability:                 false,
+				P2mpLspUpdateCapability:        false,
+				P2mpLspInstantiationCapability: false,
+				LspSchedulingCapability:        false,
+				PdLspCapability:                false,
+				PathRecomputationCapability:    false,
+				StrictPathCapability:           false,
+				Relax:                          false,
 			}
 			polaCaps = append(polaCaps, tlv)
 		case *LSPDBVersion:

--- a/pkg/packet/pcep/capability.go
+++ b/pkg/packet/pcep/capability.go
@@ -27,6 +27,7 @@ func PolaCapability(caps []CapabilityInterface) []CapabilityInterface {
 				P2mpLspInstantiationCapability: false,
 				LspSchedulingCapability:        false,
 				PdLspCapability:                false,
+				ColorCapability:                true,
 				PathRecomputationCapability:    false,
 				StrictPathCapability:           false,
 				Relax:                          false,

--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -441,12 +441,12 @@ func NewPCInitiateMessage(srpID uint32, lspName string, lspDelete bool, plspID u
 	}
 
 	if lspDelete {
-		if m.LspObject, err = NewLspObject(lspName, plspID); err != nil {
+		if m.LspObject, err = NewLspObject(lspName, &color, plspID); err != nil {
 			return nil, err
 		}
 		return m, nil
 	} else {
-		if m.LspObject, err = NewLspObject(lspName, 0); err != nil {
+		if m.LspObject, err = NewLspObject(lspName, &color, 0); err != nil {
 			return nil, err
 		}
 	}
@@ -515,7 +515,7 @@ func NewPCUpdMessage(srpID uint32, lspName string, plspID uint32, segmentList []
 	if m.SrpObject, err = NewSrpObject(segmentList, srpID, false); err != nil {
 		return nil, err
 	}
-	if m.LspObject, err = NewLspObject(lspName, plspID); err != nil {
+	if m.LspObject, err = NewLspObject(lspName, nil, plspID); err != nil {
 		return nil, err
 	}
 	if m.EroObject, err = NewEroObject(segmentList); err != nil {

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -739,8 +739,8 @@ func NewEroObject(segmentList []table.Segment) (*EroObject, error) {
 }
 
 func (o *EroObject) AddEroSubobjects(SegmentList []table.Segment) error {
-	for _, seg := range SegmentList {
-		eroSubobject, err := NewEroSubobject(seg)
+	for _, segment := range SegmentList {
+		eroSubobject, err := NewEroSubobject(segment)
 		if err != nil {
 			return err
 		}

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -612,7 +612,7 @@ func (o *LspObject) Len() uint16 {
 	return uint16(COMMON_OBJECT_HEADER_LENGTH) + lspObjectBodyLength
 }
 
-func NewLspObject(lspName string, plspID uint32) (*LspObject, error) {
+func NewLspObject(lspName string, color *uint32, plspID uint32) (*LspObject, error) {
 	o := &LspObject{
 		ObjectType: OT_LSP_LSP,
 		Name:       lspName,
@@ -628,8 +628,30 @@ func NewLspObject(lspName string, plspID uint32) (*LspObject, error) {
 	symbolicPathNameTLV := &SymbolicPathName{
 		Name: lspName,
 	}
+
 	o.TLVs = append(o.TLVs, TLVInterface(symbolicPathNameTLV))
+
+	var colorTLV *Color
+	if color != nil {
+		colorTLV = &Color{
+			Color: *color,
+		}
+	}
+	if colorTLV != nil {
+		o.TLVs = append(o.TLVs, TLVInterface(colorTLV))
+	}
 	return o, nil
+}
+
+// (I.D.draft-ietf-pce-pcep-color-12)
+func (o *LspObject) Color() uint32 {
+	for _, tlv := range o.TLVs {
+		if t, ok := tlv.(*Color); ok {
+			return t.Color
+		}
+
+	}
+	return 0
 }
 
 // ERO Object (RFC5440 7.9)

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -49,7 +49,7 @@ const ( // PCEP TLV
 	TLV_EXTENDED_ASSOCIATION_ID               uint16 = 0x1f // RFC8697
 	TLV_P2MP_IPV4_LSP_IDENTIFIERS             uint16 = 0x20 // RFC8623
 	TLV_P2MP_IPV6_LSP_IDENTIFIERS             uint16 = 0x21 // RFC8623
-	TLV_PATH_SETUP_TYPE_CAPABILITY            uint16 = 0x22 // RFC8409
+	TLV_PATH_SETUP_TYPE_CAPABILITY            uint16 = 0x22 // RFC8408
 	TLV_ASSOC_TYPE_LIST                       uint16 = 0x23 // RFC8697
 	TLV_AUTO_BANDWIDTH_CAPABILITY             uint16 = 0x24 // RFC8733
 	TLV_AUTO_BANDWIDTH_ATTRIBUTES             uint16 = 0x25 // RFC8733
@@ -66,14 +66,28 @@ const ( // PCEP TLV
 	TLV_POLICY_PARAMETERSjTLV                 uint16 = 0x30 // RFC9005
 	TLV_SCHED_LSP_ATTRIBUTE                   uint16 = 0x31 // RFC8934
 	TLV_SCHED_PD_LSP_ATTRIBUTE                uint16 = 0x32 // RFC8934
-	TLV_PCE_FLOWSPEC_CAPABILITY               uint16 = 0x33 // ietf-pce-pcep-flowspec-12
-	TLV_FLOW_FILTER                           uint16 = 0x34 // ietf-pce-pcep-flowspec-12
-	TLV_L2_FLOW_FILTER                        uint16 = 0x35 // ietf-pce-pcep-flowspec-12
+	TLV_PCE_FLOWSPEC_CAPABILITY               uint16 = 0x33 // RFC9168
+	TLV_FLOW_FILTER                           uint16 = 0x34 // RFC9168
 	TLV_BIDIRECTIONAL_LSP_ASSOCIATION_GROUP   uint16 = 0x36 // RFC9059
+	TLV_TE_PATH_BINDING                       uint16 = 0x37 // RFC9604
 	TLV_SRPOLICY_POL_NAME                     uint16 = 0x38 // ietf-pce-segment-routing-policy-cp-07
 	TLV_SRPOLICY_CPATH_ID                     uint16 = 0x39 // ietf-pce-segment-routing-policy-cp-07
 	TLV_SRPOLICY_CPATH_NAME                   uint16 = 0x3a // ietf-pce-segment-routing-policy-cp-07
 	TLV_SRPOLICY_CPATH_PREFERENCE             uint16 = 0x3b // ietf-pce-segment-routing-policy-cp-07
+	TLV_MULTIPATH_CAP                         uint16 = 0x3c // ietf-pce-pcep-multipath-07
+	TLV_MULTIPATH_WIGHT                       uint16 = 0x3d // ietf-pce-pcep-multipath-07
+	TLV_MULTIPATH_BACKUP                      uint16 = 0x3e // ietf-pce-pcep-multipath-07
+	TLV_LSP_EXTENDED_FLAG                     uint16 = 0x3f // RFC9357
+	TLV_VIRTUAL_NETWORK_TLV                   uint16 = 0x41 // RFC9358
+	TLV_SR_ALGORITHM                          uint16 = 0x42 // ietf-pce-sid-algo-12
+	TLV_COMPUTATION_PRIORITY                  uint16 = 0x44 // ietf-pce-segment-routing-policy-cp-14
+	TLV_EXPLICIT_NULL_LABEL_POLICY            uint16 = 0x45 // draft-ietf-pce-segment-routing-policy-cp-14
+	TLV_INVALIDATION                          uint16 = 0x4c // draft-ietf-pce-segment-routing-policy-cp-14
+	TLV_SRPOLICY_CAPABILITY                   uint16 = 0x4d // draft-ietf-pce-segment-routing-policy-cp-14
+	TLV_PATH_RECOMPUTATION                    uint16 = 0x4e // draft-ietf-pce-circuit-style-pcep-extensions-03
+	TLV_SR_P2MP_POLICY_CAPABILITY             uint16 = 0x4f // draft-ietf-pce-sr-p2mp-policy-09
+	TLV_IPV4_SR_P2MP_INSTANCE_ID              uint16 = 0x50 // draft-ietf-pce-sr-p2mp-policy-09
+	TLV_IPV6_SR_P2MP_INSTANCE_ID              uint16 = 0x51 // draft-ietf-pce-sr-p2mp-policy-09
 )
 
 const (
@@ -100,22 +114,37 @@ type TLVInterface interface {
 }
 
 type StatefulPceCapability struct {
-	LspUpdateCapability        bool
-	IncludeDBVersion           bool
-	LspInstantiationCapability bool
-	TriggeredResync            bool
-	DeltaLspSyncCapability     bool
-	TriggeredInitialSync       bool
+	LspUpdateCapability            bool // 31
+	IncludeDBVersion               bool // 30
+	LspInstantiationCapability     bool // 29
+	TriggeredResync                bool // 28
+	DeltaLspSyncCapability         bool // 27
+	TriggeredInitialSync           bool // 26
+	P2mpCapability                 bool // 25
+	P2mpLspUpdateCapability        bool // 24
+	P2mpLspInstantiationCapability bool // 23
+	LspSchedulingCapability        bool // 22
+	PdLspCapability                bool // 21
+	PathRecomputationCapability    bool // 19
+	StrictPathCapability           bool // 18
+	Relax                          bool // 17
 }
 
-func (tlv *StatefulPceCapability) DecodeFromBytes(data []uint8) error {
-	tlv.LspUpdateCapability = (data[7] & 0x01) != 0
-	tlv.IncludeDBVersion = (data[7] & 0x02) != 0
-	tlv.LspInstantiationCapability = (data[7] & 0x04) != 0
-	tlv.TriggeredResync = (data[7] & 0x08) != 0
-	tlv.DeltaLspSyncCapability = (data[7] & 0x10) != 0
-	tlv.TriggeredInitialSync = (data[7] & 0x20) != 0
-
+func (tlv *StatefulPceCapability) DecodeFromBytes(flags []uint8) error {
+	tlv.LspUpdateCapability = (flags[3] & 0x01) != 0
+	tlv.IncludeDBVersion = (flags[3] & 0x02) != 0
+	tlv.LspInstantiationCapability = (flags[3] & 0x04) != 0
+	tlv.TriggeredResync = (flags[3] & 0x08) != 0
+	tlv.DeltaLspSyncCapability = (flags[3] & 0x10) != 0
+	tlv.TriggeredInitialSync = (flags[3] & 0x20) != 0
+	tlv.P2mpCapability = (flags[3] & 0x40) != 0
+	tlv.P2mpLspUpdateCapability = (flags[3] & 0x80) != 0
+	tlv.P2mpLspInstantiationCapability = (flags[2] & 0x01) != 0
+	tlv.LspSchedulingCapability = (flags[2] & 0x02) != 0
+	tlv.PdLspCapability = (flags[2] & 0x04) != 0
+	tlv.PathRecomputationCapability = (flags[2] & 0x10) != 0
+	tlv.StrictPathCapability = (flags[2] & 0x20) != 0
+	tlv.Relax = (flags[2] & 0x40) != 0
 	return nil
 }
 
@@ -130,26 +159,53 @@ func (tlv *StatefulPceCapability) Serialize() []uint8 {
 	binary.BigEndian.PutUint16(length, TLV_STATEFUL_PCE_CAPABILITY_LENGTH)
 	buf = append(buf, length...)
 
-	val := make([]uint8, TLV_STATEFUL_PCE_CAPABILITY_LENGTH)
+	flags := make([]uint8, TLV_STATEFUL_PCE_CAPABILITY_LENGTH)
 	if tlv.LspUpdateCapability {
-		val[3] = val[3] | 0x01
+		flags[3] = flags[3] | 0x01
 	}
 	if tlv.IncludeDBVersion {
-		val[3] = val[3] | 0x02
+		flags[3] = flags[3] | 0x02
 	}
 	if tlv.LspInstantiationCapability {
-		val[3] = val[3] | 0x04
+		flags[3] = flags[3] | 0x04
 	}
 	if tlv.TriggeredResync {
-		val[3] = val[3] | 0x08
+		flags[3] = flags[3] | 0x08
 	}
 	if tlv.DeltaLspSyncCapability {
-		val[3] = val[3] | 0x10
+		flags[3] = flags[3] | 0x10
 	}
 	if tlv.TriggeredInitialSync {
-		val[3] = val[3] | 0x20
+		flags[3] = flags[3] | 0x20
 	}
-	buf = append(buf, val...)
+	if tlv.P2mpCapability {
+		flags[3] = flags[3] | 0x40
+	}
+	if tlv.P2mpLspUpdateCapability {
+		flags[3] = flags[3] | 0x80
+	}
+	if tlv.P2mpLspInstantiationCapability {
+		flags[2] = flags[2] | 0x01
+	}
+	if tlv.P2mpLspInstantiationCapability {
+		flags[2] = flags[2] | 0x01
+	}
+	if tlv.LspSchedulingCapability {
+		flags[2] = flags[2] | 0x02
+	}
+	if tlv.PdLspCapability {
+		flags[2] = flags[2] | 0x04
+	}
+	if tlv.PathRecomputationCapability {
+		flags[2] = flags[2] | 0x10
+	}
+	if tlv.StrictPathCapability {
+		flags[2] = flags[2] | 0x20
+	}
+	if tlv.Relax {
+		flags[2] = flags[2] | 0x40
+	}
+	buf = append(buf, flags...)
 
 	return buf
 }


### PR DESCRIPTION
## Description
Bugfix for #97 to improve YAML error handling, ensuring that parsing errors are properly reported. 
Also, renamed some variables for consistency and clarity.


## Type of change
* [x] Bug fixes
* [x] Refactoring

## Motivation and Context
#97 

## How is This Tested?
*  ls examples/tinet/sr-mpls_te_l3vpn/README.md

## Other Information
No functional changes were made outside of the bugfix for YAML error handling. This change is a combination of refactoring and bugfixes.
