### PR TITLE
Keep the PCEP session up when the TED is disabled

### DIFF
--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -59,8 +59,7 @@ func (ss *Session) Established() {
 		return
 	}
 
-	done := make(chan struct{})
-	defer close(done)
+	done := make(chan struct{}, 1)
 
 	// Receive PCEP messages in a separate goroutine
 	go func() {
@@ -80,7 +79,7 @@ func (ss *Session) Established() {
 		case <-ticker.C:
 			if err := ss.SendKeepalive(); err != nil {
 				ss.logger.Debug("ERROR! Send Keepalive Message", zap.Error(err))
-				done <- struct{}{}
+				return
 			}
 		}
 	}
@@ -266,32 +265,29 @@ func (ss *Session) handlePCRpt(length uint16) error {
 	}
 
 	for _, sr := range message.StateReports {
-		if sr.LSPObject.SFlag {
-			if err := ss.handleSynchronization(sr, message); err != nil {
-				return err
-			}
-			continue
-		}
-
-		switch {
-		case sr.LSPObject.PlspID == 0:
-			ss.handleFinishSynchronization()
-		case sr.SrpObject.SrpID != 0:
-			if err := ss.handleStatefulPCERequest(sr); err != nil {
-				return err
-			}
-		case sr.LSPObject.PlspID != 0:
-			if err := ss.handleSRPolicyWithPLSPID(sr); err != nil {
-				return err
-			}
-		default:
-			if err := ss.handleDefaultSRPolicy(sr); err != nil {
-				return err
-			}
+		if err := ss.handleStateReport(sr, message); err != nil {
+			ss.logger.Warn("Failed to handle state report",
+				zap.Uint32("plspID", sr.LSPObject.PlspID), zap.Error(err))
 		}
 	}
 
 	return nil
+}
+
+func (ss *Session) handleStateReport(sr *pcep.StateReport, message *pcep.PCRptMessage) error {
+	if sr.LSPObject.SFlag {
+		return ss.handleSynchronization(sr, message)
+	}
+
+	switch {
+	case sr.LSPObject.PlspID == 0:
+		ss.handleFinishSynchronization()
+		return nil
+	case sr.SrpObject.SrpID != 0:
+		return ss.handleStatefulPCERequest(sr)
+	default:
+		return ss.handleSRPolicyWithPLSPID(sr)
+	}
 }
 
 // Synchronization (S-Flag)
@@ -326,6 +322,11 @@ func (ss *Session) handleStatefulPCERequest(sr *pcep.StateReport) error {
 func (ss *Session) handleSRPolicyWithPLSPID(sr *pcep.StateReport) error {
 	ss.logger.Debug("Received SR Policy", zap.Uint32("plspID", sr.LSPObject.PlspID))
 
+	// Skip path computation for removed SR Policies or when no TED is available.
+	if sr.LSPObject.RFlag || ss.ted == nil {
+		return ss.handleReportedSRPolicy(sr)
+	}
+
 	computedSegmentList, err := ss.computePathFromTED(*sr)
 	if err != nil {
 		ss.logger.Error("Failed to compute path from TED", zap.Error(err))
@@ -351,12 +352,12 @@ func (ss *Session) handleSRPolicyWithPLSPID(sr *pcep.StateReport) error {
 	return nil
 }
 
-// Default case
-func (ss *Session) handleDefaultSRPolicy(sr *pcep.StateReport) error {
+// Register (or delete) an SR Policy exactly as reported by the PCC
+func (ss *Session) handleReportedSRPolicy(sr *pcep.StateReport) error {
 	if sr.LSPObject.RFlag {
 		ss.DeleteSRPolicy(*sr)
 	} else if err := ss.RegisterSRPolicy(*sr); err != nil {
-		ss.logger.Error("Failed to register SR Policy (default case)", zap.Error(err), zap.Uint32("plspID", sr.LSPObject.PlspID))
+		ss.logger.Error("Failed to register reported SR Policy", zap.Error(err), zap.Uint32("plspID", sr.LSPObject.PlspID))
 		return err
 	}
 	return nil

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package server
+
+import (
+	"net/netip"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/nttcom/pola/pkg/packet/pcep"
+	"github.com/nttcom/pola/pkg/table"
+)
+
+// newTestStateReport builds a PCRpt state report for an SR-MPLS policy with an explicit path.
+func newTestStateReport(t *testing.T, plspID uint32, srpID uint32) *pcep.StateReport {
+	t.Helper()
+
+	sr, err := pcep.NewStateReport()
+	if err != nil {
+		t.Fatalf("failed to create state report: %v", err)
+	}
+
+	sr.SrpObject.SrpID = srpID
+	sr.LSPObject.PlspID = plspID
+	sr.LSPObject.Name = "pe01-policy1"
+	sr.LSPObject.SrcAddr = netip.MustParseAddr("10.255.0.1")
+	sr.LSPObject.DstAddr = netip.MustParseAddr("10.255.0.2")
+	sr.LSPObject.OFlag = 0x02
+
+	for _, sid := range []uint32{16002, 16003} {
+		subobj, err := pcep.NewSREroSubobject(table.NewSegmentSRMPLS(sid))
+		if err != nil {
+			t.Fatalf("failed to create SR ERO subobject: %v", err)
+		}
+		sr.EroObject.EroSubobjects = append(sr.EroObject.EroSubobjects, subobj)
+	}
+
+	return sr
+}
+
+// A PCC may report an SR Policy on its own (SRP-ID 0), which asks the PCE to compute a path.
+// With the TED disabled the PCE cannot compute anything, but that must not fail the state report:
+// doing so used to tear down the PCEP session and made the PCC reconnect in a loop.
+func TestHandleStateReportWithoutTED(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil)
+	sr := newTestStateReport(t, 1, 0)
+
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if policy.Name != sr.LSPObject.Name {
+		t.Errorf("policy name: got %q, want %q", policy.Name, sr.LSPObject.Name)
+	}
+	if len(policy.SegmentList) != 2 {
+		t.Errorf("segment list length: got %d, want 2", len(policy.SegmentList))
+	}
+}
+
+// The same report with the R-Flag set removes the SR Policy instead of registering it.
+func TestHandleStateReportRemove(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil)
+	sr := newTestStateReport(t, 1, 0)
+
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	sr.LSPObject.RFlag = true
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	if _, found := ss.SearchSRPolicy(sr.LSPObject.PlspID); found {
+		t.Error("SR Policy is still registered after being reported as removed")
+	}
+}


### PR DESCRIPTION
## Description
`polad` no longer tears down the PCEP session when a PCC reports an SR Policy while the TED is disabled (`ted.enable: false`).

- Register (or remove) reported SR Policies as-is, skipping path computation, when the TED is unavailable or the LSP has the R-Flag set.
- Log and skip a failed state report instead of closing the session.
- Extract `handleStateReport()` and rename `handleDefaultSRPolicy()` to `handleReportedSRPolicy()`.
- Fix the keepalive failure path so the session goroutine exits instead of blocking.
- Add tests for state reports handled without a TED.

## Type of change
- [x] Bug fixes
- [x] Refactoring

## Motivation and Context
With `ted.enable: false`, path computation always failed with `TED not available` and the session was closed before reported SR Policies could be registered. Explicit-path deployments do not need it: the PCC already provides the complete segment list.

## How is This Tested?
- `go test ./pkg/server/`