### PR TITLE
 SRv6 ERO decoding, SR-MPLS LSE attributes and SRv6/Multipath cap

### DIFF
--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -536,6 +536,18 @@ func (o *SrpObject) DecodeFromBytes(typ ObjectType, objectBody []uint8) error {
 	o.ObjectType = typ
 	o.RFlag = (objectBody[3] & 0x01) != 0
 	o.SrpID = binary.BigEndian.Uint32(objectBody[4:8])
+
+	if len(objectBody) > 8 {
+		byteTLVs := objectBody[8:]
+
+		tlvs, err := DecodeTLVs(byteTLVs)
+		if err != nil {
+			return err
+		}
+
+		o.TLVs = tlvs
+	}
+
 	return nil
 }
 
@@ -925,8 +937,15 @@ func (o *SREroSubobject) DecodeFromBytes(subObject []uint8) error {
 	o.CFlag = (subObject[3] & 0x02) != 0
 	o.MFlag = (subObject[3] & 0x01) != 0
 
-	sid := binary.BigEndian.Uint32(subObject[4:8]) >> 12
+	sidWord := binary.BigEndian.Uint32(subObject[4:8])
+	sid := sidWord >> 12
 	o.Segment = table.NewSegmentSRMPLS(sid)
+	if o.CFlag {
+		// Per RFC 8664 §4.3.1: when C=1, TC/S/TTL of the MPLS LSE are set by the PCE.
+		o.Segment.TC = uint8((sidWord >> 9) & 0x07)
+		o.Segment.S = (sidWord & (uint32(1) << 8)) != 0
+		o.Segment.TTL = uint8(sidWord & 0xFF)
+	}
 	if o.NAIType == NAITypeSRIPv4Node {
 		o.NAI, _ = netip.AddrFromSlice(subObject[8:12])
 	}
@@ -954,10 +973,27 @@ func (o *SREroSubobject) Serialize() ([]uint8, error) {
 		buf[3] |= 0x01
 	}
 
+	sidWord := (o.Segment.Sid & 0xFFFFF) << 12
+	if o.CFlag {
+		sidWord |= uint32(o.Segment.TC&0x07) << 9
+		if o.Segment.S {
+			sidWord |= uint32(1) << 8
+		}
+		sidWord |= uint32(o.Segment.TTL)
+	}
+
 	byteSid := make([]uint8, 4)
-	binary.BigEndian.PutUint32(byteSid, o.Segment.Sid<<12)
+	binary.BigEndian.PutUint32(byteSid, sidWord)
 
 	byteSREroSubobject := AppendByteSlices(buf, byteSid)
+
+	// Per RFC 8664 §4.3.1, when NAI is present (F=0), the NAI value follows the SID.
+	switch o.NAIType {
+	case NAITypeSRIPv4Node, NAITypeSRIPv6Node:
+		if o.NAI.IsValid() {
+			byteSREroSubobject = append(byteSREroSubobject, o.NAI.AsSlice()...)
+		}
+	}
 
 	return byteSREroSubobject, nil
 }
@@ -985,7 +1021,7 @@ func NewSREroSubObject(seg table.SegmentSRMPLS) (*SREroSubobject, error) {
 		NAIType:       NAITypeSRAbsent,
 		FFlag:         true, // NAI is absent
 		SFlag:         false,
-		CFlag:         false,
+		CFlag:         seg.HasMPLSStackEntryAttrs(),
 		MFlag:         true, // TODO: Determine either MPLS label or index
 		Segment:       seg,
 	}
