### PR TITLE
test(tlv): add unit tests and refactor tlv.go

### DIFF
--- a/pkg/packet/pcep/capability_test.go
+++ b/pkg/packet/pcep/capability_test.go
@@ -84,6 +84,13 @@ func TestPolaCapability(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Includes LSPDBVersion (should be skipped)",
+			input: []CapabilityInterface{
+				&LSPDBVersion{},
+			},
+			expected: []CapabilityInterface{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -745,7 +745,7 @@ func (tlv *SRPCECapability) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("SRPCECapability: invalid value length %d", valueLen)
 	}
 
-	val := data[TLVValueOffset:]
+	val := data[TLVValueOffset : TLVValueOffset+valueLen]
 
 	flags := val[SRPCECapabilityFlagsOffset]
 	tlv.HasUnlimitedMaxSIDDepth = IsBitSet(flags, UnlimitedMaximumSIDDepthFlag)

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1014,15 +1014,30 @@ const (
 )
 
 func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
-	length := binary.BigEndian.Uint16(data[2:4])
-
-	pstNum := int(data[7])
-	for i := 0; i < pstNum; i++ {
-		tlv.PathSetupTypes = append(tlv.PathSetupTypes, Pst(data[8+i]))
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("PathSetupTypeCapability: %w", err)
 	}
 
-	if pstNum%4 != 0 {
-		pstNum += 4 - (pstNum % 4) // padding byte
+	if tlv.SubTLVs == nil {
+		tlv.SubTLVs = []TLVInterface{}
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	if len(value) < PathSetupTypeCapabilityFixedPartLength {
+		return fmt.Errorf("PathSetupTypeCapability: value too short for fixed part")
+	}
+
+	pstNum := int(value[PathSetupTypeCapabilityPSTCountOffset])
+
+	tlv.PathSetupTypes = make([]Pst, 0, pstNum)
+	for i := 0; i < pstNum; i++ {
+		offset := PathSetupTypeCapabilityFixedPartLength + i
+		if offset >= len(value) {
+			return fmt.Errorf("PathSetupTypeCapability: value too short for PathSetupTypes entries")
+		}
+		tlv.PathSetupTypes = append(tlv.PathSetupTypes, Pst(value[offset]))
 	}
 
 	padded := paddedLength(uint16(pstNum), TLVAlignment)
@@ -1160,11 +1175,23 @@ type AssocTypeList struct {
 }
 
 func (tlv *AssocTypeList) DecodeFromBytes(data []byte) error {
-	AssocTypeNum := binary.BigEndian.Uint16(data[2:4]) / 2
-	for i := 0; i < int(AssocTypeNum); i++ {
-		at := binary.BigEndian.Uint16(data[4+2*i : 6+2*i])
-		tlv.AssocTypes = append(tlv.AssocTypes, AssocType(at))
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("AssocTypeList: %w", err)
 	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	if len(value)%2 != 0 {
+		return fmt.Errorf("AssocTypeList: value length not even, cannot contain 16-bit AssocType entries")
+	}
+
+	assocNum := len(value) / 2
+	tlv.AssocTypes = make([]AssocType, assocNum)
+	for i := 0; i < assocNum; i++ {
+		tlv.AssocTypes[i] = AssocType(binary.BigEndian.Uint16(value[2*i : 2*i+2]))
+	}
+
 	return nil
 }
 
@@ -1225,11 +1252,31 @@ func (tlv *AssocTypeList) CapStrings() []string {
 }
 
 type SRPolicyCandidatePathIdentifier struct {
-	OriginatorAddr netip.Addr // After DecodeFromBytes, even ipv4 addresses are assigned in ipv6 format
+	OriginatorAddr netip.Addr // After DecodeFromBytes, IPv4 addresses are stored as native IPv4 (upper 12 bytes zero), not IPv4-mapped IPv6
 }
 
 func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
-	tlv.OriginatorAddr, _ = netip.AddrFromSlice(data[12:28])
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("SRPolicyCandidatePathIdentifier: %w", err)
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	if len(value) < 8+16 {
+		return fmt.Errorf("SRPolicyCandidatePathIdentifier: value too short for OriginatorAddr")
+	}
+
+	addrBytes := value[8 : 8+16]
+
+	if isIPv4Bytes(addrBytes) {
+		var v4 [4]byte
+		copy(v4[:], addrBytes[12:])
+		tlv.OriginatorAddr = netip.AddrFrom4(v4)
+	} else {
+		tlv.OriginatorAddr = netip.AddrFrom16(*(*[16]byte)(addrBytes))
+	}
+
 	return nil
 }
 
@@ -1281,7 +1328,18 @@ type SRPolicyCandidatePathPreference struct {
 }
 
 func (tlv *SRPolicyCandidatePathPreference) DecodeFromBytes(data []byte) error {
-	tlv.Preference = binary.BigEndian.Uint32(data[4:8])
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("SRPolicyCandidatePathPreference: %w", err)
+	}
+
+	if valueLen != 4 {
+		return fmt.Errorf("SRPolicyCandidatePathPreference: invalid value length %d", valueLen)
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	tlv.Preference = binary.BigEndian.Uint32(value)
 	return nil
 }
 
@@ -1325,7 +1383,18 @@ type Color struct {
 }
 
 func (tlv *Color) DecodeFromBytes(data []byte) error {
-	tlv.Color = binary.BigEndian.Uint32(data[4:8])
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("Color: %w", err)
+	}
+
+	if valueLen != 4 {
+		return fmt.Errorf("Color: invalid value length %d", valueLen)
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	tlv.Color = binary.BigEndian.Uint32(value)
 	return nil
 }
 
@@ -1371,10 +1440,15 @@ type UndefinedTLV struct {
 }
 
 func (tlv *UndefinedTLV) DecodeFromBytes(data []byte) error {
-	tlv.Typ = TLVType(binary.BigEndian.Uint16(data[0:2]))
-	tlv.Length = binary.BigEndian.Uint16(data[2:4])
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("UndefinedTLV: %w", err)
+	}
 
-	tlv.Value = data[4 : 4+tlv.Length]
+	tlv.Typ = TLVType(binary.BigEndian.Uint16(data[TLVTypeOffset:TLVLengthOffset]))
+	tlv.Length = uint16(valueLen)
+	tlv.Value = data[TLVValueOffset : TLVValueOffset+valueLen]
+
 	return nil
 }
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -427,6 +427,7 @@ func (tlv *SymbolicPathName) DecodeFromBytes(data []byte) error {
 
 func (tlv *SymbolicPathName) Serialize() []byte {
 	value := []byte(tlv.Name)
+
 	padding := (TLVAlignment - (len(value) % TLVAlignment)) % TLVAlignment
 	value = append(value, make([]byte, padding)...)
 
@@ -675,21 +676,15 @@ func (tlv *LSPDBVersion) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *LSPDBVersion) Serialize() []byte {
-	buf := []byte{}
+	value := make([]byte, TLVLSPDBVersionValueLength)
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
+	binary.BigEndian.PutUint64(value, tlv.VersionNumber)
 
-	length := make([]byte, 2)
-	binary.BigEndian.PutUint16(length, TLVLSPDBVersionValueLength)
-	buf = append(buf, length...)
-
-	val := make([]byte, TLVLSPDBVersionValueLength)
-	binary.BigEndian.PutUint64(val, tlv.VersionNumber)
-
-	buf = append(buf, val...)
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVLSPDBVersionValueLength),
+		value,
+	)
 }
 
 func (tlv *LSPDBVersion) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -877,6 +872,7 @@ func (tlv *PathSetupType) DecodeFromBytes(data []byte) error {
 
 func (tlv *PathSetupType) Serialize() []byte {
 	value := make([]byte, TLVPathSetupTypeValueLength)
+
 	value[PathSetupTypeValueOffset] = byte(tlv.PathSetupType)
 
 	return AppendByteSlices(
@@ -961,6 +957,7 @@ func (tlv *ExtendedAssociationID) Serialize() []byte {
 	}
 
 	value := make([]byte, length)
+
 	binary.BigEndian.PutUint32(value[ExtendedAssociationIDColorOffset:ExtendedAssociationIDColorOffset+TLVColorValueLength], tlv.Color)
 	copy(value[ExtendedAssociationIDEndpointOffset:], tlv.Endpoint.AsSlice())
 
@@ -1062,36 +1059,36 @@ func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *PathSetupTypeCapability) Serialize() []byte {
-	buf := []byte{}
+	pstCount := uint16(len(tlv.PathSetupTypes))
+	pstPaddedLen := tlv.paddedPSTLength()
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
+	fixedPartLen := uint16(PathSetupTypeCapabilityFixedPartLength) + pstPaddedLen
 
-	numOfPst := uint16(len(tlv.PathSetupTypes))
-	paddedPSTLen := tlv.paddedPSTLength()
-
-	length := uint16(PathSetupTypeCapabilityFixedPartLength) + paddedPSTLen
+	subTLVsLen := uint16(0)
 	for _, subTLV := range tlv.SubTLVs {
-		length += subTLV.Len()
+		subTLVsLen += subTLV.Len()
 	}
 
-	lengthBytes := make([]byte, 2)
-	binary.BigEndian.PutUint16(lengthBytes, length)
-	buf = append(buf, lengthBytes...)
+	totalLen := fixedPartLen + subTLVsLen
 
-	val := make([]byte, PathSetupTypeCapabilityFixedPartLength+paddedPSTLen)
-	val[PathSetupTypeCapabilityPSTCountOffset] = byte(numOfPst)
+	value := make([]byte, fixedPartLen)
+	value[PathSetupTypeCapabilityPSTCountOffset] = byte(pstCount)
+
 	for i, pst := range tlv.PathSetupTypes {
-		val[PathSetupTypeCapabilityFixedPartLength+i] = byte(pst)
+		value[PathSetupTypeCapabilityFixedPartLength+i] = byte(pst)
 	}
 
-	buf = append(buf, val...)
+	subTLVsBytes := []byte{}
 	for _, subTLV := range tlv.SubTLVs {
-		buf = append(buf, subTLV.Serialize()...)
+		subTLVsBytes = append(subTLVsBytes, subTLV.Serialize()...)
 	}
 
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(totalLen),
+		value,
+		subTLVsBytes,
+	)
 }
 
 func (tlv *PathSetupTypeCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -1212,27 +1209,23 @@ func (tlv *AssocTypeList) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *AssocTypeList) Serialize() []byte {
-	buf := []byte{}
+	valueLen := uint16(len(tlv.AssocTypes)) * 2
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
+	padding := (TLVAlignment - (valueLen % TLVAlignment)) % TLVAlignment
 
-	length := uint16(len(tlv.AssocTypes)) * 2
-	lengthBytes := make([]byte, 2)
-	binary.BigEndian.PutUint16(lengthBytes, length)
-	buf = append(buf, lengthBytes...)
+	value := make([]byte, valueLen+padding)
 
+	offset := 0
 	for _, at := range tlv.AssocTypes {
-		binAt := make([]byte, 2)
-		binary.BigEndian.PutUint16(binAt, uint16(at))
-		buf = append(buf, binAt...)
+		binary.BigEndian.PutUint16(value[offset:offset+2], uint16(at))
+		offset += 2
 	}
-	if length%4 != 0 {
-		pad := make([]byte, 4-(length%4))
-		buf = append(buf, pad...)
-	}
-	return buf
+
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(valueLen),
+		value,
+	)
 }
 
 func (tlv *AssocTypeList) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -1275,6 +1268,8 @@ const (
 	SRPolicyCPathIDASNOffset  = 4
 	SRPolicyCPathIDAddrOffset = 8
 	SRPolicyCPathIDIPv4Offset = 12
+	DiscriminatorLen          = 4
+	ProtocolOriginPCEP        = 0x0a
 )
 
 func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
@@ -1304,34 +1299,44 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
-	buf := make([]byte, 0, TLVValueOffset+TLVSRPolicyCPathIDValueLength)
 
-	buf = append(buf, Uint16ToByteSlice(tlv.Type())...)
-	buf = append(buf, Uint16ToByteSlice(TLVSRPolicyCPathIDValueLength)...)
-	buf = append(buf, 0x0a, 0x00, 0x00, 0x00) // protocol origin (1 byte) + reserved (3 bytes)
-	buf = append(buf, 0x00, 0x00, 0x00, 0x00) // originator AS (4 bytes)
+	value := make([]byte, TLVSRPolicyCPathIDValueLength)
+
+	value[0] = ProtocolOriginPCEP
 
 	addr := tlv.OriginatorAddr
 
 	switch {
 	case !addr.IsValid():
-		// Invalid or zero-value address: serialize as all zeros to avoid panic.
-		var addr16 [IPv6AddrLen]byte
-		buf = append(buf, addr16[:]...)
+		// keep zero
+
 	case addr.Is4():
-		// IPv4 address encoded into last 4 bytes of 16-byte zero-padded field
 		ipv4 := addr.As4()
-		var addr16 [IPv6AddrLen]byte
-		copy(addr16[SRPolicyCPathIDIPv4Offset:], ipv4[:])
-		buf = append(buf, addr16[:]...)
+
+		copy(
+			value[SRPolicyCPathIDAddrOffset+SRPolicyCPathIDIPv4Offset:SRPolicyCPathIDAddrOffset+SRPolicyCPathIDIPv4Offset+IPv4AddrLen],
+			ipv4[:],
+		)
+
 	case addr.Is6():
-		addr16 := addr.As16()
-		buf = append(buf, addr16[:]...)
+		ipv6 := addr.As16()
+
+		copy(
+			value[SRPolicyCPathIDAddrOffset:SRPolicyCPathIDAddrOffset+IPv6AddrLen],
+			ipv6[:],
+		)
 	}
 
-	buf = append(buf, Uint32ToByteSlice(1)...) // discriminator (4 bytes)
+	binary.BigEndian.PutUint32(
+		value[SRPolicyCPathIDAddrOffset+IPv6AddrLen:SRPolicyCPathIDAddrOffset+IPv6AddrLen+DiscriminatorLen],
+		1, // TODO: set discriminator properly if needed
+	)
 
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVSRPolicyCPathIDValueLength),
+		value,
+	)
 }
 
 func (tlv *SRPolicyCandidatePathIdentifier) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -1372,21 +1377,18 @@ func (tlv *SRPolicyCandidatePathPreference) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *SRPolicyCandidatePathPreference) Serialize() []byte {
-	buf := []byte{}
+	value := make([]byte, TLVSRPolicyCPathPreferenceValueLength)
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
+	binary.BigEndian.PutUint32(
+		value,
+		tlv.Preference,
+	)
 
-	length := make([]byte, 2)
-	binary.BigEndian.PutUint16(length, TLVSRPolicyCPathPreferenceValueLength)
-	buf = append(buf, length...)
-
-	preference := make([]byte, 4)
-	binary.BigEndian.PutUint32(preference, tlv.Preference)
-	buf = append(buf, preference...)
-
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVSRPolicyCPathPreferenceValueLength),
+		value,
+	)
 }
 
 func (tlv *SRPolicyCandidatePathPreference) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -1427,21 +1429,18 @@ func (tlv *Color) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *Color) Serialize() []byte {
-	buf := []byte{}
+	value := make([]byte, TLVColorValueLength)
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
+	binary.BigEndian.PutUint32(
+		value,
+		tlv.Color,
+	)
 
-	length := make([]byte, 2)
-	binary.BigEndian.PutUint16(length, TLVColorValueLength)
-	buf = append(buf, length...)
-
-	color := make([]byte, 4)
-	binary.BigEndian.PutUint32(color, tlv.Color)
-	buf = append(buf, color...)
-
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVColorValueLength),
+		value,
+	)
 }
 
 func (tlv *Color) MarshalLogObject(enc zapcore.ObjectEncoder) error {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -588,7 +588,7 @@ func (tlv *IPv6LSPIdentifiers) DecodeFromBytes(data []byte) error {
 	value := data[TLVValueOffset : TLVValueOffset+valueLen]
 
 	// ok (second return value) is ignored because slice length is guaranteed by decodeTLVLength
-	addr, _ := netip.AddrFromSlice(value[IPv6SenderOffset : IPv6SenderOffset+IPv6AddrLen])
+	addr, _ := netip.AddrFromSlice(value[IPv6SenderOffset:IPv6LSPIDOffset])
 	tlv.IPv6TunnelSenderAddress = addr
 
 	tlv.LSPID = binary.BigEndian.Uint16(value[IPv6LSPIDOffset:IPv6TunnelIDOffset])

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -922,6 +922,9 @@ func (tlv *ExtendedAssociationID) DecodeFromBytes(data []byte) error {
 	}
 
 	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+	if len(value) < int(TLVColorValueLength) {
+		return fmt.Errorf("ExtendedAssociationID: value too short: got %d, want at least %d", valueLen, TLVColorValueLength)
+	}
 
 	tlv.Color = binary.BigEndian.Uint32(value[ExtendedAssociationIDColorOffset : ExtendedAssociationIDColorOffset+TLVColorValueLength])
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1285,7 +1285,9 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 		copy(v4[:], addrBytes[12:])
 		tlv.OriginatorAddr = netip.AddrFrom4(v4)
 	} else {
-		tlv.OriginatorAddr = netip.AddrFrom16(*(*[16]byte)(addrBytes))
+		var addr16 [16]byte
+		copy(addr16[:], addrBytes)
+		tlv.OriginatorAddr = netip.AddrFrom16(addr16)
 	}
 
 	return nil

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -289,12 +289,18 @@ const (
 )
 
 func (tlv *StatefulPCECapability) DecodeFromBytes(data []byte) error {
-	expectedLength := TLVHeaderLength + int(TLVStatefulPCECapabilityValueLength)
-	if len(data) < expectedLength {
-		return fmt.Errorf("data is too short: expected at least %d bytes, but got %d bytes for StatefulPCECapability", expectedLength, len(data))
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("StatefulPCECapability: %w", err)
 	}
 
-	flags := uint32(data[TLVHeaderLength+StatefulPCECapabilityFlagsIndex])
+	if valueLen != int(TLVStatefulPCECapabilityValueLength) {
+		return fmt.Errorf("StatefulPCECapability: invalid value length %d", valueLen)
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	flags := binary.BigEndian.Uint32(value[:TLVStatefulPCECapabilityValueLength])
 	tlv.ExtractCapabilities(flags)
 
 	return nil
@@ -387,21 +393,18 @@ type SymbolicPathName struct {
 }
 
 func (tlv *SymbolicPathName) DecodeFromBytes(data []byte) error {
-	if len(data) < TLVHeaderLength {
-		return fmt.Errorf("data is too short: expected at least %d bytes, but got %d bytes for SymbolicPathName", TLVHeaderLength, len(data))
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("SymbolicPathName: %w", err)
 	}
 
-	nameLen := binary.BigEndian.Uint16(data[2:4])
-	totalLength := TLVHeaderLength + int(nameLen)
-	if len(data) < totalLength {
-		return fmt.Errorf("data is too short: expected at least %d bytes, but got %d bytes for SymbolicPathName", totalLength, len(data))
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	if !utf8.Valid(value) {
+		return fmt.Errorf("SymbolicPathName: invalid UTF-8")
 	}
 
-	tlv.Name = string(data[TLVHeaderLength:totalLength])
-	if !utf8.Valid([]byte(tlv.Name)) {
-		return fmt.Errorf("invalid UTF-8 sequence in SymbolicPathName")
-	}
-
+	tlv.Name = string(value)
 	return nil
 }
 
@@ -454,23 +457,28 @@ const (
 )
 
 func (tlv *IPv4LSPIdentifiers) DecodeFromBytes(data []byte) error {
-	expectedLength := TLVHeaderLength + int(TLVIPv4LSPIdentifiersValueLength)
-	if len(data) != expectedLength {
-		return fmt.Errorf("data length mismatch: expected %d bytes, but got %d bytes for IPv4LSPIdentifiers", expectedLength, len(data))
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("IPv4LSPIdentifiers: %w", err)
 	}
 
-	var ok bool
-	if tlv.IPv4TunnelSenderAddress, ok = netip.AddrFromSlice(data[TLVHeaderLength : TLVHeaderLength+IPv4LSPIdentifiersTunnelSenderAddressIndex]); !ok {
-		return fmt.Errorf("failed to parse IPv4TunnelSenderAddress")
+	if valueLen != int(TLVIPv4LSPIdentifiersValueLength) {
+		return fmt.Errorf("IPv4LSPIdentifiers: invalid value length %d", valueLen)
 	}
 
-	tlv.LSPID = binary.BigEndian.Uint16(data[TLVHeaderLength+IPv4LSPIdentifiersTunnelSenderAddressIndex : TLVHeaderLength+IPv4LSPIdentifiersLSPIDIndex])
-	tlv.TunnelID = binary.BigEndian.Uint16(data[TLVHeaderLength+IPv4LSPIdentifiersLSPIDIndex : TLVHeaderLength+IPv4LSPIdentifiersTunnelIDIndex])
-	tlv.ExtendedTunnelID = binary.BigEndian.Uint32(data[TLVHeaderLength+IPv4LSPIdentifiersTunnelIDIndex : TLVHeaderLength+IPv4LSPIdentifiersExtendedTunnelIDIndex])
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
 
-	if tlv.IPv4TunnelEndpointAddress, ok = netip.AddrFromSlice(data[TLVHeaderLength+IPv4LSPIdentifiersExtendedTunnelIDIndex : TLVHeaderLength+TLVIPv4LSPIdentifiersValueLength]); !ok {
-		return fmt.Errorf("failed to parse IPv4TunnelEndpointAddress")
-	}
+	// ok (second return value) is ignored because slice length is guaranteed by decodeTLVLength
+	addr, _ := netip.AddrFromSlice(value[IPv4SenderOffset:IPv4LSPIDOffset])
+	tlv.IPv4TunnelSenderAddress = addr
+
+	tlv.LSPID = binary.BigEndian.Uint16(value[IPv4LSPIDOffset:IPv4TunnelIDOffset])
+	tlv.TunnelID = binary.BigEndian.Uint16(value[IPv4TunnelIDOffset:IPv4ExtTunnelIDOffset])
+	tlv.ExtendedTunnelID = binary.BigEndian.Uint32(value[IPv4ExtTunnelIDOffset:IPv4TunnelEPOffset])
+
+	// ok (second return value) is ignored because slice length is guaranteed by decodeTLVLength
+	addr, _ = netip.AddrFromSlice(value[IPv4TunnelEPOffset : IPv4TunnelEPOffset+IPv4AddrLen])
+	tlv.IPv4TunnelEndpointAddress = addr
 
 	return nil
 }
@@ -531,29 +539,34 @@ const (
 )
 
 func (tlv *IPv6LSPIdentifiers) DecodeFromBytes(data []byte) error {
-	expectedLength := TLVHeaderLength + int(TLVIPv6LSPIdentifiersValueLength)
-	if len(data) != expectedLength {
-		return fmt.Errorf("data length mismatch: expected %d bytes, but got %d bytes for IPv6LSPIdentifiers", expectedLength, len(data))
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("IPv6LSPIdentifiers: %w", err)
 	}
 
-	var ok bool
-	if tlv.IPv6TunnelSenderAddress, ok = netip.AddrFromSlice(data[4:20]); !ok {
-		return fmt.Errorf("failed to parse IPv6TunnelSenderAddress")
+	if valueLen != int(TLVIPv6LSPIdentifiersValueLength) {
+		return fmt.Errorf("IPv6LSPIdentifiers: invalid value length %d", valueLen)
 	}
 
-	tlv.LSPID = binary.BigEndian.Uint16(data[20:22])
-	tlv.TunnelID = binary.BigEndian.Uint16(data[22:24])
-	copy(tlv.ExtendedTunnelID[:], data[24:40])
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
 
-	if tlv.IPv6TunnelEndpointAddress, ok = netip.AddrFromSlice(data[40:56]); !ok {
-		return fmt.Errorf("failed to parse IPv6TunnelEndpointAddress")
-	}
+	// ok (second return value) is ignored because slice length is guaranteed by decodeTLVLength
+	addr, _ := netip.AddrFromSlice(value[IPv6SenderOffset : IPv6SenderOffset+IPv6AddrLen])
+	tlv.IPv6TunnelSenderAddress = addr
+
+	tlv.LSPID = binary.BigEndian.Uint16(value[IPv6LSPIDOffset:IPv6TunnelIDOffset])
+	tlv.TunnelID = binary.BigEndian.Uint16(value[IPv6TunnelIDOffset:IPv6ExtendedTunnelIDOffset])
+	copy(tlv.ExtendedTunnelID[:], value[IPv6ExtendedTunnelIDOffset:IPv6TunnelEPOffset])
+
+	// ok (second return value) is ignored because slice length is guaranteed by decodeTLVLength
+	addr, _ = netip.AddrFromSlice(value[IPv6TunnelEPOffset : IPv6TunnelEPOffset+IPv6AddrLen])
+	tlv.IPv6TunnelEndpointAddress = addr
 
 	return nil
 }
 
 func (tlv *IPv6LSPIdentifiers) Serialize() []byte {
-	buf := make([]byte, tlv.Len())
+	value := make([]byte, TLVIPv6LSPIdentifiersValueLength)
 
 	copy(value[IPv6SenderOffset:IPv6SenderOffset+IPv6AddrLen], tlv.IPv6TunnelSenderAddress.AsSlice())
 	binary.BigEndian.PutUint16(value[IPv6LSPIDOffset:IPv6TunnelIDOffset], tlv.LSPID)
@@ -591,12 +604,18 @@ type LSPDBVersion struct {
 }
 
 func (tlv *LSPDBVersion) DecodeFromBytes(data []byte) error {
-	expectedLength := TLVHeaderLength + int(TLVLSPDBVersionValueLength)
-	if len(data) != expectedLength {
-		return fmt.Errorf("data length mismatch: expected %d bytes, but got %d bytes for LSPDBVersion", expectedLength, len(data))
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("LSPDBVersion: %w", err)
 	}
 
-	tlv.VersionNumber = binary.BigEndian.Uint64(data[4:12])
+	if valueLen != int(TLVLSPDBVersionValueLength) {
+		return fmt.Errorf("LSPDBVersion: invalid value length %d", valueLen)
+	}
+
+	value := data[TLVValueOffset:]
+	tlv.VersionNumber = binary.BigEndian.Uint64(value)
+
 	return nil
 }
 
@@ -657,16 +676,13 @@ const (
 )
 
 func (tlv *SRPCECapability) DecodeFromBytes(data []byte) error {
-	expectedLength := TLVHeaderLength + int(TLVSRPCECapabilityValueLength)
-	if len(data) != expectedLength {
-		return fmt.Errorf("data length mismatch: expected %d bytes, but got %d bytes for SRPCECapability", expectedLength, len(data))
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("SRPCECapability: %w", err)
 	}
 
-	// Extract TLV value field (after 4-byte TLV header)
-	val := data[TLVHeaderLength:]
-
-	if len(val) != int(TLVSRPCECapabilityValueLength) {
-		return fmt.Errorf("invalid value length for SRPCECapability: expected %d bytes, but got %d bytes", TLVSRPCECapabilityValueLength, len(val))
+	if valueLen != int(TLVSRPCECapabilityValueLength) {
+		return fmt.Errorf("SRPCECapability: invalid value length %d", valueLen)
 	}
 
 	val := data[TLVValueOffset:]
@@ -784,9 +800,9 @@ type PathSetupType struct {
 const PathSetupTypeValueOffset = 3
 
 func (tlv *PathSetupType) DecodeFromBytes(data []byte) error {
-	expectedLength := TLVHeaderLength + int(TLVPathSetupTypeValueLength)
-	if len(data) != expectedLength {
-		return fmt.Errorf("data length mismatch: expected %d bytes, but got %d bytes for PathSetupType", expectedLength, len(data))
+	_, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("PathSetupType: %w", err)
 	}
 
 	value := data[TLVValueOffset:]
@@ -843,9 +859,12 @@ const (
 )
 
 func (tlv *ExtendedAssociationID) DecodeFromBytes(data []byte) error {
-	length := binary.BigEndian.Uint16(data[2:4])
+	valueLen, err := decodeTLVLength(data)
+	if err != nil {
+		return fmt.Errorf("ExtendedAssociationID: %w", err)
+	}
 
-	tlv.Color = binary.BigEndian.Uint32(data[4:8])
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
 
 	tlv.Color = binary.BigEndian.Uint32(value[ExtendedAssociationIDColorOffset : ExtendedAssociationIDColorOffset+TLVColorValueLength])
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1294,25 +1294,25 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 	buf := make([]byte, 0, TLVValueOffset+TLVSRPolicyCPathIDValueLength)
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
+	buf = append(buf, Uint16ToByteSlice(tlv.Type())...)
+	buf = append(buf, Uint16ToByteSlice(TLVSRPolicyCPathIDValueLength)...)
+	buf = append(buf, 0x0a, 0x00, 0x00, 0x00) // protocol origin (1 byte) + reserved (3 bytes)
+	buf = append(buf, 0x00, 0x00, 0x00, 0x00) // originator AS (4 bytes)
 
-	length := make([]byte, 2)
-	binary.BigEndian.PutUint16(length, TLVSRPolicyCPathIDValueLength)
-	buf = append(buf, length...)
+	addr := tlv.OriginatorAddr
 
-	buf = append(buf, 0x0a)                   // protocol origin, PCEP = 10
-	buf = append(buf, 0x00, 0x00, 0x00)       // mbz
-	buf = append(buf, 0x00, 0x00, 0x00, 0x00) // Originator ASN
-	// Originator Address
-	if tlv.OriginatorAddr.Is4() {
-		buf = append(buf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
-		buf = append(buf, tlv.OriginatorAddr.AsSlice()...)
-	} else if tlv.OriginatorAddr.Is6() {
-		buf = append(buf, tlv.OriginatorAddr.AsSlice()...)
+	if addr.Is4() {
+		// IPv4 → IPv4-mapped IPv6
+		ipv4 := addr.As4()
+		var addr16 [16]byte
+		copy(addr16[12:], ipv4[:])
+		buf = append(buf, addr16[:]...)
+	} else {
+		addr16 := addr.As16()
+		buf = append(buf, addr16[:]...)
 	}
-	buf = append(buf, 0x00, 0x00, 0x00, 0x01) // discriminator
+
+	buf = append(buf, Uint32ToByteSlice(1)...) // discriminator (4 bytes)
 
 	return buf
 }

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1270,6 +1270,12 @@ type SRPolicyCandidatePathIdentifier struct {
 	OriginatorAddr netip.Addr // After DecodeFromBytes, IPv4 addresses are stored as native IPv4 (upper 12 bytes zero), not IPv4-mapped IPv6
 }
 
+const (
+	SRPolicyCPathIDASNOffset  = 4
+	SRPolicyCPathIDAddrOffset = 8
+	SRPolicyCPathIDIPv4Offset = 12
+)
+
 func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
@@ -1277,19 +1283,18 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 	}
 
 	value := data[TLVValueOffset : TLVValueOffset+valueLen]
-
-	if len(value) < 8+16 {
-		return fmt.Errorf("SRPolicyCandidatePathIdentifier: value too short for OriginatorAddr")
+	if len(value) != int(TLVSRPolicyCPathIDValueLength) {
+		return fmt.Errorf("SRPolicyCandidatePathIdentifier: invalid value length, expected %d, got %d", TLVSRPolicyCPathIDValueLength, len(value))
 	}
 
-	addrBytes := value[8 : 8+16]
+	addrBytes := value[SRPolicyCPathIDAddrOffset : SRPolicyCPathIDAddrOffset+IPv6AddrLen]
 
 	if isIPv4Bytes(addrBytes) {
-		var v4 [4]byte
-		copy(v4[:], addrBytes[12:])
+		var v4 [IPv4AddrLen]byte
+		copy(v4[:], addrBytes[SRPolicyCPathIDIPv4Offset:])
 		tlv.OriginatorAddr = netip.AddrFrom4(v4)
 	} else {
-		var addr16 [16]byte
+		var addr16 [IPv6AddrLen]byte
 		copy(addr16[:], addrBytes)
 		tlv.OriginatorAddr = netip.AddrFrom16(addr16)
 	}
@@ -1310,13 +1315,13 @@ func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 	switch {
 	case !addr.IsValid():
 		// Invalid or zero-value address: serialize as all zeros to avoid panic.
-		var addr16 [16]byte
+		var addr16 [IPv6AddrLen]byte
 		buf = append(buf, addr16[:]...)
 	case addr.Is4():
 		// IPv4 address encoded into last 4 bytes of 16-byte zero-padded field
 		ipv4 := addr.As4()
-		var addr16 [16]byte
-		copy(addr16[12:], ipv4[:])
+		var addr16 [IPv6AddrLen]byte
+		copy(addr16[SRPolicyCPathIDIPv4Offset:], ipv4[:])
 		buf = append(buf, addr16[:]...)
 	case addr.Is6():
 		addr16 := addr.As16()

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1573,6 +1573,12 @@ func DecodeTLVs(data []byte) ([]TLVInterface, error) {
 			return nil, fmt.Errorf("truncated TLV padding (type=0x%x)", tlvType)
 		}
 
+		// Validate that padding bytes between TLVs are zero-filled.
+		for i := totalLen; i < paddedLen; i++ {
+			if data[i] != 0 {
+				return nil, fmt.Errorf("invalid TLV padding (expected zero bytes) (type=0x%x)", tlvType)
+			}
+		}
 		data = data[paddedLen:]
 	}
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -297,7 +297,7 @@ const definedStatefulPCEFlagsMask uint32 = LSPUpdateCapabilityBit |
 	ColorCapabilityBit
 
 func (tlv *StatefulPCECapability) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("StatefulPCECapability: %w", err)
 	}
@@ -410,7 +410,7 @@ type SymbolicPathName struct {
 }
 
 func (tlv *SymbolicPathName) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, true)
 	if err != nil {
 		return fmt.Errorf("SymbolicPathName: %w", err)
 	}
@@ -478,7 +478,7 @@ const (
 )
 
 func (tlv *IPv4LSPIdentifiers) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("IPv4LSPIdentifiers: %w", err)
 	}
@@ -575,7 +575,7 @@ const (
 )
 
 func (tlv *IPv6LSPIdentifiers) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("IPv6LSPIdentifiers: %w", err)
 	}
@@ -659,7 +659,7 @@ type LSPDBVersion struct {
 }
 
 func (tlv *LSPDBVersion) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("LSPDBVersion: %w", err)
 	}
@@ -736,7 +736,7 @@ const (
 )
 
 func (tlv *SRPCECapability) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("SRPCECapability: %w", err)
 	}
@@ -858,7 +858,7 @@ type PathSetupType struct {
 const PathSetupTypeValueOffset = 3
 
 func (tlv *PathSetupType) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("PathSetupType: %w", err)
 	}
@@ -868,7 +868,6 @@ func (tlv *PathSetupType) DecodeFromBytes(data []byte) error {
 	}
 
 	value := data[TLVValueOffset : TLVValueOffset+valueLen]
-
 	tlv.PathSetupType = Pst(value[PathSetupTypeValueOffset])
 
 	return nil
@@ -919,7 +918,7 @@ const (
 )
 
 func (tlv *ExtendedAssociationID) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("ExtendedAssociationID: %w", err)
 	}
@@ -1020,7 +1019,7 @@ const (
 )
 
 func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("PathSetupTypeCapability: %w", err)
 	}
@@ -1191,7 +1190,7 @@ type AssocTypeList struct {
 }
 
 func (tlv *AssocTypeList) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("AssocTypeList: %w", err)
 	}
@@ -1272,7 +1271,7 @@ type SRPolicyCandidatePathIdentifier struct {
 }
 
 func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("SRPolicyCandidatePathIdentifier: %w", err)
 	}
@@ -1351,7 +1350,7 @@ type SRPolicyCandidatePathPreference struct {
 }
 
 func (tlv *SRPolicyCandidatePathPreference) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("SRPolicyCandidatePathPreference: %w", err)
 	}
@@ -1406,7 +1405,7 @@ type Color struct {
 }
 
 func (tlv *Color) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, false)
 	if err != nil {
 		return fmt.Errorf("Color: %w", err)
 	}
@@ -1463,7 +1462,7 @@ type UndefinedTLV struct {
 }
 
 func (tlv *UndefinedTLV) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data, true)
 	if err != nil {
 		return fmt.Errorf("UndefinedTLV: %w", err)
 	}

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1015,7 +1015,19 @@ type PathSetupTypeCapability struct {
 const (
 	PathSetupTypeCapabilityFixedPartLength = 4
 	PathSetupTypeCapabilityPSTCountOffset  = 3
+	MaxPathSetupTypes                      = 255
 )
+
+func (tlv *PathSetupTypeCapability) pstCount() int {
+	if len(tlv.PathSetupTypes) > MaxPathSetupTypes {
+		return MaxPathSetupTypes
+	}
+	return len(tlv.PathSetupTypes)
+}
+
+func (tlv *PathSetupTypeCapability) paddedPSTLength() uint16 {
+	return uint16(paddedLength(tlv.pstCount(), TLVAlignment))
+}
 
 func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 	valueLen, err := decodeTLVLength(data, false)
@@ -1059,10 +1071,11 @@ func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *PathSetupTypeCapability) Serialize() []byte {
-	pstCount := uint16(len(tlv.PathSetupTypes))
-	pstPaddedLen := tlv.paddedPSTLength()
+	pstCount := tlv.pstCount()
 
-	fixedPartLen := uint16(PathSetupTypeCapabilityFixedPartLength) + pstPaddedLen
+	pstPaddedLen := paddedLength(pstCount, TLVAlignment)
+
+	fixedPartLen := uint16(PathSetupTypeCapabilityFixedPartLength) + uint16(pstPaddedLen)
 
 	subTLVsLen := uint16(0)
 	for _, subTLV := range tlv.SubTLVs {
@@ -1074,8 +1087,9 @@ func (tlv *PathSetupTypeCapability) Serialize() []byte {
 	value := make([]byte, fixedPartLen)
 	value[PathSetupTypeCapabilityPSTCountOffset] = byte(pstCount)
 
-	for i, pst := range tlv.PathSetupTypes {
-		value[PathSetupTypeCapabilityFixedPartLength+i] = byte(pst)
+	for i := 0; i < pstCount; i++ {
+		value[PathSetupTypeCapabilityFixedPartLength+i] =
+			byte(tlv.PathSetupTypes[i])
 	}
 
 	subTLVsBytes := []byte{}
@@ -1139,19 +1153,16 @@ func (tlv *PathSetupTypeCapability) Len() uint16 {
 func (tlv *PathSetupTypeCapability) CapStrings() []string {
 	ret := []string{}
 
-	if slices.Contains(tlv.PathSetupTypes, PathSetupTypeSRTE) {
+	psts := tlv.PathSetupTypes[:tlv.pstCount()]
+
+	if slices.Contains(psts, PathSetupTypeSRTE) {
 		ret = append(ret, "SR-TE")
 	}
-	if slices.Contains(tlv.PathSetupTypes, PathSetupTypeSRv6TE) {
+	if slices.Contains(psts, PathSetupTypeSRv6TE) {
 		ret = append(ret, "SRv6-TE")
 	}
 
 	return ret
-}
-
-func (tlv *PathSetupTypeCapability) paddedPSTLength() uint16 {
-	numOfPst := len(tlv.PathSetupTypes)
-	return uint16(paddedLength(numOfPst, TLVAlignment))
 }
 
 type AssocType uint16

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -449,6 +449,10 @@ func (tlv *SymbolicPathName) Len() uint16 {
 }
 
 func (tlv *SymbolicPathName) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
 	enc.AddString("symbolicPathName", tlv.Name)
 	return nil
 }
@@ -517,6 +521,21 @@ func (tlv *IPv4LSPIdentifiers) Serialize() []byte {
 }
 
 func (tlv *IPv4LSPIdentifiers) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	if tlv.IPv4TunnelSenderAddress.IsValid() {
+		enc.AddString("ipv4TunnelSenderAddress", tlv.IPv4TunnelSenderAddress.String())
+	}
+	if tlv.IPv4TunnelEndpointAddress.IsValid() {
+		enc.AddString("ipv4TunnelEndpointAddress", tlv.IPv4TunnelEndpointAddress.String())
+	}
+
+	enc.AddUint16("lspID", tlv.LSPID)
+	enc.AddUint16("tunnelID", tlv.TunnelID)
+	enc.AddUint32("extendedTunnelID", tlv.ExtendedTunnelID)
+
 	return nil
 }
 
@@ -595,6 +614,21 @@ func (tlv *IPv6LSPIdentifiers) Serialize() []byte {
 }
 
 func (tlv *IPv6LSPIdentifiers) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	if tlv.IPv6TunnelSenderAddress.IsValid() {
+		enc.AddString("ipv6TunnelSenderAddress", tlv.IPv6TunnelSenderAddress.String())
+	}
+	if tlv.IPv6TunnelEndpointAddress.IsValid() {
+		enc.AddString("ipv6TunnelEndpointAddress", tlv.IPv6TunnelEndpointAddress.String())
+	}
+
+	enc.AddUint16("lspID", tlv.LSPID)
+	enc.AddUint16("tunnelID", tlv.TunnelID)
+	enc.AddString("extendedTunnelID", fmt.Sprintf("%x", tlv.ExtendedTunnelID[:]))
+
 	return nil
 }
 
@@ -655,6 +689,11 @@ func (tlv *LSPDBVersion) Serialize() []byte {
 }
 
 func (tlv *LSPDBVersion) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddUint64("versionNumber", tlv.VersionNumber)
 	return nil
 }
 
@@ -733,6 +772,10 @@ func (tlv *SRPCECapability) Serialize() []byte {
 }
 
 func (tlv *SRPCECapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
 	enc.AddBool("unlimited_max_sid_depth", tlv.HasUnlimitedMaxSIDDepth)
 	enc.AddBool("nai_is_supported", tlv.IsNAISupported)
 	enc.AddUint8("maximum_sid_depth", tlv.MaximumSidDepth)
@@ -848,6 +891,11 @@ func (tlv *PathSetupType) Serialize() []byte {
 }
 
 func (tlv *PathSetupType) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddString("pathSetupType", tlv.PathSetupType.String())
 	return nil
 }
 
@@ -924,6 +972,20 @@ func (tlv *ExtendedAssociationID) Serialize() []byte {
 }
 
 func (tlv *ExtendedAssociationID) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddUint32("color", tlv.Color)
+
+	if tlv.Endpoint.IsValid() {
+		if tlv.Endpoint.Is4() {
+			enc.AddString("ipv4Addr", tlv.Endpoint.String())
+		} else if tlv.Endpoint.Is6() {
+			enc.AddString("ipv6Addr", tlv.Endpoint.String())
+		}
+	}
+
 	return nil
 }
 
@@ -1007,6 +1069,32 @@ func (tlv *PathSetupTypeCapability) Serialize() []byte {
 }
 
 func (tlv *PathSetupTypeCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	pstStrings := make([]string, len(tlv.PathSetupTypes))
+	for i, pst := range tlv.PathSetupTypes {
+		pstStrings[i] = pst.String()
+	}
+	_ = enc.AddArray("pathSetupTypes", zapcore.ArrayMarshalerFunc(func(ae zapcore.ArrayEncoder) error {
+		for _, s := range pstStrings {
+			ae.AppendString(s)
+		}
+		return nil
+	}))
+
+	subTLVTypes := make([]string, len(tlv.SubTLVs))
+	for i, stlv := range tlv.SubTLVs {
+		subTLVTypes[i] = fmt.Sprintf("0x%04x", stlv.Type())
+	}
+	_ = enc.AddArray("subTLVs", zapcore.ArrayMarshalerFunc(func(ae zapcore.ArrayEncoder) error {
+		for _, s := range subTLVTypes {
+			ae.AppendString(s)
+		}
+		return nil
+	}))
+
 	return nil
 }
 
@@ -1105,6 +1193,17 @@ func (tlv *AssocTypeList) Serialize() []byte {
 }
 
 func (tlv *AssocTypeList) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	_ = enc.AddArray("assocTypes", zapcore.ArrayMarshalerFunc(func(ae zapcore.ArrayEncoder) error {
+		for _, at := range tlv.AssocTypes {
+			ae.AppendString(at.String())
+		}
+		return nil
+	}))
+
 	return nil
 }
 
@@ -1161,6 +1260,11 @@ func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 }
 
 func (tlv *SRPolicyCandidatePathIdentifier) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddString("originatorAddr", tlv.OriginatorAddr.String())
 	return nil
 }
 
