### PR TITLE
Add LsSRv6SIDNLRI for BGP-LS Service Segment

### DIFF
--- a/cmd/pola/ted.go
+++ b/cmd/pola/ted.go
@@ -86,6 +86,21 @@ func print(jsonFlag bool) error {
 				}
 				tmpNode["prefixes"] = prefixes
 
+				srv6SIDs := []map[string]interface{}{}
+				for _, srv6SID := range node.SRv6SIDs {
+					tmpSrv6SID := map[string]interface{}{
+						"sids":             srv6SID.Sids,
+						"endpointBehavior": srv6SID.EndpointBehavior,
+						"multiTopoIDs":     srv6SID.MultiTopoIDs,
+						"serviceType":      srv6SID.ServiceType,
+						"trafficType":      srv6SID.TrafficType,
+						"opaqueType":       srv6SID.OpaqueType,
+						"value":            hex.EncodeToString(srv6SID.Value),
+					}
+					srv6SIDs = append(srv6SIDs, tmpSrv6SID)
+				}
+				tmpNode["srv6SIDs"] = srv6SIDs
+
 				nodes = append(nodes, tmpNode)
 			}
 		}

--- a/internal/pkg/gobgp/interface.go
+++ b/internal/pkg/gobgp/interface.go
@@ -159,10 +159,11 @@ func getLsNodeNLRI(typedLinkStateNlri *api.LsNodeNLRI, pathAttrs []*anypb.Any) (
 
 		srCapabilities := bgplsAttr.GetNode().GetSrCapabilities().GetRanges()
 		if len(srCapabilities) != 1 {
-			return nil, errors.New("invalid SR Capability TLV")
+			return nil, fmt.Errorf("expected 1 SR Capability TLV, got: %d", len(srCapabilities))
+		} else {
+			lsNode.SrgbBegin = srCapabilities[0].GetBegin()
+			lsNode.SrgbEnd = srCapabilities[0].GetEnd()
 		}
-		lsNode.SrgbBegin = srCapabilities[0].GetBegin()
-		lsNode.SrgbEnd = srCapabilities[0].GetEnd()
 	}
 
 	return lsNode, nil

--- a/internal/pkg/gobgp/interface.go
+++ b/internal/pkg/gobgp/interface.go
@@ -72,7 +72,6 @@ func GetBgplsNlris(serverAddr string, serverPort string) ([]table.TedElem, error
 			}
 			return nil, fmt.Errorf("error receiving stream data: %v", err)
 		}
-
 		convertedElems, err := ConvertToTedElem(r.Destination)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert path to TED element: %v", err)
@@ -120,6 +119,15 @@ func ConvertToTedElem(dst *api.Destination) ([]table.TedElem, error) {
 				return nil, fmt.Errorf("failed to process LS Prefix V4 NLRI: %v", err)
 			}
 			return lsPrefixV4List, nil
+		case *api.LsSrv6SIDNLRI:
+			lsSrv6SIDList, err := getLsSrv6SIDNLRIList(linkStateNlri, path.GetPattrs())
+			if err != nil {
+				return nil, err
+			}
+			return lsSrv6SIDList, nil
+		// TODO: Implement LsPrefixV6NLRI handling
+		case *api.LsPrefixV6NLRI:
+			return nil, nil
 		default:
 			return nil, errors.New("invalid LS Link State NLRI type")
 		}
@@ -274,4 +282,67 @@ func getLsPrefixV4(lsNlri *api.LsAddrPrefix, sidIndex uint32) (*table.LsPrefixV4
 	}
 
 	return lsPrefixV4, nil