@@ -1052,6 +1088,10 @@ type SRv6EroSubobject struct {
 }
 
 func (o *SRv6EroSubobject) DecodeFromBytes(subObject []uint8) error {
+	if len(subObject) < 8 {
+		return errors.New("SRv6EroSubobject: subobject too short")
+	}
+
 	o.LFlag = (subObject[0] & 0x80) != 0
 	o.SubobjectType = SubObjectType(subObject[0] & 0x7f)
 	o.Length = subObject[1]
@@ -1061,15 +1101,63 @@ func (o *SRv6EroSubobject) DecodeFromBytes(subObject []uint8) error {
 	o.FFlag = (subObject[3] & 0x02) != 0
 	o.SFlag = (subObject[3] & 0x01) != 0
 
-	sid, _ := netip.AddrFromSlice(subObject[8:24])
-	o.Segment = table.NewSegmentSRv6(sid)
-	if o.NAIType == NAITypeSRv6IPv6Node {
-		o.Segment.LocalAddr, _ = netip.AddrFromSlice(subObject[24:40])
+	behavior := binary.BigEndian.Uint16(subObject[6:8])
+
+	off := 8
+	if !o.SFlag {
+		if len(subObject) < off+16 {
+			return errors.New("SRv6EroSubobject: truncated SID")
+		}
+		sid, _ := netip.AddrFromSlice(subObject[off : off+16])
+		o.Segment = table.NewSegmentSRv6(sid)
+		off += 16
+	} else {
+		o.Segment = table.SegmentSRv6{}
 	}
-	if o.NAIType == NAITypeSRv6IPv6AdjacencyGlobal {
-		o.Segment.LocalAddr, _ = netip.AddrFromSlice(subObject[24:40])
-		o.Segment.RemoteAddr, _ = netip.AddrFromSlice(subObject[40:56])
+
+	if !o.FFlag {
+		switch o.NAIType {
+		case NAITypeSRv6IPv6Node:
+			if len(subObject) < off+16 {
+				return errors.New("SRv6EroSubobject: truncated NAI (Node)")
+			}
+			o.Segment.LocalAddr, _ = netip.AddrFromSlice(subObject[off : off+16])
+			off += 16
+		case NAITypeSRv6IPv6AdjacencyGlobal:
+			if len(subObject) < off+32 {
+				return errors.New("SRv6EroSubobject: truncated NAI (AdjGlobal)")
+			}
+			o.Segment.LocalAddr, _ = netip.AddrFromSlice(subObject[off : off+16])
+			o.Segment.RemoteAddr, _ = netip.AddrFromSlice(subObject[off+16 : off+32])
+			off += 32
+		case NAITypeSRv6IPv6AdjacencyLinkLocal:
+			if len(subObject) < off+40 {
+				return errors.New("SRv6EroSubobject: truncated NAI (AdjLinkLocal)")
+			}
+			o.Segment.LocalAddr, _ = netip.AddrFromSlice(subObject[off : off+16])
+			// subObject[off+16 : off+20] — Local Interface ID (not parsed)
+			o.Segment.RemoteAddr, _ = netip.AddrFromSlice(subObject[off+20 : off+36])
+			// subObject[off+36 : off+40] — Remote Interface ID (not parsed)
+			off += 40
+		}
 	}
+
+	if o.TFlag {
+		if len(subObject) < off+8 {
+			return errors.New("SRv6EroSubobject: truncated SID-Structure")
+		}
+		o.Segment.Structure = []uint8{
+			subObject[off+0],
+			subObject[off+1],
+			subObject[off+2],
+			subObject[off+3],
+		}
+	}
+
+	if behavior == table.BehaviorUN || behavior == table.BehaviorUA {
+		o.Segment.USid = true
+	}
+
 	return nil
 }
 

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package pcep
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nttcom/pola/pkg/table"
+)
+
+func TestSREroSubobject_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	mkSRMPLS := func(sid uint32, tc uint8, s bool, ttl uint8) table.SegmentSRMPLS {
+		seg := table.NewSegmentSRMPLS(sid)
+		seg.TC, seg.S, seg.TTL = tc, s, ttl
+		return seg
+	}
+
+	cases := map[string]SREroSubobject{
+		"NAIAbsent_LabelOnly": {
+			SubobjectType: SubObjectTypeEROSR,
+			NAIType:       NAITypeSRAbsent,
+			FFlag:         true, MFlag: true,
+			Segment: table.NewSegmentSRMPLS(16000),
+		},
+		"NAIAbsent_LFlag": {
+			LFlag:         true,
+			SubobjectType: SubObjectTypeEROSR,
+			NAIType:       NAITypeSRAbsent,
+			FFlag:         true, MFlag: true,
+			Segment: table.NewSegmentSRMPLS(24),
+		},
+		"NAIAbsent_CFlag_MPLSStackAttrs": {
+			SubobjectType: SubObjectTypeEROSR,
+			NAIType:       NAITypeSRAbsent,
+			FFlag:         true, CFlag: true, MFlag: true,
+			Segment: mkSRMPLS(100500, 5, true, 64),
+		},
+		"IPv4Node": {
+			SubobjectType: SubObjectTypeEROSR,
+			NAIType:       NAITypeSRIPv4Node,
+			MFlag:         true,
+			Segment:       table.NewSegmentSRMPLS(16001),
+			NAI:           netip.MustParseAddr("10.0.0.1"),
+		},
+	}
+
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			l, err := want.Len()
+			require.NoError(t, err, "Len failed")
+			want.Length = uint8(l)
+
+			raw, err := want.Serialize()
+			require.NoError(t, err, "Serialize failed")
+			require.Equal(t, int(l), len(raw), "Len() must match serialized size")
+
+			var got SREroSubobject
+			require.NoError(t, got.DecodeFromBytes(raw), "DecodeFromBytes failed")
+			assert.Equal(t, want, got, "round-trip value mismatch")
+
+			raw2, err := got.Serialize()
+			require.NoError(t, err, "re-Serialize failed")
+			assert.Equal(t, raw, raw2, "re-serialized bytes differ")
+		})
+	}
+}
+
+func TestSRv6EroSubobject_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	sid := netip.MustParseAddr("fc00:0:1::")
+	local := netip.MustParseAddr("2001:db8::1")
+	remote := netip.MustParseAddr("2001:db8::2")
+
+	cases := map[string]SRv6EroSubobject{
+		"IPv6Node_END": {
+			SubobjectType: SubObjectTypeEROSRv6,
+			NAIType:       NAITypeSRv6IPv6Node,
+			Segment:       table.SegmentSRv6{Sid: sid, LocalAddr: local},
+		},
+		"IPv6AdjGlobal_ENDX": {
+			SubobjectType: SubObjectTypeEROSRv6,
+			NAIType:       NAITypeSRv6IPv6AdjacencyGlobal,
+			Segment:       table.SegmentSRv6{Sid: sid, LocalAddr: local, RemoteAddr: remote},
+		},
+		"IPv6Node_USid_WithStructure": {
+			SubobjectType: SubObjectTypeEROSRv6,
+			NAIType:       NAITypeSRv6IPv6Node,
+			TFlag:         true,
+			Segment: table.SegmentSRv6{
+				Sid: sid, LocalAddr: local, USid: true,
+				Structure: []uint8{32, 16, 16, 0},
+			},
+		},
+		"LFlag_IPv6Node": {
+			LFlag:         true,
+			SubobjectType: SubObjectTypeEROSRv6,
+			NAIType:       NAITypeSRv6IPv6Node,
+			Segment:       table.SegmentSRv6{Sid: sid, LocalAddr: local},
+		},
+	}
+
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			l, err := want.Len()
+			require.NoError(t, err, "Len failed")
+			want.Length = uint8(l)
+
+			raw, err := want.Serialize()
+			require.NoError(t, err, "Serialize failed")
+			require.Equal(t, int(l), len(raw), "Len() must match serialized size")
+
+			var got SRv6EroSubobject
+			require.NoError(t, got.DecodeFromBytes(raw), "DecodeFromBytes failed")
+			assert.Equal(t, want, got, "round-trip value mismatch")
+
+			raw2, err := got.Serialize()
+			require.NoError(t, err, "re-Serialize failed")
+			assert.Equal(t, raw, raw2, "re-serialized bytes differ")
+		})
+	}
+}
+
+func TestSrpObject_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]SrpObject{
+		"NoTLVs_RFalse": {
+			ObjectType: ObjectTypeSRPSRP, SrpID: 42,
+		},
+		"NoTLVs_RTrue": {
+			ObjectType: ObjectTypeSRPSRP, RFlag: true, SrpID: 0xDEADBEEF,
+		},
+		"PathSetupType_SRTE": {
+			ObjectType: ObjectTypeSRPSRP, SrpID: 1,
+			TLVs: []TLVInterface{&PathSetupType{PathSetupType: PathSetupTypeSRTE}},
+		},
+		"PathSetupType_SRv6TE": {
+			ObjectType: ObjectTypeSRPSRP, RFlag: true, SrpID: 100,
+			TLVs: []TLVInterface{&PathSetupType{PathSetupType: PathSetupTypeSRv6TE}},
+		},
+	}
+
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := want.Serialize()
+			require.Equal(t, int(want.Len()), len(raw), "Len() must match serialized size")
+
+			// DecodeFromBytes expects the object body (without 4-byte CommonObjectHeader).
+			var got SrpObject
+			require.NoError(t,
+				got.DecodeFromBytes(ObjectTypeSRPSRP, raw[commonObjectHeaderLength:]),
+				"DecodeFromBytes failed",
+			)
+			assert.Equal(t, want, got, "round-trip value mismatch")
+
+			assert.Equal(t, raw, got.Serialize(), "re-serialized bytes differ")
+		})
+	}
+}

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -46,6 +46,7 @@ const (
 	TLVLSPDBVersion                       TLVType = 0x17
 	TLVSpeakerEntityID                    TLVType = 0x18
 	TLVSRPCECapability                    TLVType = 0x1a
+	TLVSRv6PCECapability                  TLVType = 0x1b
 	TLVPathSetupType                      TLVType = 0x1c
 	TLVOperatorConfiguredAssociationRange TLVType = 0x1d
 	TLVGlobalAssociationSource            TLVType = 0x1e
@@ -123,6 +124,7 @@ var tlvDescriptions = map[TLVType]struct {
 	TLVLSPDBVersion:                       {"LSP-DB-VERSION", "RFC8232"},
 	TLVSpeakerEntityID:                    {"SPEAKER-ENTITY-ID", "RFC8232"},
 	TLVSRPCECapability:                    {"SR-PCE-CAPABILITY", "RFC8664"},
+	TLVSRv6PCECapability:                  {"SRv6-PCE-CAPABILITY", "RFC9603"},
 	TLVPathSetupType:                      {"PATH-SETUP-TYPE", "RFC8408"},
 	TLVOperatorConfiguredAssociationRange: {"OPERATOR-CONFIGURED-ASSOCIATION-RANGE", "RFC8697"},
 	TLVGlobalAssociationSource:            {"GLOBAL-ASSOCIATION-SOURCE", "RFC8697"},
@@ -201,6 +203,8 @@ const (
 	TLVIPv6LSPIdentifiersValueLength        uint16 = 52
 	TLVLSPDBVersionValueLength              uint16 = 8
 	TLVSRPCECapabilityValueLength           uint16 = 4
+	TLVSRv6PCECapabilityValueLength         uint16 = 4
+	TLVMultipathCapValueLength              uint16 = 4
 	TLVPathSetupTypeValueLength             uint16 = 4
 	TLVExtendedAssociationIDIPv4ValueLength uint16 = 8
 	TLVExtendedAssociationIDIPv6ValueLength uint16 = 20
@@ -243,6 +247,8 @@ var tlvMap = map[TLVType]func() TLVInterface{
 	TLVIPv6LSPIdentifiers:      func() TLVInterface { return &IPv6LSPIdentifiers{} },
 	TLVLSPDBVersion:            func() TLVInterface { return &LSPDBVersion{} },
 	TLVSRPCECapability:         func() TLVInterface { return &SRPCECapability{} },
+	TLVSRv6PCECapability:       func() TLVInterface { return &SRv6PCECapability{} },
+	TLVMultipathCap:            func() TLVInterface { return &MultipathCapability{} },
 	TLVPathSetupType:           func() TLVInterface { return &PathSetupType{} },
 	TLVExtendedAssociationID:   func() TLVInterface { return &ExtendedAssociationID{} },
 	TLVPathSetupTypeCapability: func() TLVInterface { return &PathSetupTypeCapability{} },
@@ -799,6 +805,187 @@ func NewSRPCECapability(hasUnlimitedMaxSIDDepth bool, isNAISupported bool, maxim
 		HasUnlimitedMaxSIDDepth: hasUnlimitedMaxSIDDepth,
 		IsNAISupported:          isNAISupported,
 		MaximumSidDepth:         maximumSidDepth,
+	}
+}
+
+type SRv6PCECapability struct {
+	IsNAISupported bool
+}
+
+const SRv6NAISupportedFlag uint16 = 0x0002
+
+const (
+	SRv6PCECapabilityReservedOffset = 0
+	SRv6PCECapabilityFlagsOffset    = 2
+)
+
+func (tlv *SRv6PCECapability) DecodeFromBytes(data []byte) error {
+	valueLen, err := decodeTLVLength(data, false)
+	if err != nil {
+		return fmt.Errorf("SRv6PCECapability: %w", err)
+	}
+
+	if valueLen < int(TLVSRv6PCECapabilityValueLength) {
+		return fmt.Errorf("SRv6PCECapability: invalid value length %d", valueLen)
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	flags := binary.BigEndian.Uint16(value[SRv6PCECapabilityFlagsOffset : SRv6PCECapabilityFlagsOffset+2])
+	tlv.IsNAISupported = (flags & SRv6NAISupportedFlag) != 0
+
+	return nil
+}
+
+func (tlv *SRv6PCECapability) Serialize() []byte {
+	value := make([]byte, TLVSRv6PCECapabilityValueLength)
+	// value[0:2] reserved, must be zero.
+	var flags uint16
+	if tlv.IsNAISupported {
+		flags |= SRv6NAISupportedFlag
+	}
+	binary.BigEndian.PutUint16(value[SRv6PCECapabilityFlagsOffset:SRv6PCECapabilityFlagsOffset+2], flags)
+
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVSRv6PCECapabilityValueLength),
+		value,
+	)
+}
+
+func (tlv *SRv6PCECapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddBool("nai_is_supported", tlv.IsNAISupported)
+	return nil
+}
+
+func (tlv *SRv6PCECapability) Type() TLVType {
+	return TLVSRv6PCECapability
+}
+
+func (tlv *SRv6PCECapability) Len() uint16 {
+	return TLVValueOffset + TLVSRv6PCECapabilityValueLength
+}
+
+func (tlv *SRv6PCECapability) CapStrings() []string {
+	ret := []string{"SRv6"}
+	if tlv.IsNAISupported {
+		ret = append(ret, "NAI-Supported")
+	}
+	return ret
+}
+
+func NewSRv6PCECapability(isNAISupported bool) *SRv6PCECapability {
+	return &SRv6PCECapability{
+		IsNAISupported: isNAISupported,
+	}
+}
+
+type MultipathCapability struct {
+	MaxMultipaths            uint16
+	IsWeightedSupported      bool
+	IsOppositeDirSupported   bool
+	IsForwardClassSupported  bool
+	IsCompositePathSupported bool
+}
+
+const (
+	MultipathFlagW uint16 = 0x0001
+	// 0x0002: unassigned
+	MultipathFlagO uint16 = 0x0004
+	MultipathFlagF uint16 = 0x0008
+	MultipathFlagC uint16 = 0x0010
+)
+
+const (
+	MultipathCapMaxMultipathsOffset = 0
+	MultipathCapFlagsOffset         = 2
+)
+
+func (tlv *MultipathCapability) DecodeFromBytes(data []byte) error {
+	valueLen, err := decodeTLVLength(data, false)
+	if err != nil {
+		return fmt.Errorf("MultipathCapability: %w", err)
+	}
+
+	if valueLen != int(TLVMultipathCapValueLength) {
+		return fmt.Errorf("MultipathCapability: invalid value length %d", valueLen)
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	tlv.MaxMultipaths = binary.BigEndian.Uint16(value[MultipathCapMaxMultipathsOffset : MultipathCapMaxMultipathsOffset+2])
+	flags := binary.BigEndian.Uint16(value[MultipathCapFlagsOffset : MultipathCapFlagsOffset+2])
+	tlv.IsWeightedSupported = (flags & MultipathFlagW) != 0
+	tlv.IsOppositeDirSupported = (flags & MultipathFlagO) != 0
+	tlv.IsForwardClassSupported = (flags & MultipathFlagF) != 0
+	tlv.IsCompositePathSupported = (flags & MultipathFlagC) != 0
+
+	return nil
+}
+
+func (tlv *MultipathCapability) Serialize() []byte {
+	value := make([]byte, TLVMultipathCapValueLength)
+
+	binary.BigEndian.PutUint16(value[MultipathCapMaxMultipathsOffset:MultipathCapMaxMultipathsOffset+2], tlv.MaxMultipaths)
+
+	var flags uint16
+	if tlv.IsWeightedSupported {
+		flags |= MultipathFlagW
+	}
+	if tlv.IsOppositeDirSupported {
+		flags |= MultipathFlagO
+	}
+	if tlv.IsForwardClassSupported {
+		flags |= MultipathFlagF
+	}
+	if tlv.IsCompositePathSupported {
+		flags |= MultipathFlagC
+	}
+	binary.BigEndian.PutUint16(value[MultipathCapFlagsOffset:MultipathCapFlagsOffset+2], flags)
+
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(TLVMultipathCapValueLength),
+		value,
+	)
+}
+
+func (tlv *MultipathCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddUint16("max_multipaths", tlv.MaxMultipaths)
+	enc.AddBool("weighted_is_supported", tlv.IsWeightedSupported)
+	enc.AddBool("opposite_dir_is_supported", tlv.IsOppositeDirSupported)
+	enc.AddBool("forward_class_is_supported", tlv.IsForwardClassSupported)
+	enc.AddBool("composite_path_is_supported", tlv.IsCompositePathSupported)
+	return nil
+}
+
+func (tlv *MultipathCapability) Type() TLVType {
+	return TLVMultipathCap
+}
+
+func (tlv *MultipathCapability) Len() uint16 {
+	return TLVValueOffset + TLVMultipathCapValueLength
+}
+
+func (tlv *MultipathCapability) CapStrings() []string {
+	return []string{"Multipath"}
+}
+
+func NewMultipathCapability(maxMultipaths uint16, isWeightedSupported, isOppositeDirSupported, isForwardClassSupported, isCompositePathSupported bool) *MultipathCapability {
+	return &MultipathCapability{
+		MaxMultipaths:            maxMultipaths,
+		IsWeightedSupported:      isWeightedSupported,
+		IsOppositeDirSupported:   isOppositeDirSupported,
+		IsForwardClassSupported:  isForwardClassSupported,
+		IsCompositePathSupported: isCompositePathSupported,
 	}
 }
 

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -44,6 +44,8 @@ func TestTLVMap(t *testing.T) {
 		"IPv6LSPIdentifiers":      {TLVIPv6LSPIdentifiers, &IPv6LSPIdentifiers{}},
 		"LSPDBVersion":            {TLVLSPDBVersion, &LSPDBVersion{}},
 		"SRPCECapability":         {TLVSRPCECapability, &SRPCECapability{}},
+		"SRv6PCECapability":       {TLVSRv6PCECapability, &SRv6PCECapability{}},
+		"MultipathCapability":     {TLVMultipathCap, &MultipathCapability{}},
 		"PathSetupType":           {TLVPathSetupType, &PathSetupType{}},
 		"ExtendedAssociationID":   {TLVExtendedAssociationID, &ExtendedAssociationID{}},
 		"PathSetupTypeCapability": {TLVPathSetupTypeCapability, &PathSetupTypeCapability{}},
@@ -1761,6 +1763,243 @@ func TestDecodeTLVs_SubTLV(t *testing.T) {
 			} else {
 				assert.NoError(t, err, "unexpected error for '%s'", name)
 			}
+		})
+	}
+}
+
+// Test data for SRv6PCECapability.
+var (
+	testSRv6PCECapability              = NewSRv6PCECapability(true)
+	testSRv6PCECapabilityBytes         = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x02)
+	testSRv6PCECapabilityNoNAIBytes    = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x00)
+	testSRv6PCECapabilityTruncated     = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00)
+	testSRv6PCECapabilityInvalidLength = append(tlvHeader(TLVSRv6PCECapability, 8), 0x00, 0x00, 0x00, 0x01, 0xde, 0xad, 0xbe, 0xef)
+	testSRv6PCECapabilityNoNAI         = &SRv6PCECapability{}
+	testSRv6PCECapabilityNAIStrs       = []string{"SRv6", "NAI-Supported"}
+	testSRv6PCECapabilityNoNAIStrs     = []string{"SRv6"}
+)
+
+func TestSRv6PCECapability_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidSRv6PCECapability":         {testSRv6PCECapabilityBytes, testSRv6PCECapability, false},
+		"ValidSRv6PCECapabilityNoNAI":    {testSRv6PCECapabilityNoNAIBytes, testSRv6PCECapabilityNoNAI, false},
+		"TruncatedSRv6PCECapability":     {testSRv6PCECapabilityTruncated, nil, true},
+		"InvalidLengthSRv6PCECapability": {testSRv6PCECapabilityInvalidLength, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRv6PCECapability{} })
+}
+
+func TestSRv6PCECapability_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"ValidSRv6PCECapability":      {testSRv6PCECapability, testSRv6PCECapabilityBytes},
+		"ValidSRv6PCECapabilityNoNAI": {testSRv6PCECapabilityNoNAI, testSRv6PCECapabilityNoNAIBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestSRv6PCECapability_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *SRv6PCECapability
+		expected map[string]any
+	}{
+		"NilTLV": {nil, map[string]any{}},
+		"EmptyTLV": {
+			&SRv6PCECapability{},
+			map[string]any{
+				"nai_is_supported": false,
+			},
+		},
+		"FullTLV": {
+			testSRv6PCECapability,
+			map[string]any{
+				"nai_is_supported": true,
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
+		})
+	}
+}
+
+func TestSRv6PCECapability_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"ValidSRv6PCECapabilityLength": {testSRv6PCECapability, TLVValueOffset + TLVSRv6PCECapabilityValueLength},
+	}
+	runTLVLenTests(t, cases)
+}
+
+func TestSRv6PCECapability_CapStrings(t *testing.T) {
+	cases := map[string]struct {
+		input    CapStringsInterface
+		expected []string
+	}{
+		"NAISupported":    {testSRv6PCECapability, testSRv6PCECapabilityNAIStrs},
+		"NAINotSupported": {testSRv6PCECapabilityNoNAI, testSRv6PCECapabilityNoNAIStrs},
+	}
+	runCapStringsTests(t, cases)
+}
+
+func TestSRv6PCECapability_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]*SRv6PCECapability{
+		"NAISupported":    NewSRv6PCECapability(true),
+		"NAINotSupported": NewSRv6PCECapability(false),
+	}
+
+	for name, original := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data := original.Serialize()
+			require.Equal(t, int(original.Len()), len(data), "Len() must match serialized size")
+
+			decoded, err := DecodeTLV(data)
+			require.NoError(t, err, "DecodeTLV failed")
+
+			got, ok := decoded.(*SRv6PCECapability)
+			require.Truef(t, ok, "expected *SRv6PCECapability, got %T", decoded)
+			assert.Equal(t, original, got, "round-trip value mismatch")
+
+			// Serialize again and verify bytes are identical (stability check).
+			assert.Equal(t, data, got.Serialize(), "re-serialized bytes differ")
+		})
+	}
+}
+
+// Test data for MultipathCapability.
+var (
+	testMultipathCapability = NewMultipathCapability(8, true, true, true, true)
+	// MaxMultipaths=8 (0x0008), Flags=W|O|F|C = 0x001D
+	testMultipathCapabilityBytes        = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x08, 0x00, 0x1d)
+	testMultipathCapabilityNoFlags      = NewMultipathCapability(1, false, false, false, false)
+	testMultipathCapabilityNoFlagsBytes = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x01, 0x00, 0x00)
+	testMultipathCapabilityTruncated    = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x08)
+	testMultipathCapabilityInvalidLen   = append(tlvHeader(TLVMultipathCap, 8), 0x00, 0x08, 0x00, 0x0f, 0xde, 0xad, 0xbe, 0xef)
+	testMultipathCapabilityCapStrs      = []string{"Multipath"}
+)
+
+func TestMultipathCapability_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"ValidMultipathCapabilityAllFlags": {testMultipathCapabilityBytes, testMultipathCapability, false},
+		"ValidMultipathCapabilityNoFlags":  {testMultipathCapabilityNoFlagsBytes, testMultipathCapabilityNoFlags, false},
+		"TruncatedMultipathCapability":     {testMultipathCapabilityTruncated, nil, true},
+		"InvalidLengthMultipathCapability": {testMultipathCapabilityInvalidLen, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &MultipathCapability{} })
+}
+
+func TestMultipathCapability_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"ValidMultipathCapabilityAllFlags": {testMultipathCapability, testMultipathCapabilityBytes},
+		"ValidMultipathCapabilityNoFlags":  {testMultipathCapabilityNoFlags, testMultipathCapabilityNoFlagsBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestMultipathCapability_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *MultipathCapability
+		expected map[string]any
+	}{
+		"NilTLV": {nil, map[string]any{}},
+		"EmptyTLV": {
+			&MultipathCapability{},
+			map[string]any{
+				"max_multipaths":              uint16(0),
+				"weighted_is_supported":       false,
+				"opposite_dir_is_supported":   false,
+				"forward_class_is_supported":  false,
+				"composite_path_is_supported": false,
+			},
+		},
+		"FullTLV": {
+			testMultipathCapability,
+			map[string]any{
+				"max_multipaths":              uint16(8),
+				"weighted_is_supported":       true,
+				"opposite_dir_is_supported":   true,
+				"forward_class_is_supported":  true,
+				"composite_path_is_supported": true,
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
+		})
+	}
+}
+
+func TestMultipathCapability_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"ValidMultipathCapabilityLength": {testMultipathCapability, TLVValueOffset + TLVMultipathCapValueLength},
+	}
+	runTLVLenTests(t, cases)
+}
+
+func TestMultipathCapability_CapStrings(t *testing.T) {
+	cases := map[string]struct {
+		input    CapStringsInterface
+		expected []string
+	}{
+		"AllFlagsEnabled": {testMultipathCapability, testMultipathCapabilityCapStrs},
+		"NoFlagsEnabled":  {testMultipathCapabilityNoFlags, testMultipathCapabilityCapStrs},
+	}
+	runCapStringsTests(t, cases)
+}
+
+func TestMultipathCapability_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]*MultipathCapability{
+		"AllFlags":         NewMultipathCapability(8, true, true, true, true),
+		"NoFlags":          NewMultipathCapability(1, false, false, false, false),
+		"OnlyWeighted":     NewMultipathCapability(2, true, false, false, false),
+		"OnlyOpposite":     NewMultipathCapability(3, false, true, false, false),
+		"OnlyForwardClass": NewMultipathCapability(4, false, false, true, false),
+		"OnlyComposite":    NewMultipathCapability(7, false, false, false, true),
+		"MaxUint16":        NewMultipathCapability(0xFFFF, true, true, true, true),
+	}
+
+	for name, original := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data := original.Serialize()
+			require.Equal(t, int(original.Len()), len(data), "Len() must match serialized size")
+
+			decoded, err := DecodeTLV(data)
+			require.NoError(t, err, "DecodeTLV failed")
+
+			got, ok := decoded.(*MultipathCapability)
+			require.Truef(t, ok, "expected *MultipathCapability, got %T", decoded)
+			assert.Equal(t, original, got, "round-trip value mismatch")
+
+			// Serialize again and verify bytes are identical (stability check).
+			assert.Equal(t, data, got.Serialize(), "re-serialized bytes differ")
 		})
 	}
 }

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -204,10 +204,17 @@ func NewSegmentSRv6WithNodeInfo(sid netip.Addr, n *LsNode) (SegmentSRv6, error) 
 
 type SegmentSRMPLS struct {
 	Sid uint32
+	TTL uint8
+	TC  uint8
+	S   bool
 }
 
 func (seg SegmentSRMPLS) SidString() string {
 	return strconv.Itoa(int(seg.Sid))
+}
+
+func (seg SegmentSRMPLS) HasMPLSStackEntryAttrs() bool {
+	return seg.TC != 0 || seg.S || seg.TTL != 0
 }
 
 func NewSegmentSRMPLS(sid uint32) SegmentSRMPLS {


### PR DESCRIPTION
## Description

SR-MPLS ERO (RFC 8664 §4.3.1): when the C flag is set, MPLS Label Stack Entry attributes (TC, S, TTL) are now correctly encoded and decoded; the NAI value is appended after the SID when present; CFlag is set automatically based on whether the segment carries stack-entry attributes.

SRv6 ERO (RFC 9603): the decoder has been reworked to honor the S, F and T flags, handle every NAIType variant (IPv6 Node, Adjacency Global, Adjacency Link-Local), parse the SID-Structure and Endpoint Behavior fields, and validate buffer bounds.

SRP object: trailing TLVs that follow the SRP-ID are now parsed.

New TLVs: SRv6-PCE-CAPABILITY (RFC 9603) and MULTIPATH-CAPABILITY (draft-ietf-pce-multipath) with full Decode/Serialize/logging support.

table.SegmentSRMPLS: new TTL, TC and S fields plus a HasMPLSStackEntryAttrs() helper.

Tests: a new object_test.go and an expanded tlv_test.go cover encode/decode round-trips and boundary conditions.

## Type of change
<!--- Select type of change and remove irrelevant options. -->
* [x] New features
* [x] Bug fixes 
* [ ] Refactoring
* [ ] Documentation updates

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How is This Tested?
Verified on a lab with Junos

## Other Information