@@ -1200,6 +1304,11 @@ func (tlv *SRPolicyCandidatePathPreference) Serialize() []byte {
 }
 
 func (tlv *SRPolicyCandidatePathPreference) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddUint32("preference", tlv.Preference)
 	return nil
 }
 
@@ -1239,6 +1348,11 @@ func (tlv *Color) Serialize() []byte {
 }
 
 func (tlv *Color) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddUint32("color", tlv.Color)
 	return nil
 }
 
@@ -1280,6 +1394,12 @@ func (tlv *UndefinedTLV) Serialize() []byte {
 }
 
 func (tlv *UndefinedTLV) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddString("type", fmt.Sprintf("0x%04x", tlv.Typ))
+	enc.AddUint16("length", tlv.Length)
 	return nil
 }
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -432,7 +432,7 @@ func (tlv *SymbolicPathName) Serialize() []byte {
 
 	return AppendByteSlices(
 		Uint16ToByteSlice(tlv.Type()),
-		Uint16ToByteSlice(nameLen),
+		Uint16ToByteSlice(uint16(len(tlv.Name))),
 		value,
 	)
 }

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -668,7 +668,7 @@ func (tlv *LSPDBVersion) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("LSPDBVersion: invalid value length %d", valueLen)
 	}
 
-	value := data[TLVValueOffset:]
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
 	tlv.VersionNumber = binary.BigEndian.Uint64(value)
 
 	return nil

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1309,7 +1309,7 @@ func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 		var addr16 [16]byte
 		buf = append(buf, addr16[:]...)
 	case addr.Is4():
