### PR TITLE
Add support for PCEP VENDOR-INFORMATION TLV

### DIFF
--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1696,23 +1696,23 @@ const (
 	ObjectTypeVendorSpecificConstraints ObjectType = 0x01
 )
 
-const (
-	EnterpriseNumberCisco uint32 = 9
-)
-
 type VendorInformationObject struct {
 	ObjectType       ObjectType // vendor specific constraints: 1
-	EnterpriseNumber uint32
+	EnterpriseNumber EnterpriseNumber
 	TLVs             []TLVInterface
 }
 
 func (o *VendorInformationObject) DecodeFromBytes(typ ObjectType, objectBody []uint8) error {
+	if len(objectBody) < int(EnterpriseNumberLength) {
+		return fmt.Errorf("vendor information object: too short (got %d bytes, want ≥ %d)", len(objectBody), EnterpriseNumberLength)
+	}
+
 	o.ObjectType = typ
-	o.EnterpriseNumber = binary.BigEndian.Uint32(objectBody[0:4])
-	if len(objectBody) > 4 {
-		byteTLVs := objectBody[4:]
+	o.EnterpriseNumber = EnterpriseNumber(binary.BigEndian.Uint32(objectBody[:EnterpriseNumberLength]))
+	if len(objectBody) > int(EnterpriseNumberLength) {
+		byteTLVs := objectBody[EnterpriseNumberLength:]
 		var err error
-		if o.TLVs, err = DecodeTLVs(byteTLVs); err != nil {
+		if o.TLVs, err = DecodeVendorTLVs(byteTLVs); err != nil {
 			return err
 		}
 
@@ -1724,7 +1724,7 @@ func (o *VendorInformationObject) Serialize() []uint8 {
 	vendorInformationObjectHeader := NewCommonObjectHeader(ObjectClassVendorInformation, o.ObjectType, o.Len())
 	byteVendorInformationObjectHeader := vendorInformationObjectHeader.Serialize()
 
-	enterpriseNumber := Uint32ToByteSlice(o.EnterpriseNumber)
+	enterpriseNumber := Uint32ToByteSlice(uint32(o.EnterpriseNumber))
 
 	byteTLVs := []uint8{}
 	for _, tlv := range o.TLVs {
@@ -1737,13 +1737,13 @@ func (o *VendorInformationObject) Serialize() []uint8 {
 	return byteVendorInformationObject
 }
 
-func (o VendorInformationObject) Len() uint16 {
+func (o *VendorInformationObject) Len() uint16 {
 	tlvsByteLength := uint16(0)
 	for _, tlv := range o.TLVs {
 		tlvsByteLength += tlv.Len()
 	}
 	// CommonObjectHeader(4byte) + Enterprise Number (4byte) + TLVs (variable)
-	return commonObjectHeaderLength + 4 + tlvsByteLength
+	return commonObjectHeaderLength + EnterpriseNumberLength + tlvsByteLength
 }
 
 func NewVendorInformationObject(vendor PccType, color uint32, preference uint32) (*VendorInformationObject, error) {
@@ -1757,9 +1757,7 @@ func NewVendorInformationObject(vendor PccType, color uint32, preference uint32)
 			&UndefinedTLV{
 				Typ:    SubTLVColorCisco,
 				Length: SubTLVColorCiscoValueLength, // TODO: 20 if ipv6 endpoint
-				Value: AppendByteSlices(
-					Uint32ToByteSlice(color),
-				),
+				Value:  Uint32ToByteSlice(color),
 			},
 			&UndefinedTLV{
 				Typ:    SubTLVPreferenceCisco,
@@ -1769,29 +1767,31 @@ func NewVendorInformationObject(vendor PccType, color uint32, preference uint32)
 		}
 		o.TLVs = append(o.TLVs, vendorInformationObjectTLVs...)
 	} else {
-		return nil, errors.New("unknown vender information object type")
+		return nil, errors.New("unknown vendor information object type")
 	}
 	return o, nil
 }
 
 func (o *VendorInformationObject) Color() uint32 {
-	for _, tlv := range o.TLVs {
-		if t, ok := tlv.(*UndefinedTLV); ok {
-			if t.Type() == SubTLVColorCisco {
-				return uint32(binary.BigEndian.Uint32(t.Value))
-			}
-		}
-	}
-	return 0
+	return o.subTLVUint32(SubTLVColorCisco)
 }
 
 func (o *VendorInformationObject) Preference() uint32 {
+	return o.subTLVUint32(SubTLVPreferenceCisco)
+}
+
+// subTLVUint32 returns the leading uint32 of the first sub-TLV of the given type,
+// or 0 if it is absent or too short to hold one.
+func (o *VendorInformationObject) subTLVUint32(typ TLVType) uint32 {
 	for _, tlv := range o.TLVs {
-		if t, ok := tlv.(*UndefinedTLV); ok {
-			if t.Type() == SubTLVPreferenceCisco {
-				return uint32(binary.BigEndian.Uint32(t.Value))
-			}
+		t, ok := tlv.(*UndefinedTLV)
+		if !ok || t.Type() != typ {
+			continue
 		}
+		if len(t.Value) < 4 {
+			return 0
+		}
+		return binary.BigEndian.Uint32(t.Value[:4])
 	}
 	return 0
 }

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -701,6 +701,110 @@ func TestAssociationObject_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestVendorInformationObject_DecodeFromBytes(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		objectBody []uint8
+		expected   *VendorInformationObject
+		wantErr    bool
+	}{
+		"EnterpriseNumberOnly": {
+			objectBody: []uint8{0x00, 0x00, 0x00, 0x09},
+			expected: &VendorInformationObject{
+				ObjectType:       ObjectTypeVendorSpecificConstraints,
+				EnterpriseNumber: EnterpriseNumberCisco,
+			},
+		},
+		"CiscoColorSubTLV": {
+			objectBody: []uint8{0x00, 0x00, 0x00, 0x09, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x64},
+			expected: &VendorInformationObject{
+				ObjectType:       ObjectTypeVendorSpecificConstraints,
+				EnterpriseNumber: EnterpriseNumberCisco,
+				TLVs: []TLVInterface{
+					&UndefinedTLV{Typ: SubTLVColorCisco, Length: 4, Value: []uint8{0x00, 0x00, 0x00, 0x64}},
+				},
+			},
+		},
+		// The enterprise-specific type space must not be resolved against tlvMap: type 0x07 is
+		// VENDOR-INFORMATION and type 0x10 is STATEFUL-PCE-CAPABILITY in the standard space.
+		"SubTLVCollidingWithStandardType": {
+			objectBody: []uint8{0x00, 0x00, 0x00, 0x09, 0x00, 0x07, 0x00, 0x02, 0xde, 0xad, 0x00, 0x00},
+			expected: &VendorInformationObject{
+				ObjectType:       ObjectTypeVendorSpecificConstraints,
+				EnterpriseNumber: EnterpriseNumberCisco,
+				TLVs: []TLVInterface{
+					&UndefinedTLV{Typ: TLVVendorInformation, Length: 2, Value: []uint8{0xde, 0xad}},
+				},
+			},
+		},
+		// A body shorter than the mandatory Enterprise Number must be rejected, not panic.
+		"EmptyBody":                 {objectBody: []uint8{}, wantErr: true},
+		"TruncatedEnterpriseNumber": {objectBody: []uint8{0x00, 0x00, 0x09}, wantErr: true},
+		"TruncatedSubTLV":           {objectBody: []uint8{0x00, 0x00, 0x00, 0x09, 0x00, 0x01, 0x00, 0x08, 0x00}, wantErr: true},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &VendorInformationObject{}
+			err := got.DecodeFromBytes(ObjectTypeVendorSpecificConstraints, tt.objectBody)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error for '%s'", name)
+				return
+			}
+			require.NoError(t, err, "unexpected error for '%s'", name)
+			assert.Equal(t, tt.expected, got, "decoded value mismatch for '%s'", name)
+		})
+	}
+}
+
+func TestVendorInformationObject_ColorPreference(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		object         *VendorInformationObject
+		wantColor      uint32
+		wantPreference uint32
+	}{
+		"NoSubTLVs": {
+			object:    &VendorInformationObject{EnterpriseNumber: EnterpriseNumberCisco},
+			wantColor: 0, wantPreference: 0,
+		},
+		"ColorAndPreference": {
+			object: &VendorInformationObject{
+				EnterpriseNumber: EnterpriseNumberCisco,
+				TLVs: []TLVInterface{
+					&UndefinedTLV{Typ: SubTLVColorCisco, Length: 4, Value: Uint32ToByteSlice(100)},
+					&UndefinedTLV{Typ: SubTLVPreferenceCisco, Length: 4, Value: Uint32ToByteSlice(200)},
+				},
+			},
+			wantColor: 100, wantPreference: 200,
+		},
+		// Values too short to hold a uint32 must yield 0 instead of panicking.
+		"ShortSubTLVValues": {
+			object: &VendorInformationObject{
+				EnterpriseNumber: EnterpriseNumberCisco,
+				TLVs: []TLVInterface{
+					&UndefinedTLV{Typ: SubTLVColorCisco, Length: 0, Value: []uint8{}},
+					&UndefinedTLV{Typ: SubTLVPreferenceCisco, Length: 2, Value: []uint8{0x00, 0x01}},
+				},
+			},
+			wantColor: 0, wantPreference: 0,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.wantColor, tt.object.Color(), "color mismatch for '%s'", name)
+			assert.Equal(t, tt.wantPreference, tt.object.Preference(), "preference mismatch for '%s'", name)
+		})
+	}
+}
+
 func TestVendorInformationObject_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -198,6 +198,7 @@ const TLVAlignment = 4
 
 // TLV value lengths, excluding the 4-byte TLV header (type + length)
 const (
+	TLVVendorInformationMinValueLength      uint16 = 4 // Enterprise Number only, without Enterprise-Specific Information
 	TLVStatefulPCECapabilityValueLength     uint16 = 4
 	TLVIPv4LSPIdentifiersValueLength        uint16 = 16
 	TLVIPv6LSPIdentifiersValueLength        uint16 = 52
@@ -241,6 +242,7 @@ type TLVInterface interface {
 }
 
 var tlvMap = map[TLVType]func() TLVInterface{
+	TLVVendorInformation:       func() TLVInterface { return &VendorInformation{} },
 	TLVStatefulPCECapability:   func() TLVInterface { return &StatefulPCECapability{} },
 	TLVSymbolicPathName:        func() TLVInterface { return &SymbolicPathName{} },
 	TLVIPv4LSPIdentifiers:      func() TLVInterface { return &IPv4LSPIdentifiers{} },
@@ -256,6 +258,90 @@ var tlvMap = map[TLVType]func() TLVInterface{
 	TLVSRPolicyCPathID:         func() TLVInterface { return &SRPolicyCandidatePathIdentifier{} },
 	TLVSRPolicyCPathPreference: func() TLVInterface { return &SRPolicyCandidatePathPreference{} },
 	TLVColor:                   func() TLVInterface { return &Color{} },
+}
+
+// VendorInformation represents the VENDOR-INFORMATION TLV (RFC7470 4).
+// The Enterprise-Specific Information is opaque, so it is kept as raw bytes.
+type VendorInformation struct {
+	EnterpriseNumber              EnterpriseNumber
+	EnterpriseSpecificInformation []byte
+}
+
+func (tlv *VendorInformation) DecodeFromBytes(data []byte) error {
+	valueLen, err := decodeTLVLength(data, true)
+	if err != nil {
+		return fmt.Errorf("VendorInformation: %w", err)
+	}
+
+	if valueLen < int(TLVVendorInformationMinValueLength) {
+		return fmt.Errorf("VendorInformation: invalid value length %d", valueLen)
+	}
+
+	value := data[TLVValueOffset : TLVValueOffset+valueLen]
+
+	tlv.EnterpriseNumber = EnterpriseNumber(binary.BigEndian.Uint32(value[:TLVVendorInformationMinValueLength]))
+
+	if info := value[TLVVendorInformationMinValueLength:]; len(info) > 0 {
+		tlv.EnterpriseSpecificInformation = slices.Clone(info)
+	} else {
+		tlv.EnterpriseSpecificInformation = nil
+	}
+
+	return nil
+}
+
+func (tlv *VendorInformation) Serialize() []byte {
+	value := make([]byte, tlv.paddedValueLength())
+	binary.BigEndian.PutUint32(value[:TLVVendorInformationMinValueLength], uint32(tlv.EnterpriseNumber))
+	copy(value[TLVVendorInformationMinValueLength:], tlv.EnterpriseSpecificInformation)
+
+	return AppendByteSlices(
+		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(tlv.valueLength()),
+		value,
+	)
+}
+
+func (tlv *VendorInformation) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if tlv == nil {
+		return nil
+	}
+
+	enc.AddUint32("enterpriseNumber", uint32(tlv.EnterpriseNumber))
+	enc.AddString("enterprise", tlv.EnterpriseNumber.String())
+
+	if len(tlv.EnterpriseSpecificInformation) > 0 {
+		enc.AddString("enterpriseSpecificInformation", fmt.Sprintf("%x", tlv.EnterpriseSpecificInformation))
+	}
+
+	return nil
+}
+
+func (tlv *VendorInformation) Type() TLVType {
+	return TLVVendorInformation
+}
+
+func (tlv *VendorInformation) Len() uint16 {
+	return TLVValueOffset + tlv.paddedValueLength()
+}
+
+func (tlv *VendorInformation) CapStrings() []string {
+	return []string{"Vendor-Info(" + tlv.EnterpriseNumber.capLabel() + ")"}
+}
+
+func (tlv *VendorInformation) valueLength() uint16 {
+	return TLVVendorInformationMinValueLength + uint16(len(tlv.EnterpriseSpecificInformation))
+}
+
+func (tlv *VendorInformation) paddedValueLength() uint16 {
+	return uint16(paddedLength(int(tlv.valueLength()), TLVAlignment))
+}
+
+func NewVendorInformation(enterpriseNumber EnterpriseNumber, enterpriseSpecificInformation []byte) *VendorInformation {
+	return &VendorInformation{
+		EnterpriseNumber:              enterpriseNumber,
+		EnterpriseSpecificInformation: enterpriseSpecificInformation,
+	}
 }
 
 type StatefulPCECapability struct {
@@ -1727,25 +1813,47 @@ func DecodeTLV(data []byte) (TLVInterface, error) {
 		return nil, errors.New("insufficient data to read TLV type")
 	}
 
-	tlvType := binary.BigEndian.Uint16(data[0:2])
+	return decodeTLV(data, TLVType(binary.BigEndian.Uint16(data[0:2])))
+}
 
-	if createTLV, found := tlvMap[TLVType(tlvType)]; found {
-		tlv := createTLV()
-		if err := tlv.DecodeFromBytes(data); err != nil {
-			return nil, fmt.Errorf("error decoding TLV type %x: %w", tlvType, err)
-		}
-		return tlv, nil
+// decodeTLV decodes a single TLV of an already known type from the standard PCEP TLV type space.
+func decodeTLV(data []byte, tlvType TLVType) (TLVInterface, error) {
+	createTLV, found := tlvMap[tlvType]
+	if !found {
+		return decodeUndefinedTLV(data, tlvType)
 	}
 
-	tlv := &UndefinedTLV{}
+	tlv := createTLV()
 	if err := tlv.DecodeFromBytes(data); err != nil {
-		return nil, fmt.Errorf("error decoding undefined TLV type %x: %w", tlvType, err)
+		return nil, fmt.Errorf("error decoding TLV type %x: %w", uint16(tlvType), err)
 	}
 
 	return tlv, nil
 }
 
+// decodeUndefinedTLV decodes a single TLV without consulting tlvMap, keeping its value as raw bytes.
+func decodeUndefinedTLV(data []byte, tlvType TLVType) (TLVInterface, error) {
+	tlv := &UndefinedTLV{}
+	if err := tlv.DecodeFromBytes(data); err != nil {
+		return nil, fmt.Errorf("error decoding undefined TLV type %x: %w", uint16(tlvType), err)
+	}
+
+	return tlv, nil
+}
+
+// DecodeTLVs decodes a sequence of TLVs using the standard PCEP TLV type space.
 func DecodeTLVs(data []byte) ([]TLVInterface, error) {
+	return decodeTLVSequence(data, decodeTLV)
+}
+
+// DecodeVendorTLVs decodes a sequence of TLVs carried in a VENDOR-INFORMATION Object (RFC7470 4).
+// Their type space is enterprise-specific and may collide with the standard one, so every TLV is
+// kept as an UndefinedTLV instead of being matched against tlvMap.
+func DecodeVendorTLVs(data []byte) ([]TLVInterface, error) {
+	return decodeTLVSequence(data, decodeUndefinedTLV)
+}
+
+func decodeTLVSequence(data []byte, decode func([]byte, TLVType) (TLVInterface, error)) ([]TLVInterface, error) {
 	var tlvs []TLVInterface
 
 	for len(data) > 0 {
@@ -1761,7 +1869,7 @@ func DecodeTLVs(data []byte) ([]TLVInterface, error) {
 			return nil, fmt.Errorf("truncated TLV value (type=0x%x)", tlvType)
 		}
 
-		tlv, err := DecodeTLV(data[:totalLen])
+		tlv, err := decode(data[:totalLen], TLVType(tlvType))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -38,6 +38,7 @@ func TestTLVMap(t *testing.T) {
 		tlvType  TLVType
 		expected TLVInterface
 	}{
+		"VendorInformation":       {TLVVendorInformation, &VendorInformation{}},
 		"StatefulPCECapability":   {TLVStatefulPCECapability, &StatefulPCECapability{}},
 		"SymbolicPathName":        {TLVSymbolicPathName, &SymbolicPathName{}},
 		"IPv4LSPIdentifiers":      {TLVIPv4LSPIdentifiers, &IPv4LSPIdentifiers{}},
@@ -128,6 +129,149 @@ func runTLVLenTests(t *testing.T, cases map[string]struct {
 
 func tlvHeader(tlvType TLVType, length uint16) []byte {
 	return []byte{byte(tlvType >> 8), byte(tlvType & 0xff), byte(length >> 8), byte(length & 0xff)}
+}
+
+// Test data for VendorInformation.
+var (
+	// Enterprise Number only, no Enterprise-Specific Information (Juniper sends this in Open)
+	testVendorInformationJuniper      = NewVendorInformation(EnterpriseNumberJuniper, nil)
+	testVendorInformationJuniperBytes = append(tlvHeader(TLVVendorInformation, 4), 0x00, 0x00, 0x0a, 0x4c)
+	// Enterprise-Specific Information already 4-byte aligned
+	testVendorInformationWithInfo      = NewVendorInformation(EnterpriseNumberJuniper, []byte{0xde, 0xad, 0xbe, 0xef})
+	testVendorInformationWithInfoBytes = append(tlvHeader(TLVVendorInformation, 8), 0x00, 0x00, 0x0a, 0x4c, 0xde, 0xad, 0xbe, 0xef)
+	// 2-byte Enterprise-Specific Information (value length 6 → 2 bytes padding)
+	testVendorInformationUnaligned      = NewVendorInformation(EnterpriseNumberCisco, []byte{0x01, 0x02})
+	testVendorInformationUnalignedBytes = append(tlvHeader(TLVVendorInformation, 6), 0x00, 0x00, 0x00, 0x09, 0x01, 0x02, 0x00, 0x00)
+	// Enterprise Number not present in enterpriseNumberNames
+	testVendorInformationUnknownEnterprise = NewVendorInformation(12345, nil)
+	// Value shorter than the mandatory Enterprise Number
+	testVendorInformationTooShort        = append(tlvHeader(TLVVendorInformation, 2), 0x00, 0x00)
+	testVendorInformationTruncatedValue  = append(tlvHeader(TLVVendorInformation, 8), 0x00, 0x00, 0x0a, 0x4c)
+	testVendorInformationTruncatedHeader = []byte{0x00, 0x07, 0x00}
+)
+
+func TestVendorInformation_DecodeFromBytes(t *testing.T) {
+	cases := map[string]TLVTestCase{
+		"EnterpriseNumberOnly": {testVendorInformationJuniperBytes, testVendorInformationJuniper, false},
+		"WithEnterpriseSpecificInformation": {
+			testVendorInformationWithInfoBytes, testVendorInformationWithInfo, false,
+		},
+		"UnalignedEnterpriseSpecificInformation": {
+			testVendorInformationUnalignedBytes, testVendorInformationUnaligned, false,
+		},
+		"ValueTooShort":   {testVendorInformationTooShort, nil, true},
+		"TruncatedValue":  {testVendorInformationTruncatedValue, nil, true},
+		"TruncatedHeader": {testVendorInformationTruncatedHeader, nil, true},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &VendorInformation{} })
+}
+
+func TestVendorInformation_Serialize(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"EnterpriseNumberOnly":                   {testVendorInformationJuniper, testVendorInformationJuniperBytes},
+		"WithEnterpriseSpecificInformation":      {testVendorInformationWithInfo, testVendorInformationWithInfoBytes},
+		"UnalignedEnterpriseSpecificInformation": {testVendorInformationUnaligned, testVendorInformationUnalignedBytes},
+	}
+	runTLVSerializeTests(t, cases)
+}
+
+func TestVendorInformation_MarshalLogObject(t *testing.T) {
+	cases := map[string]struct {
+		input    *VendorInformation
+		expected map[string]any
+	}{
+		"EnterpriseNumberOnly": {
+			testVendorInformationJuniper,
+			map[string]any{
+				"enterpriseNumber": uint32(EnterpriseNumberJuniper),
+				"enterprise":       "Juniper (2636)",
+			},
+		},
+		"WithEnterpriseSpecificInformation": {
+			testVendorInformationWithInfo,
+			map[string]any{
+				"enterpriseNumber":              uint32(EnterpriseNumberJuniper),
+				"enterprise":                    "Juniper (2636)",
+				"enterpriseSpecificInformation": "deadbeef",
+			},
+		},
+		"UnknownEnterprise": {
+			testVendorInformationUnknownEnterprise,
+			map[string]any{
+				"enterpriseNumber": uint32(12345),
+				"enterprise":       "Unknown Enterprise (12345)",
+			},
+		},
+		"NilTLV": {
+			nil,
+			map[string]any{},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+			err := tt.input.MarshalLogObject(enc)
+			assert.NoError(t, err, "unexpected error during MarshalLogObject for '%s'", name)
+			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
+		})
+	}
+}
+
+func TestVendorInformation_Len(t *testing.T) {
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"EnterpriseNumberOnly":                   {testVendorInformationJuniper, TLVValueOffset + 4},
+		"WithEnterpriseSpecificInformation":      {testVendorInformationWithInfo, TLVValueOffset + 8},
+		"UnalignedEnterpriseSpecificInformation": {testVendorInformationUnaligned, TLVValueOffset + 8}, // 6-byte value + 2 pad
+	}
+	runTLVLenTests(t, cases)
+}
+
+func TestVendorInformation_CapStrings(t *testing.T) {
+	cases := map[string]struct {
+		input    CapStringsInterface
+		expected []string
+	}{
+		"KnownEnterprise":   {testVendorInformationJuniper, []string{"Vendor-Info(Juniper)"}},
+		"UnknownEnterprise": {testVendorInformationUnknownEnterprise, []string{"Vendor-Info(EN-12345)"}},
+	}
+	runCapStringsTests(t, cases)
+}
+
+func TestVendorInformation_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]*VendorInformation{
+		"EnterpriseNumberOnly":                   testVendorInformationJuniper,
+		"WithEnterpriseSpecificInformation":      testVendorInformationWithInfo,
+		"UnalignedEnterpriseSpecificInformation": testVendorInformationUnaligned,
+		"UnknownEnterprise":                      testVendorInformationUnknownEnterprise,
+	}
+
+	for name, original := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data := original.Serialize()
+			require.Equal(t, int(original.Len()), len(data), "Len() must match serialized size")
+
+			decoded, err := DecodeTLV(data)
+			require.NoError(t, err, "DecodeTLV failed")
+
+			got, ok := decoded.(*VendorInformation)
+			require.Truef(t, ok, "expected *VendorInformation, got %T", decoded)
+			assert.Equal(t, original, got, "round-trip value mismatch")
+
+			// Serialize again and verify bytes are identical (stability check).
+			assert.Equal(t, data, got.Serialize(), "re-serialized bytes differ")
+		})
+	}
 }
 
 // Test data for StatefulPCECapability.

