### PR TITLE
Bump go from 1.26.0 to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nttcom/pola
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/osrg/gobgp/v4 v4.3.0


### PR DESCRIPTION
Bumps golang from 1.25.0 to 1.26.1.