### PR TITLE
Add scenario test for dynamic uSID SRv6 policy

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,15 +1,26 @@
 import pytest
 import subprocess
-import os
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def clab_deploy():
-    def _clab_deploy(dir="./"):
+    lab_dirs = []
+
+    def deploy(lab_dir="."):
+        lab_dirs.append(lab_dir)
         print("start containerlab")
-        os.chdir(dir)
-        subprocess.run("clab deploy", shell=True)
+        subprocess.run(
+            ["clab", "deploy", "--reconfigure"],
+            check=True,
+            cwd=lab_dir,
+        )
 
-    yield _clab_deploy
+    yield deploy
 
-    print("finish containerlab")
-    subprocess.run("clab destroy", shell=True)
+    for lab_dir in lab_dirs:
+        print("finish containerlab")
+        subprocess.run(
+            ["clab", "destroy", "--cleanup"],
+            check=False,
+            cwd=lab_dir,
+        )

--- a/test/scenario_test/dynamic_path/srv6-usid/input/gobgpd.cfg.yaml
+++ b/test/scenario_test/dynamic_path/srv6-usid/input/gobgpd.cfg.yaml
@@ -1,0 +1,11 @@
+global:
+  config:
+    as: 65000
+    router-id: "10.255.0.255"
+neighbors:
+  - config:
+      peer-as: 65000
+      neighbor-address: "fd00::1"
+    afi-safis:
+      - config:
+          afi-safi-name: ls

--- a/test/scenario_test/dynamic_path/srv6-usid/input/polad.cfg.yaml
+++ b/test/scenario_test/dynamic_path/srv6-usid/input/polad.cfg.yaml
@@ -1,0 +1,17 @@
+global:
+  pcep:
+    address: "::"
+    port: 4189
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: true
+    source: "gobgp"
+  gobgp:
+    grpcClient:
+      address: "10.0.0.4"
+      port: 50051

--- a/test/scenario_test/dynamic_path/srv6-usid/input/sr-policies/pe02-policy1.yaml
+++ b/test/scenario_test/dynamic_path/srv6-usid/input/sr-policies/pe02-policy1.yaml
@@ -1,0 +1,9 @@
+asn: 65000
+srPolicy:
+  pcepSessionAddr: "fd00::2"
+  srcRouterID: "0000.0001.0002"
+  dstRouterID: "0000.0001.0001"
+  name: "DYNAMIC-POLICY"
+  color: 100
+  type: dynamic
+  metric: igp

--- a/test/scenario_test/dynamic_path/srv6-usid/input/startup-configs/p01.cfg
+++ b/test/scenario_test/dynamic_path/srv6-usid/input/startup-configs/p01.cfg
@@ -1,0 +1,106 @@
+hostname p01
+username admin
+ group root-lr
+ group cisco-support
+ secret 10 $6$MTEbC5od1RuC....$xvQt1LVtwS9akjpzHYOZyj6ZMLZwJ5R9PvRCMaqjrR9iqeoPXisq.rXiiJZPoPE6Gi5XL1yjIlzAY4dfWC6Gr1
+!
+grpc
+ vrf MGMT
+ no-tls
+ address-family dual
+!
+vrf MGMT
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+!
+line default
+ transport input ssh
+!
+call-home
+ service active
+ contact smart-licensing
+ profile CiscoTAC-1
+  active
+  destination transport-method email disable
+  destination transport-method http
+ !
+!
+netconf-yang agent
+ ssh
+!
+interface Loopback0
+ ipv6 address fd00:ffff::3/128
+!
+interface GigabitEthernet0/0/0/0
+ description to:pe01
+ ipv6 enable
+!
+interface GigabitEthernet0/0/0/1
+ description to:pe02
+ ipv6 enable
+!
+interface GigabitEthernet0/0/0/2
+ description to:p02
+ ipv6 enable
+!
+router isis 1
+ is-type level-2-only
+ net 49.0000.0000.0001.0003.00
+ address-family ipv6 unicast
+  metric-style wide
+  router-id Loopback0
+  segment-routing srv6
+   locator uSID
+    level 2
+   !
+  !
+ !
+ interface Loopback0
+  passive
+  address-family ipv6 unicast
+  !
+ !
+ interface GigabitEthernet0/0/0/0
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/1
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv6 unicast
+   metric 100 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/2
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+!
+mpls oam
+!
+segment-routing
+ srv6
+  logging locator status
+  locators
+   locator uSID
+    micro-segment behavior unode psp-usd
+    prefix fcbb:bb00:1003::/48
+   !
+  !
+ !
+!
+ssh server v2
+ssh server vrf MGMT
+ssh server netconf vrf MGMT
+end