--- a/pkg/packet/pcep/vendor.go
+++ b/pkg/packet/pcep/vendor.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package pcep
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// EnterpriseNumber is an IANA Private Enterprise Number, used by the VENDOR-INFORMATION TLV and Object (RFC7470).
+// See https://www.iana.org/assignments/enterprise-numbers/
+type EnterpriseNumber uint32
+
+// EnterpriseNumberLength is the wire length of the Enterprise Number field.
+const EnterpriseNumberLength uint16 = 4
+
+// Enterprise Numbers of vendors whose PCEP implementation has been verified against pola.
+const (
+	EnterpriseNumberCisco   EnterpriseNumber = 9
+	EnterpriseNumberHuawei  EnterpriseNumber = 2011
+	EnterpriseNumberJuniper EnterpriseNumber = 2636
+)
+
+// enterpriseNumberNames holds space-free vendor names so they can be used in capability listings.
+var enterpriseNumberNames = map[EnterpriseNumber]string{
+	EnterpriseNumberCisco:   "Cisco",
+	EnterpriseNumberHuawei:  "Huawei",
+	EnterpriseNumberJuniper: "Juniper",
+}
+
+func (en EnterpriseNumber) String() string {
+	if name, ok := enterpriseNumberNames[en]; ok {
+		return fmt.Sprintf("%s (%d)", name, uint32(en))
+	}
+	return fmt.Sprintf("Unknown Enterprise (%d)", uint32(en))
+}
+
+// capLabel returns a compact, space-free vendor label for capability listings.
+func (en EnterpriseNumber) capLabel() string {
+	if name, ok := enterpriseNumberNames[en]; ok {
+		return name
+	}
+	return "EN-" + strconv.FormatUint(uint64(en), 10)
+}

