### PR TITLE
Remove the duplicate security vulnerability contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Security vulnerability
-    url: https://github.com/nttcom/pola/blob/main/SECURITY.md
-    about: Do not open a public issue. Report vulnerabilities privately as described in the security policy.
   - name: Documentation
     url: https://github.com/nttcom/pola/blob/main/docs/sources/getting-started.md
     about: Read the Getting Started guide and the examples before opening an issue.


### PR DESCRIPTION
## Description

Remove the duplicate security vulnerability contact link
Follow-up to #387.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

Checked the rendered issue chooser after #387 was merged. 
`make ci` passes locally.

## Checklist

- [x] `make ci` passes locally
- [ ] Tests added or updated if needed
- [ ] Documentation updated if needed
