### PR TITLE
Fix and extend SRv6 PCE Capability TLV decode tests

### DIFF
--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1769,22 +1769,22 @@ func TestDecodeTLVs_SubTLV(t *testing.T) {
 
 // Test data for SRv6PCECapability.
 var (
-	testSRv6PCECapability              = NewSRv6PCECapability(true)
-	testSRv6PCECapabilityBytes         = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x02)
-	testSRv6PCECapabilityNoNAIBytes    = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x00)
-	testSRv6PCECapabilityTruncated     = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00)
-	testSRv6PCECapabilityInvalidLength = append(tlvHeader(TLVSRv6PCECapability, 8), 0x00, 0x00, 0x00, 0x01, 0xde, 0xad, 0xbe, 0xef)
-	testSRv6PCECapabilityNoNAI         = &SRv6PCECapability{}
-	testSRv6PCECapabilityNAIStrs       = []string{"SRv6", "NAI-Supported"}
-	testSRv6PCECapabilityNoNAIStrs     = []string{"SRv6"}
+	testSRv6PCECapability           = NewSRv6PCECapability(true)
+	testSRv6PCECapabilityBytes      = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x02)
+	testSRv6PCECapabilityNoNAIBytes = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x00)
+	testSRv6PCECapabilityExtended   = append(tlvHeader(TLVSRv6PCECapability, 8), 0x00, 0x00, 0x00, 0x02, 0xde, 0xad, 0xbe, 0xef)
+	testSRv6PCECapabilityTruncated  = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00)
+	testSRv6PCECapabilityNoNAI      = &SRv6PCECapability{}
+	testSRv6PCECapabilityNAIStrs    = []string{"SRv6", "NAI-Supported"}
+	testSRv6PCECapabilityNoNAIStrs  = []string{"SRv6"}
 )
 
 func TestSRv6PCECapability_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
-		"ValidSRv6PCECapability":         {testSRv6PCECapabilityBytes, testSRv6PCECapability, false},
-		"ValidSRv6PCECapabilityNoNAI":    {testSRv6PCECapabilityNoNAIBytes, testSRv6PCECapabilityNoNAI, false},
-		"TruncatedSRv6PCECapability":     {testSRv6PCECapabilityTruncated, nil, true},
-		"InvalidLengthSRv6PCECapability": {testSRv6PCECapabilityInvalidLength, nil, true},
+		"ValidSRv6PCECapability":          {testSRv6PCECapabilityBytes, testSRv6PCECapability, false},
+		"ValidSRv6PCECapabilityNoNAI":     {testSRv6PCECapabilityNoNAIBytes, testSRv6PCECapabilityNoNAI, false},
+		"ExtendedLengthSRv6PCECapability": {testSRv6PCECapabilityExtended, testSRv6PCECapability, false},
+		"TruncatedSRv6PCECapability":      {testSRv6PCECapabilityTruncated, nil, true},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRv6PCECapability{} })
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1769,14 +1769,15 @@ func TestDecodeTLVs_SubTLV(t *testing.T) {
 
 // Test data for SRv6PCECapability.
 var (
-	testSRv6PCECapability           = NewSRv6PCECapability(true)
-	testSRv6PCECapabilityBytes      = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x02)
-	testSRv6PCECapabilityNoNAIBytes = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x00)
-	testSRv6PCECapabilityExtended   = append(tlvHeader(TLVSRv6PCECapability, 8), 0x00, 0x00, 0x00, 0x02, 0xde, 0xad, 0xbe, 0xef)
-	testSRv6PCECapabilityTruncated  = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00)
-	testSRv6PCECapabilityNoNAI      = &SRv6PCECapability{}
-	testSRv6PCECapabilityNAIStrs    = []string{"SRv6", "NAI-Supported"}
-	testSRv6PCECapabilityNoNAIStrs  = []string{"SRv6"}
+	testSRv6PCECapability            = NewSRv6PCECapability(true)
+	testSRv6PCECapabilityBytes       = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x02)
+	testSRv6PCECapabilityNoNAIBytes  = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x00)
+	testSRv6PCECapabilityExtended    = append(tlvHeader(TLVSRv6PCECapability, 8), 0x00, 0x00, 0x00, 0x02, 0xde, 0xad, 0xbe, 0xef)
+	testSRv6PCECapabilityShortLength = append(tlvHeader(TLVSRv6PCECapability, 3), 0x00, 0x00, 0x00)
+	testSRv6PCECapabilityTruncated   = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00)
+	testSRv6PCECapabilityNoNAI       = &SRv6PCECapability{}
+	testSRv6PCECapabilityNAIStrs     = []string{"SRv6", "NAI-Supported"}
+	testSRv6PCECapabilityNoNAIStrs   = []string{"SRv6"}
 )
 
 func TestSRv6PCECapability_DecodeFromBytes(t *testing.T) {
@@ -1784,6 +1785,7 @@ func TestSRv6PCECapability_DecodeFromBytes(t *testing.T) {
 		"ValidSRv6PCECapability":          {testSRv6PCECapabilityBytes, testSRv6PCECapability, false},
 		"ValidSRv6PCECapabilityNoNAI":     {testSRv6PCECapabilityNoNAIBytes, testSRv6PCECapabilityNoNAI, false},
 		"ExtendedLengthSRv6PCECapability": {testSRv6PCECapabilityExtended, testSRv6PCECapability, false},
+		"ShortLengthSRv6PCECapability":    {testSRv6PCECapabilityShortLength, nil, true},
 		"TruncatedSRv6PCECapability":      {testSRv6PCECapabilityTruncated, nil, true},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRv6PCECapability{} })


### PR DESCRIPTION
## Description

Update the SRv6 PCE Capability TLV decode tests to match the current decoder behavior.

This change:
- Renames the extended-length test case to reflect that extended TLVs are accepted.
- Adds a short-length test case to cover the invalid value length error path.

## Type of change

* [ ] New features
* [x] Bug fixes
* [ ] Refactoring
* [ ] Documentation updates

## Motivation and Context

The existing test incorrectly expected an error for an extended-length SRv6 PCE Capability TLV, while the implementation accepts TLVs whose value length is greater than or equal to the minimum required length.

This update aligns the tests with the implementation and adds coverage for the actual invalid-length case.

## How is This Tested?

- [x] `go test ./...`
- [x] Verified that `pkg/packet/pcep/tlv.go` has 100% test coverage.