--- a/test/scenario_test/dynamic_path/srv6-usid/input/startup-configs/p02.cfg
+++ b/test/scenario_test/dynamic_path/srv6-usid/input/startup-configs/p02.cfg
@@ -1,0 +1,106 @@
+hostname p02
+username admin
+ group root-lr
+ group cisco-support
+ secret 10 $6$MTEbC5od1RuC....$xvQt1LVtwS9akjpzHYOZyj6ZMLZwJ5R9PvRCMaqjrR9iqeoPXisq.rXiiJZPoPE6Gi5XL1yjIlzAY4dfWC6Gr1
+!
+grpc
+ vrf MGMT
+ no-tls
+ address-family dual
+!
+vrf MGMT
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+!
+line default
+ transport input ssh
+!
+call-home
+ service active
+ contact smart-licensing
+ profile CiscoTAC-1
+  active
+  destination transport-method email disable
+  destination transport-method http
+ !
+!
+netconf-yang agent
+ ssh
+!
+interface Loopback0
+ ipv6 address fd00:ffff::4/128
+!
+interface GigabitEthernet0/0/0/0
+ description to:pe01
+ ipv6 enable
+!
+interface GigabitEthernet0/0/0/1
+ description to:pe02
+ ipv6 enable
+!
+interface GigabitEthernet0/0/0/2
+ description to:p01
+ ipv6 enable
+!
+router isis 1
+ is-type level-2-only
+ net 49.0000.0000.0001.0004.00
+ address-family ipv6 unicast
+  metric-style wide
+  router-id Loopback0
+  segment-routing srv6
+   locator uSID
+    level 2
+   !
+  !
+ !
+ interface Loopback0
+  passive
+  address-family ipv6 unicast
+  !
+ !
+ interface GigabitEthernet0/0/0/0
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv6 unicast
+   metric 100 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/1
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/2
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+!
+mpls oam
+!
+segment-routing
+ srv6
+  logging locator status
+  locators
+   locator uSID
+    micro-segment behavior unode psp-usd
+    prefix fcbb:bb00:1004::/48
+   !
+  !
+ !
+!
+ssh server v2
+ssh server vrf MGMT
+ssh server netconf vrf MGMT
+end

--- a/test/scenario_test/dynamic_path/srv6-usid/input/startup-configs/pe01.cfg
+++ b/test/scenario_test/dynamic_path/srv6-usid/input/startup-configs/pe01.cfg
@@ -1,0 +1,124 @@
+hostname pe01
+username admin
+ group root-lr
+ group cisco-support
+ secret admin@123
+!
+grpc
+ vrf MGMT
+ port 9339
+ no-tls
+ address-family dual
+!
+vrf MGMT
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+!
+line default
+ transport input ssh
+!
+call-home
+ service active
+ contact smart-licensing
+ profile CiscoTAC-1
+  active
+  destination transport-method email disable
+  destination transport-method http
+ !
+!
+netconf-yang agent
+ ssh
+!
+interface Loopback0
+ ipv6 address fd00:ffff::1/128
+!
+interface GigabitEthernet0/0/0/0
+ description to:p01
+ ipv6 enable
+!
+interface GigabitEthernet0/0/0/1
+ description to:p02
+ ipv6 enable
+!
+interface GigabitEthernet0/0/0/2
+ description to:pce
+ ipv6 address fd00::1/64
+!
+router isis 1
+ is-type level-2-only
+ net 49.0000.0000.0001.0001.00
+ distribute link-state level 2
+ address-family ipv6 unicast
+  metric-style wide
+  router-id Loopback0
+  segment-routing srv6
+   locator uSID
+    level 2
+   !
+  !
+ !
+ interface Loopback0
+  passive
+  address-family ipv6 unicast
+  !
+ !
+ interface GigabitEthernet0/0/0/0
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/1
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv6 unicast
+   metric 100 level 2
+  !
+ !
+!
+router bgp 65000
+ bgp router-id 10.255.0.1
+ address-family link-state link-state
+ !
+ neighbor fd00::4
+  remote-as 65000
+  update-source GigabitEthernet0/0/0/2
+  address-family link-state link-state
+  !
+ !
+!
+mpls oam
+!
+segment-routing
+ traffic-eng
+  candidate-paths
+   pcep
+   !
+  !
+  pcc
+   pce address ipv6 fd00::3
+   !
+  !
+ !
+ srv6
+  logging locator status
+  micro-segment
+   merge-overlay-underlay-sids
+  !
+  locators
+   locator uSID
+    micro-segment behavior unode psp-usd
+    prefix fcbb:bb00:1001::/48
+   !
+  !
+ !
+!
+ssh server v2
+ssh server vrf MGMT
+ssh server netconf vrf MGMT
+end

