### PR TITLE
chore(go): bump golang from 1.26.3 to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nttcom/pola
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/osrg/gobgp/v4 v4.7.0


### PR DESCRIPTION
Bump Go from 1.26.3 to 1.26.5.