+}
+
+func getLsSrv6SIDNLRIList(lsSRv6SIDNlri *api.LsSrv6SIDNLRI, pathAttrs []*anypb.Any) ([]table.TedElem, error) {
+	var lsSrv6SIDList []table.TedElem
+	var endpointBehavior uint32
+
+	for _, pathAttr := range pathAttrs {
+		typedPathAttr, err := pathAttr.UnmarshalNew()
+		if err != nil {
+			return nil, err
+		}
+
+		switch typedPathAttr := typedPathAttr.(type) {
+		case *api.SRv6EndPointBehavior:
+			endpointBehavior = uint32(typedPathAttr.GetBehavior())
+		case *api.MpReachNLRIAttribute:
+			for _, nlri := range typedPathAttr.GetNlris() {
+				typedNlri, err := nlri.UnmarshalNew()
+				if err != nil {
+					return nil, err
+				}
+				if lsNlri, ok := typedNlri.(*api.LsAddrPrefix); ok {
+					lsSrv6SID, err := getLsSrv6SIDNLRI(lsNlri, endpointBehavior)
+					if err != nil {
+						return nil, err
+					}
+					lsSrv6SIDList = append(lsSrv6SIDList, lsSrv6SID)
+				}
+			}
+		}
+	}
+	return lsSrv6SIDList, nil
+}
+
+func getLsSrv6SIDNLRI(lsNlri *api.LsAddrPrefix, endpointBehavior uint32) (*table.LsSrv6SID, error) {
+	srv6Nlri, err := lsNlri.GetNlri().UnmarshalNew()
+	if err != nil {
+		return nil, err
+	}
+	srv6SIDNlri, ok := srv6Nlri.(*api.LsSrv6SIDNLRI)
+	if !ok {
+		return nil, errors.New("invalid LS SRv6 SID NLRI type")
+	}
+	localNodeID := srv6SIDNlri.GetLocalNode().GetIgpRouterId()
+	localNodeAsn := srv6SIDNlri.GetLocalNode().GetAsn()
+	srv6SIDs := srv6SIDNlri.GetSrv6SidInformation().GetSids()
+	multiTopoIDs := srv6SIDNlri.GetMultiTopoId().GetMultiTopoIds()
+	serviceType := srv6SIDNlri.GetServiceChaining().GetServicetype()
+	trafficType := srv6SIDNlri.GetServiceChaining().GetTraffictype()
+	opaqueType := srv6SIDNlri.GetOpaqueMetadata().GetOpaquetype()
+	value := srv6SIDNlri.GetOpaqueMetadata().GetValue()
+
+	localNode := table.NewLsNode(localNodeAsn, localNodeID)
+	lsSrv6SID := table.NewLsSrv6SID(localNode)
+	lsSrv6SID.EndpointBehavior = endpointBehavior
+	lsSrv6SID.Sids = srv6SIDs
+	lsSrv6SID.MultiTopoIDs = multiTopoIDs
+	lsSrv6SID.ServiceType = serviceType
+	lsSrv6SID.TrafficType = trafficType
+	lsSrv6SID.OpaqueType = opaqueType
+	lsSrv6SID.Value = value
+
+	return lsSrv6SID, nil
 }

--- a/internal/pkg/table/ted.go
+++ b/internal/pkg/table/ted.go
@@ -39,7 +39,6 @@ func (ted *LsTed) Print() {
 					fmt.Printf("      index: %d\n", prefix.SidIndex)
 				}
 			}
-
 			fmt.Printf("  Links:\n")
 			for _, link := range node.Links {
 				fmt.Printf("    Local: %s Remote: %s\n", link.LocalIP.String(), link.RemoteIP.String())
@@ -50,6 +49,17 @@ func (ted *LsTed) Print() {
 				}
 				fmt.Printf("      Adj-SID: %d\n", link.AdjSid)
 			}
+			fmt.Printf("  SRv6 SIDs:\n")
+			for _, srv6SID := range node.SRv6SIDs {
+				fmt.Printf("    SIDs: %v\n", srv6SID.Sids)
+				fmt.Printf("    EndpointBehavior: %d\n", srv6SID.EndpointBehavior)
+				fmt.Printf("    MultiTopoIDs: %v\n", srv6SID.MultiTopoIDs)
+				fmt.Printf("    ServiceType: %d\n", srv6SID.ServiceType)
+				fmt.Printf("    TrafficType: %d\n", srv6SID.TrafficType)
+				fmt.Printf("    OpaqueType: %d\n", srv6SID.OpaqueType)
+				fmt.Printf("    Value: 0x%x\n", srv6SID.Value)
+			}
+
 			nodeCnt++
 			fmt.Printf("\n")
 		}