-		// IPv4 → IPv4-mapped IPv6
+		// IPv4 address encoded into last 4 bytes of 16-byte zero-padded field
 		ipv4 := addr.As4()
 		var addr16 [16]byte
 		copy(addr16[12:], ipv4[:])

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -858,12 +858,17 @@ type PathSetupType struct {
 const PathSetupTypeValueOffset = 3
 
 func (tlv *PathSetupType) DecodeFromBytes(data []byte) error {
-	_, err := decodeTLVLength(data)
+	valueLen, err := decodeTLVLength(data)
 	if err != nil {
 		return fmt.Errorf("PathSetupType: %w", err)
 	}
 
-	value := data[TLVValueOffset:]
+	if valueLen != int(TLVPathSetupTypeValueLength) {
+		return fmt.Errorf("PathSetupType: unexpected value length: expected %d, got %d", TLVPathSetupTypeValueLength, valueLen)
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
 	tlv.PathSetupType = Pst(value[PathSetupTypeValueOffset])
 
 	return nil

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -247,6 +247,8 @@ var tlvMap = map[TLVType]func() TLVInterface{
 	TLVExtendedAssociationID:   func() TLVInterface { return &ExtendedAssociationID{} },
 	TLVPathSetupTypeCapability: func() TLVInterface { return &PathSetupTypeCapability{} },
 	TLVAssocTypeList:           func() TLVInterface { return &AssocTypeList{} },
+	TLVSRPolicyCPathID:         func() TLVInterface { return &SRPolicyCandidatePathIdentifier{} },
+	TLVSRPolicyCPathPreference: func() TLVInterface { return &SRPolicyCandidatePathPreference{} },
 	TLVColor:                   func() TLVInterface { return &Color{} },
 }
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1040,7 +1040,7 @@ func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 		tlv.PathSetupTypes = append(tlv.PathSetupTypes, Pst(value[offset]))
 	}
 
-	padded := paddedLength(uint16(pstNum), TLVAlignment)
+	padded := paddedLength(int(pstNum), TLVAlignment)
 	subTLVOffset := PathSetupTypeCapabilityFixedPartLength + int(padded)
 
 	if subTLVOffset > len(value) {
@@ -1150,8 +1150,8 @@ func (tlv *PathSetupTypeCapability) CapStrings() []string {
 }
 
 func (tlv *PathSetupTypeCapability) paddedPSTLength() uint16 {
-	numOfPst := uint16(len(tlv.PathSetupTypes))
-	return paddedLength(numOfPst, TLVAlignment)
+	numOfPst := len(tlv.PathSetupTypes)
+	return uint16(paddedLength(numOfPst, TLVAlignment))
 }
 
 type AssocType uint16

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1047,8 +1047,12 @@ func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 	subTLVData := value[subTLVOffset:]
 	tlv.SubTLVs, err = DecodeTLVs(subTLVData)
 	if err != nil {
-		return err
+		return fmt.Errorf("PathSetupTypeCapability: %w", err)
 	}
+	if tlv.SubTLVs == nil {
+		tlv.SubTLVs = []TLVInterface{}
+	}
+
 	return nil
 }
 
@@ -1060,6 +1064,7 @@ func (tlv *PathSetupTypeCapability) Serialize() []byte {
 	buf = append(buf, typ...)
 
 	numOfPst := uint16(len(tlv.PathSetupTypes))
+	paddedPSTLen := tlv.paddedPSTLength()
 
 	length := uint16(PathSetupTypeCapabilityFixedPartLength) + paddedPSTLen
 	for _, subTLV := range tlv.SubTLVs {
@@ -1140,6 +1145,11 @@ func (tlv *PathSetupTypeCapability) CapStrings() []string {
 	}
 
 	return ret
+}
+
+func (tlv *PathSetupTypeCapability) paddedPSTLength() uint16 {
+	numOfPst := uint16(len(tlv.PathSetupTypes))
+	return paddedLength(numOfPst, TLVAlignment)
 }
 
 type AssocType uint16

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -253,30 +253,39 @@ var tlvMap = map[TLVType]func() TLVInterface{
 }
 
 type StatefulPCECapability struct {
-	LSPUpdateCapability            bool // 31
-	IncludeDBVersion               bool // 30
-	LSPInstantiationCapability     bool // 29
-	TriggeredResync                bool // 28
-	DeltaLSPSyncCapability         bool // 27
-	TriggeredInitialSync           bool // 26
-	P2mpCapability                 bool // 25
-	P2mpLSPUpdateCapability        bool // 24
-	P2mpLSPInstantiationCapability bool // 23
-	LSPSchedulingCapability        bool // 22
-	PdLSPCapability                bool // 21
-	ColorCapability                bool // 20
-	PathRecomputationCapability    bool // 19
-	StrictPathCapability           bool // 18
-	Relax                          bool // 17
+	LSPUpdateCapability            bool
+	IncludeDBVersion               bool
+	LSPInstantiationCapability     bool
+	TriggeredResync                bool
+	DeltaLSPSyncCapability         bool
+	TriggeredInitialSync           bool
+	P2mpCapability                 bool
+	P2mpLSPUpdateCapability        bool
+	P2mpLSPInstantiationCapability bool
+	LSPSchedulingCapability        bool
+	PdLSPCapability                bool
+	ColorCapability                bool
+	PathRecomputationCapability    bool
+	StrictPathCapability           bool
+	Relax                          bool
 }
 
 const (
-	LSPUpdateCapabilityBit        uint32 = 0x01
-	IncludeDBVersionCapabilityBit uint32 = 0x02
-	LSPInstantiationCapabilityBit uint32 = 0x04
-	TriggeredResyncCapabilityBit  uint32 = 0x08
-	DeltaLSPSyncCapabilityBit     uint32 = 0x10
-	TriggeredInitialSyncBit       uint32 = 0x20
+	LSPUpdateCapabilityBit         uint32 = 1 << 0  // bit 31 (RFC 8231)
+	IncludeDBVersionCapabilityBit  uint32 = 1 << 1  // bit 30 (RFC 8232)
+	LSPInstantiationCapabilityBit  uint32 = 1 << 2  // bit 29 (RFC 8281)
+	TriggeredResyncCapabilityBit   uint32 = 1 << 3  // bit 28 (RFC 8232)
+	DeltaLSPSyncCapabilityBit      uint32 = 1 << 4  // bit 27 (RFC 8232)
+	TriggeredInitialSyncBit        uint32 = 1 << 5  // bit 26 (RFC 8232)
+	P2mpCapabilityBit              uint32 = 1 << 6  // bit 25 (RFC 8623)
+	P2mpLSPUpdateBit               uint32 = 1 << 7  // bit 24 (RFC 8623)
+	P2mpLSPInstantiationBit        uint32 = 1 << 8  // bit 23 (RFC 8623)
+	LSPSchedulingCapabilityBit     uint32 = 1 << 9  // bit 22 (RFC 8934)
+	PdLSPCapabilityBit             uint32 = 1 << 10 // bit 21 (RFC 8934)
+	ColorCapabilityBit             uint32 = 1 << 11 // bit 20 (RFC 9863)
+	PathRecomputationCapabilityBit uint32 = 1 << 12 // bit 19 (draft-ietf-pce-circuit-style-pcep-extensions)
+	StrictPathCapabilityBit        uint32 = 1 << 13 // bit 18 (draft-ietf-pce-circuit-style-pcep-extensions)
+	RelaxBit                       uint32 = 1 << 14 // bit 17 (RFC 9753)
 )
 
 const definedStatefulPCEFlagsMask uint32 = LSPUpdateCapabilityBit |

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1303,13 +1303,18 @@ func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 
 	addr := tlv.OriginatorAddr
 
-	if addr.Is4() {
+	switch {
+	case !addr.IsValid():
+		// Invalid or zero-value address: serialize as all zeros to avoid panic.
+		var addr16 [16]byte
+		buf = append(buf, addr16[:]...)
+	case addr.Is4():
 		// IPv4 → IPv4-mapped IPv6
 		ipv4 := addr.As4()
 		var addr16 [16]byte
 		copy(addr16[12:], ipv4[:])
 		buf = append(buf, addr16[:]...)
-	} else {
+	case addr.Is6():
 		addr16 := addr.As16()
 		buf = append(buf, addr16[:]...)
 	}

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1026,10 +1026,6 @@ func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("PathSetupTypeCapability: %w", err)
 	}
 
-	if tlv.SubTLVs == nil {
-		tlv.SubTLVs = []TLVInterface{}
-	}
-
 	value := data[TLVValueOffset : TLVValueOffset+valueLen]
 
 	if len(value) < PathSetupTypeCapabilityFixedPartLength {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1050,6 +1050,9 @@ func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 	padded := paddedLength(uint16(pstNum), TLVAlignment)
 	subTLVOffset := PathSetupTypeCapabilityFixedPartLength + int(padded)
 
+	if subTLVOffset > len(value) {
+		return fmt.Errorf("PathSetupTypeCapability: value too short for subTLVs")
+	}
 	subTLVData := value[subTLVOffset:]
 	tlv.SubTLVs, err = DecodeTLVs(subTLVData)
 	if err != nil {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1361,7 +1361,7 @@ func (tlv *SRPolicyCandidatePathPreference) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("SRPolicyCandidatePathPreference: %w", err)
 	}
 
-	if valueLen != 4 {
+	if valueLen != int(TLVSRPolicyCPathPreferenceValueLength) {
 		return fmt.Errorf("SRPolicyCandidatePathPreference: invalid value length %d", valueLen)
 	}
 
@@ -1416,7 +1416,7 @@ func (tlv *Color) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("Color: %w", err)
 	}
 
-	if valueLen != 4 {
+	if valueLen != int(TLVColorValueLength) {
 		return fmt.Errorf("Color: invalid value length %d", valueLen)
 	}
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -293,11 +293,8 @@ const definedStatefulPCEFlagsMask uint32 = LSPUpdateCapabilityBit |
 	LSPInstantiationCapabilityBit |
 	TriggeredResyncCapabilityBit |
 	DeltaLSPSyncCapabilityBit |
-	TriggeredInitialSyncBit
-
-const (
-	StatefulPCECapabilityFlagsIndex = 3
-)
+	TriggeredInitialSyncBit |
+	ColorCapabilityBit
 
 func (tlv *StatefulPCECapability) DecodeFromBytes(data []byte) error {
 	valueLen, err := decodeTLVLength(data)
@@ -328,12 +325,18 @@ func (tlv *StatefulPCECapability) Serialize() []byte {
 }
 
 func (tlv *StatefulPCECapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
 	enc.AddBool("lspUpdateCapability", tlv.LSPUpdateCapability)
 	enc.AddBool("includeDBVersion", tlv.IncludeDBVersion)
 	enc.AddBool("lspInstantiationCapability", tlv.LSPInstantiationCapability)
 	enc.AddBool("triggeredResync", tlv.TriggeredResync)
 	enc.AddBool("deltaLSPSyncCapability", tlv.DeltaLSPSyncCapability)
 	enc.AddBool("triggeredInitialSync", tlv.TriggeredInitialSync)
+	enc.AddBool("colorCapability", tlv.ColorCapability)
+
 	return nil
 }
 
@@ -352,6 +355,7 @@ func (tlv *StatefulPCECapability) ExtractCapabilities(flags uint32) {
 	tlv.TriggeredResync = flags&TriggeredResyncCapabilityBit != 0
 	tlv.DeltaLSPSyncCapability = flags&DeltaLSPSyncCapabilityBit != 0
 	tlv.TriggeredInitialSync = flags&TriggeredInitialSyncBit != 0
+	tlv.ColorCapability = flags&ColorCapabilityBit != 0
 }
 
 func (tlv *StatefulPCECapability) SetFlags() uint32 {
@@ -362,6 +366,8 @@ func (tlv *StatefulPCECapability) SetFlags() uint32 {
 	flags = SetBit(flags, TriggeredResyncCapabilityBit, tlv.TriggeredResync)
 	flags = SetBit(flags, DeltaLSPSyncCapabilityBit, tlv.DeltaLSPSyncCapability)
 	flags = SetBit(flags, TriggeredInitialSyncBit, tlv.TriggeredInitialSync)
+	flags = SetBit(flags, ColorCapabilityBit, tlv.ColorCapability)
+
 	return flags
 }
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -935,21 +935,23 @@ func (tlv *ExtendedAssociationID) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("ExtendedAssociationID: unsupported value length %d", valueLen)
 	}
 
+	addr, _ := netip.AddrFromSlice(addrBytes)
+
+	tlv.Endpoint = addr
 	return nil
 }
 
 func (tlv *ExtendedAssociationID) Serialize() []byte {
-	buf := []byte{}
+	if !tlv.Endpoint.IsValid() {
+		return nil
+	}
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
-
-	length := make([]byte, 2)
-	if tlv.Endpoint.Is4() {
-		binary.BigEndian.PutUint16(length, TLVExtendedAssociationIDIPv4ValueLength)
-	} else if tlv.Endpoint.Is6() {
-		binary.BigEndian.PutUint16(length, TLVExtendedAssociationIDIPv6ValueLength)
+	var length uint16
+	switch {
+	case tlv.Endpoint.Is4():
+		length = TLVExtendedAssociationIDIPv4ValueLength
+	case tlv.Endpoint.Is6():
+		length = TLVExtendedAssociationIDIPv6ValueLength
 	}
 
 	value := make([]byte, length)
@@ -993,6 +995,13 @@ func (tlv *ExtendedAssociationID) Len() uint16 {
 	}
 	return 0
 
+}
+
+func NewExtendedAssociationID(color uint32, endpoint netip.Addr) *ExtendedAssociationID {
+	return &ExtendedAssociationID{
+		Color:    color,
+		Endpoint: endpoint,
+	}
 }
 
 type PathSetupTypeCapability struct {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1042,7 +1042,7 @@ func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 	}
 
 	padded := paddedLength(uint16(pstNum), TLVAlignment)
-	subTLVOffset := PathSetupTypeCapabilityFixedPartLength + padded
+	subTLVOffset := PathSetupTypeCapabilityFixedPartLength + int(padded)
 
 	subTLVData := value[subTLVOffset:]
 	tlv.SubTLVs, err = DecodeTLVs(subTLVData)

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -610,7 +610,11 @@ func (tlv *IPv6LSPIdentifiers) Serialize() []byte {
 	copy(value[IPv6ExtendedTunnelIDOffset:IPv6TunnelEPOffset], tlv.ExtendedTunnelID[:])
 	copy(value[IPv6TunnelEPOffset:IPv6TunnelEPOffset+IPv6AddrLen], tlv.IPv6TunnelEndpointAddress.AsSlice())
 
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVIPv6LSPIdentifiersValueLength),
+		value,
+	)
 }
 
 func (tlv *IPv6LSPIdentifiers) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -758,17 +762,11 @@ func (tlv *SRPCECapability) Serialize() []byte {
 	value[SRPCECapabilityFlagsOffset] = SetBit(value[SRPCECapabilityFlagsOffset], NAISupportedFlag, tlv.IsNAISupported)
 	value[SRPCECapabilityMSDOffset] = tlv.MaximumSidDepth
 
-	length := make([]byte, 2)
-	binary.BigEndian.PutUint16(length, TLVSRPCECapabilityValueLength)
-	buf = append(buf, length...)
-
-	val := make([]byte, TLVSRPCECapabilityValueLength)
-	val[SRPCECapabilityFlagsIndex] = SetBit(val[SRPCECapabilityFlagsIndex], UnlimitedMaximumSIDDepthFlag, tlv.HasUnlimitedMaxSIDDepth)
-	val[SRPCECapabilityFlagsIndex] = SetBit(val[SRPCECapabilityFlagsIndex], NAISupportedFlag, tlv.IsNAISupported)
-	val[SRPCECapabilityMSDIndex] = tlv.MaximumSidDepth
-
-	buf = append(buf, val...)
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVSRPCECapabilityValueLength),
+		value,
+	)
 }
 
 func (tlv *SRPCECapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -875,19 +873,11 @@ func (tlv *PathSetupType) Serialize() []byte {
 	value := make([]byte, TLVPathSetupTypeValueLength)
 	value[PathSetupTypeValueOffset] = byte(tlv.PathSetupType)
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
-
-	length := make([]byte, 2)
-	binary.BigEndian.PutUint16(length, TLVPathSetupTypeValueLength)
-	buf = append(buf, length...)
-
-	val := make([]byte, TLVPathSetupTypeValueLength)
-	val[PathSetupTypePathSetupTypeIndex] = byte(tlv.PathSetupType)
-
-	buf = append(buf, val...)
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVPathSetupTypeValueLength),
+		value,
+	)
 }
 
 func (tlv *PathSetupType) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -961,14 +951,16 @@ func (tlv *ExtendedAssociationID) Serialize() []byte {
 	} else if tlv.Endpoint.Is6() {
 		binary.BigEndian.PutUint16(length, TLVExtendedAssociationIDIPv6ValueLength)
 	}
-	buf = append(buf, length...)
 
 	value := make([]byte, length)
 	binary.BigEndian.PutUint32(value[ExtendedAssociationIDColorOffset:ExtendedAssociationIDColorOffset+TLVColorValueLength], tlv.Color)
 	copy(value[ExtendedAssociationIDEndpointOffset:], tlv.Endpoint.AsSlice())
 
-	buf = append(buf, tlv.Endpoint.AsSlice()...)
-	return buf
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(length),
+		value,
+	)
 }
 
 func (tlv *ExtendedAssociationID) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -1455,16 +1447,12 @@ func (tlv *UndefinedTLV) DecodeFromBytes(data []byte) error {
 func (tlv *UndefinedTLV) Serialize() []byte {
 	padding := (TLVAlignment - (tlv.Length % TLVAlignment)) % TLVAlignment
 
-	byteTLVLength := make([]byte, 2)
-	binary.BigEndian.PutUint16(byteTLVLength, tlv.Length)
-	bytePCEPTLV = append(bytePCEPTLV, byteTLVLength...) // Length (2byte)
-
-	bytePCEPTLV = append(bytePCEPTLV, tlv.Value...) // Value (Length byte)
-	if padding := tlv.Length % 4; padding != 0 {
-		bytePadding := make([]byte, 4-padding)
-		bytePCEPTLV = append(bytePCEPTLV, bytePadding...)
-	}
-	return bytePCEPTLV
+	return AppendByteSlices(
+		Uint16ToByteSlice(uint16(tlv.Typ)),
+		Uint16ToByteSlice(tlv.Length),
+		tlv.Value,
+		make([]byte, padding),
+	)
 }
 
 func (tlv *UndefinedTLV) MarshalLogObject(enc zapcore.ObjectEncoder) error {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -7,12 +7,12 @@ package pcep
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/netip"
 	"slices"
 	"strconv"
-	"strings"
 	"unicode/utf8"
 
 	"go.uber.org/zap/zapcore"
@@ -838,17 +838,19 @@ func (pst Pst) String() string {
 type Psts []Pst
 
 func (ts Psts) MarshalJSON() ([]byte, error) {
-	var result string
 	if ts == nil {
-		result = "null"
-	} else {
-		var values []string
-		for _, pst := range ts {
-			values = append(values, fmt.Sprintf("%d", pst))
-		}
-		result = strings.Join(values, ",")
+		return []byte("null"), nil
 	}
-	return []byte(result), nil
+
+	if len(ts) == 0 {
+		return []byte("[]"), nil
+	}
+
+	values := make([]int, len(ts))
+	for i, pst := range ts {
+		values[i] = int(pst)
+	}
+	return json.Marshal(values)
 }
 
 type PathSetupType struct {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1112,7 +1112,7 @@ func (tlv *PathSetupTypeCapability) MarshalLogObject(enc zapcore.ObjectEncoder) 
 
 	subTLVTypes := make([]string, len(tlv.SubTLVs))
 	for i, stlv := range tlv.SubTLVs {
-		subTLVTypes[i] = fmt.Sprintf("0x%04x", stlv.Type())
+		subTLVTypes[i] = fmt.Sprintf("0x%x (%s)", stlv.Type(), stlv.Type().String())
 	}
 	_ = enc.AddArray("subTLVs", zapcore.ArrayMarshalerFunc(func(ae zapcore.ArrayEncoder) error {
 		for _, s := range subTLVTypes {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1188,7 +1188,7 @@ type AssocTypeList struct {
 }
 
 func (tlv *AssocTypeList) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data, false)
+	valueLen, err := decodeTLVLength(data, true)
 	if err != nil {
 		return fmt.Errorf("AssocTypeList: %w", err)
 	}

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -179,8 +179,20 @@ func (t TLVType) String() string {
 	return fmt.Sprintf("Unknown TLV (0x%04x)", uint16(t))
 }
 
-// TLV header length (type + length)
-const TLVHeaderLength = 4
+// IP Length
+const (
+	IPv4AddrLen = 4
+	IPv6AddrLen = 16
+)
+
+const (
+	TLVTypeOffset   = 0
+	TLVLengthOffset = 2
+	TLVValueOffset  = 4
+)
+
+// TLV Alignment (4 bytes)
+const TLVAlignment = 4
 
 // TLV value lengths, excluding the 4-byte TLV header (type + length)
 const (
@@ -290,6 +302,7 @@ func (tlv *StatefulPCECapability) DecodeFromBytes(data []byte) error {
 
 func (tlv *StatefulPCECapability) Serialize() []byte {
 	flags := tlv.SetFlags() & definedStatefulPCEFlagsMask
+
 	return AppendByteSlices(
 		Uint16ToByteSlice(tlv.Type()),
 		Uint16ToByteSlice(TLVStatefulPCECapabilityValueLength),
@@ -312,7 +325,7 @@ func (tlv *StatefulPCECapability) Type() TLVType {
 }
 
 func (tlv *StatefulPCECapability) Len() uint16 {
-	return TLVHeaderLength + TLVStatefulPCECapabilityValueLength
+	return TLVValueOffset + TLVStatefulPCECapabilityValueLength
 }
 
 func (tlv *StatefulPCECapability) ExtractCapabilities(flags uint32) {
@@ -337,6 +350,7 @@ func (tlv *StatefulPCECapability) SetFlags() uint32 {
 
 func (tlv *StatefulPCECapability) CapStrings() []string {
 	ret := []string{"Stateful"}
+
 	if tlv.LSPUpdateCapability {
 		ret = append(ret, "Update")
 	}
@@ -358,6 +372,7 @@ func (tlv *StatefulPCECapability) CapStrings() []string {
 	if tlv.ColorCapability {
 		ret = append(ret, "Color")
 	}
+
 	return ret
 }
 
@@ -391,13 +406,8 @@ func (tlv *SymbolicPathName) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *SymbolicPathName) Serialize() []byte {
-	const alignment = 4
-
-	nameLen := uint16(len(tlv.Name))
-	padding := (alignment - (nameLen % alignment)) % alignment // Padding for 4-byte alignment
-
-	value := make([]byte, 0, int(nameLen)+int(padding))
-	value = append(value, []byte(tlv.Name)...)
+	value := []byte(tlv.Name)
+	padding := (TLVAlignment - (len(value) % TLVAlignment)) % TLVAlignment
 	value = append(value, make([]byte, padding)...)
 
 	return AppendByteSlices(
@@ -413,12 +423,9 @@ func (tlv *SymbolicPathName) Type() TLVType {
 
 func (tlv *SymbolicPathName) Len() uint16 {
 	length := uint16(len(tlv.Name))
-	padding := uint16(0)
-	if mod := length % 4; mod != 0 {
-		padding = 4 - mod
-	}
+	padding := (TLVAlignment - (length % TLVAlignment)) % TLVAlignment
 
-	return TLVHeaderLength + length + padding
+	return TLVValueOffset + length + padding
 }
 
 func (tlv *SymbolicPathName) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -439,10 +446,11 @@ type IPv4LSPIdentifiers struct {
 }
 
 const (
-	IPv4LSPIdentifiersTunnelSenderAddressIndex = 4
-	IPv4LSPIdentifiersLSPIDIndex               = 6
-	IPv4LSPIdentifiersTunnelIDIndex            = 8
-	IPv4LSPIdentifiersExtendedTunnelIDIndex    = 12
+	IPv4SenderOffset      = 0
+	IPv4LSPIDOffset       = 4
+	IPv4TunnelIDOffset    = 6
+	IPv4ExtTunnelIDOffset = 8
+	IPv4TunnelEPOffset    = 12
 )
 
 func (tlv *IPv4LSPIdentifiers) DecodeFromBytes(data []byte) error {
@@ -470,11 +478,11 @@ func (tlv *IPv4LSPIdentifiers) DecodeFromBytes(data []byte) error {
 func (tlv *IPv4LSPIdentifiers) Serialize() []byte {
 	value := make([]byte, TLVIPv4LSPIdentifiersValueLength)
 
-	copy(value[0:4], tlv.IPv4TunnelSenderAddress.AsSlice())
-	binary.BigEndian.PutUint16(value[4:6], tlv.LSPID)
-	binary.BigEndian.PutUint16(value[6:8], tlv.TunnelID)
-	binary.BigEndian.PutUint32(value[8:12], tlv.ExtendedTunnelID)
-	copy(value[12:16], tlv.IPv4TunnelEndpointAddress.AsSlice())
+	copy(value[IPv4SenderOffset:IPv4LSPIDOffset], tlv.IPv4TunnelSenderAddress.AsSlice())
+	binary.BigEndian.PutUint16(value[IPv4LSPIDOffset:IPv4TunnelIDOffset], tlv.LSPID)
+	binary.BigEndian.PutUint16(value[IPv4TunnelIDOffset:IPv4ExtTunnelIDOffset], tlv.TunnelID)
+	binary.BigEndian.PutUint32(value[IPv4ExtTunnelIDOffset:IPv4TunnelEPOffset], tlv.ExtendedTunnelID)
+	copy(value[IPv4TunnelEPOffset:IPv4TunnelEPOffset+IPv4AddrLen], tlv.IPv4TunnelEndpointAddress.AsSlice())
 
 	return AppendByteSlices(
 		Uint16ToByteSlice(tlv.Type()),
@@ -492,7 +500,7 @@ func (tlv *IPv4LSPIdentifiers) Type() TLVType {
 }
 
 func (tlv *IPv4LSPIdentifiers) Len() uint16 {
-	return TLVHeaderLength + TLVIPv4LSPIdentifiersValueLength
+	return TLVValueOffset + TLVIPv4LSPIdentifiersValueLength
 }
 
 func NewIPv4LSPIdentifiers(senderAddr, endpointAddr netip.Addr, lspID, tunnelID uint16, extendedTunnelID uint32) *IPv4LSPIdentifiers {
@@ -512,6 +520,15 @@ type IPv6LSPIdentifiers struct {
 	TunnelID                  uint16
 	ExtendedTunnelID          [16]byte
 }
+
+const (
+	// IPv6 LSP Identifiers
+	IPv6SenderOffset           = 0
+	IPv6LSPIDOffset            = 16
+	IPv6TunnelIDOffset         = 18
+	IPv6ExtendedTunnelIDOffset = 20
+	IPv6TunnelEPOffset         = 36
+)
 
 func (tlv *IPv6LSPIdentifiers) DecodeFromBytes(data []byte) error {
 	expectedLength := TLVHeaderLength + int(TLVIPv6LSPIdentifiersValueLength)
@@ -538,13 +555,11 @@ func (tlv *IPv6LSPIdentifiers) DecodeFromBytes(data []byte) error {
 func (tlv *IPv6LSPIdentifiers) Serialize() []byte {
 	buf := make([]byte, tlv.Len())
 
-	binary.BigEndian.PutUint16(buf[0:2], uint16(tlv.Type()))
-	binary.BigEndian.PutUint16(buf[2:4], TLVIPv6LSPIdentifiersValueLength)
-	copy(buf[4:20], tlv.IPv6TunnelSenderAddress.AsSlice())
-	binary.BigEndian.PutUint16(buf[20:22], tlv.LSPID)
-	binary.BigEndian.PutUint16(buf[22:24], tlv.TunnelID)
-	copy(buf[24:40], tlv.ExtendedTunnelID[:])
-	copy(buf[40:56], tlv.IPv6TunnelEndpointAddress.AsSlice())
+	copy(value[IPv6SenderOffset:IPv6SenderOffset+IPv6AddrLen], tlv.IPv6TunnelSenderAddress.AsSlice())
+	binary.BigEndian.PutUint16(value[IPv6LSPIDOffset:IPv6TunnelIDOffset], tlv.LSPID)
+	binary.BigEndian.PutUint16(value[IPv6TunnelIDOffset:IPv6ExtendedTunnelIDOffset], tlv.TunnelID)
+	copy(value[IPv6ExtendedTunnelIDOffset:IPv6TunnelEPOffset], tlv.ExtendedTunnelID[:])
+	copy(value[IPv6TunnelEPOffset:IPv6TunnelEPOffset+IPv6AddrLen], tlv.IPv6TunnelEndpointAddress.AsSlice())
 
 	return buf
 }
@@ -558,7 +573,7 @@ func (tlv *IPv6LSPIdentifiers) Type() TLVType {
 }
 
 func (tlv *IPv6LSPIdentifiers) Len() uint16 {
-	return TLVHeaderLength + TLVIPv6LSPIdentifiersValueLength
+	return TLVValueOffset + TLVIPv6LSPIdentifiersValueLength
 }
 
 func NewIPv6LSPIdentifiers(senderAddr, endpointAddr netip.Addr, lspID, tunnelID uint16, extendedTunnelID [16]byte) *IPv6LSPIdentifiers {
@@ -612,7 +627,7 @@ func (tlv *LSPDBVersion) Type() TLVType {
 }
 
 func (tlv *LSPDBVersion) Len() uint16 {
-	return TLVHeaderLength + TLVLSPDBVersionValueLength
+	return TLVValueOffset + TLVLSPDBVersionValueLength
 }
 
 func (tlv *LSPDBVersion) CapStrings() []string {
@@ -637,8 +652,8 @@ const (
 )
 
 const (
-	SRPCECapabilityFlagsIndex = 2
-	SRPCECapabilityMSDIndex   = 3
+	SRPCECapabilityFlagsOffset = 0
+	SRPCECapabilityMSDOffset   = 1
 )
 
 func (tlv *SRPCECapability) DecodeFromBytes(data []byte) error {
@@ -654,20 +669,22 @@ func (tlv *SRPCECapability) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("invalid value length for SRPCECapability: expected %d bytes, but got %d bytes", TLVSRPCECapabilityValueLength, len(val))
 	}
 
-	flags := val[SRPCECapabilityFlagsIndex]
+	val := data[TLVValueOffset:]
+
+	flags := val[SRPCECapabilityFlagsOffset]
 	tlv.HasUnlimitedMaxSIDDepth = IsBitSet(flags, UnlimitedMaximumSIDDepthFlag)
 	tlv.IsNAISupported = IsBitSet(flags, NAISupportedFlag)
-	tlv.MaximumSidDepth = val[SRPCECapabilityMSDIndex]
+	tlv.MaximumSidDepth = val[SRPCECapabilityMSDOffset]
 
 	return nil
 }
 
 func (tlv *SRPCECapability) Serialize() []byte {
-	buf := make([]byte, 0, TLVHeaderLength+TLVSRPCECapabilityValueLength)
+	value := make([]byte, TLVSRPCECapabilityValueLength)
 
-	typ := make([]byte, 2)
-	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
-	buf = append(buf, typ...)
+	value[SRPCECapabilityFlagsOffset] = SetBit(value[SRPCECapabilityFlagsOffset], UnlimitedMaximumSIDDepthFlag, tlv.HasUnlimitedMaxSIDDepth)
+	value[SRPCECapabilityFlagsOffset] = SetBit(value[SRPCECapabilityFlagsOffset], NAISupportedFlag, tlv.IsNAISupported)
+	value[SRPCECapabilityMSDOffset] = tlv.MaximumSidDepth
 
 	length := make([]byte, 2)
 	binary.BigEndian.PutUint16(length, TLVSRPCECapabilityValueLength)
@@ -694,7 +711,7 @@ func (tlv *SRPCECapability) Type() TLVType {
 }
 
 func (tlv *SRPCECapability) Len() uint16 {
-	return TLVHeaderLength + TLVSRPCECapabilityValueLength
+	return TLVValueOffset + TLVSRPCECapabilityValueLength
 }
 
 func (tlv *SRPCECapability) CapStrings() []string {
@@ -764,9 +781,7 @@ type PathSetupType struct {
 	PathSetupType Pst
 }
 
-const (
-	PathSetupTypePathSetupTypeIndex = 3
-)
+const PathSetupTypeValueOffset = 3
 
 func (tlv *PathSetupType) DecodeFromBytes(data []byte) error {
 	expectedLength := TLVHeaderLength + int(TLVPathSetupTypeValueLength)
@@ -774,12 +789,15 @@ func (tlv *PathSetupType) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("data length mismatch: expected %d bytes, but got %d bytes for PathSetupType", expectedLength, len(data))
 	}
 
-	tlv.PathSetupType = Pst(data[TLVHeaderLength+PathSetupTypePathSetupTypeIndex])
+	value := data[TLVValueOffset:]
+	tlv.PathSetupType = Pst(value[PathSetupTypeValueOffset])
+
 	return nil
 }
 
 func (tlv *PathSetupType) Serialize() []byte {
-	buf := []byte{}
+	value := make([]byte, TLVPathSetupTypeValueLength)
+	value[PathSetupTypeValueOffset] = byte(tlv.PathSetupType)
 
 	typ := make([]byte, 2)
 	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
@@ -805,7 +823,7 @@ func (tlv *PathSetupType) Type() TLVType {
 }
 
 func (tlv *PathSetupType) Len() uint16 {
-	return TLVHeaderLength + TLVPathSetupTypeValueLength
+	return TLVValueOffset + TLVPathSetupTypeValueLength
 }
 
 func NewPathSetupType(pst Pst) *PathSetupType {
@@ -819,16 +837,28 @@ type ExtendedAssociationID struct {
 	Endpoint netip.Addr
 }
 
+const (
+	ExtendedAssociationIDColorOffset    = 0
+	ExtendedAssociationIDEndpointOffset = 4
+)
+
 func (tlv *ExtendedAssociationID) DecodeFromBytes(data []byte) error {
 	length := binary.BigEndian.Uint16(data[2:4])
 
 	tlv.Color = binary.BigEndian.Uint32(data[4:8])
 
-	switch length {
-	case TLVExtendedAssociationIDIPv4ValueLength:
-		tlv.Endpoint, _ = netip.AddrFromSlice(data[8:12])
-	case TLVExtendedAssociationIDIPv6ValueLength:
-		tlv.Endpoint, _ = netip.AddrFromSlice(data[8:24])
+	tlv.Color = binary.BigEndian.Uint32(value[ExtendedAssociationIDColorOffset : ExtendedAssociationIDColorOffset+TLVColorValueLength])
+
+	var addrBytes []byte
+	switch valueLen {
+	case int(TLVExtendedAssociationIDIPv4ValueLength):
+		addrBytes = value[ExtendedAssociationIDEndpointOffset : ExtendedAssociationIDEndpointOffset+IPv4AddrLen]
+
+	case int(TLVExtendedAssociationIDIPv6ValueLength):
+		addrBytes = value[ExtendedAssociationIDEndpointOffset : ExtendedAssociationIDEndpointOffset+IPv6AddrLen]
+
+	default:
+		return fmt.Errorf("ExtendedAssociationID: unsupported value length %d", valueLen)
 	}
 
 	return nil
@@ -849,9 +879,9 @@ func (tlv *ExtendedAssociationID) Serialize() []byte {
 	}
 	buf = append(buf, length...)
 
-	color := make([]byte, 4)
-	binary.BigEndian.PutUint32(color, tlv.Color)
-	buf = append(buf, color...)
+	value := make([]byte, length)
+	binary.BigEndian.PutUint32(value[ExtendedAssociationIDColorOffset:ExtendedAssociationIDColorOffset+TLVColorValueLength], tlv.Color)
+	copy(value[ExtendedAssociationIDEndpointOffset:], tlv.Endpoint.AsSlice())
 
 	buf = append(buf, tlv.Endpoint.AsSlice()...)
 	return buf
@@ -867,9 +897,9 @@ func (tlv *ExtendedAssociationID) Type() TLVType {
 
 func (tlv *ExtendedAssociationID) Len() uint16 {
 	if tlv.Endpoint.Is4() {
-		return TLVHeaderLength + TLVExtendedAssociationIDIPv4ValueLength
+		return TLVValueOffset + TLVExtendedAssociationIDIPv4ValueLength
 	} else if tlv.Endpoint.Is6() {
-		return TLVHeaderLength + TLVExtendedAssociationIDIPv6ValueLength
+		return TLVValueOffset + TLVExtendedAssociationIDIPv6ValueLength
 	}
 	return 0
 
@@ -879,6 +909,11 @@ type PathSetupTypeCapability struct {
 	PathSetupTypes Psts
 	SubTLVs        []TLVInterface
 }
+
+const (
+	PathSetupTypeCapabilityFixedPartLength = 4
+	PathSetupTypeCapabilityPSTCountOffset  = 3
+)
 
 func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 	length := binary.BigEndian.Uint16(data[2:4])
@@ -891,8 +926,12 @@ func (tlv *PathSetupTypeCapability) DecodeFromBytes(data []byte) error {
 	if pstNum%4 != 0 {
 		pstNum += 4 - (pstNum % 4) // padding byte
 	}
-	var err error
-	tlv.SubTLVs, err = DecodeTLVs(data[8+pstNum : TLVHeaderLength+length]) // 8 byte: Type&Length (4 byte) + Reserve&pstNum (4 byte)
+
+	padded := paddedLength(uint16(pstNum), TLVAlignment)
+	subTLVOffset := PathSetupTypeCapabilityFixedPartLength + padded
+
+	subTLVData := value[subTLVOffset:]
+	tlv.SubTLVs, err = DecodeTLVs(subTLVData)
 	if err != nil {
 		return err
 	}
@@ -908,35 +947,26 @@ func (tlv *PathSetupTypeCapability) Serialize() []byte {
 
 	numOfPst := uint16(len(tlv.PathSetupTypes))
 
-	length := uint16(4) // 4 byte: reserve & num of PSTs field
-	length += numOfPst
-	if numOfPst%4 != 0 {
-		length += 4 - (numOfPst % 4)
-	}
+	length := uint16(PathSetupTypeCapabilityFixedPartLength) + paddedPSTLen
 	for _, subTLV := range tlv.SubTLVs {
 		length += subTLV.Len()
 	}
+
 	lengthBytes := make([]byte, 2)
 	binary.BigEndian.PutUint16(lengthBytes, length)
 	buf = append(buf, lengthBytes...)
 
-	var val []byte
-	if numOfPst%4 == 0 {
-		val = make([]byte, 4+numOfPst) // 4 byte: Reserve & Num of PST
-
-	} else {
-		val = make([]byte, 4+numOfPst+(4-(numOfPst%4))) // 4 byte: Reserve & Num of PST
-	}
-
-	val[3] = byte(numOfPst)
+	val := make([]byte, PathSetupTypeCapabilityFixedPartLength+paddedPSTLen)
+	val[PathSetupTypeCapabilityPSTCountOffset] = byte(numOfPst)
 	for i, pst := range tlv.PathSetupTypes {
-		val[4+i] = byte(pst)
+		val[PathSetupTypeCapabilityFixedPartLength+i] = byte(pst)
 	}
 
-	for _, subTLV := range tlv.SubTLVs {
-		val = append(val, subTLV.Serialize()...)
-	}
 	buf = append(buf, val...)
+	for _, subTLV := range tlv.SubTLVs {
+		buf = append(buf, subTLV.Serialize()...)
+	}
+
 	return buf
 }
 
@@ -949,26 +979,26 @@ func (tlv *PathSetupTypeCapability) Type() TLVType {
 }
 
 func (tlv *PathSetupTypeCapability) Len() uint16 {
-	length := uint16(4) // 4 byte: reserve & num of PSTs field
-	numOfPst := uint16(len(tlv.PathSetupTypes))
-	length += numOfPst
-	if numOfPst%4 != 0 {
-		length += 4 - (numOfPst % 4)
-	}
+	length := uint16(PathSetupTypeCapabilityFixedPartLength)
+	length += tlv.paddedPSTLength()
+
 	for _, subTLV := range tlv.SubTLVs {
 		length += subTLV.Len()
 	}
-	return TLVHeaderLength + length
+
+	return TLVValueOffset + length
 }
 
 func (tlv *PathSetupTypeCapability) CapStrings() []string {
 	ret := []string{}
+
 	if slices.Contains(tlv.PathSetupTypes, PathSetupTypeSRTE) {
 		ret = append(ret, "SR-TE")
 	}
 	if slices.Contains(tlv.PathSetupTypes, PathSetupTypeSRv6TE) {
 		ret = append(ret, "SRv6-TE")
 	}
+
 	return ret
 }
 
@@ -1052,7 +1082,7 @@ func (tlv *AssocTypeList) Len() uint16 {
 	if length%4 != 0 {
 		padding = 2
 	}
-	return TLVHeaderLength + length + padding
+	return TLVValueOffset + length + padding
 }
 
 func (tlv *AssocTypeList) CapStrings() []string {
@@ -1069,7 +1099,7 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
-	buf := []byte{}
+	buf := make([]byte, 0, TLVValueOffset+TLVSRPolicyCPathIDValueLength)
 
 	typ := make([]byte, 2)
 	binary.BigEndian.PutUint16(typ, uint16(tlv.Type()))
@@ -1103,7 +1133,7 @@ func (tlv *SRPolicyCandidatePathIdentifier) Type() TLVType {
 }
 
 func (tlv *SRPolicyCandidatePathIdentifier) Len() uint16 {
-	return TLVHeaderLength + TLVSRPolicyCPathIDValueLength
+	return TLVValueOffset + TLVSRPolicyCPathIDValueLength
 }
 
 type SRPolicyCandidatePathPreference struct {
@@ -1142,7 +1172,7 @@ func (tlv *SRPolicyCandidatePathPreference) Type() TLVType {
 }
 
 func (tlv *SRPolicyCandidatePathPreference) Len() uint16 {
-	return TLVHeaderLength + TLVSRPolicyCPathPreferenceValueLength
+	return TLVValueOffset + TLVSRPolicyCPathPreferenceValueLength
 }
 
 type Color struct {
@@ -1181,7 +1211,7 @@ func (tlv *Color) Type() TLVType {
 }
 
 func (tlv *Color) Len() uint16 {
-	return TLVHeaderLength + TLVColorValueLength
+	return TLVValueOffset + TLVColorValueLength
 }
 
 type UndefinedTLV struct {
@@ -1199,11 +1229,7 @@ func (tlv *UndefinedTLV) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *UndefinedTLV) Serialize() []byte {
-	bytePCEPTLV := []byte{}
-
-	byteTLVType := make([]byte, 2)
-	binary.BigEndian.PutUint16(byteTLVType, uint16(tlv.Typ))
-	bytePCEPTLV = append(bytePCEPTLV, byteTLVType...) // Type (2byte)
+	padding := (TLVAlignment - (tlv.Length % TLVAlignment)) % TLVAlignment
 
 	byteTLVLength := make([]byte, 2)
 	binary.BigEndian.PutUint16(byteTLVLength, tlv.Length)
@@ -1230,7 +1256,7 @@ func (tlv *UndefinedTLV) Len() uint16 {
 	if tlv.Length%4 != 0 {
 		padding = (4 - tlv.Length%4)
 	}
-	return TLVHeaderLength + tlv.Length + padding
+	return TLVValueOffset + tlv.Length + padding
 }
 
 func (tlv *UndefinedTLV) CapStrings() []string {
@@ -1267,29 +1293,33 @@ func DecodeTLV(data []byte) (TLVInterface, error) {
 
 func DecodeTLVs(data []byte) ([]TLVInterface, error) {
 	var tlvs []TLVInterface
-	offset := 0
 
-	for offset < len(data) {
-		if len(data[offset:]) < 4 {
-			return nil, fmt.Errorf("truncated TLV header at offset %d", offset)
+	for len(data) > 0 {
+		if len(data) < int(TLVValueOffset) {
+			return nil, fmt.Errorf("truncated TLV header")
 		}
 
-		tlvType := binary.BigEndian.Uint16(data[offset : offset+2])
-		valueLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
-		totalLen := 4 + valueLen
+		valueLen := int(binary.BigEndian.Uint16(data[TLVLengthOffset:TLVValueOffset]))
+		totalLen := int(TLVValueOffset) + valueLen
 
-		if len(data[offset:]) < totalLen {
-			return nil, fmt.Errorf("truncated TLV value for type 0x%x at offset %d", tlvType, offset)
+		tlvType := binary.BigEndian.Uint16(data[TLVTypeOffset:TLVLengthOffset])
+		if len(data) < totalLen {
+			return nil, fmt.Errorf("truncated TLV value (type=0x%x)", tlvType)
 		}
 
-		tlv, err := DecodeTLV(data[offset : offset+totalLen])
+		tlv, err := DecodeTLV(data[:totalLen])
 		if err != nil {
-			return nil, fmt.Errorf("error decoding TLV type 0x%x: %w", tlvType, err)
+			return nil, err
 		}
 
 		tlvs = append(tlvs, tlv)
-		paddedLen := (totalLen + 3) & ^3
-		offset += paddedLen
+
+		paddedLen := (totalLen + TLVAlignment - 1) & ^(TLVAlignment - 1)
+		if len(data) < paddedLen {
+			return nil, fmt.Errorf("truncated TLV padding (type=0x%x)", tlvType)
+		}
+
+		data = data[paddedLen:]
 	}
 
 	return tlvs, nil

--- a/pkg/packet/pcep/tlv_common.go
+++ b/pkg/packet/pcep/tlv_common.go
@@ -18,22 +18,30 @@ func decodeTLVLength(data []byte, allowPadding bool) (int, error) {
 	length := int(binary.BigEndian.Uint16(data[2:4]))
 	expected := TLVValueOffset + length
 
-	// Calculate the maximum allowed length considering optional padding.
-	maxAllowed := expected
-	if allowPadding && TLVAlignment > 0 {
-		maxAllowed = expected + int(TLVAlignment) - 1
+	// Validate length and optional padding strictly.
+	if len(data) < expected {
+		return 0, fmt.Errorf("tlv: invalid length (expected at least %d bytes, got %d)", expected, len(data))
 	}
 
-	if len(data) < expected || len(data) > maxAllowed {
-		return 0, fmt.Errorf("tlv: invalid length (expected between %d and %d bytes, got %d)", expected, maxAllowed, len(data))
+	// No padding case: length must match exactly.
+	if len(data) == expected {
+		return length, nil
+	}
+
+	// Padding is present; ensure it is allowed and correctly aligned.
+	if !allowPadding || TLVAlignment <= 0 {
+		return 0, fmt.Errorf("tlv: invalid length (expected %d bytes, got %d)", expected, len(data))
+	}
+
+	paddedExpected := int(paddedLength(uint16(expected), uint16(TLVAlignment)))
+	if len(data) != paddedExpected {
+		return 0, fmt.Errorf("tlv: invalid length (expected %d or %d bytes with padding, got %d)", expected, paddedExpected, len(data))
 	}
 
 	// If padding bytes exist, ensure they are all zero.
-	if len(data) > expected {
-		for _, b := range data[expected:] {
-			if b != 0 {
-				return 0, fmt.Errorf("tlv: invalid padding (expected zero bytes after offset %d)", expected)
-			}
+	for _, b := range data[expected:] {
+		if b != 0 {
+			return 0, fmt.Errorf("tlv: invalid padding (expected zero bytes after offset %d)", expected)
 		}
 	}
 

--- a/pkg/packet/pcep/tlv_common.go
+++ b/pkg/packet/pcep/tlv_common.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-func decodeTLVLength(data []byte) (int, error) {
+func decodeTLVLength(data []byte, allowPadding bool) (int, error) {
 	if len(data) < TLVValueOffset {
 		return 0, fmt.Errorf("tlv: too short (got %d bytes, want ≥ %d)", len(data), TLVValueOffset)
 	}
@@ -18,8 +18,23 @@ func decodeTLVLength(data []byte) (int, error) {
 	length := int(binary.BigEndian.Uint16(data[2:4]))
 	expected := TLVValueOffset + length
 
-	if len(data) != expected {
-		return 0, fmt.Errorf("tlv: invalid length (expected %d bytes, got %d)", expected, len(data))
+	// Calculate the maximum allowed length considering optional padding.
+	maxAllowed := expected
+	if allowPadding && TLVAlignment > 0 {
+		maxAllowed = expected + int(TLVAlignment) - 1
+	}
+
+	if len(data) < expected || len(data) > maxAllowed {
+		return 0, fmt.Errorf("tlv: invalid length (expected between %d and %d bytes, got %d)", expected, maxAllowed, len(data))
+	}
+
+	// If padding bytes exist, ensure they are all zero.
+	if len(data) > expected {
+		for _, b := range data[expected:] {
+			if b != 0 {
+				return 0, fmt.Errorf("tlv: invalid padding (expected zero bytes after offset %d)", expected)
+			}
+		}
 	}
 
 	return length, nil

--- a/pkg/packet/pcep/tlv_common.go
+++ b/pkg/packet/pcep/tlv_common.go
@@ -24,3 +24,10 @@ func decodeTLVLength(data []byte) (int, error) {
 
 	return length, nil
 }
+
+func paddedLength(n uint16, align uint16) uint16 {
+	if n%align == 0 {
+		return n
+	}
+	return n + (align - (n % align))
+}

--- a/pkg/packet/pcep/tlv_common.go
+++ b/pkg/packet/pcep/tlv_common.go
@@ -31,3 +31,16 @@ func paddedLength(n uint16, align uint16) uint16 {
 	}
 	return n + (align - (n % align))
 }
+
+// isIPv4Bytes returns true if the given 16-byte slice encodes an IPv4 address (upper 12 bytes zero).
+func isIPv4Bytes(b []byte) bool {
+	if len(b) != 16 {
+		return false
+	}
+	for i := 0; i < 12; i++ {
+		if b[i] != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/packet/pcep/tlv_common.go
+++ b/pkg/packet/pcep/tlv_common.go
@@ -33,7 +33,7 @@ func decodeTLVLength(data []byte, allowPadding bool) (int, error) {
 		return 0, fmt.Errorf("tlv: invalid length (expected %d bytes, got %d)", expected, len(data))
 	}
 
-	paddedExpected := int(paddedLength(uint16(expected), uint16(TLVAlignment)))
+	paddedExpected := paddedLength(expected, TLVAlignment)
 	if len(data) != paddedExpected {
 		return 0, fmt.Errorf("tlv: invalid length (expected %d or %d bytes with padding, got %d)", expected, paddedExpected, len(data))
 	}
@@ -48,7 +48,7 @@ func decodeTLVLength(data []byte, allowPadding bool) (int, error) {
 	return length, nil
 }
 
-func paddedLength(n uint16, align uint16) uint16 {
+func paddedLength(n int, align int) int {
 	if n%align == 0 {
 		return n
 	}

--- a/pkg/packet/pcep/tlv_common.go
+++ b/pkg/packet/pcep/tlv_common.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package pcep
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+func decodeTLVLength(data []byte) (int, error) {
+	if len(data) < TLVValueOffset {
+		return 0, fmt.Errorf("tlv: too short (got %d bytes, want ≥ %d)", len(data), TLVValueOffset)
+	}
+
+	length := int(binary.BigEndian.Uint16(data[2:4]))
+	expected := TLVValueOffset + length
+
+	if len(data) != expected {
+		return 0, fmt.Errorf("tlv: invalid length (expected %d bytes, got %d)", expected, len(data))
+	}
+
+	return length, nil
+}

--- a/pkg/packet/pcep/tlv_common.go
+++ b/pkg/packet/pcep/tlv_common.go
@@ -15,7 +15,7 @@ func decodeTLVLength(data []byte, allowPadding bool) (int, error) {
 		return 0, fmt.Errorf("tlv: too short (got %d bytes, want ≥ %d)", len(data), TLVValueOffset)
 	}
 
-	length := int(binary.BigEndian.Uint16(data[2:4]))
+	length := int(binary.BigEndian.Uint16(data[TLVLengthOffset:TLVValueOffset]))
 	expected := TLVValueOffset + length
 
 	// Validate length and optional padding strictly.
@@ -55,12 +55,16 @@ func paddedLength(n int, align int) int {
 	return n + (align - (n % align))
 }
 
+const (
+	IPv4InIPv6Offset = 12
+)
+
 // isIPv4Bytes returns true if the given 16-byte slice encodes an IPv4 address (upper 12 bytes zero).
 func isIPv4Bytes(b []byte) bool {
-	if len(b) != 16 {
+	if len(b) != IPv6AddrLen {
 		return false
 	}
-	for i := 0; i < 12; i++ {
+	for i := 0; i < IPv4InIPv6Offset; i++ {
 		if b[i] != 0 {
 			return false
 		}

--- a/pkg/packet/pcep/tlv_common_test.go
+++ b/pkg/packet/pcep/tlv_common_test.go
@@ -151,17 +151,17 @@ func TestIsIPv4Bytes(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Not IPv4-mapped (first byte non-zero)",
+			name: "Not IPv4-compatible (first byte non-zero)",
 			b:    append([]byte{1}, append(make([]byte, 11), 192, 0, 2, 1)...),
 			want: false,
 		},
 		{
-			name: "Not IPv4-mapped (random bytes in first 12)",
+			name: "Not IPv4-compatible (random bytes in first 12)",
 			b:    append([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 192, 0, 2, 1),
 			want: false,
 		},
 		{
-			name: "Exactly 16 zero bytes (still IPv4?)",
+			name: "Exactly 16 zero bytes (IPv4-compatible all zeros)",
 			b:    make([]byte, 16),
 			want: true,
 		},

--- a/pkg/packet/pcep/tlv_common_test.go
+++ b/pkg/packet/pcep/tlv_common_test.go
@@ -123,3 +123,51 @@ func TestPaddedLength(t *testing.T) {
 		})
 	}
 }
+
+func TestIsIPv4Bytes(t *testing.T) {
+	tests := []struct {
+		name string
+		b    []byte
+		want bool
+	}{
+		{
+			name: "Valid IPv4-mapped IPv6",
+			b:    append(make([]byte, 12), 192, 0, 2, 1),
+			want: true,
+		},
+		{
+			name: "Not IPv4-mapped (first byte non-zero)",
+			b:    append([]byte{1}, append(make([]byte, 11), 192, 0, 2, 1)...),
+			want: false,
+		},
+		{
+			name: "Not IPv4-mapped (random bytes in first 12)",
+			b:    append([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 192, 0, 2, 1),
+			want: false,
+		},
+		{
+			name: "Exactly 16 zero bytes (still IPv4?)",
+			b:    make([]byte, 16),
+			want: true,
+		},
+		{
+			name: "Too short (<16 bytes)",
+			b:    make([]byte, 15),
+			want: false,
+		},
+		{
+			name: "Too long (>16 bytes)",
+			b:    make([]byte, 17),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isIPv4Bytes(tt.b)
+			if got != tt.want {
+				t.Errorf("isIPv4Bytes(%v) = %v; want %v", tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/packet/pcep/tlv_common_test.go
+++ b/pkg/packet/pcep/tlv_common_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package pcep
+
+import "testing"
+
+func TestDecodeTLVLength(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      []byte
+		wantLen   int
+		wantError bool
+	}{
+		{
+			name: "Valid TLV (length=4)",
+			data: []byte{
+				0x00, 0x01, // Type
+				0x00, 0x04, // Length = 4
+				0xAA, 0xBB, 0xCC, 0xDD, // Value (4 bytes)
+			},
+			wantLen:   4,
+			wantError: false,
+		},
+		{
+			name: "Too short (< TLVValueOffset)",
+			data: []byte{
+				0x00, 0x01,
+				0x00,
+			},
+			wantError: true,
+		},
+		{
+			name: "Invalid length (data shorter than expected)",
+			data: []byte{
+				0x00, 0x01,
+				0x00, 0x04, // Length = 4
+				0xAA, 0xBB, // Only 2 bytes
+			},
+			wantError: true,
+		},
+		{
+			name: "Invalid length (data longer than expected)",
+			data: []byte{
+				0x00, 0x01,
+				0x00, 0x02, // Length = 2
+				0xAA, 0xBB,
+				0xCC, 0xDD, // Extra bytes
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLen, err := decodeTLVLength(tt.data)
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if gotLen != tt.wantLen {
+				t.Errorf("expected length %d, got %d", tt.wantLen, gotLen)
+			}
+		})
+	}
+}

--- a/pkg/packet/pcep/tlv_common_test.go
+++ b/pkg/packet/pcep/tlv_common_test.go
@@ -74,3 +74,52 @@ func TestDecodeTLVLength(t *testing.T) {
 		})
 	}
 }
+
+func TestPaddedLength(t *testing.T) {
+	tests := []struct {
+		name     string
+		n        uint16
+		align    uint16
+		expected uint16
+	}{
+		{
+			name:     "Already aligned",
+			n:        8,
+			align:    4,
+			expected: 8,
+		},
+		{
+			name:     "Needs padding",
+			n:        6,
+			align:    4,
+			expected: 8,
+		},
+		{
+			name:     "Zero length",
+			n:        0,
+			align:    4,
+			expected: 0,
+		},
+		{
+			name:     "Length 1",
+			n:        1,
+			align:    4,
+			expected: 4,
+		},
+		{
+			name:     "Non-4 alignment",
+			n:        10,
+			align:    8,
+			expected: 16,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := paddedLength(tt.n, tt.align)
+			if result != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/packet/pcep/tlv_common_test.go
+++ b/pkg/packet/pcep/tlv_common_test.go
@@ -146,7 +146,7 @@ func TestIsIPv4Bytes(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "Valid IPv4-mapped IPv6",
+			name: "Valid IPv4-compatible IPv6 (12 leading zero bytes)",
 			b:    append(make([]byte, 12), 192, 0, 2, 1),
 			want: true,
 		},

--- a/pkg/packet/pcep/tlv_common_test.go
+++ b/pkg/packet/pcep/tlv_common_test.go
@@ -9,53 +9,68 @@ import "testing"
 
 func TestDecodeTLVLength(t *testing.T) {
 	tests := []struct {
-		name      string
-		data      []byte
-		wantLen   int
-		wantError bool
+		name         string
+		data         []byte
+		allowPadding bool
+		wantLen      int
+		wantError    bool
 	}{
 		{
-			name: "Valid TLV (length=4)",
-			data: []byte{
-				0x00, 0x01, // Type
-				0x00, 0x04, // Length = 4
-				0xAA, 0xBB, 0xCC, 0xDD, // Value (4 bytes)
-			},
-			wantLen:   4,
-			wantError: false,
+			name:         "Valid TLV, length=4, no padding, allowPadding=false",
+			data:         []byte{0x00, 0x01, 0x00, 0x04, 0xDE, 0xAD, 0xBE, 0xEF},
+			allowPadding: false,
+			wantLen:      4,
+			wantError:    false,
 		},
 		{
-			name: "Too short (< TLVValueOffset)",
-			data: []byte{
-				0x00, 0x01,
-				0x00,
-			},
-			wantError: true,
+			name:         "Valid TLV, length=4, no padding, allowPadding=true",
+			data:         []byte{0x00, 0x01, 0x00, 0x04, 0xDE, 0xAD, 0xBE, 0xEF},
+			allowPadding: true,
+			wantLen:      4,
+			wantError:    false,
 		},
 		{
-			name: "Invalid length (data shorter than expected)",
-			data: []byte{
-				0x00, 0x01,
-				0x00, 0x04, // Length = 4
-				0xAA, 0xBB, // Only 2 bytes
-			},
-			wantError: true,
+			name:         "Fixed length TLV, extra zero byte, allowPadding=false",
+			data:         []byte{0x00, 0x01, 0x00, 0x04, 0xDE, 0xAD, 0xBE, 0xEF, 0x00},
+			allowPadding: false,
+			wantError:    true,
 		},
 		{
-			name: "Invalid length (data longer than expected)",
-			data: []byte{
-				0x00, 0x01,
-				0x00, 0x02, // Length = 2
-				0xAA, 0xBB,
-				0xCC, 0xDD, // Extra bytes
-			},
-			wantError: true,
+			name:         "Too short TLV, less than header, allowPadding=false",
+			data:         []byte{0x00, 0x01, 0x00},
+			allowPadding: false,
+			wantError:    true,
+		},
+		{
+			name:         "Invalid length, shorter than value, allowPadding=false",
+			data:         []byte{0x00, 0x01, 0x00, 0x04, 0xDE, 0xAD},
+			allowPadding: false,
+			wantError:    true,
+		},
+		{
+			name:         "Invalid length, longer than value, allowPadding=false",
+			data:         []byte{0x00, 0x01, 0x00, 0x02, 0xDE, 0xAD, 0xBE, 0xEF},
+			allowPadding: false,
+			wantError:    true,
+		},
+		{
+			name:         "Valid TLV, zero padding, allowPadding=true",
+			data:         []byte{0x00, 0x01, 0x00, 0x02, 0xDE, 0xAD, 0x00, 0x00},
+			allowPadding: true,
+			wantLen:      2,
+			wantError:    false,
+		},
+		{
+			name:         "Invalid padding, non-zero bytes, allowPadding=true",
+			data:         []byte{0x00, 0x01, 0x00, 0x02, 0xDE, 0xAD, 0x01, 0x02},
+			allowPadding: true,
+			wantError:    true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLen, err := decodeTLVLength(tt.data)
+			gotLen, err := decodeTLVLength(tt.data, tt.allowPadding)
 
 			if tt.wantError {
 				if err == nil {

--- a/pkg/packet/pcep/tlv_common_test.go
+++ b/pkg/packet/pcep/tlv_common_test.go
@@ -93,9 +93,9 @@ func TestDecodeTLVLength(t *testing.T) {
 func TestPaddedLength(t *testing.T) {
 	tests := []struct {
 		name     string
-		n        uint16
-		align    uint16
-		expected uint16
+		n        int
+		align    int
+		expected int
 	}{
 		{
 			name:     "Already aligned",

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -851,17 +851,39 @@ var (
 		0x01, 0x00,
 		0xFF, 0xFF, 0x00, 0x04, 0x01, 0x02,
 	}
+
+	testPathSetupTypeCapabilityZeroPSTBytes = []byte{
+		0x00, 0x22, 0x00, 0x04, // TLV header
+		0x00, 0x00, 0x00, 0x00, // PST count = 0
+	}
+	testPathSetupTypeCapabilityZeroPST = &PathSetupTypeCapability{
+		PathSetupTypes: Psts{},
+		SubTLVs:        []TLVInterface{},
+	}
+
+	testPathSetupTypeCapabilityNilPST = &PathSetupTypeCapability{
+		PathSetupTypes: Psts{},
+		SubTLVs:        []TLVInterface{},
+	}
+	testPathSetupTypeCapabilitySubTLVOffsetOverflowBytes = []byte{
+		0x00, 0x22, 0x00, 0x05, // TLV header, length=5
+		0x00, 0x00, 0x00, 0x01, // PST count = 1
+		0x01, // PST entry
+	}
 )
 
 // TestPathSetupTypeCapability_DecodeFromBytes tests PathSetupTypeCapability.DecodeFromBytes.
 func TestPathSetupTypeCapability_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
-		"ValidBasic":       {testPathSetupTypeCapabilityBasicBytes, testPathSetupTypeCapabilityBasic, false},
-		"ValidWithSubTLV":  {testPathSetupTypeCapabilityWithSubTLVBytes, testPathSetupTypeCapabilityWithSubTLV, false},
-		"TooShort":         {testPathSetupTypeCapabilityTooShort, nil, true},
-		"PSTCountOverflow": {testPathSetupTypeCapabilityPSTOverflow, nil, true},
-		"InvalidTLVLength": {testPathSetupTypeCapabilityInvalidLength, nil, true},
-		"BadSubTLV":        {testPathSetupTypeCapabilityBadSubTLVBytes, nil, true},
+		"ValidBasic":               {testPathSetupTypeCapabilityBasicBytes, testPathSetupTypeCapabilityBasic, false},
+		"ValidWithSubTLV":          {testPathSetupTypeCapabilityWithSubTLVBytes, testPathSetupTypeCapabilityWithSubTLV, false},
+		"ZeroPST":                  {testPathSetupTypeCapabilityZeroPSTBytes, testPathSetupTypeCapabilityZeroPST, false},
+		"NilPST":                   {testPathSetupTypeCapabilityZeroPSTBytes, testPathSetupTypeCapabilityNilPST, false},
+		"SubTLVOffsetExceedsValue": {testPathSetupTypeCapabilitySubTLVOffsetOverflowBytes, nil, true},
+		"TooShort":                 {testPathSetupTypeCapabilityTooShort, nil, true},
+		"PSTCountOverflow":         {testPathSetupTypeCapabilityPSTOverflow, nil, true},
+		"InvalidTLVLength":         {testPathSetupTypeCapabilityInvalidLength, nil, true},
+		"BadSubTLV":                {testPathSetupTypeCapabilityBadSubTLVBytes, nil, true},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &PathSetupTypeCapability{} })
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -499,18 +499,20 @@ func TestIPv6LSPIdentifiers_Len(t *testing.T) {
 
 // Test data for LSPDBVersion.
 var (
-	testLSPDBVersion           = NewLSPDBVersion(12345)
-	testLSPDBVersionBytes      = append(tlvHeader(TLVLSPDBVersion, 8), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39)
-	testLSPDBVersionTruncated  = append(tlvHeader(TLVLSPDBVersion, 4), 0x00, 0x00, 0x00, 0x00)
-	testLSPDBVersionExtra      = append(tlvHeader(TLVLSPDBVersion, 16), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39, 0xde, 0xad, 0xbe, 0xef)
-	testLSPDBVersionCapStrings = []string{"LSP-DB-VERSION"}
+	testLSPDBVersion              = NewLSPDBVersion(12345)
+	testLSPDBVersionBytes         = append(tlvHeader(TLVLSPDBVersion, 8), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39)
+	testLSPDBVersionTruncated     = append(tlvHeader(TLVLSPDBVersion, 4), 0x00, 0x00, 0x00, 0x00)
+	testLSPDBVersionExtra         = append(tlvHeader(TLVLSPDBVersion, 8), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39, 0xde, 0xad, 0xbe, 0xef)
+	testLSPDBVersionInvalidLength = append(tlvHeader(TLVLSPDBVersion, 16), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39, 0xde, 0xad, 0xbe, 0xef)
+	testLSPDBVersionCapStrings    = []string{"LSP-DB-VERSION"}
 )
 
 func TestLSPDBVersion_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
-		"ValidLSPDBVersion":        {testLSPDBVersionBytes, testLSPDBVersion, false},
-		"TruncatedLSPDBVersion":    {testLSPDBVersionTruncated, nil, true},
-		"ExtraBytesInLSPDBVersion": {testLSPDBVersionExtra, nil, true},
+		"ValidLSPDBVersion":         {testLSPDBVersionBytes, testLSPDBVersion, false},
+		"TruncatedLSPDBVersion":     {testLSPDBVersionTruncated, nil, true},
+		"ExtraBytesInLSPDBVersion":  {testLSPDBVersionExtra, nil, true},
+		"InvalidLengthLSPDBVersion": {testLSPDBVersionInvalidLength, nil, true},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &LSPDBVersion{} })
 }
@@ -576,7 +578,8 @@ var (
 	testSRPCECapability               = NewSRPCECapability(true, true, 10)
 	testSRPCECapabilityBytes          = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x0a, 0x00, 0x00)
 	testSRPCECapabilityTruncated      = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x02)
-	testSRPCECapabilityExtra          = append(tlvHeader(TLVSRPCECapability, 8), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
+	testSRPCECapabilityExtra          = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
+	testSRPCECapabilityInvalidLength  = append(tlvHeader(TLVSRPCECapability, 8), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
 	testSRPCECapabilityAllEnabled     = &SRPCECapability{HasUnlimitedMaxSIDDepth: true, IsNAISupported: true}
 	testSRPCECapabilityUnlimitedOnly  = &SRPCECapability{HasUnlimitedMaxSIDDepth: true}
 	testSRPCECapabilityNAIOnly        = &SRPCECapability{IsNAISupported: true}
@@ -589,9 +592,10 @@ var (
 
 func TestSRPCECapability_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
-		"ValidSRPCECapability":        {testSRPCECapabilityBytes, testSRPCECapability, false},
-		"TruncatedSRPCECapability":    {testSRPCECapabilityTruncated, nil, true},
-		"ExtraBytesInSRPCECapability": {testSRPCECapabilityExtra, nil, true},
+		"ValidSRPCECapability":         {testSRPCECapabilityBytes, testSRPCECapability, false},
+		"TruncatedSRPCECapability":     {testSRPCECapabilityTruncated, nil, true},
+		"ExtraBytesInSRPCECapability":  {testSRPCECapabilityExtra, nil, true},
+		"InvalidLengthSRPCECapability": {testSRPCECapabilityInvalidLength, nil, true},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRPCECapability{} })
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -872,7 +872,6 @@ var (
 	}
 )
 
-// TestPathSetupTypeCapability_DecodeFromBytes tests PathSetupTypeCapability.DecodeFromBytes.
 func TestPathSetupTypeCapability_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
 		"ValidBasic":               {testPathSetupTypeCapabilityBasicBytes, testPathSetupTypeCapabilityBasic, false},
@@ -900,7 +899,6 @@ func TestPathSetupTypeCapability_Serialize(t *testing.T) {
 	runTLVSerializeTests(t, cases)
 }
 
-// TestPathSetupTypeCapability_MarshalLogObject tests PathSetupTypeCapability.MarshalLogObject.
 func TestPathSetupTypeCapability_MarshalLogObject(t *testing.T) {
 	cases := map[string]struct {
 		input    *PathSetupTypeCapability
@@ -941,7 +939,6 @@ func TestPathSetupTypeCapability_MarshalLogObject(t *testing.T) {
 	}
 }
 
-// TestPathSetupTypeCapability_Len tests PathSetupTypeCapability.Len.
 func TestPathSetupTypeCapability_Len(t *testing.T) {
 	var subTLVLen uint16
 	for _, s := range testPathSetupTypeCapabilityWithSubTLV.SubTLVs {
@@ -958,7 +955,6 @@ func TestPathSetupTypeCapability_Len(t *testing.T) {
 	runTLVLenTests(t, cases)
 }
 
-// TestPathSetupTypeCapability_CapStrings tests PathSetupTypeCapability.CapStrings.
 func TestPathSetupTypeCapability_CapStrings(t *testing.T) {
 	cases := map[string]struct {
 		input    CapStringsInterface
@@ -972,7 +968,6 @@ func TestPathSetupTypeCapability_CapStrings(t *testing.T) {
 	runCapStringsTests(t, cases)
 }
 
-// TestAssocType_String tests AssocType.String.
 func TestAssocType_String(t *testing.T) {
 	cases := map[string]struct {
 		input    AssocType
@@ -1027,7 +1022,6 @@ var (
 	}
 )
 
-// TestExtendedAssociationID_DecodeFromBytes tests ExtendedAssociationID.DecodeFromBytes.
 func TestExtendedAssociationID_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
 		"IPv4":              {testIPv4ExtendedAssociationIDBytes, testIPv4ExtendedAssociationID, false},
@@ -1039,7 +1033,6 @@ func TestExtendedAssociationID_DecodeFromBytes(t *testing.T) {
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &ExtendedAssociationID{} })
 }
 
-// TestExtendedAssociationID_Serialize tests ExtendedAssociationID.Serialize.
 func TestExtendedAssociationID_Serialize(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1058,7 +1051,6 @@ func TestExtendedAssociationID_Serialize(t *testing.T) {
 	}
 }
 
-// TestExtendedAssociationID_MarshalLogObject tests ExtendedAssociationID.MarshalLogObject.
 func TestExtendedAssociationID_MarshalLogObject(t *testing.T) {
 	cases := map[string]struct {
 		input    *ExtendedAssociationID
@@ -1094,7 +1086,6 @@ func TestExtendedAssociationID_MarshalLogObject(t *testing.T) {
 	}
 }
 
-// TestExtendedAssociationID_Len tests ExtendedAssociationID.Len.
 func TestExtendedAssociationID_Len(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1131,8 +1122,8 @@ var (
 
 	// Bytes for testAssocTypeList (2 entries = 4 bytes value, no padding needed).
 	testAssocTypeListBytes = []byte{
-		0x00, 0x23, 0x00, 0x04,
-		0x00, 0x01, 0x00, 0x06,
+		0x00, 0x23, 0x00, 0x04, // Type, Length
+		0x00, 0x01, 0x00, 0x06, // Value
 	}
 	// Bytes for Serialize test: 1 entry + padding to 4-byte alignment.
 	testAssocTypeListSingleBytesWithPadding = []byte{
@@ -1155,7 +1146,6 @@ var (
 	}
 )
 
-// TestAssocTypeList_DecodeFromBytes tests AssocTypeList.DecodeFromBytes.
 func TestAssocTypeList_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
 		"ValidTwoEntries":  {testAssocTypeListBytes, testAssocTypeList, false},
@@ -1166,7 +1156,6 @@ func TestAssocTypeList_DecodeFromBytes(t *testing.T) {
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &AssocTypeList{} })
 }
 
-// TestAssocTypeList_Serialize tests AssocTypeList.Serialize.
 func TestAssocTypeList_Serialize(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1178,7 +1167,6 @@ func TestAssocTypeList_Serialize(t *testing.T) {
 	runTLVSerializeTests(t, cases)
 }
 
-// TestAssocTypeList_MarshalLogObject tests AssocTypeList.MarshalLogObject.
 func TestAssocTypeList_MarshalLogObject(t *testing.T) {
 	cases := map[string]struct {
 		input    *AssocTypeList
@@ -1232,7 +1220,6 @@ func TestAssocTypeList_MarshalLogObject(t *testing.T) {
 	}
 }
 
-// TestAssocTypeList_Len tests AssocTypeList.Len.
 func TestAssocTypeList_Len(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1246,7 +1233,6 @@ func TestAssocTypeList_Len(t *testing.T) {
 	runTLVLenTests(t, cases)
 }
 
-// TestAssocTypeList_CapStrings tests AssocTypeList.CapStrings.
 func TestAssocTypeList_CapStrings(t *testing.T) {
 	cases := map[string]struct {
 		input    CapStringsInterface
@@ -1297,7 +1283,6 @@ var (
 	}
 )
 
-// TestSRPolicyCandidatePathIdentifier_DecodeFromBytes tests SRPolicyCandidatePathIdentifier.DecodeFromBytes.
 func TestSRPolicyCandidatePathIdentifier_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
 		"ValidIPv4":       {testSRPolicyCPathIDIPv4Bytes, testSRPolicyCPathIDIPv4, false},
@@ -1308,7 +1293,6 @@ func TestSRPolicyCandidatePathIdentifier_DecodeFromBytes(t *testing.T) {
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRPolicyCandidatePathIdentifier{} })
 }
 
-// TestSRPolicyCandidatePathIdentifier_Serialize tests SRPolicyCandidatePathIdentifier.Serialize.
 func TestSRPolicyCandidatePathIdentifier_Serialize(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1330,7 +1314,6 @@ func TestSRPolicyCandidatePathIdentifier_Serialize_Invalid(t *testing.T) {
 	runTLVSerializeTests(t, cases)
 }
 
-// TestSRPolicyCandidatePathIdentifier_MarshalLogObject tests SRPolicyCandidatePathIdentifier.MarshalLogObject.
 func TestSRPolicyCandidatePathIdentifier_MarshalLogObject(t *testing.T) {
 	cases := map[string]struct {
 		input    *SRPolicyCandidatePathIdentifier
@@ -1440,7 +1423,6 @@ func TestSRPolicyCandidatePathPreference_MarshalLogObject(t *testing.T) {
 	}
 }
 
-// TestSRPolicyCandidatePathPreference_Len tests SRPolicyCandidatePathPreference.Len.
 func TestSRPolicyCandidatePathPreference_Len(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1471,7 +1453,6 @@ var (
 	}
 )
 
-// TestColor_DecodeFromBytes tests Color.DecodeFromBytes.
 func TestColor_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
 		"ValidColor":      {testColorBytes, testColor, false},
@@ -1481,7 +1462,6 @@ func TestColor_DecodeFromBytes(t *testing.T) {
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &Color{} })
 }
 
-// TestColor_Serialize tests Color.Serialize.
 func TestColor_Serialize(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1492,7 +1472,6 @@ func TestColor_Serialize(t *testing.T) {
 	runTLVSerializeTests(t, cases)
 }
 
-// TestColor_MarshalLogObject tests Color.MarshalLogObject.
 func TestColor_MarshalLogObject(t *testing.T) {
 	cases := map[string]struct {
 		input    *Color
@@ -1526,7 +1505,6 @@ func TestColor_MarshalLogObject(t *testing.T) {
 	}
 }
 
-// TestColor_Len tests Color.Len.
 func TestColor_Len(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1559,7 +1537,6 @@ var (
 	testUndefinedTLVTruncatedValue  = []byte{0xff, 0xff, 0x00, 0x08, 0x01, 0x02}
 )
 
-// TestUndefinedTLV_DecodeFromBytes tests UndefinedTLV.DecodeFromBytes.
 func TestUndefinedTLV_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
 		"ValidUndefinedTLV": {testUndefinedTLVBytes, testUndefinedTLV, false},
@@ -1569,7 +1546,6 @@ func TestUndefinedTLV_DecodeFromBytes(t *testing.T) {
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &UndefinedTLV{} })
 }
 
-// TestUndefinedTLV_Serialize tests UndefinedTLV.Serialize.
 func TestUndefinedTLV_Serialize(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1581,7 +1557,6 @@ func TestUndefinedTLV_Serialize(t *testing.T) {
 	runTLVSerializeTests(t, cases)
 }
 
-// TestUndefinedTLV_MarshalLogObject tests UndefinedTLV.MarshalLogObject.
 func TestUndefinedTLV_MarshalLogObject(t *testing.T) {
 	cases := map[string]struct {
 		input    *UndefinedTLV
@@ -1617,7 +1592,6 @@ func TestUndefinedTLV_MarshalLogObject(t *testing.T) {
 	}
 }
 
-// TestUndefinedTLV_Len tests UndefinedTLV.Len.
 func TestUndefinedTLV_Len(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
@@ -1629,7 +1603,6 @@ func TestUndefinedTLV_Len(t *testing.T) {
 	runTLVLenTests(t, cases)
 }
 
-// TestUndefinedTLV_CapStrings tests UndefinedTLV.CapStrings.
 func TestUndefinedTLV_CapStrings(t *testing.T) {
 	cases := map[string]struct {
 		input    CapStringsInterface
@@ -1644,7 +1617,6 @@ func TestUndefinedTLV_CapStrings(t *testing.T) {
 	runCapStringsTests(t, cases)
 }
 
-// TestUndefinedTLV_SetLength tests UndefinedTLV.SetLength.
 func TestUndefinedTLV_SetLength(t *testing.T) {
 	tlv := &UndefinedTLV{Value: []byte{0x01, 0x02, 0x03}}
 	tlv.SetLength()
@@ -1653,28 +1625,19 @@ func TestUndefinedTLV_SetLength(t *testing.T) {
 
 // Test data for DecodeTLV / DecodeTLVs.
 var (
-	// Known TLV: StatefulPCECapability with only LSP Update enabled
 	testDecodeStatefulLSPUpdateBytes = append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x01)
-	// Unknown TLV type 0xffff with 4-byte value
-	testDecodeUnknownTLVBytes = append(tlvHeader(TLVType(0xffff), 4), 0xde, 0xad, 0xbe, 0xef)
-	// Truncated TLV header (less than 4 bytes)
-	testDecodeTruncatedHeader = []byte{0x00}
-	// StatefulPCECapability with invalid body length (3 instead of 4)
-	testDecodeStatefulInvalidBody = append(tlvHeader(TLVStatefulPCECapability, 3), 0x00, 0x00, 0x00)
-	// Unknown TLV claims 8 bytes, only 2 provided
-	testDecodeUnknownTruncatedValue = []byte{0xff, 0xff, 0x00, 0x08, 0x01, 0x02}
-	// Multiple TLVs: StatefulPCECapability + SymbolicPathName("Test")
-	testDecodeMultipleTLVs = append(
+	testDecodeUnknownTLVBytes        = append(tlvHeader(TLVType(0xffff), 4), 0xde, 0xad, 0xbe, 0xef)
+	testDecodeTruncatedHeader        = []byte{0x00}
+	testDecodeStatefulInvalidBody    = append(tlvHeader(TLVStatefulPCECapability, 3), 0x00, 0x00, 0x00)
+	testDecodeUnknownTruncatedValue  = []byte{0xff, 0xff, 0x00, 0x08, 0x01, 0x02}
+	testDecodeMultipleTLVs           = append(
 		append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x01),
 		append(tlvHeader(TLVSymbolicPathName, 4), 'T', 'e', 's', 't')...,
 	)
-	// Truncated TLV value (declares length 8 but only 2 bytes)
-	testDecodeTruncatedValue = []byte{0x00, 0x10, 0x00, 0x08, 0x00, 0x00}
-	// Truncated TLV padding (odd length missing pad byte)
+	testDecodeTruncatedValue   = []byte{0x00, 0x10, 0x00, 0x08, 0x00, 0x00}
 	testDecodeTruncatedPadding = []byte{0x00, 0xff, 0x00, 0x03, 0x01, 0x02, 0x03}
 )
 
-// TestDecodeTLV tests DecodeTLV.
 func TestDecodeTLV(t *testing.T) {
 	cases := map[string]struct {
 		input   []byte
@@ -1701,27 +1664,41 @@ func TestDecodeTLV(t *testing.T) {
 	}
 }
 
-// TestDecodeTLVs tests DecodeTLVs.
 func TestDecodeTLVs(t *testing.T) {
+	invalidPaddingBytes := func() []byte {
+		valueLen := 5
+		header := tlvHeader(0xFFFF, uint16(valueLen))
+		body := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+		tlv := append(header, body...)
+		tlv = append(tlv, 0xFF, 0x00, 0x00) // invalid padding (should be 0x00)
+		return tlv
+	}()
+
 	cases := map[string]struct {
 		input   []byte
 		wantErr bool
 		wantLen int
+		errMsg  string
 	}{
-		"Empty":               {[]byte{}, false, 0},
-		"SingleKnownTLV":      {testDecodeStatefulLSPUpdateBytes, false, 1},
-		"MultipleTLVs":        {testDecodeMultipleTLVs, false, 2},
-		"TruncatedTLVHeader":  {[]byte{0x00, 0x10, 0x00}, true, 0},
-		"TruncatedTLVValue":   {testDecodeTruncatedValue, true, 0},
-		"TruncatedTLVPadding": {testDecodeTruncatedPadding, true, 0},
-		"InvalidKnownTLVBody": {append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x00), false, 1},
+		"Empty":               {[]byte{}, false, 0, ""},
+		"SingleKnownTLV":      {testDecodeStatefulLSPUpdateBytes, false, 1, ""},
+		"MultipleTLVs":        {testDecodeMultipleTLVs, false, 2, ""},
+		"TruncatedTLVHeader":  {[]byte{0x00, 0x10, 0x00}, true, 0, "truncated TLV header"},
+		"TruncatedTLVValue":   {testDecodeTruncatedValue, true, 0, "truncated TLV value"},
+		"TruncatedTLVPadding": {testDecodeTruncatedPadding, true, 0, "truncated TLV padding"},
+		"InvalidKnownTLVBody": {append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x00), false, 1, ""},
+		"InvalidPadding":      {invalidPaddingBytes, true, 0, "invalid TLV padding"},
 	}
 
 	for name, tt := range cases {
 		t.Run(name, func(t *testing.T) {
 			tlvs, err := DecodeTLVs(tt.input)
 			if tt.wantErr {
-				assert.Error(t, err, "expected error for '%s'", name)
+				require.Error(t, err, "expected error for '%s'", name)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg, "error message mismatch for '%s'", name)
+				}
+				assert.Nil(t, tlvs)
 			} else {
 				require.NoError(t, err, "unexpected error for '%s'", name)
 				assert.Len(t, tlvs, tt.wantLen, "TLV count mismatch for '%s'", name)
@@ -1730,19 +1707,31 @@ func TestDecodeTLVs(t *testing.T) {
 	}
 }
 
-// TestDecodeTLVs_SubTLVDecodeError tests that DecodeTLVs returns an error if a sub-TLV fails to decode.
-func TestDecodeTLVs_SubTLVDecodeError(t *testing.T) {
+func TestDecodeTLVs_SubTLV(t *testing.T) {
 	fixedPart := make([]byte, PathSetupTypeCapabilityFixedPartLength)
 	fixedPart[PathSetupTypeCapabilityPSTCountOffset] = 0x01 // Set PST count in fixed part
 	pathSetupType := []byte{0x00}
 	subTLV := append(tlvHeader(TLVStatefulPCECapability, 4), 0x01, 0x02)
-
 	value := append(fixedPart, pathSetupType...)
 	value = append(value, subTLV...)
-
 	header := tlvHeader(TLVPathSetupTypeCapability, uint16(len(value)))
 	data := append(header, value...)
 
-	_, err := DecodeTLVs(data)
-	assert.Error(t, err, "expected DecodeTLV error for invalid subTLV")
+	cases := map[string]struct {
+		input   []byte
+		wantErr bool
+	}{
+		"InvalidSubTLV": {data, true},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := DecodeTLVs(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error for '%s'", name)
+			} else {
+				assert.NoError(t, err, "unexpected error for '%s'", name)
+			}
+		})
+	}
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1258,6 +1258,20 @@ var (
 
 	testSRPolicyCPathIDTooShort        = []byte{0x00, 0x39, 0x00, 0x0a, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} // Less than 16 bytes for OriginatorAddr
 	testSRPolicyCPathIDTruncatedHeader = []byte{0x00, 0x39, 0x00}                                                                   // Truncated header (less than 4 bytes)
+
+	testSRPolicyCPathIDInvalid = &SRPolicyCandidatePathIdentifier{
+		OriginatorAddr: netip.Addr{}, // zero value, IsValid() == false
+	}
+	testSRPolicyCPathIDInvalidBytes = []byte{
+		0x00, 0x39, 0x00, 0x1c, // type + length
+		0x0a, 0x00, 0x00, 0x00, // protocol + mbz
+		0x00, 0x00, 0x00, 0x00, // ASN
+		0x00, 0x00, 0x00, 0x00, // originator addr (16 bytes)
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01, // discriminator
+	}
 )
 
 // TestSRPolicyCandidatePathIdentifier_DecodeFromBytes tests SRPolicyCandidatePathIdentifier.DecodeFromBytes.
@@ -1279,6 +1293,16 @@ func TestSRPolicyCandidatePathIdentifier_Serialize(t *testing.T) {
 	}{
 		"SerializeIPv4": {testSRPolicyCPathIDIPv4, testSRPolicyCPathIDIPv4Bytes},
 		"SerializeIPv6": {testSRPolicyCPathIDIPv6, testSRPolicyCPathIDIPv6Bytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestSRPolicyCandidatePathIdentifier_Serialize_Invalid(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"ZeroAddr": {testSRPolicyCPathIDInvalid, testSRPolicyCPathIDInvalidBytes},
 	}
 	runTLVSerializeTests(t, cases)
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -701,10 +701,11 @@ func TestPsts_MarshalJSON(t *testing.T) {
 		expected string
 	}{
 		"Nil Psts":      {nil, "null"},
-		"Empty Psts":    {Psts{}, ""},
-		"Single Pst":    {Psts{Pst(0x01)}, "1"},
-		"Multiple Psts": {Psts{Pst(0x01), Pst(0x02)}, "1,2"},
+		"Empty Psts":    {Psts{}, "[]"},
+		"Single Pst":    {Psts{Pst(1)}, "[1]"},
+		"Multiple Psts": {Psts{Pst(1), Pst(2)}, "[1,2]"},
 	}
+
 	for name, tt := range cases {
 		t.Run(name, func(t *testing.T) {
 			actual, err := tt.input.MarshalJSON()

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1044,15 +1044,20 @@ var (
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x01,
 	}
+	testExtendedAssociationIDValueTooShort = []byte{
+		byte(TLVExtendedAssociationID >> 8), byte(TLVExtendedAssociationID & 0xff), 0x00, 0x03,
+		0x00, 0x00, 0x00,
+	}
 )
 
 func TestExtendedAssociationID_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
-		"IPv4":              {testIPv4ExtendedAssociationIDBytes, testIPv4ExtendedAssociationID, false},
-		"IPv6":              {testIPv6ExtendedAssociationIDBytes, testIPv6ExtendedAssociationID, false},
-		"TooShort":          {testExtendedAssociationIDTooShort, nil, true},
-		"InvalidLength":     {testExtendedAssociationIDInvalidLen, nil, true},
-		"UnsupportedLength": {testExtendedAssociationIDUnsupportedLen, nil, true},
+		"IPv4":                  {testIPv4ExtendedAssociationIDBytes, testIPv4ExtendedAssociationID, false},
+		"IPv6":                  {testIPv6ExtendedAssociationIDBytes, testIPv6ExtendedAssociationID, false},
+		"TooShort":              {testExtendedAssociationIDTooShort, nil, true},
+		"ValueTooShortForColor": {testExtendedAssociationIDValueTooShort, nil, true},
+		"InvalidLength":         {testExtendedAssociationIDInvalidLen, nil, true},
+		"UnsupportedLength":     {testExtendedAssociationIDUnsupportedLen, nil, true},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &ExtendedAssociationID{} })
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -922,7 +922,7 @@ func TestPathSetupTypeCapability_MarshalLogObject(t *testing.T) {
 				"pathSetupTypes": []interface{}{
 					"Traffic engineering path is set up using Segment Routing (RFC8664)",
 				},
-				"subTLVs": []interface{}{"0x53522d5043452d4341504142494c49545920285246433836363429"}, // ASCII: "SR-PCE-CAPABILITY (RFC8664)"
+				"subTLVs": []interface{}{"0x53522d5043452d4341504142494c49545920285246433836363429 (SR-PCE-CAPABILITY (RFC8664))"},
 			},
 		},
 		"NilTLV": {

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -872,6 +872,26 @@ var (
 	}
 )
 
+func TestPathSetupTypeCapability_pstCount(t *testing.T) {
+	cases := map[string]struct {
+		numPST   int
+		expected int
+	}{
+		"BelowMax": {numPST: 10, expected: 10},
+		"AtMax":    {numPST: MaxPathSetupTypes, expected: MaxPathSetupTypes},
+		"AboveMax": {numPST: MaxPathSetupTypes + 10, expected: MaxPathSetupTypes},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			tlv := &PathSetupTypeCapability{
+				PathSetupTypes: make(Psts, tt.numPST),
+			}
+			assert.Equal(t, tt.expected, tlv.pstCount())
+		})
+	}
+}
+
 func TestPathSetupTypeCapability_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
 		"ValidBasic":               {testPathSetupTypeCapabilityBasicBytes, testPathSetupTypeCapabilityBasic, false},

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -397,7 +397,7 @@ var (
 	testIPv6LSPIdentifiers = NewIPv6LSPIdentifiers(
 		netip.MustParseAddr("2001:db8::1"),
 		netip.MustParseAddr("2001:db8::2"),
-		1, 2, [16]byte{},
+		1, 2, [IPv6AddrLen]byte{},
 	)
 
 	// Serialized TLV bytes for testIPv6LSPIdentifiers.
@@ -457,7 +457,7 @@ func TestIPv6LSPIdentifiers_MarshalLogObject(t *testing.T) {
 			&IPv6LSPIdentifiers{
 				LSPID:            1,
 				TunnelID:         2,
-				ExtendedTunnelID: [16]byte{},
+				ExtendedTunnelID: [IPv6AddrLen]byte{},
 			},
 			map[string]interface{}{
 				"lspID":            uint16(1),

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -6,605 +6,1696 @@
 package pcep
 
 import (
+	"fmt"
 	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 )
 
-func TestStatefulPCECapability_DecodeFromBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []uint8
-		expected *StatefulPCECapability
-		err      bool
+func TestTLVType_String(t *testing.T) {
+	cases := map[string]struct {
+		tlvType  TLVType
+		expected string
 	}{
-		{
-			name:     "Single capability: LSP Update enabled",
-			input:    NewStatefulPCECapability(0x01).Serialize(),
-			expected: NewStatefulPCECapability(0x01),
-			err:      false,
-		},
-		{
-			name:     "All capabilities enabled",
-			input:    NewStatefulPCECapability(0x3F).Serialize(),
-			expected: NewStatefulPCECapability(0x3F),
-			err:      false,
-		},
-		{
-			name:     "Input too short (missing TLV body)",
-			input:    []uint8{uint8(TLVStatefulPCECapability >> 8), uint8(TLVStatefulPCECapability & 0xFF), 0x00, 0x04}, // type=0x0010, length=4, but body missing
-			expected: nil,
-			err:      true,
-		},
+		"StatefulPCECapability": {TLVStatefulPCECapability, "STATEFUL-PCE-CAPABILITY (RFC8231)"},
+		"IPv4LSPIdentifiers":    {TLVIPv4LSPIdentifiers, "IPV4-LSP-IDENTIFIERS (RFC8231)"},
+		"UnknownType":           {TLVType(0xdead), "Unknown TLV (0xdead)"},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var actual StatefulPCECapability
-			err := actual.DecodeFromBytes(tt.input)
-			if tt.err {
-				assert.Error(t, err, "expected error for input: %v", tt.input)
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.tlvType.String()
+			assert.Equal(t, tt.expected, actual, "unexpected TLVType.String() result")
+		})
+	}
+}
+
+func TestTLVMap(t *testing.T) {
+	cases := map[string]struct {
+		tlvType  TLVType
+		expected TLVInterface
+	}{
+		"StatefulPCECapability":   {TLVStatefulPCECapability, &StatefulPCECapability{}},
+		"SymbolicPathName":        {TLVSymbolicPathName, &SymbolicPathName{}},
+		"IPv4LSPIdentifiers":      {TLVIPv4LSPIdentifiers, &IPv4LSPIdentifiers{}},
+		"IPv6LSPIdentifiers":      {TLVIPv6LSPIdentifiers, &IPv6LSPIdentifiers{}},
+		"LSPDBVersion":            {TLVLSPDBVersion, &LSPDBVersion{}},
+		"SRPCECapability":         {TLVSRPCECapability, &SRPCECapability{}},
+		"PathSetupType":           {TLVPathSetupType, &PathSetupType{}},
+		"ExtendedAssociationID":   {TLVExtendedAssociationID, &ExtendedAssociationID{}},
+		"PathSetupTypeCapability": {TLVPathSetupTypeCapability, &PathSetupTypeCapability{}},
+		"AssocTypeList":           {TLVAssocTypeList, &AssocTypeList{}},
+		"SRPolicyCPathID":         {TLVSRPolicyCPathID, &SRPolicyCandidatePathIdentifier{}},
+		"SRPolicyCPathPreference": {TLVSRPolicyCPathPreference, &SRPolicyCandidatePathPreference{}},
+		"Color":                   {TLVColor, &Color{}},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			constructor, ok := tlvMap[tt.tlvType]
+			require.True(t, ok, "constructor not found for TLVType '%s'", name)
+			actual := constructor()
+			assert.IsType(t, tt.expected, actual, "unexpected type for TLV '%s'", name)
+		})
+	}
+}
+
+type TLVTestCase struct {
+	input    []byte
+	expected TLVInterface
+	wantErr  bool
+}
+
+func runTLVDecodeTests(t *testing.T, cases map[string]TLVTestCase, constructor func() TLVInterface) {
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			tlv := constructor()
+			err := tlv.DecodeFromBytes(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error for '%s' but got none", name)
 			} else {
-				assert.NoError(t, err, "unexpected error for input: %v", tt.input)
-				assert.Equal(t, *tt.expected, actual, "decoded capability mismatch")
+				assert.NoError(t, err, "unexpected error for '%s'", name)
+				assert.Equal(t, tt.expected, tlv, "decoded value mismatch for '%s'", name)
 			}
 		})
 	}
+}
+
+func runTLVSerializeTests(t *testing.T, cases map[string]struct {
+	input    TLVInterface
+	expected []byte
+}) {
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.input.Serialize()
+			assert.Equal(t, tt.expected, actual, "serialized value mismatch for '%s'", name)
+		})
+	}
+}
+
+type CapStringsInterface interface {
+	CapStrings() []string
+}
+
+func runCapStringsTests(t *testing.T, cases map[string]struct {
+	input    CapStringsInterface
+	expected []string
+}) {
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.input.CapStrings()
+			assert.Equal(t, tt.expected, actual, "capabilities mismatch for '%s'", name)
+		})
+	}
+}
+
+func runTLVLenTests(t *testing.T, cases map[string]struct {
+	input    TLVInterface
+	expected uint16
+}) {
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.input.Len()
+			assert.Equal(t, tt.expected, actual, "length mismatch for '%s'", name)
+		})
+	}
+}
+
+func tlvHeader(tlvType TLVType, length uint16) []byte {
+	return []byte{byte(tlvType >> 8), byte(tlvType & 0xff), byte(length >> 8), byte(length & 0xff)}
+}
+
+// Test data for StatefulPCECapability.
+var (
+	testStatefulLSPUpdate      = NewStatefulPCECapability(0x00000001) // LSP Update capability only
+	testStatefulAll            = NewStatefulPCECapability(0x0000083f) // All capabilities enabled
+	testStatefulNone           = NewStatefulPCECapability(0x00000000) // No capabilities enabled
+	testStatefulLSPUpdateBytes = append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x01)
+	testStatefulAllBytes       = append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x08, 0x3f)
+	testStatefulNoneBytes      = append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x00)
+	testStatefulMissingTLVBody = tlvHeader(TLVStatefulPCECapability, 4)
+	testStatefulTooShort       = append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x01, 0x02)
+	testStatefulInvalidLength  = append(tlvHeader(TLVStatefulPCECapability, 3), 0x00, 0x00, 0x00)
+	testCapsAllStrings         = []string{"Stateful", "Update", "Include-DB-Ver", "Instantiation", "Triggered-Resync", "Delta-LSP-Sync", "Triggered-Initial-Sync", "Color"}
+	testCapsNoneStrings        = []string{"Stateful"}
+)
+
+func TestStatefulPCECapability_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"SingleCapability":   {testStatefulLSPUpdateBytes, testStatefulLSPUpdate, false},
+		"AllCapabilities":    {testStatefulAllBytes, testStatefulAll, false},
+		"MissingTLVBody":     {testStatefulMissingTLVBody, nil, true},
+		"ValueTooShort":      {testStatefulTooShort, nil, true},
+		"InvalidValueLength": {testStatefulInvalidLength, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &StatefulPCECapability{} })
 }
 
 func TestStatefulPCECapability_Serialize(t *testing.T) {
-	tests := []struct {
-		name string
-		bits uint32
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
 	}{
-		{
-			name: "LSP Update Capability enabled",
-			bits: 0x01,
-		},
-		{
-			name: "All capabilities enabled",
-			bits: 0x3F,
-		},
-		{
-			name: "No capabilities enabled",
-			bits: 0x00,
-		},
+		"LSPUpdate":       {testStatefulLSPUpdate, testStatefulLSPUpdateBytes},
+		"AllCapabilities": {testStatefulAll, testStatefulAllBytes},
+		"NoCapabilities":  {testStatefulNone, testStatefulNoneBytes},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tlv := NewStatefulPCECapability(tt.bits)
-			expected := AppendByteSlices(
-				Uint16ToByteSlice(TLVStatefulPCECapability),
-				Uint16ToByteSlice(TLVStatefulPCECapabilityValueLength),
-				Uint32ToByteSlice(tlv.SetFlags()),
-			)
-
-			assert.Equal(t, expected, tlv.Serialize(), "serialized output mismatch")
-		})
-	}
+	runTLVSerializeTests(t, cases)
 }
 
 func TestStatefulPCECapability_MarshalLogObject(t *testing.T) {
-	tests := []struct {
-		name     string
-		tlv      *StatefulPCECapability
+	cases := map[string]struct {
+		input    *StatefulPCECapability
 		expected bool
 	}{
-		{
-			name: "LSP Update Capability enabled",
-			tlv: &StatefulPCECapability{
-				LSPUpdateCapability: true,
-			},
-			expected: true,
-		},
-		{
-			name: "LSP Update Capability disabled",
-			tlv: &StatefulPCECapability{
-				LSPUpdateCapability: false,
-			},
-			expected: false,
-		},
+		"LSPUpdateEnabled":  {testStatefulLSPUpdate, true},
+		"LSPUpdateDisabled": {testStatefulNone, false},
+		"NilTLV":            {nil, false},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
 			enc := zapcore.NewMapObjectEncoder()
-			err := tt.tlv.MarshalLogObject(enc)
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
 
-			assert.NoError(t, err, "expected no error while marshaling log object")
-			assert.Equal(t, tt.expected, enc.Fields["lspUpdateCapability"], "field 'lspUpdateCapability' mismatch")
-		})
-	}
-}
-
-func TestStatefulPCECapability_CapStrings(t *testing.T) {
-	tests := []struct {
-		name     string
-		bits     uint32
-		expected []string
-	}{
-		{
-			name:     "All capabilities enabled",
-			bits:     0x3F,
-			expected: []string{"Stateful", "Update", "Include-DB-Ver", "Instantiation", "Triggered-Resync", "Delta-LSP-Sync", "Triggered-Initial-Sync"},
-		},
-		{
-			name:     "No capabilities enabled",
-			bits:     0x00,
-			expected: []string{"Stateful"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			input := NewStatefulPCECapability(tt.bits)
-			assert.ElementsMatch(t, tt.expected, input.CapStrings(), "capabilities mismatch")
-		})
-	}
-}
-
-func TestSymbolicPathName_DecodeFromBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []uint8
-		expected *SymbolicPathName
-		err      bool
-	}{
-		{
-			name:     "Valid Symbolic Path Name",
-			input:    NewSymbolicPathName("Test").Serialize(),
-			expected: NewSymbolicPathName("Test"),
-			err:      false,
-		},
-		{
-			name:     "Invalid input (too short data)",
-			input:    []byte{0x00, 0x11, 0x00, 0x02, 'T'}, // Input too short for valid decoding
-			expected: NewSymbolicPathName(""),
-			err:      true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var tlv SymbolicPathName
-			err := tlv.DecodeFromBytes(tt.input)
-			if tt.err {
-				assert.Error(t, err, "expected error for input: %v", tt.input)
+			got, ok := enc.Fields["lspUpdateCapability"]
+			if tt.input == nil {
+				assert.False(t, ok, "expected no lspUpdateCapability field for nil TLV")
 			} else {
-				assert.NoError(t, err, "unexpected error for input: %v", tt.input)
-				assert.Equal(t, tt.expected, &tlv)
+				assert.Equal(t, tt.expected, got, "unexpected value for '%s'", name)
 			}
 		})
 	}
 }
 
-func TestSymbolicPathName_Serialize(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *SymbolicPathName
-		expected []uint8
+func TestStatefulPCECapability_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
 	}{
-		{
-			name:     "Valid Symbolic Path Name",
-			input:    NewSymbolicPathName("Test"),
-			expected: NewSymbolicPathName("Test").Serialize(),
-		},
+		"LSPUpdate": {testStatefulLSPUpdate, TLVValueOffset + 4},
+	}
+	runTLVLenTests(t, cases)
+}
+
+func TestStatefulPCECapability_CapStrings(t *testing.T) {
+	cases := map[string]struct {
+		input    CapStringsInterface
+		expected []string
+	}{
+		"AllCapabilities": {testStatefulAll, testCapsAllStrings},
+		"NoCapabilities":  {testStatefulNone, testCapsNoneStrings},
+	}
+	runCapStringsTests(t, cases)
+}
+
+// Test data for SymbolicPathName.
+var (
+	testSymbolicPathName            = NewSymbolicPathName("Test") // Normal case
+	testSymbolicPathNameWithPadding = NewSymbolicPathName("ABC")  // 1 padding byte
+	testSymbolicPathNameEmptyString = NewSymbolicPathName("")     // Empty string
+
+	testSymbolicPathNameBytes            = []byte{byte(TLVSymbolicPathName >> 8), byte(TLVSymbolicPathName & 0xff), 0x00, 0x04, 'T', 'e', 's', 't'}
+	testSymbolicPathNameEmptyBytes       = []byte{byte(TLVSymbolicPathName >> 8), byte(TLVSymbolicPathName & 0xff), 0x00, 0x00}
+	testSymbolicPathNameInvalidUTF8Bytes = []byte{byte(TLVSymbolicPathName >> 8), byte(TLVSymbolicPathName & 0xff), 0x00, 0x01, 0xff}
+	testSymbolicPathNameTooShort         = []byte{byte(TLVSymbolicPathName >> 8), byte(TLVSymbolicPathName & 0xff), 0x00, 0x02, 'T'}
+	testSymbolicPathNameTooLong          = []byte{byte(TLVSymbolicPathName >> 8), byte(TLVSymbolicPathName & 0xff), 0x00, 0x01, 'T', 'e'}
+	testSymbolicPathNameTruncatedHeader  = []byte{byte(TLVSymbolicPathName >> 8), byte(TLVSymbolicPathName & 0xff), 0x00}
+)
+
+func TestSymbolicPathName_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"Valid":           {testSymbolicPathNameBytes, testSymbolicPathName, false},
+		"Empty":           {testSymbolicPathNameEmptyBytes, testSymbolicPathNameEmptyString, false},
+		"InvalidUTF8":     {testSymbolicPathNameInvalidUTF8Bytes, nil, true},
+		"TruncatedHeader": {testSymbolicPathNameTruncatedHeader, nil, true},
+		"TooShort":        {testSymbolicPathNameTooShort, nil, true},
+		"TooLong":         {testSymbolicPathNameTooLong, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &SymbolicPathName{} })
+}
+
+func TestSymbolicPathName_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"Valid": {testSymbolicPathName, testSymbolicPathNameBytes},
+		"Empty": {testSymbolicPathNameEmptyString, testSymbolicPathNameEmptyBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestSymbolicPathName_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *SymbolicPathName
+		expected string
+	}{
+		"Valid":  {testSymbolicPathName, "Test"},
+		"Empty":  {testSymbolicPathNameEmptyString, ""},
+		"NilTLV": {nil, ""},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Serialize())
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+
+			if tt.input == nil {
+				_, ok := enc.Fields["symbolicPathName"]
+				assert.False(t, ok, "expected no symbolicPathName field for nil TLV")
+			} else {
+				assert.Equal(t, tt.expected, enc.Fields["symbolicPathName"], "unexpected value for '%s'", name)
+			}
 		})
 	}
 }
 
 func TestSymbolicPathName_Len(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *SymbolicPathName
+	cases := map[string]struct {
+		input    TLVInterface
 		expected uint16
 	}{
-		{
-			name:     "Symbolic Path Name length",
-			input:    NewSymbolicPathName("Test"),
-			expected: TLVHeaderLength + 4,
-		},
-		{
-			name:     "Symbolic Path Name with padding",
-			input:    NewSymbolicPathName("ABC"), // 3 bytes + 1 byte padding
-			expected: TLVHeaderLength + 3 + 1,
-		},
+		"Valid":  {testSymbolicPathName, TLVValueOffset + 4},
+		"Padded": {testSymbolicPathNameWithPadding, TLVValueOffset + 4}, // "ABC" + 1 padding
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Len())
-		})
-	}
+	runTLVLenTests(t, cases)
 }
 
-func TestIPv4LSPIdentifiers_DecodeFromBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []uint8
-		expected *IPv4LSPIdentifiers
-		err      bool
-	}{
-		{
-			name:     "Valid IPv4 LSP Identifiers",
-			input:    NewIPv4LSPIdentifiers(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr("192.0.2.2"), 1, 2, 1234).Serialize(),
-			expected: NewIPv4LSPIdentifiers(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr("192.0.2.2"), 1, 2, 1234),
-			err:      false,
-		},
-		{
-			name: "Invalid IPv4 LSP Identifiers (truncated '192.0.2.1')",
-			input: []uint8{
-				0x00, 0x12, 0x00, 0x14, // Type (0x12) and Length (0x10)
-				0xC0, 0x00, 0x02, // Incomplete address: missing last byte (0x01)
-			},
-			expected: NewIPv4LSPIdentifiers(netip.Addr{}, netip.Addr{}, 0, 0, 0),
-			err:      true,
-		},
-		{
-			name: "Invalid IPv4 LSP Identifiers (extra bytes after '192.0.2.1')",
-			input: []uint8{
-				0x00, 0x12, 0x00, 0x14, // Type (0x12) and Length (0x10)
-				0xC0, 0x00, 0x02, 0x01, // Valid IPv4 address: 192.0.2.1
-				0xDE, 0xAD, 0xBE, 0xEF, // Extra unexpected bytes
-			},
-			expected: NewIPv4LSPIdentifiers(netip.Addr{}, netip.Addr{}, 0, 0, 0),
-			err:      true,
-		},
+// Test data for IPv4LSPIdentifiers.
+var (
+	testIPv4LSPIdentifiers      = NewIPv4LSPIdentifiers(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr("192.0.2.2"), 1, 2, 1234)
+	testIPv4LSPIdentifiersBytes = append(tlvHeader(TLVIPv4LSPIdentifiers, TLVIPv4LSPIdentifiersValueLength),
+		0xc0, 0x00, 0x02, 0x01, // Sender Address
+		0x00, 0x01, // LSP ID
+		0x00, 0x02, // Tunnel ID
+		0x00, 0x00, 0x04, 0xd2, // Extended Tunnel ID
+		0xc0, 0x00, 0x02, 0x02, // Endpoint Address
+	)
+	testIPv4LSPIdentifiersTruncated = []byte{
+		byte(TLVIPv4LSPIdentifiers >> 8), byte(TLVIPv4LSPIdentifiers & 0xff), 0x00, 0x03,
+		0xc0, 0x00, 0x02,
 	}
+	testIPv4LSPIdentifiersExtra     = append(testIPv4LSPIdentifiersBytes, 0xde, 0xad, 0xbe, 0xef)
+	testIPv4LSPIdentifiersBadSender = append(
+		tlvHeader(TLVIPv4LSPIdentifiers, TLVIPv4LSPIdentifiersValueLength),
+		0xc0, 0x00, 0x02, // 3 bytes only → invalid sender
+		0x00, 0x01, // LSP ID
+		0x00, 0x02, // Tunnel ID
+		0x00, 0x00, 0x04, 0xd2, // Extended Tunnel ID
+		0xc0, 0x00, 0x02, 0x02, // Endpoint Address
+	)
+	testIPv4LSPIdentifiersBadEndpoint = append(
+		tlvHeader(TLVIPv4LSPIdentifiers, TLVIPv4LSPIdentifiersValueLength),
+		0xc0, 0x00, 0x02, 0x01, // Sender Address
+		0x00, 0x01, // LSP ID
+		0x00, 0x02, // Tunnel ID
+		0x00, 0x00, 0x04, 0xd2, // Extended Tunnel ID
+		0xc0, 0x00, 0x02, // Endpoint Address (3 bytes only)
+	)
+)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var tlv IPv4LSPIdentifiers
-			err := tlv.DecodeFromBytes(tt.input)
-			if tt.err {
-				assert.Error(t, err, "expected error for input: %v", tt.input)
-			} else {
-				assert.NoError(t, err, "unexpected error for input: %v", tt.input)
-				assert.Equal(t, tt.expected, &tlv)
-			}
-		})
+func TestIPv4LSPIdentifiers_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidIPv4LSPIdentifiers":        {testIPv4LSPIdentifiersBytes, testIPv4LSPIdentifiers, false},
+		"TruncatedIPv4LSPIdentifiers":    {testIPv4LSPIdentifiersTruncated, nil, true},
+		"ExtraBytesInIPv4LSPIdentifiers": {testIPv4LSPIdentifiersExtra, nil, true},
+		"InvalidSenderAddress":           {testIPv4LSPIdentifiersBadSender, nil, true},
+		"InvalidEndpointAddress":         {testIPv4LSPIdentifiersBadEndpoint, nil, true},
 	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &IPv4LSPIdentifiers{} })
 }
 
 func TestIPv4LSPIdentifiers_Serialize(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *IPv4LSPIdentifiers
-		expected []uint8
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
 	}{
-		{
-			name:     "Valid IPv4 LSP Identifiers",
-			input:    NewIPv4LSPIdentifiers(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr("192.0.2.2"), 1, 2, 1234),
-			expected: NewIPv4LSPIdentifiers(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr("192.0.2.2"), 1, 2, 1234).Serialize(),
+		"ValidIPv4LSPIdentifiers": {testIPv4LSPIdentifiers, testIPv4LSPIdentifiersBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestIPv4LSPIdentifiers_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *IPv4LSPIdentifiers
+		expected map[string]interface{}
+	}{
+		"NilTLV": {nil, map[string]interface{}{}},
+		"EmptyTLV": {
+			&IPv4LSPIdentifiers{
+				LSPID:            1,
+				TunnelID:         2,
+				ExtendedTunnelID: 1234,
+			},
+			map[string]interface{}{
+				"lspID":            uint16(1),
+				"tunnelID":         uint16(2),
+				"extendedTunnelID": uint32(1234),
+			},
+		},
+		"FullTLV": {
+			testIPv4LSPIdentifiers,
+			map[string]interface{}{
+				"ipv4TunnelSenderAddress":   "192.0.2.1",
+				"ipv4TunnelEndpointAddress": "192.0.2.2",
+				"lspID":                     uint16(1),
+				"tunnelID":                  uint16(2),
+				"extendedTunnelID":          uint32(1234),
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Serialize())
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
 		})
 	}
 }
 
-func TestIPv6LSPIdentifiers_DecodeFromBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []uint8
-		expected *IPv6LSPIdentifiers
-		err      bool
+func TestIPv4LSPIdentifiers_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
 	}{
-		{
-			name:     "Valid IPv6 LSP Identifiers",
-			input:    NewIPv6LSPIdentifiers(netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr("2001:db8::2"), 1, 2, [16]byte{}).Serialize(),
-			expected: NewIPv6LSPIdentifiers(netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr("2001:db8::2"), 1, 2, [16]byte{}),
-			err:      false,
-		},
-		{
-			name: "Invalid IPv6 LSP Identifiers (truncated '2001:db8::1')",
-			input: []uint8{
-				0x00, 0x13, 0x00, 0x20, // Type IPV6-LSP-IDENTIFIERS (0x13)、Length 32 (0x20)
-				0x20, 0x01, 0x0D, 0xB8, // Start of '2001:db8::'
-				0x00, 0x00, 0x00, // Incomplete (should be 16 bytes total)
-			},
-			expected: NewIPv6LSPIdentifiers(netip.Addr{}, netip.Addr{}, 0, 0, [16]byte{}),
-			err:      true,
-		},
-		{
-			name: "Invalid IPv6 LSP Identifiers (extra bytes after '2001:db8::1')",
-			input: []uint8{
-				0x00, 0x13, 0x00, 0x20, // Type IPV6-LSP-IDENTIFIERS (0x13), Length 32 (0x20)
-				0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // Valid IPv6: 2001:db8::1
-				0xCA, 0xFE, 0xBA, 0xBE, // Extra unexpected bytes
-			},
-			expected: NewIPv6LSPIdentifiers(netip.Addr{}, netip.Addr{}, 0, 0, [16]byte{}),
-			err:      true,
-		},
+		"ValidIPv4LSPIdentifiersLength": {testIPv4LSPIdentifiers, TLVValueOffset + TLVIPv4LSPIdentifiersValueLength},
+	}
+	runTLVLenTests(t, cases)
+}
+
+// Test data for IPv6LSPIdentifiers.
+var (
+	// Valid IPv6LSPIdentifiers with typical values.
+	testIPv6LSPIdentifiers = NewIPv6LSPIdentifiers(
+		netip.MustParseAddr("2001:db8::1"),
+		netip.MustParseAddr("2001:db8::2"),
+		1, 2, [16]byte{},
+	)
+
+	// Serialized TLV bytes for testIPv6LSPIdentifiers.
+	testIPv6LSPIdentifiersBytes = append(
+		tlvHeader(TLVIPv6LSPIdentifiers, TLVIPv6LSPIdentifiersValueLength),
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // Sender Address
+		0x00, 0x01, // LSP ID
+		0x00, 0x02, // Tunnel ID
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Extended Tunnel ID (all zeros)
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // Endpoint Address
+	)
+
+	// TLV bytes with intentionally invalid value length (to cover valueLen != expected case)
+	testIPv6LSPIdentifiersInvalidLength = []byte{
+		byte(TLVIPv6LSPIdentifiers >> 8),
+		byte(TLVIPv6LSPIdentifiers & 0xff),
+		0x00, 0x10, // Length = 16 (too short, expected 40)
+		// Fill 16 bytes of value (only part of sender address)
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, // First half of Sender Address
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // Second half of Sender Address
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var tlv IPv6LSPIdentifiers
-			err := tlv.DecodeFromBytes(tt.input)
-			if tt.err {
-				assert.Error(t, err, "expected error for input: %v", tt.input)
-			} else {
-				assert.NoError(t, err, "unexpected error for input: %v", tt.input)
-				assert.Equal(t, tt.expected, &tlv)
-			}
-		})
+	// TLV bytes truncated (cut from the end) to simulate incomplete TLV.
+	testIPv6LSPIdentifiersTruncated = testIPv6LSPIdentifiersBytes[:len(testIPv6LSPIdentifiersBytes)-5]
+
+	// TLV bytes with extra bytes appended at the end.
+	testIPv6LSPIdentifiersExtra = append(testIPv6LSPIdentifiersBytes, 0xca, 0xfe, 0xba, 0xbe)
+)
+
+func TestIPv6LSPIdentifiers_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidIPv6LSPIdentifiers":        {testIPv6LSPIdentifiersBytes, testIPv6LSPIdentifiers, false},
+		"InvalidValueLength":             {testIPv6LSPIdentifiersInvalidLength, nil, true},
+		"TruncatedIPv6LSPIdentifiers":    {testIPv6LSPIdentifiersTruncated, nil, true},
+		"ExtraBytesInIPv6LSPIdentifiers": {testIPv6LSPIdentifiersExtra, nil, true},
 	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &IPv6LSPIdentifiers{} })
 }
 
 func TestIPv6LSPIdentifiers_Serialize(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *IPv6LSPIdentifiers
-		expected []uint8
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
 	}{
-		{
-			name:     "Valid IPv6 LSP Identifiers",
-			input:    NewIPv6LSPIdentifiers(netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr("2001:db8::2"), 1, 2, [16]byte{}),
-			expected: NewIPv6LSPIdentifiers(netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr("2001:db8::2"), 1, 2, [16]byte{}).Serialize(),
+		"ValidIPv6LSPIdentifiers": {testIPv6LSPIdentifiers, testIPv6LSPIdentifiersBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestIPv6LSPIdentifiers_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *IPv6LSPIdentifiers
+		expected map[string]interface{}
+	}{
+		"NilTLV": {nil, map[string]interface{}{}},
+		"EmptyTLV": {
+			&IPv6LSPIdentifiers{
+				LSPID:            1,
+				TunnelID:         2,
+				ExtendedTunnelID: [16]byte{},
+			},
+			map[string]interface{}{
+				"lspID":            uint16(1),
+				"tunnelID":         uint16(2),
+				"extendedTunnelID": "00000000000000000000000000000000",
+			},
+		},
+		"FullTLV": {
+			testIPv6LSPIdentifiers,
+			map[string]interface{}{
+				"ipv6TunnelSenderAddress":   "2001:db8::1",
+				"ipv6TunnelEndpointAddress": "2001:db8::2",
+				"lspID":                     uint16(1),
+				"tunnelID":                  uint16(2),
+				"extendedTunnelID":          "00000000000000000000000000000000",
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Serialize())
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
 		})
 	}
 }
 
-func TestLSPDBVersion_DecodeFromBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []uint8
-		expected *LSPDBVersion
-		err      bool
+func TestIPv6LSPIdentifiers_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
 	}{
-		{
-			name:     "Valid LSPDB Version",
-			input:    NewLSPDBVersion(12345).Serialize(),
-			expected: NewLSPDBVersion(12345),
-			err:      false,
-		},
-		{
-			name:     "Invalid input (too short data)",
-			input:    []byte{0x00, 0x17, 0x00, 0x02}, // Type LSP-DB-VERSION (0x17)、Input too short for valid decoding
-			expected: NewLSPDBVersion(0),
-			err:      true,
-		},
-		{
-			name: "Invalid input (too long data)",
-			input: []byte{
-				0x00, 0x17, 0x00, 0x09, // Type LSP-DB-VERSION (0x17)、Length 8
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39,
-				0x00, // Extra bytes after version
-			},
-			expected: NewLSPDBVersion(0),
-			err:      true,
-		},
+		"ValidIPv6LSPIdentifiersLength": {testIPv6LSPIdentifiers, TLVValueOffset + TLVIPv6LSPIdentifiersValueLength},
 	}
+	runTLVLenTests(t, cases)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var tlv LSPDBVersion
-			err := tlv.DecodeFromBytes(tt.input)
-			if tt.err {
-				assert.Error(t, err, "expected error for input: %v", tt.input)
-			} else {
-				assert.NoError(t, err, "unexpected error for input: %v", tt.input)
-				assert.Equal(t, tt.expected, &tlv)
-			}
-		})
+// Test data for LSPDBVersion.
+var (
+	testLSPDBVersion           = NewLSPDBVersion(12345)
+	testLSPDBVersionBytes      = append(tlvHeader(TLVLSPDBVersion, 8), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39)
+	testLSPDBVersionTruncated  = append(tlvHeader(TLVLSPDBVersion, 4), 0x00, 0x00, 0x00, 0x00)
+	testLSPDBVersionExtra      = append(tlvHeader(TLVLSPDBVersion, 16), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39, 0xde, 0xad, 0xbe, 0xef)
+	testLSPDBVersionCapStrings = []string{"LSP-DB-VERSION"}
+)
+
+func TestLSPDBVersion_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidLSPDBVersion":        {testLSPDBVersionBytes, testLSPDBVersion, false},
+		"TruncatedLSPDBVersion":    {testLSPDBVersionTruncated, nil, true},
+		"ExtraBytesInLSPDBVersion": {testLSPDBVersionExtra, nil, true},
 	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &LSPDBVersion{} })
 }
 
 func TestLSPDBVersion_Serialize(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *LSPDBVersion
-		expected []uint8
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
 	}{
-		{
-			name:     "Valid LSPDB Version",
-			input:    NewLSPDBVersion(12345),
-			expected: NewLSPDBVersion(12345).Serialize(),
+		"ValidLSPDBVersion": {testLSPDBVersion, testLSPDBVersionBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestLSPDBVersion_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *LSPDBVersion
+		expected map[string]interface{}
+	}{
+		"NilTLV": {nil, map[string]interface{}{}},
+		"EmptyTLV": {
+			&LSPDBVersion{},
+			map[string]interface{}{
+				"versionNumber": uint64(0),
+			},
+		},
+		"FullTLV": {
+			testLSPDBVersion,
+			map[string]interface{}{
+				"versionNumber": uint64(12345),
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Serialize())
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
 		})
 	}
 }
 
 func TestLSPDBVersion_Len(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *LSPDBVersion
+	cases := map[string]struct {
+		input    TLVInterface
 		expected uint16
 	}{
-		{
-			name:     "LSPDB Version length",
-			input:    NewLSPDBVersion(12345),
-			expected: TLVHeaderLength + TLVLSPDBVersionValueLength,
-		},
+		"ValidLSPDBVersionLength": {testLSPDBVersion, TLVValueOffset + TLVLSPDBVersionValueLength},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Len())
-		})
-	}
+	runTLVLenTests(t, cases)
 }
 
-func TestSRPCECapability_DecodeFromBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []uint8
-		expected *SRPCECapability
-		err      bool
-	}{
-		{
-			name:     "Valid SRPCE Capability",
-			input:    NewSRPCECapability(true, true, 42).Serialize(), // Maximum SID Depth 42
-			expected: NewSRPCECapability(true, true, 42),
-			err:      false,
-		},
-		{
-			name:     "Invalid input (too short data)",
-			input:    []uint8{0x00, 0x11, 0x00, 0x02}, // Too short for valid decoding
-			expected: NewSRPCECapability(false, false, 0),
-			err:      true,
-		},
-		{
-			name:     "Invalid input (too long data)",
-			input:    []uint8{0x00, 0x11, 0x00, 0x02, 0x00, 0x00, 0x03, 0x05, 0x01}, // Too long for valid decoding
-			expected: NewSRPCECapability(false, false, 0),
-			err:      true,
-		},
-	}
+func TestLSPDBVersion_CapStrings(t *testing.T) {
+	tlv := &LSPDBVersion{}
+	actual := tlv.CapStrings()
+	assert.Equal(t, testLSPDBVersionCapStrings, actual, "CapStrings() did not return expected value")
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var tlv SRPCECapability
-			err := tlv.DecodeFromBytes(tt.input)
-			if tt.err {
-				assert.Error(t, err, "expected error for input: %v", tt.input)
-			} else {
-				assert.NoError(t, err, "unexpected error for input: %v", tt.input)
-				assert.Equal(t, tt.expected, &tlv)
-			}
-		})
+// Test data for SRPCECapability.
+var (
+	testSRPCECapability               = NewSRPCECapability(true, true, 10)
+	testSRPCECapabilityBytes          = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x0a, 0x00, 0x00)
+	testSRPCECapabilityTruncated      = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x02)
+	testSRPCECapabilityExtra          = append(tlvHeader(TLVSRPCECapability, 8), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
+	testSRPCECapabilityAllEnabled     = &SRPCECapability{HasUnlimitedMaxSIDDepth: true, IsNAISupported: true}
+	testSRPCECapabilityUnlimitedOnly  = &SRPCECapability{HasUnlimitedMaxSIDDepth: true}
+	testSRPCECapabilityNAIOnly        = &SRPCECapability{IsNAISupported: true}
+	testSRPCECapabilityNoneEnabled    = &SRPCECapability{}
+	testSRPCECapabilityAllEnabledStrs = []string{"Unlimited-SID-Depth", "NAI-Supported"}
+	testSRPCECapabilityUnlimitedStrs  = []string{"Unlimited-SID-Depth"}
+	testSRPCECapabilityNAIStrs        = []string{"NAI-Supported"}
+	testSRPCECapabilityNoneStrs       = []string(nil)
+)
+
+func TestSRPCECapability_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidSRPCECapability":        {testSRPCECapabilityBytes, testSRPCECapability, false},
+		"TruncatedSRPCECapability":    {testSRPCECapabilityTruncated, nil, true},
+		"ExtraBytesInSRPCECapability": {testSRPCECapabilityExtra, nil, true},
 	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRPCECapability{} })
 }
 
 func TestSRPCECapability_Serialize(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *SRPCECapability
-		expected []uint8
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
 	}{
-		{
-			name:     "Valid SRPCE Capability",
-			input:    NewSRPCECapability(true, true, 5),
-			expected: NewSRPCECapability(true, true, 5).Serialize(),
+		"ValidSRPCECapability": {testSRPCECapability, testSRPCECapabilityBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestSRPCECapability_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *SRPCECapability
+		expected map[string]interface{}
+	}{
+		"NilTLV": {nil, map[string]interface{}{}},
+		"EmptyTLV": {
+			&SRPCECapability{},
+			map[string]interface{}{
+				"unlimited_max_sid_depth": false,
+				"nai_is_supported":        false,
+				"maximum_sid_depth":       uint8(0),
+			},
+		},
+		"FullTLV": {
+			testSRPCECapability,
+			map[string]interface{}{
+				"unlimited_max_sid_depth": true,
+				"nai_is_supported":        true,
+				"maximum_sid_depth":       uint8(10),
+			},
+		},
+		"OnlyUnlimited": {
+			testSRPCECapabilityUnlimitedOnly,
+			map[string]interface{}{
+				"unlimited_max_sid_depth": true,
+				"nai_is_supported":        false,
+				"maximum_sid_depth":       uint8(0),
+			},
+		},
+		"OnlyNAI": {
+			testSRPCECapabilityNAIOnly,
+			map[string]interface{}{
+				"unlimited_max_sid_depth": false,
+				"nai_is_supported":        true,
+				"maximum_sid_depth":       uint8(0),
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Serialize())
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
 		})
 	}
 }
 
 func TestSRPCECapability_Len(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *SRPCECapability
+	cases := map[string]struct {
+		input    TLVInterface
 		expected uint16
 	}{
-		{
-			name:     "SRPCE Capability length",
-			input:    NewSRPCECapability(true, true, 5),
-			expected: TLVHeaderLength + TLVSRPCECapabilityValueLength,
-		},
+		"ValidSRPCECapabilityLength": {testSRPCECapability, TLVValueOffset + TLVSRPCECapabilityValueLength},
 	}
+	runTLVLenTests(t, cases)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Len())
+func TestSRPCECapability_CapStrings(t *testing.T) {
+	cases := map[string]struct {
+		input    CapStringsInterface
+		expected []string
+	}{
+		"AllCapabilitiesEnabled":          {testSRPCECapabilityAllEnabled, testSRPCECapabilityAllEnabledStrs},
+		"OnlyUnlimitedMaxSIDDepthEnabled": {testSRPCECapabilityUnlimitedOnly, testSRPCECapabilityUnlimitedStrs},
+		"OnlyNAISupportedEnabled":         {testSRPCECapabilityNAIOnly, testSRPCECapabilityNAIStrs},
+		"NoCapabilitiesEnabled":           {testSRPCECapabilityNoneEnabled, testSRPCECapabilityNoneStrs},
+	}
+	runCapStringsTests(t, cases)
+}
+
+func TestPst_String(t *testing.T) {
+	cases := map[string]struct {
+		input    Pst
+		expected string
+	}{
+		"Known PathSetupType":   {Pst(0x01), "Traffic engineering path is set up using Segment Routing (RFC8664)"},
+		"Unknown PathSetupType": {Pst(0xff), "Unknown PathSetupType (0xff)"},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.input.String()
+			assert.Equal(t, tt.expected, actual, "unexpected Pst.String() result for '%s'", name)
 		})
 	}
 }
 
-func TestPathSetupType_DecodeFromBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []uint8
-		expected *PathSetupType
-		err      bool
+func TestPsts_MarshalJSON(t *testing.T) {
+	cases := map[string]struct {
+		input    Psts
+		expected string
 	}{
-		{
-			name:     "Valid PathSetupType SRv6TE",
-			input:    NewPathSetupType(PathSetupTypeSRv6TE).Serialize(),
-			expected: NewPathSetupType(PathSetupTypeSRv6TE),
-			err:      false,
-		},
-		{
-			name:     "Invalid input (too short)",
-			input:    []uint8{0x00, 0x15, 0x00, 0x04}, // insufficient data
-			expected: NewPathSetupType(0),
-			err:      true,
-		},
-		{
-			name:     "Invalid input (too long)",
-			input:    append(NewPathSetupType(PathSetupTypeSRTE).Serialize(), 0x00, 0x00),
-			expected: NewPathSetupType(0),
-			err:      true,
-		},
+		"Nil Psts":      {nil, "null"},
+		"Empty Psts":    {Psts{}, ""},
+		"Single Pst":    {Psts{Pst(0x01)}, "1"},
+		"Multiple Psts": {Psts{Pst(0x01), Pst(0x02)}, "1,2"},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var tlv PathSetupType
-			err := tlv.DecodeFromBytes(tt.input)
-			if tt.err {
-				assert.Error(t, err, "expected error for input: %v", tt.input)
-			} else {
-				assert.NoError(t, err, "unexpected error for input: %v", tt.input)
-				assert.Equal(t, tt.expected, &tlv)
-			}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := tt.input.MarshalJSON()
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, string(actual), "MarshalJSON output mismatch for '%s'", name)
 		})
 	}
+}
+
+// Test data for PathSetupType.
+var (
+	testPathSetupTypeSRTE   = NewPathSetupType(PathSetupTypeSRTE)
+	testPathSetupTypeRSVPTE = NewPathSetupType(PathSetupTypeRSVPTE)
+	testPathSetupTypeSRv6TE = NewPathSetupType(PathSetupTypeSRv6TE)
+
+	// Serialized bytes for PathSetupType SRTE.
+	testPathSetupTypeSRTEBytes = []byte{
+		byte(TLVPathSetupType >> 8), byte(TLVPathSetupType & 0xff), 0x00, 0x04, 0x00, 0x00, 0x00, byte(PathSetupTypeSRTE),
+	}
+	// Serialized bytes for PathSetupType RSVPTE.
+	testPathSetupTypeRSVPTEBytes = []byte{
+		byte(TLVPathSetupType >> 8), byte(TLVPathSetupType & 0xff), 0x00, 0x04, 0x00, 0x00, 0x00, byte(PathSetupTypeRSVPTE),
+	}
+	// Serialized bytes for PathSetupType SRv6TE.
+	testPathSetupTypeSRv6TEBytes = []byte{
+		byte(TLVPathSetupType >> 8), byte(TLVPathSetupType & 0xff), 0x00, 0x04, 0x00, 0x00, 0x00, byte(PathSetupTypeSRv6TE),
+	}
+	// Invalid input for PathSetupType (too short).
+	testPathSetupTypeTooShort = []byte{
+		0x00, 0x15, 0x00, 0x04,
+	}
+	// Invalid input for PathSetupType (too long).
+	testPathSetupTypeTooLong = append(NewPathSetupType(PathSetupTypeSRTE).Serialize(), 0x00, 0x00)
+	// Invalid input for PathSetupType (value length mismatch)
+	testPathSetupTypeInvalidLength = []byte{
+		byte(TLVPathSetupType >> 8), byte(TLVPathSetupType & 0xff),
+		0x00, 0x06,
+		0x01, 0x02, 0x03, 0x04,
+		0x00, 0x00,
+	}
+)
+
+func TestPathSetupType_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"Valid SRv6TE":       {testPathSetupTypeSRv6TEBytes, testPathSetupTypeSRv6TE, false},
+		"TooShort":           {testPathSetupTypeTooShort, nil, true},
+		"TooLong":            {testPathSetupTypeTooLong, nil, true},
+		"InvalidValueLength": {testPathSetupTypeInvalidLength, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &PathSetupType{} })
 }
 
 func TestPathSetupType_Serialize(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *PathSetupType
-		expected []uint8
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
 	}{
-		{
-			name:     "Serialize PathSetupType SRTE",
-			input:    NewPathSetupType(PathSetupTypeSRTE),
-			expected: NewPathSetupType(PathSetupTypeSRTE).Serialize(),
+		"SRTE":   {testPathSetupTypeSRTE, testPathSetupTypeSRTEBytes},
+		"RSVPTE": {testPathSetupTypeRSVPTE, testPathSetupTypeRSVPTEBytes},
+		"SRv6TE": {testPathSetupTypeSRv6TE, testPathSetupTypeSRv6TEBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestPathSetupType_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *PathSetupType
+		expected map[string]interface{}
+	}{
+		"NilTLV": {nil, map[string]interface{}{}},
+		"SRTE": {
+			testPathSetupTypeSRTE,
+			map[string]interface{}{
+				"pathSetupType": "Traffic engineering path is set up using Segment Routing (RFC8664)",
+			},
+		},
+		"RSVPTE": {
+			testPathSetupTypeRSVPTE,
+			map[string]interface{}{
+				"pathSetupType": "Path is set up using the RSVP-TE signaling protocol (RFC8408)",
+			},
+		},
+		"SRv6TE": {
+			testPathSetupTypeSRv6TE,
+			map[string]interface{}{
+				"pathSetupType": "Traffic engineering path is set up using SRv6 (RFC9603)",
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Serialize())
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
 		})
 	}
 }
 
 func TestPathSetupType_Len(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *PathSetupType
+	cases := map[string]struct {
+		input    TLVInterface
 		expected uint16
 	}{
-		{
-			name:     "Length should be header + value length",
-			input:    NewPathSetupType(PathSetupTypeRSVPTE),
-			expected: TLVHeaderLength + TLVPathSetupTypeValueLength,
+		"RSVPTELength": {testPathSetupTypeRSVPTE, TLVValueOffset + TLVPathSetupTypeValueLength},
+	}
+	runTLVLenTests(t, cases)
+}
+
+// test data for PathSetupTypeCapability.
+var (
+	// PathSetupTypeCapability instances
+	testPathSetupTypeCapabilityBasic = &PathSetupTypeCapability{
+		PathSetupTypes: Psts{PathSetupTypeRSVPTE, PathSetupTypeSRTE},
+		SubTLVs:        []TLVInterface{},
+	}
+	testPathSetupTypeCapabilityWithSubTLV = &PathSetupTypeCapability{
+		PathSetupTypes: Psts{PathSetupTypeSRTE},
+		SubTLVs:        []TLVInterface{NewSRPCECapability(true, true, 10)},
+	}
+
+	// Serialized TLV bytes
+	testPathSetupTypeCapabilityBasicBytes = []byte{
+		0x00, 0x22, 0x00, 0x08,
+		0x00, 0x00, 0x00, 0x02,
+		0x00, 0x01, 0x00, 0x00,
+	}
+	testPathSetupTypeCapabilityWithSubTLVBytes = []byte{
+		0x00, 0x22, 0x00, 0x10,
+		0x00, 0x00, 0x00, 0x01,
+		0x01, 0x00, 0x00, 0x00,
+		0x00, 0x1a, 0x00, 0x04, 0x03, 0x0a, 0x00, 0x00,
+	}
+
+	// Invalid / error test cases
+	testPathSetupTypeCapabilityTooShort       = []byte{0x00, 0x22, 0x00, 0x02, 0x00, 0x00}
+	testPathSetupTypeCapabilityPSTOverflow    = []byte{0x00, 0x22, 0x00, 0x04, 0x00, 0x00, 0x00, 0x05}
+	testPathSetupTypeCapabilityInvalidLength  = []byte{0x00, 0x22, 0xFF, 0xFF}
+	testPathSetupTypeCapabilityBadSubTLVBytes = []byte{
+		0x00, 0x22, 0x00, 0x0C,
+		0x00, 0x00, 0x00, 0x01,
+		0x01, 0x00,
+		0xFF, 0xFF, 0x00, 0x04, 0x01, 0x02,
+	}
+)
+
+// TestPathSetupTypeCapability_DecodeFromBytes tests PathSetupTypeCapability.DecodeFromBytes.
+func TestPathSetupTypeCapability_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidBasic":       {testPathSetupTypeCapabilityBasicBytes, testPathSetupTypeCapabilityBasic, false},
+		"ValidWithSubTLV":  {testPathSetupTypeCapabilityWithSubTLVBytes, testPathSetupTypeCapabilityWithSubTLV, false},
+		"TooShort":         {testPathSetupTypeCapabilityTooShort, nil, true},
+		"PSTCountOverflow": {testPathSetupTypeCapabilityPSTOverflow, nil, true},
+		"InvalidTLVLength": {testPathSetupTypeCapabilityInvalidLength, nil, true},
+		"BadSubTLV":        {testPathSetupTypeCapabilityBadSubTLVBytes, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &PathSetupTypeCapability{} })
+}
+
+// TestPathSetupTypeCapability_Serialize tests PathSetupTypeCapability.Serialize.
+func TestPathSetupTypeCapability_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"Basic":   {testPathSetupTypeCapabilityBasic, testPathSetupTypeCapabilityBasicBytes},
+		"WithSub": {testPathSetupTypeCapabilityWithSubTLV, testPathSetupTypeCapabilityWithSubTLVBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+// TestPathSetupTypeCapability_MarshalLogObject tests PathSetupTypeCapability.MarshalLogObject.
+func TestPathSetupTypeCapability_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *PathSetupTypeCapability
+		expected map[string]interface{}
+	}{
+		"Basic": {
+			testPathSetupTypeCapabilityBasic,
+			map[string]interface{}{
+				"pathSetupTypes": []interface{}{
+					"Path is set up using the RSVP-TE signaling protocol (RFC8408)",
+					"Traffic engineering path is set up using Segment Routing (RFC8664)",
+				},
+				"subTLVs": []interface{}{},
+			},
+		},
+		"WithSub": {
+			testPathSetupTypeCapabilityWithSubTLV,
+			map[string]interface{}{
+				"pathSetupTypes": []interface{}{
+					"Traffic engineering path is set up using Segment Routing (RFC8664)",
+				},
+				"subTLVs": []interface{}{"0x53522d5043452d4341504142494c49545920285246433836363429"}, // ASCII: "SR-PCE-CAPABILITY (RFC8664)"
+			},
+		},
+		"NilTLV": {
+			nil,
+			map[string]interface{}{},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.Len())
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, enc.Fields)
 		})
 	}
+}
+
+// TestPathSetupTypeCapability_Len tests PathSetupTypeCapability.Len.
+func TestPathSetupTypeCapability_Len(t *testing.T) {
+	var subTLVLen uint16
+	for _, s := range testPathSetupTypeCapabilityWithSubTLV.SubTLVs {
+		subTLVLen += s.Len()
+	}
+
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"Basic":   {input: testPathSetupTypeCapabilityBasic, expected: TLVValueOffset + PathSetupTypeCapabilityFixedPartLength + testPathSetupTypeCapabilityBasic.paddedPSTLength()},
+		"WithSub": {input: testPathSetupTypeCapabilityWithSubTLV, expected: TLVValueOffset + PathSetupTypeCapabilityFixedPartLength + testPathSetupTypeCapabilityWithSubTLV.paddedPSTLength() + subTLVLen},
+	}
+	runTLVLenTests(t, cases)
+}
+
+// TestPathSetupTypeCapability_CapStrings tests PathSetupTypeCapability.CapStrings.
+func TestPathSetupTypeCapability_CapStrings(t *testing.T) {
+	cases := map[string]struct {
+		input    CapStringsInterface
+		expected []string
+	}{
+		"SRTEAndSRv6TE":        {&PathSetupTypeCapability{PathSetupTypes: Psts{PathSetupTypeSRTE, PathSetupTypeSRv6TE}}, []string{"SR-TE", "SRv6-TE"}},
+		"SRTEOnly":             {&PathSetupTypeCapability{PathSetupTypes: Psts{PathSetupTypeSRTE}}, []string{"SR-TE"}},
+		"SRv6TEOnly":           {&PathSetupTypeCapability{PathSetupTypes: Psts{PathSetupTypeSRv6TE}}, []string{"SRv6-TE"}},
+		"NeitherSRTENorSRv6TE": {&PathSetupTypeCapability{PathSetupTypes: Psts{PathSetupTypeRSVPTE}}, []string{}},
+	}
+	runCapStringsTests(t, cases)
+}
+
+// TestAssocType_String tests AssocType.String.
+func TestAssocType_String(t *testing.T) {
+	cases := map[string]struct {
+		input    AssocType
+		expected string
+	}{
+		"PathProtection":   {AssocTypePathProtectionAssociation, "Path Protection Association"},
+		"Disjoint":         {AssocTypeDisjointAssociation, "Disjoint Association"},
+		"Policy":           {AssocTypePolicyAssociation, "Policy Association"},
+		"SingleSidedBidir": {AssocTypeSingleSidedBidirectionalLSPAssociation, "Single Sided Bidirectional LSP Association"},
+		"DoubleSidedBidir": {AssocTypeDoubleSidedBidirectionalLSPAssociation, "Double Sided Bidirectional LSP Association"},
+		"SRPolicy":         {AssocTypeSRPolicyAssociation, "SR Policy Association"},
+		"VnAssociation":    {AssocTypeVnAssociationType, "VN Association Type"},
+		"Unknown":          {AssocType(0xffff), "Unknown AssocType (0xffff)"},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.input.String()
+			assert.Equal(t, tt.expected, actual, "unexpected AssocType.String() result for '%s'", name)
+		})
+	}
+}
+
+// Test data for ExtendedAssociationID.
+var (
+	testIPv4ExtendedAssociationID = NewExtendedAssociationID(1, netip.MustParseAddr("127.0.0.1"))
+	testIPv6ExtendedAssociationID = NewExtendedAssociationID(1, netip.MustParseAddr("2001:db8::1"))
+
+	testIPv4ExtendedAssociationIDBytes = []byte{
+		byte(TLVExtendedAssociationID >> 8), byte(TLVExtendedAssociationID & 0xff), 0x00, 0x08,
+		0x00, 0x00, 0x00, 0x01, 0x7f, 0x00, 0x00, 0x01,
+	}
+	testIPv6ExtendedAssociationIDBytes = []byte{
+		byte(TLVExtendedAssociationID >> 8), byte(TLVExtendedAssociationID & 0xff), 0x00, 0x14,
+		0x00, 0x00, 0x00, 0x01,
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}
+	testExtendedAssociationIDTooShort = []byte{
+		byte(TLVExtendedAssociationID >> 8), byte(TLVExtendedAssociationID & 0xff), 0x00,
+	}
+	testExtendedAssociationIDInvalidLen = []byte{
+		byte(TLVExtendedAssociationID >> 8), byte(TLVExtendedAssociationID & 0xff), 0x00, 0x10,
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}
+	testExtendedAssociationIDUnsupportedLen = []byte{
+		byte(TLVExtendedAssociationID >> 8), byte(TLVExtendedAssociationID & 0xff), 0x00, 0x0f,
+		0x00, 0x00, 0x00, 0x01,
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x01,
+	}
+)
+
+// TestExtendedAssociationID_DecodeFromBytes tests ExtendedAssociationID.DecodeFromBytes.
+func TestExtendedAssociationID_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"IPv4":              {testIPv4ExtendedAssociationIDBytes, testIPv4ExtendedAssociationID, false},
+		"IPv6":              {testIPv6ExtendedAssociationIDBytes, testIPv6ExtendedAssociationID, false},
+		"TooShort":          {testExtendedAssociationIDTooShort, nil, true},
+		"InvalidLength":     {testExtendedAssociationIDInvalidLen, nil, true},
+		"UnsupportedLength": {testExtendedAssociationIDUnsupportedLen, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &ExtendedAssociationID{} })
+}
+
+// TestExtendedAssociationID_Serialize tests ExtendedAssociationID.Serialize.
+func TestExtendedAssociationID_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"IPv4":            {testIPv4ExtendedAssociationID, testIPv4ExtendedAssociationIDBytes},
+		"IPv6":            {testIPv6ExtendedAssociationID, testIPv6ExtendedAssociationIDBytes},
+		"InvalidEndpoint": {&ExtendedAssociationID{Color: 1}, nil}, // Endpoint zero-value
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.input.Serialize()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+// TestExtendedAssociationID_MarshalLogObject tests ExtendedAssociationID.MarshalLogObject.
+func TestExtendedAssociationID_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *ExtendedAssociationID
+		expected map[string]interface{}
+	}{
+		"IPv4": {
+			NewExtendedAssociationID(123, netip.MustParseAddr("192.0.2.1")),
+			map[string]interface{}{
+				"color":    uint32(123),
+				"ipv4Addr": "192.0.2.1",
+			},
+		},
+		"IPv6": {
+			NewExtendedAssociationID(456, netip.MustParseAddr("2001:db8::1")),
+			map[string]interface{}{
+				"color":    uint32(456),
+				"ipv6Addr": "2001:db8::1",
+			},
+		},
+		"NilTLV": {
+			nil,
+			map[string]interface{}{},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error during MarshalLogObject for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
+		})
+	}
+}
+
+// TestExtendedAssociationID_Len tests ExtendedAssociationID.Len.
+func TestExtendedAssociationID_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"IPv4Length":        {testIPv4ExtendedAssociationID, TLVValueOffset + TLVExtendedAssociationIDIPv4ValueLength},
+		"IPv6Length":        {testIPv6ExtendedAssociationID, TLVValueOffset + TLVExtendedAssociationIDIPv6ValueLength},
+		"UnsupportedLength": {&ExtendedAssociationID{Color: 1}, 0},
+	}
+	runTLVLenTests(t, cases)
+}
+
+// Test data for AssocTypeList.
+var (
+	// AssocTypeList with two entries.
+	testAssocTypeList = &AssocTypeList{
+		AssocTypes: []AssocType{AssocTypePathProtectionAssociation, AssocTypeSRPolicyAssociation},
+	}
+	// AssocTypeList with a single entry (requires padding to 4-byte alignment).
+	testAssocTypeListSingle = &AssocTypeList{
+		AssocTypes: []AssocType{AssocTypePathProtectionAssociation},
+	}
+	// AssocTypeList with four entries (already 4-byte aligned).
+	testAssocTypeListFour = &AssocTypeList{
+		AssocTypes: []AssocType{
+			AssocTypePathProtectionAssociation,
+			AssocTypeDisjointAssociation,
+			AssocTypePolicyAssociation,
+			AssocTypeSRPolicyAssociation,
+		},
+	}
+	// Empty AssocTypeList.
+	testAssocTypeListEmpty = &AssocTypeList{AssocTypes: []AssocType{}}
+
+	// Bytes for testAssocTypeList (2 entries = 4 bytes value, no padding needed).
+	testAssocTypeListBytes = []byte{
+		0x00, 0x23, 0x00, 0x04,
+		0x00, 0x01, 0x00, 0x06,
+	}
+	// Bytes for Serialize test: 1 entry + padding to 4-byte alignment.
+	testAssocTypeListSingleBytesWithPadding = []byte{
+		0x00, 0x23, 0x00, 0x02, // Type, Length
+		0x00, 0x01, 0x00, 0x00, // Value + padding
+	}
+	// Bytes for DecodeFromBytes test: 1 entry without padding.
+	testAssocTypeListSingleBytesWithoutPadding = []byte{
+		0x00, 0x23, 0x00, 0x02, // Type, Length
+		0x00, 0x01, // Value only
+	}
+	// TLV with odd-length value (should fail decode).
+	testAssocTypeListOddLength = []byte{
+		0x00, 0x23, 0x00, 0x03,
+		0x00, 0x01, 0x00,
+	}
+	// Truncated header.
+	testAssocTypeListTruncatedHeader = []byte{
+		0x00, 0x23, 0x00,
+	}
+)
+
+// TestAssocTypeList_DecodeFromBytes tests AssocTypeList.DecodeFromBytes.
+func TestAssocTypeList_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidTwoEntries":  {testAssocTypeListBytes, testAssocTypeList, false},
+		"ValidSingleEntry": {testAssocTypeListSingleBytesWithoutPadding, testAssocTypeListSingle, false},
+		"OddLengthValue":   {testAssocTypeListOddLength, nil, true},
+		"TruncatedHeader":  {testAssocTypeListTruncatedHeader, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &AssocTypeList{} })
+}
+
+// TestAssocTypeList_Serialize tests AssocTypeList.Serialize.
+func TestAssocTypeList_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"TwoEntries":  {testAssocTypeList, testAssocTypeListBytes},
+		"SingleEntry": {testAssocTypeListSingle, testAssocTypeListSingleBytesWithPadding},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+// TestAssocTypeList_MarshalLogObject tests AssocTypeList.MarshalLogObject.
+func TestAssocTypeList_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *AssocTypeList
+		expected map[string]interface{}
+	}{
+		"TwoEntries": {
+			testAssocTypeList,
+			map[string]interface{}{
+				"assocTypes": []interface{}{
+					"Path Protection Association",
+					"SR Policy Association",
+				},
+			},
+		},
+		"SingleEntry": {
+			testAssocTypeListSingle,
+			map[string]interface{}{
+				"assocTypes": []interface{}{"Path Protection Association"},
+			},
+		},
+		"FourEntries": {
+			testAssocTypeListFour,
+			map[string]interface{}{
+				"assocTypes": []interface{}{
+					"Path Protection Association",
+					"Disjoint Association",
+					"Policy Association",
+					"SR Policy Association",
+				},
+			},
+		},
+		"EmptyList": {
+			testAssocTypeListEmpty,
+			map[string]interface{}{
+				"assocTypes": []interface{}{},
+			},
+		},
+		"NilTLV": {
+			nil,
+			map[string]interface{}{},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, enc.Fields)
+		})
+	}
+}
+
+// TestAssocTypeList_Len tests AssocTypeList.Len.
+func TestAssocTypeList_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"TwoEntriesLen":  {testAssocTypeList, TLVValueOffset + 4},       // 2*2 = 4, already aligned
+		"SingleEntryLen": {testAssocTypeListSingle, TLVValueOffset + 4}, // 1*2 + 2 pad = 4
+		"FourEntriesLen": {testAssocTypeListFour, TLVValueOffset + 8},   // 4*2 = 8, already aligned
+		"EmptyLen":       {testAssocTypeListEmpty, TLVValueOffset + 0},  // 0 entries = 0 bytes
+	}
+	runTLVLenTests(t, cases)
+}
+
+// TestAssocTypeList_CapStrings tests AssocTypeList.CapStrings.
+func TestAssocTypeList_CapStrings(t *testing.T) {
+	cases := map[string]struct {
+		input    CapStringsInterface
+		expected []string
+	}{
+		"EmptyList": {&AssocTypeList{}, []string{}},
+	}
+	runCapStringsTests(t, cases)
+}
+
+// Test data for SRPolicyCandidatePathIdentifier.
+var (
+	testSRPolicyCPathIDIPv4 = &SRPolicyCandidatePathIdentifier{OriginatorAddr: netip.AddrFrom4([4]byte{192, 0, 2, 1})} // IPv4 originator
+	testSRPolicyCPathIDIPv6 = &SRPolicyCandidatePathIdentifier{OriginatorAddr: netip.MustParseAddr("2001:db8::1")}     // IPv6 originator
+
+	testSRPolicyCPathIDIPv4Bytes = []byte{
+		0x00, 0x39, 0x00, 0x1c, // type=0x0039, len=28
+		0x0a, 0x00, 0x00, 0x00, // protocol=0x0a + mbz
+		0x00, 0x00, 0x00, 0x00, // ASN=0
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // originator addr padding
+		0xc0, 0x00, 0x02, 0x01, // IPv4 addr
+		0x00, 0x00, 0x00, 0x01, // discriminator
+	}
+
+	testSRPolicyCPathIDIPv6Bytes = []byte{
+		0x00, 0x39, 0x00, 0x1c, // type=0x0039, len=28
+		0x0a, 0x00, 0x00, 0x00, // protocol + mbz
+		0x00, 0x00, 0x00, 0x00, // ASN
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // IPv6 addr
+		0x00, 0x00, 0x00, 0x01, // discriminator
+	}
+
+	testSRPolicyCPathIDTooShort        = []byte{0x00, 0x39, 0x00, 0x0a, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} // Less than 16 bytes for OriginatorAddr
+	testSRPolicyCPathIDTruncatedHeader = []byte{0x00, 0x39, 0x00}                                                                   // Truncated header (less than 4 bytes)
+)
+
+// TestSRPolicyCandidatePathIdentifier_DecodeFromBytes tests SRPolicyCandidatePathIdentifier.DecodeFromBytes.
+func TestSRPolicyCandidatePathIdentifier_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidIPv4":       {testSRPolicyCPathIDIPv4Bytes, testSRPolicyCPathIDIPv4, false},
+		"ValidIPv6":       {testSRPolicyCPathIDIPv6Bytes, testSRPolicyCPathIDIPv6, false},
+		"TooShort":        {testSRPolicyCPathIDTooShort, nil, true},
+		"TruncatedHeader": {testSRPolicyCPathIDTruncatedHeader, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRPolicyCandidatePathIdentifier{} })
+}
+
+// TestSRPolicyCandidatePathIdentifier_Serialize tests SRPolicyCandidatePathIdentifier.Serialize.
+func TestSRPolicyCandidatePathIdentifier_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"SerializeIPv4": {testSRPolicyCPathIDIPv4, testSRPolicyCPathIDIPv4Bytes},
+		"SerializeIPv6": {testSRPolicyCPathIDIPv6, testSRPolicyCPathIDIPv6Bytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+// TestSRPolicyCandidatePathIdentifier_MarshalLogObject tests SRPolicyCandidatePathIdentifier.MarshalLogObject.
+func TestSRPolicyCandidatePathIdentifier_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *SRPolicyCandidatePathIdentifier
+		expected map[string]interface{}
+	}{
+		"IPv4": {
+			testSRPolicyCPathIDIPv4,
+			map[string]interface{}{
+				"originatorAddr": testSRPolicyCPathIDIPv4.OriginatorAddr.String(),
+			},
+		},
+		"IPv6": {
+			testSRPolicyCPathIDIPv6,
+			map[string]interface{}{
+				"originatorAddr": testSRPolicyCPathIDIPv6.OriginatorAddr.String(),
+			},
+		},
+		"NilTLV": {
+			nil,
+			map[string]interface{}{},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error during MarshalLogObject for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
+		})
+	}
+}
+
+func TestSRPolicyCandidatePathIdentifier_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"ValidLen": {testSRPolicyCPathIDIPv4, TLVValueOffset + TLVSRPolicyCPathIDValueLength},
+	}
+	runTLVLenTests(t, cases)
+}
+
+// Test data for SRPolicyCandidatePathPreference.
+var (
+	testSRPolicyCPathPreference = &SRPolicyCandidatePathPreference{Preference: 100}
+
+	// Serialized bytes for testSRPolicyCPathPreference.
+	testSRPolicyCPathPreferenceBytes = []byte{
+		0x00, 0x3b, 0x00, 0x04,
+		0x00, 0x00, 0x00, 0x64,
+	}
+	// Truncated input (invalid length = 3).
+	testSRPolicyCPathPreferenceTruncated = []byte{
+		0x00, 0x3b, 0x00, 0x03,
+		0x00, 0x00, 0x00,
+	}
+	// Truncated header.
+	testSRPolicyCPathPreferenceTruncatedHeader = []byte{
+		0x00, 0x3b, 0x00,
+	}
+)
+
+func TestSRPolicyCandidatePathPreference_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidPreference": {testSRPolicyCPathPreferenceBytes, testSRPolicyCPathPreference, false},
+		"InvalidLength":   {testSRPolicyCPathPreferenceTruncated, nil, true},
+		"TruncatedHeader": {testSRPolicyCPathPreferenceTruncatedHeader, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRPolicyCandidatePathPreference{} })
+}
+
+func TestSRPolicyCandidatePathPreference_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"ValidPreference": {testSRPolicyCPathPreference, testSRPolicyCPathPreferenceBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestSRPolicyCandidatePathPreference_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *SRPolicyCandidatePathPreference
+		expected map[string]interface{}
+	}{
+		"Preference": {
+			testSRPolicyCPathPreference,
+			map[string]interface{}{
+				"preference": testSRPolicyCPathPreference.Preference,
+			},
+		},
+		"NilTLV": {
+			nil,
+			map[string]interface{}{},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error during MarshalLogObject for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
+		})
+	}
+}
+
+// TestSRPolicyCandidatePathPreference_Len tests SRPolicyCandidatePathPreference.Len.
+func TestSRPolicyCandidatePathPreference_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"ValidLen": {testSRPolicyCPathPreference, TLVValueOffset + TLVSRPolicyCPathPreferenceValueLength},
+	}
+	runTLVLenTests(t, cases)
+}
+
+// Test data for Color.
+var (
+	testColor = &Color{Color: 255}
+
+	// Serialized bytes for testColor.
+	testColorBytes = []byte{
+		0x00, 0x43, 0x00, 0x04,
+		0x00, 0x00, 0x00, 0xff,
+	}
+	// Truncated input (invalid length = 3).
+	testColorTruncated = []byte{
+		0x00, 0x43, 0x00, 0x03,
+		0x00, 0x00, 0x00,
+	}
+	// Truncated header.
+	testColorTruncatedHeader = []byte{
+		0x00, 0x43, 0x00,
+	}
+)
+
+// TestColor_DecodeFromBytes tests Color.DecodeFromBytes.
+func TestColor_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidColor":      {testColorBytes, testColor, false},
+		"InvalidLength":   {testColorTruncated, nil, true},
+		"TruncatedHeader": {testColorTruncatedHeader, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &Color{} })
+}
+
+// TestColor_Serialize tests Color.Serialize.
+func TestColor_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"ValidColor": {testColor, testColorBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+// TestColor_MarshalLogObject tests Color.MarshalLogObject.
+func TestColor_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *Color
+		expected map[string]interface{}
+	}{
+		"ValidColor": {
+			testColor,
+			map[string]interface{}{
+				"color": testColor.Color,
+			},
+		},
+		"ZeroColor": {
+			&Color{Color: 0},
+			map[string]interface{}{
+				"color": uint32(0),
+			},
+		},
+		"NilTLV": {
+			nil,
+			map[string]interface{}{},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error during MarshalLogObject for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
+		})
+	}
+}
+
+// TestColor_Len tests Color.Len.
+func TestColor_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"ValidLen": {testColor, TLVValueOffset + TLVColorValueLength},
+	}
+	runTLVLenTests(t, cases)
+}
+
+// Test data for UndefinedTLV.
+var (
+	// Standard 4-byte UndefinedTLV
+	testUndefinedTLV = &UndefinedTLV{
+		Typ:    TLVType(0xffff),
+		Length: 4,
+		Value:  []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+	// 3-byte value (odd → 1 byte padding required)
+	testUndefinedTLVOddLength = &UndefinedTLV{
+		Typ:    TLVType(0xffff),
+		Length: 3,
+		Value:  []byte{0x01, 0x02, 0x03},
+	}
+
+	// Serialized TLV bytes
+	testUndefinedTLVBytes           = []byte{0xff, 0xff, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef}
+	testUndefinedTLVOddLengthBytes  = []byte{0xff, 0xff, 0x00, 0x03, 0x01, 0x02, 0x03, 0x00}
+	testUndefinedTLVTruncatedHeader = []byte{0xff, 0xff, 0x00}
+	testUndefinedTLVTruncatedValue  = []byte{0xff, 0xff, 0x00, 0x08, 0x01, 0x02}
+)
+
+// TestUndefinedTLV_DecodeFromBytes tests UndefinedTLV.DecodeFromBytes.
+func TestUndefinedTLV_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidUndefinedTLV": {testUndefinedTLVBytes, testUndefinedTLV, false},
+		"TruncatedHeader":   {testUndefinedTLVTruncatedHeader, nil, true},
+		"TruncatedValue":    {testUndefinedTLVTruncatedValue, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &UndefinedTLV{} })
+}
+
+// TestUndefinedTLV_Serialize tests UndefinedTLV.Serialize.
+func TestUndefinedTLV_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"AlignedValue":   {testUndefinedTLV, testUndefinedTLVBytes},
+		"UnalignedValue": {testUndefinedTLVOddLength, testUndefinedTLVOddLengthBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+// TestUndefinedTLV_MarshalLogObject tests UndefinedTLV.MarshalLogObject.
+func TestUndefinedTLV_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *UndefinedTLV
+		expected map[string]interface{}
+	}{
+		"StandardTLV": {
+			testUndefinedTLV,
+			map[string]interface{}{
+				"type":   fmt.Sprintf("0x%04x", testUndefinedTLV.Typ),
+				"length": testUndefinedTLV.Length,
+			},
+		},
+		"OddLength": {
+			testUndefinedTLVOddLength,
+			map[string]interface{}{
+				"type":   fmt.Sprintf("0x%04x", testUndefinedTLVOddLength.Typ),
+				"length": testUndefinedTLVOddLength.Length,
+			},
+		},
+		"NilTLV": {
+			nil,
+			map[string]interface{}{},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error during MarshalLogObject for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
+		})
+	}
+}
+
+// TestUndefinedTLV_Len tests UndefinedTLV.Len.
+func TestUndefinedTLV_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"AlignedLen":   {testUndefinedTLV, TLVValueOffset + 4},          // 4-byte value
+		"UnalignedLen": {testUndefinedTLVOddLength, TLVValueOffset + 4}, // 3-byte value + 1 pad = 4
+	}
+	runTLVLenTests(t, cases)
+}
+
+// TestUndefinedTLV_CapStrings tests UndefinedTLV.CapStrings.
+func TestUndefinedTLV_CapStrings(t *testing.T) {
+	cases := map[string]struct {
+		input    CapStringsInterface
+		expected []string
+	}{
+		"UnknownType42": {
+			input:    &UndefinedTLV{Typ: TLVType(42)},
+			expected: []string{"unknown_type_42"},
+		},
+	}
+
+	runCapStringsTests(t, cases)
+}
+
+// TestUndefinedTLV_SetLength tests UndefinedTLV.SetLength.
+func TestUndefinedTLV_SetLength(t *testing.T) {
+	tlv := &UndefinedTLV{Value: []byte{0x01, 0x02, 0x03}}
+	tlv.SetLength()
+	assert.Equal(t, uint16(3), tlv.Length, "SetLength() should set Length to len(Value)")
+}
+
+// Test data for DecodeTLV / DecodeTLVs.
+var (
+	// Known TLV: StatefulPCECapability with only LSP Update enabled
+	testDecodeStatefulLSPUpdateBytes = append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x01)
+	// Unknown TLV type 0xffff with 4-byte value
+	testDecodeUnknownTLVBytes = append(tlvHeader(TLVType(0xffff), 4), 0xde, 0xad, 0xbe, 0xef)
+	// Truncated TLV header (less than 4 bytes)
+	testDecodeTruncatedHeader = []byte{0x00}
+	// StatefulPCECapability with invalid body length (3 instead of 4)
+	testDecodeStatefulInvalidBody = append(tlvHeader(TLVStatefulPCECapability, 3), 0x00, 0x00, 0x00)
+	// Unknown TLV claims 8 bytes, only 2 provided
+	testDecodeUnknownTruncatedValue = []byte{0xff, 0xff, 0x00, 0x08, 0x01, 0x02}
+	// Multiple TLVs: StatefulPCECapability + SymbolicPathName("Test")
+	testDecodeMultipleTLVs = append(
+		append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x01),
+		append(tlvHeader(TLVSymbolicPathName, 4), 'T', 'e', 's', 't')...,
+	)
+	// Truncated TLV value (declares length 8 but only 2 bytes)
+	testDecodeTruncatedValue = []byte{0x00, 0x10, 0x00, 0x08, 0x00, 0x00}
+	// Truncated TLV padding (odd length missing pad byte)
+	testDecodeTruncatedPadding = []byte{0x00, 0xff, 0x00, 0x03, 0x01, 0x02, 0x03}
+)
+
+// TestDecodeTLV tests DecodeTLV.
+func TestDecodeTLV(t *testing.T) {
+	cases := map[string]struct {
+		input   []byte
+		wantErr bool
+		wantTyp TLVType
+	}{
+		"KnownTLV_StatefulPCECapability": {testDecodeStatefulLSPUpdateBytes, false, TLVStatefulPCECapability},
+		"UnknownTLV":                     {testDecodeUnknownTLVBytes, false, TLVType(0xffff)},
+		"TooShort":                       {testDecodeTruncatedHeader, true, 0},
+		"KnownTLV_InvalidBody":           {testDecodeStatefulInvalidBody, true, 0},
+		"UnknownTLV_TruncatedValue":      {testDecodeUnknownTruncatedValue, true, 0},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			tlv, err := DecodeTLV(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error for '%s'", name)
+			} else {
+				require.NoError(t, err, "unexpected error for '%s'", name)
+				assert.Equal(t, tt.wantTyp, tlv.Type(), "TLV type mismatch for '%s'", name)
+			}
+		})
+	}
+}
+
+// TestDecodeTLVs tests DecodeTLVs.
+func TestDecodeTLVs(t *testing.T) {
+	cases := map[string]struct {
+		input   []byte
+		wantErr bool
+		wantLen int
+	}{
+		"Empty":               {[]byte{}, false, 0},
+		"SingleKnownTLV":      {testDecodeStatefulLSPUpdateBytes, false, 1},
+		"MultipleTLVs":        {testDecodeMultipleTLVs, false, 2},
+		"TruncatedTLVHeader":  {[]byte{0x00, 0x10, 0x00}, true, 0},
+		"TruncatedTLVValue":   {testDecodeTruncatedValue, true, 0},
+		"TruncatedTLVPadding": {testDecodeTruncatedPadding, true, 0},
+		"InvalidKnownTLVBody": {append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x00), false, 1},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			tlvs, err := DecodeTLVs(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error for '%s'", name)
+			} else {
+				require.NoError(t, err, "unexpected error for '%s'", name)
+				assert.Len(t, tlvs, tt.wantLen, "TLV count mismatch for '%s'", name)
+			}
+		})
+	}
+}
+
+// TestDecodeTLVs_SubTLVDecodeError tests that DecodeTLVs returns an error if a sub-TLV fails to decode.
+func TestDecodeTLVs_SubTLVDecodeError(t *testing.T) {
+	fixedPart := make([]byte, PathSetupTypeCapabilityFixedPartLength)
+	pstCount := []byte{0x01}
+	pathSetupType := []byte{0x00}
+	subTLV := append(tlvHeader(TLVStatefulPCECapability, 4), 0x01, 0x02)
+
+	value := append(append(fixedPart, pstCount...), pathSetupType...)
+	value = append(value, subTLV...)
+
+	header := tlvHeader(TLVPathSetupTypeCapability, uint16(len(value)))
+	data := append(header, value...)
+
+	_, err := DecodeTLVs(data)
+	assert.Error(t, err, "expected DecodeTLV error for invalid subTLV")
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1710,11 +1710,11 @@ func TestDecodeTLVs(t *testing.T) {
 // TestDecodeTLVs_SubTLVDecodeError tests that DecodeTLVs returns an error if a sub-TLV fails to decode.
 func TestDecodeTLVs_SubTLVDecodeError(t *testing.T) {
 	fixedPart := make([]byte, PathSetupTypeCapabilityFixedPartLength)
-	pstCount := []byte{0x01}
+	fixedPart[PathSetupTypeCapabilityPSTCountOffset] = 0x01 // Set PST count in fixed part
 	pathSetupType := []byte{0x00}
 	subTLV := append(tlvHeader(TLVStatefulPCECapability, 4), 0x01, 0x02)
 
-	value := append(append(fixedPart, pstCount...), pathSetupType...)
+	value := append(fixedPart, pathSetupType...)
 	value = append(value, subTLV...)
 
 	header := tlvHeader(TLVPathSetupTypeCapability, uint16(len(value)))


### PR DESCRIPTION
## Description
* Fixed SRPolicyCandidatePathIdentifier to comply with RFC 9862/9256 (correct Originator IPv4 handling)
* Added missing TLV fields and MarshalLogObject implementations
* Improved padding and slice handling
* Enhanced JSON marshaling of (ts Psts) MarshalJSON()
* Replaced magic numbers with constants
* Consolidated common TLV decoding into decodeTLVLength
* Added error checks

## Type of change
* [x] New features (added TLV tests)
* [x] Refactoring (improved TLV Serialize/Decode, helper functions)

## Motivation and Context
To increase test coverage and improve readability and maintainability of TLV handling code.

## How is This Tested?
* Verified TLV Serialize/Decode/MarshalLogObject using `go test ./...`
* Scenario tests in the `test/` directory

## Other Information
No additional information.
