### PR TITLE
ci: provide GITHUB_TOKEN to buf-setup-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         uses: bufbuild/buf-setup-action@v1
         with:
           version: latest
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run buf lint
         run: buf lint


### PR DESCRIPTION
## Description
Pass GITHUB_TOKEN to bufbuild/buf-setup-action in CI to avoid GitHub API rate limits when downloading buf CLI.