--- a/pkg/packet/pcep/vendor_test.go
+++ b/pkg/packet/pcep/vendor_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package pcep
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnterpriseNumber_String(t *testing.T) {
+	cases := map[string]struct {
+		enterpriseNumber EnterpriseNumber
+		expected         string
+	}{
+		"Cisco":       {EnterpriseNumberCisco, "Cisco (9)"},
+		"Huawei":      {EnterpriseNumberHuawei, "Huawei (2011)"},
+		"Juniper":     {EnterpriseNumberJuniper, "Juniper (2636)"},
+		"UnknownEN":   {12345, "Unknown Enterprise (12345)"},
+		"ZeroEN":      {0, "Unknown Enterprise (0)"},
+		"MaxUint32EN": {EnterpriseNumber(^uint32(0)), "Unknown Enterprise (4294967295)"},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.enterpriseNumber.String()
+			assert.Equal(t, tt.expected, actual, "unexpected EnterpriseNumber.String() result")
+		})
+	}
+}
+
+func TestEnterpriseNumber_capLabel(t *testing.T) {
+	cases := map[string]struct {
+		enterpriseNumber EnterpriseNumber
+		expected         string
+	}{
+		"Cisco":     {EnterpriseNumberCisco, "Cisco"},
+		"Huawei":    {EnterpriseNumberHuawei, "Huawei"},
+		"Juniper":   {EnterpriseNumberJuniper, "Juniper"},
+		"UnknownEN": {12345, "EN-12345"},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.enterpriseNumber.capLabel()
+			assert.Equal(t, tt.expected, actual, "unexpected enterpriseNumberCapLabel() result")
+			assert.NotContains(t, actual, " ", "capability labels must not contain spaces")
+		})
+	}
+}


### PR DESCRIPTION
## Description
Add support for decoding and encoding the PCEP VENDOR-INFORMATION TLV.

## Type of change
* [x] New features
* [ ] Bug fixes 
* [ ] Refactoring
* [ ] Documentation updates

## Motivation and Context
The VENDOR-INFORMATION TLV was previously displayed as an unknown TLV.
This change enables decoding vendor information (e.g., Juniper) and provides more meaningful capability output.

## How is This Tested?
* pkg/packet/pcep/tlv_test.go
* pkg/packet/pcep/object_test.go
* pkg/packet/pcep/vendor_test.go

## Other Information