--- a/test/scenario_test/dynamic_path/srv6-usid/input/startup-configs/pe02.cfg
+++ b/test/scenario_test/dynamic_path/srv6-usid/input/startup-configs/pe02.cfg
@@ -1,0 +1,134 @@
+chassis {
+    network-services enhanced-ip;
+}
+
+interfaces {
+    ge-0/0/0 {
+        description "to:p01";
+        unit 0 {
+            family iso;
+            family inet6;
+        }
+    }
+    ge-0/0/1 {
+        description "to:p02";
+        unit 0 {
+            family iso;
+            family inet6;
+        }
+    }
+    ge-0/0/2 {
+        description "POLA-PCE";
+        unit 0 {
+            family inet6 {
+                address fd00::2/64;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family iso {
+                address 49.0000.0000.0001.0002.00;
+            }
+            family inet6 {
+                address fd00:ffff::2/128;
+            }
+        }
+    }
+}
+
+routing-options {
+    router-id 10.255.0.2;
+    autonomous-system 65000;
+    forwarding-table {
+        srv6-chain-merge;
+    }
+    source-packet-routing {
+        srv6 {
+            no-reduced-srh;
+            block usid-block {
+                fcbb:bb00::/32;
+                local-micro-sid {
+                    maximum-static-sids 1000;
+                }
+            }
+            locator loc-pe02 {
+                fcbb:bb00:1002::/48;
+                micro-sid {
+                    block-name usid-block;
+                    flavor psp;
+                    flavor usd;
+                }
+            }
+        }
+    }
+}
+
+protocols {
+    isis {
+        level 1 disable;
+        level 2 {
+            wide-metrics-only;
+        }
+        no-ipv4-routing;
+        topologies {
+            ipv6-unicast;
+        }
+        net 49.0000.0000.0001.0002.00;
+        interface ge-0/0/0.0 {
+            point-to-point;
+            level 2 {
+                ipv6-unicast-metric 100;
+                srv6-adjacency-segment {
+                    unprotected {
+                        locator loc-pe02 {
+                            micro-adjacency-sid;
+                        }
+                    }
+                }
+            }
+        }
+        interface ge-0/0/1.0 {
+            point-to-point;
+            level 2 {
+                ipv6-unicast-metric 10;
+                srv6-adjacency-segment {
+                    unprotected {
+                        locator loc-pe02 {
+                            micro-adjacency-sid;
+                        }
+                    }
+                }
+            }
+        }
+        interface lo0.0 {
+            passive;
+        }
+        source-packet-routing {
+            srv6 {
+                locator loc-pe02 {
+                    micro-node-sid;
+                }
+            }
+        }
+    }
+    mpls {
+        lsp-external-controller pccd;
+    }
+    source-packet-routing {
+        lsp-external-controller pccd;
+        srv6;
+        preserve-nexthop-hierarchy;
+    }
+    pcep {
+        pce POLA-PCE {
+            local-ipv6-address fd00::2;
+            destination-ipv6-address fd00::3;
+            pce-type active;
+            pce-type stateful;
+            lsp-provisioning;
+            spring-capability;
+            srv6-capability;
+        }
+    }
+}

--- a/test/scenario_test/dynamic_path/srv6-usid/topo.clab.yaml
+++ b/test/scenario_test/dynamic_path/srv6-usid/topo.clab.yaml
@@ -1,0 +1,66 @@
+name: srv6-usid
+topology:
+  kinds:
+    xrd:
+      image: ios-xr/xrd-control-plane:7.8.1
+    juniper_vjunosrouter:
+      image: vrnetlab/juniper_vjunos-router:25.2R1.9
+    linux:
+      image: golang:1.24.2
+    bridge:
+      image: ghcr.io/containernet/bridge:latest
+  nodes:
+    pe01:
+      kind: xrd
+      startup-config: input/startup-configs/pe01.cfg
+    pe02:
+      kind: juniper_vjunosrouter
+      startup-config: input/startup-configs/pe02.cfg
+    p01:
+      kind: xrd
+      startup-config: input/startup-configs/p01.cfg
+    p02:
+      kind: xrd
+      startup-config: input/startup-configs/p02.cfg
+    gobgp:
+      kind: linux
+      binds:
+        - ../../../bin/gobgpd:/bin/gobgpd
+        - ../../../bin/gobgp:/bin/gobgp
+        - input/gobgpd.cfg.yaml:/gobgpd.cfg.yaml
+      exec:
+        - apt update
+        - apt install -y iproute2 iputils-ping
+        - ip link set eth1 up
+        - ip addr add 10.0.0.4/24 dev eth1
+        - ip -6 addr add fd00::4/64 dev eth1
+      cmd: /bin/gobgpd -f /gobgpd.cfg.yaml &
+    pola:
+      kind: linux
+      startup-delay: 10
+      binds:
+        - ../../../bin/polad:/bin/polad
+        - ../../../bin/pola:/bin/pola
+        - input/polad.cfg.yaml:/polad.cfg.yaml
+        - input/sr-policies/pe02-policy1.yaml:/pe02-policy1.yaml
+      exec:
+        - apt update
+        - apt install -y iproute2 iputils-ping
+        - ip link set eth1 up
+        - ip addr add 10.0.0.3/24 dev eth1
+        - ip -6 addr add fd00::3/64 dev eth1
+      cmd: /bin/polad -f /polad.cfg.yaml &
+    switch:
+      kind: bridge
+  links:
+    # SRv6 domain
+    - endpoints: ["pe01:Gi0-0-0-0", "p01:Gi0-0-0-0"]
+    - endpoints: ["pe01:Gi0-0-0-1", "p02:Gi0-0-0-0"]
+    - endpoints: ["pe02:eth1", "p01:Gi0-0-0-1"]
+    - endpoints: ["pe02:eth2", "p02:Gi0-0-0-1"]
+    - endpoints: ["p01:Gi0-0-0-2", "p02:Gi0-0-0-2"]
+    # Switch
+    - endpoints: ["pe01:Gi0-0-0-2", "switch:eth1"]
+    - endpoints: ["pe02:eth3", "switch:eth2"]
+    - endpoints: ["pola:eth1", "switch:eth3"]
+    - endpoints: ["gobgp:eth1", "switch:eth4"]

--- a/test/scenario_test/dynamic_path/test_dynamic_path.py
+++ b/test/scenario_test/dynamic_path/test_dynamic_path.py
@@ -1,0 +1,182 @@
+import pytest
+import os
+import time
+import subprocess
+import json
+import paramiko
+import re
+
+
+class TestDynamicPath:
+    TEST_ABS_DIR = os.getcwd()[: os.getcwd().rfind("/test")] + "/test"
+    BIN_ABS_DIR = TEST_ABS_DIR + "/bin"
+
+    TEST_DYNAMIC_PATH_DIR = TEST_ABS_DIR + "/scenario_test/dynamic_path/srv6-usid"
+    EXPECTED_LSP_FILE = TEST_DYNAMIC_PATH_DIR + "/expected/sr-policy_output.txt"
+
+    def _run(self, cmd: str) -> subprocess.CompletedProcess:
+        """Run a shell command and return CompletedProcess."""
+        return subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def _wait_until_pcep_success(self, cmd, interval=10, timeout=600):
+        start = time.time()
+        while True:
+            result = self._run(cmd)
+            if result.returncode == 0:
+                return
+            if time.time() - start > timeout:
+                pytest.fail(f"Timeout waiting for command to succeed: {cmd}")
+            time.sleep(interval)
+
+    def _wait_until_ted_has_routers(self, router_ids, interval=10, timeout=600):
+        """
+        Wait until pola TED contains all given router_ids.
+        """
+        cmd = "docker exec clab-srv6-usid-pola /bin/pola ted -j -p 50052"
+        start = time.time()
+        router_ids = set(router_ids)
+
+        while True:
+            result = self._run(cmd)
+            if result.returncode == 0:
+                try:
+                    data = json.loads(result.stdout)
+                    present = {node.get("routerID") for node in data.get("ted", [])}
+                    missing = router_ids - present
+                    if not missing:
+                        print(f"TED contains routers: {router_ids}")
+                        return
+                except json.JSONDecodeError:
+                    pass
+
+            if time.time() - start > timeout:
+                pytest.fail(f"Timeout waiting for routers {router_ids} in TED")
+
+            print(f"Waiting for routers {router_ids} in TED...")
+            time.sleep(interval)
+
+    def _wait_until_ted_has_all_links(self, expected_links, interval=10, timeout=600):
+        """
+        Wait until pola TED contains all expected links.
+        """
+        cmd = "docker exec clab-srv6-usid-pola /bin/pola ted -j -p 50052"
+        start = time.time()
+
+        while True:
+            result = self._run(cmd)
+            if result.returncode == 0:
+                try:
+                    data = json.loads(result.stdout)
+                    found_links = set()
+
+                    for node in data.get("ted", []):
+                        local = node.get("routerID")
+                        for link in node.get("links", []):
+                            remote = link.get("remoteNode")
+                            if local and remote:
+                                found_links.add(frozenset((local, remote)))
+
+                    missing = expected_links - found_links
+                    if not missing:
+                        print("TED contains all expected links")
+                        return
+                except json.JSONDecodeError:
+                    pass
+
+            if time.time() - start > timeout:
+                pytest.fail(f"Timeout waiting for links in TED. Missing: {missing}")
+
+            print(f"Waiting for links in TED. Missing: {missing}")
+            time.sleep(interval)
+
+    def test__bin_ready(self):
+        """Ensure required binaries exist and are executable."""
+        for binname in ["gobgpd", "polad", "pola"]:
+            path = f"{self.BIN_ABS_DIR}/{binname}"
+            assert os.path.exists(path)
+            assert os.access(path, os.X_OK)
+
+    def test__srv6_usid_dynamic_path(self, clab_deploy):
+        TEST_DIR = self.TEST_DYNAMIC_PATH_DIR
+
+        # Deploy containerlab topology
+        clab_deploy(TEST_DIR)
+
+        # Wait for routers to boot
+        print("Waiting for vJunos boot (120s)")
+        time.sleep(120)
+
+        # Wait until PCEP session is up (POLA <-> PE02)
+        self._wait_until_pcep_success(
+            "docker exec clab-srv6-usid-pola "
+            "/bin/pola session -p 50052 | grep 'sessionAddr(0): fd00::2'"
+        )
+
+        # Wait until TED is populated
+        self._wait_until_ted_has_routers(
+            [
+                "0000.0001.0001",
+                "0000.0001.0002",
+                "0000.0001.0003",
+                "0000.0001.0004",
+            ]
+        )
+
+        # Wait until all expected links are present
+        expected_links = {
+            frozenset(("0000.0001.0001", "0000.0001.0003")),
+            frozenset(("0000.0001.0001", "0000.0001.0004")),
+            frozenset(("0000.0001.0002", "0000.0001.0003")),
+            frozenset(("0000.0001.0002", "0000.0001.0004")),
+            frozenset(("0000.0001.0003", "0000.0001.0004")),
+        }
+        self._wait_until_ted_has_all_links(expected_links)
+
+        # Inject SR Policy via Pola CLI (PCEP)
+        result = self._run(
+            "docker exec clab-srv6-usid-pola /bin/pola "
+            "sr-policy add -f /pe02-policy1.yaml -p 50052"
+        )
+        assert "success" in result.stdout.lower()
+        time.sleep(10)  # wait for SR Policy propagation
+
+        # SSH to PE02 and capture LSP detail output
+        ssh_client = paramiko.SSHClient()
+        ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh_client.connect(
+            hostname="clab-srv6-usid-pe02",
+            username="admin",
+            password="admin@123",
+        )
+
+        stdin, stdout, stderr = ssh_client.exec_command(
+            "show spring-traffic-engineering lsp name DYNAMIC-POLICY detail"
+        )
+        lsp_output = stdout.read().decode()
+        ssh_client.close()
+
+        assert "DYNAMIC-POLICY" in lsp_output
+        assert "fd00:ffff::1-100" in lsp_output
+        assert "State: Up" in lsp_output
+        assert "SID type: Micro SRv6 SID" in lsp_output
+
+        # Verify SR-ERO content and order by comparing the exact SRv6 segment list
+        expected_segments = [
+          "fcbb:bb00:1004::",
+          "fcbb:bb00:1003::",
+          "fcbb:bb00:1001::",
+        ]
+        actual_segments = re.findall(
+            r"SID type:\s*Micro SRv6 SID,\s*Value:\s*([0-9a-fA-F:]+)",
+            lsp_output,
+        )
+        assert actual_segments == expected_segments, (
+            f"SR-ERO segment list mismatch.\n"
+            f"Expected: {expected_segments}\n"
+            f"Actual:   {actual_segments}"
+        )

--- a/test/scenario_test/show_ted/test_show_ted.py
+++ b/test/scenario_test/show_ted/test_show_ted.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 import time
 import subprocess
@@ -6,98 +5,150 @@ import json
 import paramiko
 from deepdiff import DeepDiff
 
+
 class TestShowTed:
-  TEST_ABS_DIR = os.getcwd()[:os.getcwd().rfind("/test")] + "/test"
-  BIN_ABS_DIR = TEST_ABS_DIR + "/bin"
+    TEST_ABS_DIR = os.getcwd()[: os.getcwd().rfind("/test")] + "/test"
+    BIN_ABS_DIR = TEST_ABS_DIR + "/bin"
 
-  TEST_SHOW_TED_DIR = TEST_ABS_DIR + "/scenario_test/show_ted"
+    TEST_SHOW_TED_DIR = TEST_ABS_DIR + "/scenario_test/show_ted"
 
-  def test__bin_ready(self):
-    assert os.path.exists(self.BIN_ABS_DIR + "/gobgpd")
-    assert os.access(self.BIN_ABS_DIR + "/gobgpd", os.X_OK)
-    assert os.path.exists(self.BIN_ABS_DIR + "/polad")
-    assert os.access(self.BIN_ABS_DIR + "/polad", os.X_OK)
-    assert os.path.exists(self.BIN_ABS_DIR + "/pola")
-    assert os.access(self.BIN_ABS_DIR + "/pola", os.X_OK)
+    def test__bin_ready(self):
+        assert os.path.exists(self.BIN_ABS_DIR + "/gobgpd")
+        assert os.access(self.BIN_ABS_DIR + "/gobgpd", os.X_OK)
+        assert os.path.exists(self.BIN_ABS_DIR + "/polad")
+        assert os.access(self.BIN_ABS_DIR + "/polad", os.X_OK)
+        assert os.path.exists(self.BIN_ABS_DIR + "/pola")
+        assert os.access(self.BIN_ABS_DIR + "/pola", os.X_OK)
 
-  def test__srmpls(self, clab_deploy):
-    TEST_SRMPLS_DIR = self.TEST_SHOW_TED_DIR + "/srmpls"
-    # deploy test environment by containerlab
-    clab_deploy(TEST_SRMPLS_DIR)
+    def test__srmpls(self, clab_deploy):
+        TEST_SRMPLS_DIR = self.TEST_SHOW_TED_DIR + "/srmpls"
+        # deploy test environment by containerlab
+        clab_deploy(TEST_SRMPLS_DIR)
 
-    print("Wait for deploy vJunosRouter for 2 minutes")
-    time.sleep(120)
+        print("Wait for deploy vJunosRouter for 2 minutes")
+        time.sleep(120)
 
-    # wait for vJunosRouter booting
-    while subprocess.run("docker exec -it clab-srmpls-gobgp ping 10.255.0.2 -c 1", shell=True).returncode != 0:
-      print("Wait for deploy vJunosRouter ...")
-      time.sleep(10)
+        # wait for vJunosRouter booting
+        while (
+            subprocess.run(
+                "docker exec -it clab-srmpls-gobgp ping 10.255.0.2 -c 1", shell=True
+            ).returncode
+            != 0
+        ):
+            print("Wait for deploy vJunosRouter ...")
+            time.sleep(10)
 
-    print("Wait for pola's TED to finish syncing...")
-    time.sleep(10)
+        print("Wait for pola's TED to finish syncing...")
+        time.sleep(10)
 
-    output = json.loads(subprocess.run("docker exec -it clab-srmpls-pola /bin/pola -p 50052 ted -j", shell=True, capture_output=True, text=True).stdout)
-    print("output is", output)
-    with open(TEST_SRMPLS_DIR+"/expected/srmpls.json") as f:
-        expected_output = json.load(f)
+        output = json.loads(
+            subprocess.run(
+                "docker exec -it clab-srmpls-pola /bin/pola -p 50052 ted -j",
+                shell=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+        print("output is", output)
+        with open(TEST_SRMPLS_DIR + "/expected/srmpls.json") as f:
+            expected_output = json.load(f)
 
-    # Run "pola ted" cmd and ensure it returns the expected result.
-    assert DeepDiff(output, expected_output, ignore_order=True) == {}
+        # Run "pola ted" cmd and ensure it returns the expected result.
+        assert DeepDiff(output, expected_output, ignore_order=True) == {}
 
-    print("Disable interface ge-0/0/0 on clab-srmpls-jun-rt1 to test real-time TED sync...")
-    ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh_client.connect(hostname="clab-srmpls-jun-rt1", username="admin", password="admin@123")
-    stdin, stdout, stderr = ssh_client.exec_command("configure; set interfaces ge-0/0/0 disable; commit")
-    print(stdout.read().decode())
-    print(stderr.read().decode())
+        print(
+            "Disable interface ge-0/0/0 on clab-srmpls-jun-rt1 to test real-time TED sync..."
+        )
+        ssh_client = paramiko.SSHClient()
+        ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh_client.connect(
+            hostname="clab-srmpls-jun-rt1", username="admin", password="admin@123"
+        )
+        stdin, stdout, stderr = ssh_client.exec_command(
+            "configure; set interfaces ge-0/0/0 disable; commit"
+        )
+        print(stdout.read().decode())
+        print(stderr.read().decode())
 
-    time.sleep(30)  # wait for pola to sync
-    output2 = json.loads(subprocess.run("docker exec -it clab-srmpls-pola /bin/pola -p 50052 ted -j", shell=True, capture_output=True, text=True).stdout)
-    print("output is", output2)
-    with open(TEST_SRMPLS_DIR+"/expected/srmpls2.json") as f:
-        expected_output2 = json.load(f)
+        time.sleep(30)  # wait for pola to sync
+        output2 = json.loads(
+            subprocess.run(
+                "docker exec -it clab-srmpls-pola /bin/pola -p 50052 ted -j",
+                shell=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+        print("output is", output2)
+        with open(TEST_SRMPLS_DIR + "/expected/srmpls2.json") as f:
+            expected_output2 = json.load(f)
 
-    # Run "pola ted" cmd and ensure it returns the expected result.
-    assert DeepDiff(output2, expected_output2, ignore_order=True) == {}
+        # Run "pola ted" cmd and ensure it returns the expected result.
+        assert DeepDiff(output2, expected_output2, ignore_order=True) == {}
 
-  def test__srv6_usid(self, clab_deploy):
-    TEST_SRV6_USID_DIR = self.TEST_SHOW_TED_DIR + "/srv6-usid"
-    # deploy test environment by containerlab
-    clab_deploy(TEST_SRV6_USID_DIR)
+    def test__srv6_usid(self, clab_deploy):
+        TEST_SRV6_USID_DIR = self.TEST_SHOW_TED_DIR + "/srv6-usid"
+        # deploy test environment by containerlab
+        clab_deploy(TEST_SRV6_USID_DIR)
 
-    print("Wait for deploy vJunosRouter for 2 minutes")
-    time.sleep(120)
+        print("Wait for deploy vJunosRouter for 2 minutes")
+        time.sleep(120)
 
-    # wait for vJunosRouter booting
-    while subprocess.run("docker exec -it clab-srv6-usid-gobgp ping fd00:ffff::2 -c 1", shell=True).returncode != 0:
-      print("Wait for deploy vJunosRouter ...")
-      time.sleep(10)
+        # wait for vJunosRouter booting
+        while (
+            subprocess.run(
+                "docker exec -it clab-srv6-usid-gobgp ping fd00:ffff::2 -c 1",
+                shell=True,
+            ).returncode
+            != 0
+        ):
+            print("Wait for deploy vJunosRouter ...")
+            time.sleep(10)
 
-    print("Wait for pola's TED to finish syncing...")
-    time.sleep(10)
-    
-    output = json.loads(subprocess.run("docker exec -it clab-srv6-usid-pola /bin/pola -p 50052 ted -j", shell=True, capture_output=True, text=True).stdout)
-    print("output is", output)
-    with open(TEST_SRV6_USID_DIR+"/expected/srv6-usid.json") as f:
-        expected_output = json.load(f)
+        print("Wait for pola's TED to finish syncing...")
+        time.sleep(10)
 
-    # Run "pola ted" cmd and ensure it returns the expected result.
-    assert DeepDiff(output, expected_output, ignore_order=True) == {}
+        output = json.loads(
+            subprocess.run(
+                "docker exec -it clab-srv6-usid-pola /bin/pola -p 50052 ted -j",
+                shell=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+        print("output is", output)
+        with open(TEST_SRV6_USID_DIR + "/expected/srv6-usid.json") as f:
+            expected_output = json.load(f)
 
-    print("Disable interface ge-0/0/0 on clab-srv6-usid-jun-rt1 to test real-time TED sync...")
-    ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh_client.connect(hostname="clab-srv6-usid-jun-rt1", username="admin", password="admin@123")
-    stdin, stdout, stderr = ssh_client.exec_command("configure; set interfaces ge-0/0/0 disable; commit")
-    print(stdout.read().decode())
-    print(stderr.read().decode())
+        # Run "pola ted" cmd and ensure it returns the expected result.
+        assert DeepDiff(output, expected_output, ignore_order=True) == {}
 
-    time.sleep(30)  # wait for pola to sync
-    output2 = json.loads(subprocess.run("docker exec -it clab-srv6-usid-pola /bin/pola -p 50052 ted -j", shell=True, capture_output=True, text=True).stdout)
-    print("output is", output2)
-    with open(TEST_SRV6_USID_DIR+"/expected/srv6-usid2.json") as f:
-        expected_output2 = json.load(f)
+        print(
+            "Disable interface ge-0/0/0 on clab-srv6-usid-jun-rt1 to test real-time TED sync..."
+        )
+        ssh_client = paramiko.SSHClient()
+        ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh_client.connect(
+            hostname="clab-srv6-usid-jun-rt1", username="admin", password="admin@123"
+        )
+        stdin, stdout, stderr = ssh_client.exec_command(
+            "configure; set interfaces ge-0/0/0 disable; commit"
+        )
+        print(stdout.read().decode())
+        print(stderr.read().decode())
 
-    # Run "pola ted" cmd and ensure it returns the expected result.
-    assert DeepDiff(output2, expected_output2, ignore_order=True) == {}
+        time.sleep(30)  # wait for pola to sync
+        output2 = json.loads(
+            subprocess.run(
+                "docker exec -it clab-srv6-usid-pola /bin/pola -p 50052 ted -j",
+                shell=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+        print("output is", output2)
+        with open(TEST_SRV6_USID_DIR + "/expected/srv6-usid2.json") as f:
+            expected_output2 = json.load(f)
+
+        # Run "pola ted" cmd and ensure it returns the expected result.
+        assert DeepDiff(output2, expected_output2, ignore_order=True) == {}


### PR DESCRIPTION
## Description
This PR introduces a new scenario under `test/scenario_test/dynamic_path/srv6-usid/` that tests:

- Deployment of a dynamic SRv6 policy using uSID (Micro SID).
- Validation of SID type (`Micro SRv6 SID`) and SR-ERO hop count.

This PR also improves the containerlab test fixture:

- Make containerlab tests more robust:
  - Always clean up environments with `containerlab destroy --cleanup` and guarantee cleanup with `try/finally`.
  - Use `clab deploy --reconfigure` and `check=True` for reliable, fail-fast deployment.
- Apply `ruff format` (no functional changes).

## Type of change
* [x] New features
* [ ] Bug fixes
* [ ] Refactoring
* [ ] Documentation updates

## Motivation and Context
This change is required to automatically test the deployment and behavior of dynamic SRv6 policies with uSID, ensuring path computation and deployment to vJunos routers via PCEP.

## How is This Tested?
* Reference: [test/README.md](https://github.com/nttcom/pola/blob/main/test/README.md)
* The scenario is tested using `test/scenario_test/dynamic_path/test_dynamic_path.py`.
* Deploys containerlab topology with PE routers, GoBGP, and Pola.
* Verifies LSP creation, state (`Up`), SID type (`Micro SRv6 SID`), and SR-ERO hop count.