@@ -69,6 +79,7 @@ type LsNode struct {
 	SrgbEnd    uint32 // in BGP-LS Attr
 	Links      []*LsLink
 	Prefixes   []*LsPrefixV4
+	SRv6SIDs   []*LsSrv6SID
 }
 
 func NewLsNode(asn uint32, nodeID string) *LsNode {
@@ -203,6 +214,43 @@ func (lp *LsPrefixV4) UpdateTed(ted *LsTed) {
 	}
 
 	localNode.Prefixes = append(localNode.Prefixes, lp)
+}
+
+type LsSrv6SID struct {
+	LocalNode        *LsNode  // primary key, in MP_REACH_NLRI Attr
+	Sids             []string // in LsSrv6SID Attr
+	EndpointBehavior uint32   // in srv6EndpointBehavior Attr
+	MultiTopoIDs     []uint32 // in LsSrv6SID Attr
+	ServiceType      uint32   // in LsSrv6SID Attr
+	TrafficType      uint32   // in LsSrv6SID Attr
+	OpaqueType       uint32   // in LsSrv6SID Attr
+	Value            []byte   // in LsSrv6SID Attr
+}
+
+func NewLsSrv6SID(node *LsNode) *LsSrv6SID {
+	return &LsSrv6SID{
+		LocalNode: node,
+	}
+}
+
+func (s *LsSrv6SID) UpdateTed(ted *LsTed) {
+	nodes, asn := ted.Nodes, s.LocalNode.Asn
+
+	if _, ok := nodes[asn]; !ok {
+		nodes[asn] = make(map[string]*LsNode)
+	}
+
+	if _, ok := nodes[asn][s.LocalNode.RouterID]; !ok {
+		nodes[asn][s.LocalNode.RouterID] = NewLsNode(s.LocalNode.Asn, s.LocalNode.RouterID)
+	}
+
+	s.LocalNode = nodes[asn][s.LocalNode.RouterID]
+
+	s.LocalNode.AddSrv6SID(s)
+}
+
+func (n *LsNode) AddSrv6SID(s *LsSrv6SID) {
+	n.SRv6SIDs = append(n.SRv6SIDs, s)
 }
 
 type Metric struct {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Add a new Interface to the Pola PCE to support BGP-LS Service Segment functionality.

## Type of change
<!--- Select type of change and remove irrelevant options. -->
* [x] New features
* [x] Bug fixes 
* [x] Refactoring
* [ ] Documentation updates

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- internal/pkg/table/ted.go: Defined a new LsSrv6SID structure and added logic to update the TED with LsSRv6SIDNLRI entries.
- internal/pkg/gobgp/interface.go: Implemented retrieval of LsSRv6SIDNLRI entries from the GoBGP API.
- cmd/pola/ted.go: Added support to fetch the TED in JSON format via the Pola CLI tool.

## How is This Tested?
### Reproduction Method
- Refer to the test environment documentation on [Github Pages](https://github.com/k1yoto/pola-verification/tree/feature/bgp-ls-service-segment).
- When verifying the implementation of Service Segment, change go.mod to refer to the local [GoBGP for Service Segment](https://github.com/watal/gobgp/tree/feature/bgp-ls-service-segments).
```
replace github.com/osrg/gobgp/v3 => ../gobgp
```

### Verify GoBGP only Topology
When verifying with [a topology created with GoBGP only](https://github.com/k1yoto/pola-verification/blob/feature/bgp-ls-service-segment/bgp-ls-service-segment/bgp-ls-service-segment-gobgp-pola.clab.yml), successfully received Link-State information from GoBGP and updated the TED with LsSRv6SIDNLRI entries.
```
root@gobgp2:/# polad -f config/polad.yaml
2025-03-31T13:18:16.093Z	info	Start listening on gRPC port	{"server": "grpc", "listenInfo": "127.0.0.1:50052"}
2025-03-31T13:18:16.093Z	info	Start listening on PCEP port	{"address": "172.100.200.102:4189"}
2025-03-31T13:18:16.096Z	info	Request TED update	{"source": "GoBGP", "session": "127.0.0.1:50051"}
Before State Update TED: &{1 map[]}
After State Update TED: &{1 map[65000:map[:0xc0004d3440]]}
Node: 1

  Hostname:
  ISIS Area ID:
  SRGB: 0 - 0
  Prefixes:
  Links:
  SRv6 SIDs:
    SIDs: [fc00:0:1::2]
    EndpointBehavior: 0
    MultiTopoIDs: [1]
    ServiceType: 1
    TrafficType: 1
    OpaqueType: 1
    Value: [116 101 115 116]
```

### Verify IOS-XRv9k Topology
When verifying with [a topology created with IOS-XRv9k](https://github.com/k1yoto/pola-verification/blob/feature/bgp-ls-service-segment/bgp-ls-service-segment/bgp-ls-service-segment-gobgp-pola-xrv9k.clab.yml), LsSRv6SIDNLRI information can be updated in the TED by excluding error processing for unsupported LinkState information other than LsSRv6SIDNLRI.

## Other Information
### Known Issues
- API for retrieving LsSrv6SID information has not been implemented yet.
- Support for other LsNLRI types is needed when collecting Link-State information in SRv6 domains.

### Notes
The feature has been tested successfully in the GoBGP - GoBGP (Pola PCE) test environment.
However, in the IOS-XRv9k - GoBGP (Pola PCE) setup, other LsNLRI types besides LsSRv6SIDNLRI are not fully supported, resulting in incomplete TED updates for non-LsSrv6SID data.