### PR TITLE
Adding UnidirectionalLinkDelay metric support

### DIFF
--- a/internal/pkg/gobgp/interface.go
+++ b/internal/pkg/gobgp/interface.go
@@ -457,13 +457,12 @@ func getLsLink(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrLink *api.LsAttribute
 	}
 
 	//  UnidirectionalLinkDelay metric support
-    if delay := lsAttrLink.GetUnidirectionalLinkDelay(); delay != 0 {
-    	lsLink.Metrics = append(
-        	lsLink.Metrics,
-            table.NewMetric(table.MetricType(table.DelayMetric), delay),
-        )
-    }
-
+	if delay := lsAttrLink.GetUnidirectionalLinkDelay(); delay != 0 {
+		lsLink.Metrics = append(
+			lsLink.Metrics,
+			table.NewMetric(table.MetricType(table.DelayMetric), delay),
+		)
+	}
 
 	lsLink.AdjSid = lsAttrLink.GetSrAdjacencySid()
 

--- a/internal/pkg/gobgp/interface.go
+++ b/internal/pkg/gobgp/interface.go
@@ -456,6 +456,15 @@ func getLsLink(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrLink *api.LsAttribute
 		lsLink.Metrics = append(lsLink.Metrics, table.NewMetric(table.MetricType(table.TEMetric), teMetric))
 	}
 
+	//  UnidirectionalLinkDelay metric support
+    if delay := lsAttrLink.GetUnidirectionalLinkDelay(); delay != 0 {
+    	lsLink.Metrics = append(
+        	lsLink.Metrics,
+            table.NewMetric(table.MetricType(table.DelayMetric), delay),
+        )
+    }
+
+
 	lsLink.AdjSid = lsAttrLink.GetSrAdjacencySid()
 
 	// handle SRv6 SID TLV


### PR DESCRIPTION
## Description
Adding UnidirectionalLinkDelay metric support due to the commit changes [osrg/gobgp@e13c9f7#diff-cb276724b7a01394c8eebc87ff78663f28a82263ae882fd480c798849934ed39](https://github.com/osrg/gobgp/commit/e13c9f7814c4c8e02377b5cd4f1213708a5b53bd#diff-cb276724b7a01394c8eebc87ff78663f28a82263ae882fd480c798849934ed39)

## Type of change
* [X] New features
* [ ] Bug fixes 
* [ ] Refactoring
* [ ] Documentation updates

## Motivation and Context
This change required the last compiled protobuf gobgp and adding the capabilities of Pola to dump the METRIC_TYPE_DELAY.

