### PR TITLE
Refactor SR Policy creation and add explicit SID validation

### DIFF
--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -432,10 +432,14 @@ func (x *SRPolicy) GetWaypoints() []*Waypoint {
 }
 
 type CreateSRPolicyRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SrPolicy      *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
-	Asn           uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
-	SidValidate   bool                   `protobuf:"varint,3,opt,name=sid_validate,json=sidValidate,proto3" json:"sid_validate,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	SrPolicy *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
+	Asn      uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
+	// Use endpoints and segments provided in the request without TED lookup
+	// or path computation (no CSPF or router-ID resolution).
+	DisablePathCompute bool `protobuf:"varint,4,opt,name=disable_path_compute,json=disablePathCompute,proto3" json:"disable_path_compute,omitempty"`
+	// Skip checking that explicit SIDs exist in the TED.
+	NoSidValidate bool `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -484,9 +488,16 @@ func (x *CreateSRPolicyRequest) GetAsn() uint32 {
 	return 0
 }
 
-func (x *CreateSRPolicyRequest) GetSidValidate() bool {
+func (x *CreateSRPolicyRequest) GetDisablePathCompute() bool {
 	if x != nil {
-		return x.SidValidate
+		return x.DisablePathCompute
+	}
+	return false
+}
+
+func (x *CreateSRPolicyRequest) GetNoSidValidate() bool {
+	if x != nil {
+		return x.NoSidValidate
 	}
 	return false
 }
@@ -1870,11 +1881,12 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\fsegment_list\x18\n" +
 	" \x03(\v2\x14.api.pola.v1.SegmentR\vsegmentList\x12/\n" +
 	"\x06metric\x18\v \x01(\x0e2\x17.api.pola.v1.MetricTypeR\x06metric\x123\n" +
-	"\twaypoints\x18\f \x03(\v2\x15.api.pola.v1.WaypointR\twaypoints\"\x80\x01\n" +
+	"\twaypoints\x18\f \x03(\v2\x15.api.pola.v1.WaypointR\twaypoints\"\xcb\x01\n" +
 	"\x15CreateSRPolicyRequest\x122\n" +
 	"\tsr_policy\x18\x01 \x01(\v2\x15.api.pola.v1.SRPolicyR\bsrPolicy\x12\x10\n" +
-	"\x03asn\x18\x02 \x01(\rR\x03asn\x12!\n" +
-	"\fsid_validate\x18\x03 \x01(\bR\vsidValidate\"7\n" +
+	"\x03asn\x18\x02 \x01(\rR\x03asn\x120\n" +
+	"\x14disable_path_compute\x18\x04 \x01(\bR\x12disablePathCompute\x12&\n" +
+	"\x0fno_sid_validate\x18\x05 \x01(\bR\rnoSidValidateJ\x04\b\x03\x10\x04R\fsid_validate\"7\n" +
 	"\x16CreateSRPolicyResponse\x12\x1d\n" +
 	"\n" +
 	"is_success\x18\x01 \x01(\bR\tisSuccess\"]\n" +

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -1085,7 +1085,7 @@ func (x *LsSrv6SID) GetMultiTopoIds() []*MultiTopoID {
 type LsPrefix struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Prefix        string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
-	SidIndex      uint32                 `protobuf:"varint,2,opt,name=sid_index,json=sidIndex,proto3" json:"sid_index,omitempty"`
+	SidIndex      *uint32                `protobuf:"varint,2,opt,name=sid_index,json=sidIndex,proto3,oneof" json:"sid_index,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1128,8 +1128,8 @@ func (x *LsPrefix) GetPrefix() string {
 }
 
 func (x *LsPrefix) GetSidIndex() uint32 {
-	if x != nil {
-		return x.SidIndex
+	if x != nil && x.SidIndex != nil {
+		return *x.SidIndex
 	}
 	return 0
 }
@@ -1926,10 +1926,12 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x04sids\x18\x01 \x03(\v2\x10.api.pola.v1.SIDR\x04sids\x12J\n" +
 	"\x11endpoint_behavior\x18\x02 \x01(\v2\x1d.api.pola.v1.EndpointBehaviorR\x10endpointBehavior\x12>\n" +
 	"\rsid_structure\x18\x03 \x01(\v2\x19.api.pola.v1.SidStructureR\fsidStructure\x12>\n" +
-	"\x0emulti_topo_ids\x18\x04 \x03(\v2\x18.api.pola.v1.MultiTopoIDR\fmultiTopoIds\"?\n" +
+	"\x0emulti_topo_ids\x18\x04 \x03(\v2\x18.api.pola.v1.MultiTopoIDR\fmultiTopoIds\"R\n" +
 	"\bLsPrefix\x12\x16\n" +
-	"\x06prefix\x18\x01 \x01(\tR\x06prefix\x12\x1b\n" +
-	"\tsid_index\x18\x02 \x01(\rR\bsidIndex\"K\n" +
+	"\x06prefix\x18\x01 \x01(\tR\x06prefix\x12 \n" +
+	"\tsid_index\x18\x02 \x01(\rH\x00R\bsidIndex\x88\x01\x01B\f\n" +
+	"\n" +
+	"_sid_index\"K\n" +
 	"\x06Metric\x12+\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x17.api.pola.v1.MetricTypeR\x04type\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\rR\x05value\"\xa0\x01\n" +
@@ -2103,6 +2105,7 @@ func file_api_pola_v1_pola_proto_init() {
 	if File_api_pola_v1_pola_proto != nil {
 		return
 	}
+	file_api_pola_v1_pola_proto_msgTypes[15].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -54,7 +54,15 @@ message SRPolicy {
 message CreateSRPolicyRequest {
   SRPolicy sr_policy = 1;
   uint32 asn = 2;
-  bool sid_validate = 3;
+  reserved 3;
+  reserved "sid_validate";
+
+  // Use endpoints and segments provided in the request without TED lookup
+  // or path computation (no CSPF or router-ID resolution).
+  bool disable_path_compute = 4;
+
+  // Skip checking that explicit SIDs exist in the TED.
+  bool no_sid_validate = 5;
 }
 
 message CreateSRPolicyResponse {

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -129,7 +129,7 @@ message LsSrv6SID {
 
 message LsPrefix {
   string prefix = 1;
-  uint32 sid_index = 2;
+  optional uint32 sid_index = 2;
 }
 
 enum MetricType {

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -197,8 +197,6 @@ JSON formatted response
 #### Case: Explicit Path
 
 Each SID may include address information for the NAI.
-See [`--no-sid-validate`](#pola-sr-policy-add--f-filepath---no-sid-validate)
-for details.
 
 YAML input format
 
@@ -225,9 +223,16 @@ JSON formatted response
 }
 ```
 
-### pola sr-policy add -f `filepath` --no-sid-validate
+#### Case: Explicit Path (endpoint addresses)
 
-Create a new SR Policy **without using TED**
+Instead of `srcRouterID`/`dstRouterID`, endpoints can be given directly as
+`srcAddr`/`dstAddr`. This form bypasses path computation: no CSPF and no
+router-ID resolution, so it accepts only `type: explicit` and takes the
+segment list verbatim.
+
+Each SID is still validated against the TED, so with `ted.enable: false` this
+form additionally needs
+[`--no-sid-validate`](#pola-sr-policy-add--f-filepath---no-sid-validate).
 
 For each SID, specify the address information required to construct the NAI.
 `localAddr` is required for SRv6 SIDs but optional for SR-MPLS labels.
@@ -265,6 +270,24 @@ json formatted response
   "status": "success"
 }
 ```
+
+### pola sr-policy add -f `filepath` --no-sid-validate
+
+Skips the check that every explicit SID exists in the TED. Without the flag,
+the request fails if any SID is missing from the TED, including when the TED is
+disabled or not yet synchronized. With the flag, the policy is provisioned and
+both the CLI and polad log a warning.
+
+Notes:
+
+- Dynamic paths and `waypoints[].sid` overrides are not validated.
+- Validation is best-effort: the TED is populated asynchronously via BGP-LS,
+  so results can lag behind the actual topology.
+- For SRv6 uSID containers, only the locator portion is checked, not the
+  full SID.
+- SID types not represented in the TED (Binding SID, Flex-Algorithm prefix
+  SID, anycast SID, static labels) always require `--no-sid-validate`.
+- The `-s` shorthand was removed in 1.4.0; use the long flag.
 
 ### pola ted \[-j\]
 

--- a/cmd/pola/docs/schemas/policy.json
+++ b/cmd/pola/docs/schemas/policy.json
@@ -3,69 +3,144 @@
     "type": "object",
     "properties": {
         "asn": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 1
         },
         "srPolicy": {
             "type": "object",
             "properties": {
                 "pcepSessionAddr": {
-                    "type": "string",
-                    "oneOf": [
-                        {
-                            "format": "ipv4"
-                        },
-                        {
-                            "format": "ipv6"
-                        }
-                    ]
+                    "$ref": "#/$defs/ipAddr"
                 },
                 "srcAddr": {
-                    "type": "string",
-                    "oneOf": [
-                        {
-                            "format": "ipv4"
-                        },
-                        {
-                            "format": "ipv6"
-                        }
-                    ]
+                    "$ref": "#/$defs/ipAddr"
                 },
                 "dstAddr": {
-                    "type": "string",
-                    "oneOf": [
-                        {
-                            "format": "ipv4"
-                        },
-                        {
-                            "format": "ipv6"
-                        }
-                    ]
+                    "$ref": "#/$defs/ipAddr"
+                },
+                "srcRouterID": {
+                    "type": "string"
+                },
+                "dstRouterID": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
                 },
                 "color": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["explicit", "dynamic"]
+                },
+                "metric": {
+                    "type": "string",
+                    "enum": ["igp", "te", "delay"]
                 },
                 "segmentList": {
                     "type": "array",
                     "items": {
                         "$ref": "segment.json"
                     }
+                },
+                "waypoints": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "routerID": {
+                                "type": "string"
+                            },
+                            "sid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["routerID"],
+                        "additionalProperties": false
+                    }
                 }
             },
-            "required": [
-                "pcepSessionAddr",
-                "srcAddr",
-                "dstAddr",
-                "name",
-                "color",
-                "segmentList"
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "title": "Endpoints resolved from the TED by router ID",
+                    "required": ["pcepSessionAddr", "srcRouterID", "dstRouterID", "name", "color", "type"],
+                    "not": {
+                        "anyOf": [
+                            { "required": ["srcAddr"] },
+                            { "required": ["dstAddr"] }
+                        ]
+                    },
+                    "allOf": [
+                        {
+                            "if": {
+                                "properties": { "type": { "const": "explicit" } }
+                            },
+                            "then": {
+                                "required": ["segmentList"]
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": { "type": { "const": "dynamic" } }
+                            },
+                            "then": {
+                                "required": ["metric"]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "title": "Endpoints given directly; no path computation, so explicit only",
+                    "required": ["pcepSessionAddr", "srcAddr", "dstAddr", "name", "color", "segmentList"],
+                    "properties": {
+                        "type": { "const": "explicit" }
+                    },
+                    "not": {
+                        "anyOf": [
+                            { "required": ["srcRouterID"] },
+                            { "required": ["dstRouterID"] },
+                            { "required": ["metric"] },
+                            { "required": ["waypoints"] }
+                        ]
+                    }
+                }
             ]
         }
     },
     "required": [
         "srPolicy"
     ],
-    "additionalProperties": false
+    "allOf": [
+        {
+            "$comment": "The router-ID form resolves endpoints from the TED, which is keyed by ASN",
+            "if": {
+                "required": ["srPolicy"],
+                "properties": {
+                    "srPolicy": {
+                        "anyOf": [
+                            { "required": ["srcRouterID"] },
+                            { "required": ["dstRouterID"] }
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "required": ["asn"]
+            }
+        }
+    ],
+    "additionalProperties": false,
+    "$defs": {
+        "ipAddr": {
+            "$comment": "anyOf, not oneOf: `format` is an annotation by default, so both branches would match and oneOf would always fail",
+            "type": "string",
+            "anyOf": [
+                { "format": "ipv4" },
+                { "format": "ipv6" }
+            ]
+        }
+    }
 }

--- a/cmd/pola/docs/schemas/segment.json
+++ b/cmd/pola/docs/schemas/segment.json
@@ -2,55 +2,48 @@
     "type": "object",
     "properties": {
         "sid": {
-            "oneOf": [
+            "anyOf": [
                 {
-                    "type": "string",
-                    "oneOf": [
-                        {
-                            "format": "ipv4"
-                        },
-                        {
-                            "format": "ipv6"
-                        }
-                    ],
-                    "$comment": "SRv6 format"
+                    "title": "SR-MPLS label",
+                    "type": "integer",
+                    "minimum": 0
                 },
                 {
-                    "type": "integer",
-                    "$comment": "SR-MPLS format"
+                    "title": "SR-MPLS label, quoted",
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                },
+                {
+                    "title": "SRv6 SID, IPv6 only",
+                    "type": "string",
+                    "format": "ipv6"
                 }
             ]
         },
         "localAddr": {
-            "type": "string",
-            "oneOf": [
-                {
-                    "format": "ipv4"
-                },
-                {
-                    "format": "ipv6"
-                }
-            ]
+            "$ref": "#/$defs/ipAddr"
         },
         "remoteAddr": {
-            "type": "string",
-            "oneOf": [
-                {
-                    "format": "ipv4"
-                },
-                {
-                    "format": "ipv6"
-                }
-            ]
+            "$ref": "#/$defs/ipAddr"
         },
         "sidStructure": {
             "type": "string",
             "pattern": "^[0-9]+,[0-9]+,[0-9]+,[0-9]+$",
-            "$comment": "<locator-block>,<locator-node>,<function>,<argument>"
+            "description": "<locator-block>,<locator-node>,<function>,<argument>"
         }
     },
     "required": [
         "sid"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "$defs": {
+        "ipAddr": {
+            "$comment": "anyOf, not oneOf: `format` is an annotation by default, so both branches would match and oneOf would always fail",
+            "type": "string",
+            "anyOf": [
+                { "format": "ipv4" },
+                { "format": "ipv6" }
+            ]
+        }
+    }
 }

--- a/cmd/pola/docs/schemas/segment.json
+++ b/cmd/pola/docs/schemas/segment.json
@@ -6,12 +6,14 @@
                 {
                     "title": "SR-MPLS label",
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "maximum": 1048575
                 },
                 {
+                    "$comment": "20-bit MPLS label range (0-1048575).",
                     "title": "SR-MPLS label, quoted",
                     "type": "string",
-                    "pattern": "^[0-9]+$"
+                    "pattern": "^0*(?:[0-9]{1,6}|10(?:[0-3][0-9]{4}|4(?:[0-7][0-9]{3}|8(?:[0-4][0-9]{2}|5(?:[0-6][0-9]|7[0-5])))))$"
                 },
                 {
                     "title": "SRv6 SID, IPv6 only",

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -193,7 +193,10 @@ func createLsPrefix(lsNode *table.LsNode, prefix *pb.LsPrefix) (*table.LsPrefix,
 	if err != nil {
 		return nil, err
 	}
-	lsPrefix.SidIndex = prefix.GetSidIndex()
+	if prefix.SidIndex != nil {
+		lsPrefix.SidIndex = prefix.GetSidIndex()
+		lsPrefix.HasSidIndex = true
+	}
 
 	return lsPrefix, nil
 }

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package grpc
+
+import (
+	"testing"
+
+	pb "github.com/nttcom/pola/api/pola/v1"
+	"github.com/nttcom/pola/pkg/table"
+	"google.golang.org/protobuf/proto"
+)
+
+// The optional sid_index field carries presence, so index 0 must not be
+// confused with an absent Prefix-SID.
+func TestCreateLsPrefix_SidIndexPresence(t *testing.T) {
+	tests := []struct {
+		name            string
+		prefix          *pb.LsPrefix
+		wantSidIndex    uint32
+		wantHasSidIndex bool
+	}{
+		{
+			name:            "no Prefix-SID",
+			prefix:          &pb.LsPrefix{Prefix: "10.0.0.1/32"},
+			wantSidIndex:    0,
+			wantHasSidIndex: false,
+		},
+		{
+			name:            "Prefix-SID index 0",
+			prefix:          &pb.LsPrefix{Prefix: "10.0.0.1/32", SidIndex: proto.Uint32(0)},
+			wantSidIndex:    0,
+			wantHasSidIndex: true,
+		},
+		{
+			name:            "Prefix-SID index 16000",
+			prefix:          &pb.LsPrefix{Prefix: "10.0.0.1/32", SidIndex: proto.Uint32(16000)},
+			wantSidIndex:    16000,
+			wantHasSidIndex: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lsPrefix, err := createLsPrefix(table.NewLsNode(65000, "0000.0000.0001"), tt.prefix)
+			if err != nil {
+				t.Fatalf("createLsPrefix() returned an error: %v", err)
+			}
+			if lsPrefix.SidIndex != tt.wantSidIndex {
+				t.Errorf("SidIndex = %d, want %d", lsPrefix.SidIndex, tt.wantSidIndex)
+			}
+			if lsPrefix.HasSidIndex != tt.wantHasSidIndex {
+				t.Errorf("HasSidIndex = %v, want %v", lsPrefix.HasSidIndex, tt.wantHasSidIndex)
+			}
+			if lsPrefix.HasPrefixSID() != tt.wantHasSidIndex {
+				t.Errorf("HasPrefixSID() = %v, want %v", lsPrefix.HasPrefixSID(), tt.wantHasSidIndex)
+			}
+		})
+	}
+}

--- a/cmd/pola/sr_policy_add.go
+++ b/cmd/pola/sr_policy_add.go
@@ -12,6 +12,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	yaml "gopkg.in/yaml.v2"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
@@ -57,7 +59,7 @@ func newSRPolicyAddCmd() *cobra.Command {
 		},
 	}
 
-	srPolicyAddCmd.Flags().BoolP("no-sid-validate", "s", false, "disable SR policy SID validation")
+	srPolicyAddCmd.Flags().Bool("no-sid-validate", false, "skip the SID existence check against the TED")
 	srPolicyAddCmd.Flags().StringP("file", "f", "", "[mandatory] path to YAML formatted LSP information file")
 
 	return srPolicyAddCmd
@@ -94,16 +96,27 @@ type InputFormat struct {
 	ASN      uint32   `yaml:"asn"`
 }
 
-func addSRPolicy(input InputFormat, jsonFlag bool, explicitPathFlag bool) error {
-	if explicitPathFlag {
-		if err := addSRPolicyWithoutSIDValidation(input); err != nil {
-			return err
+func addSRPolicy(input InputFormat, jsonFlag bool, noSIDValidate bool) error {
+	if noSIDValidate {
+		fmt.Fprintln(os.Stderr, "warning: skipping SID validation (--no-sid-validate)")
+	}
+
+	usesRouterID := input.SRPolicy.SrcRouterID != "" || input.SRPolicy.DstRouterID != ""
+	usesEndpointAddr := input.SRPolicy.SrcAddr.IsValid() || input.SRPolicy.DstAddr.IsValid()
+	if usesRouterID && usesEndpointAddr {
+		return errors.New("srcRouterID / dstRouterID and srcAddr / dstAddr are mutually exclusive, use one form only")
+	}
+
+	if usesRouterID {
+		if err := addSRPolicyWithRouterID(input, noSIDValidate); err != nil {
+			return translateCreateSRPolicyError(err)
 		}
 	} else {
-		if err := addSRPolicyWithSIDValidation(input); err != nil {
-			return err
+		if err := addSRPolicyWithEndpointAddr(input, noSIDValidate); err != nil {
+			return translateCreateSRPolicyError(err)
 		}
 	}
+
 	if jsonFlag {
 		fmt.Printf("{\"status\": \"success\"}\n")
 	} else {
@@ -113,7 +126,26 @@ func addSRPolicy(input InputFormat, jsonFlag bool, explicitPathFlag bool) error 
 	return nil
 }
 
-func addSRPolicyWithoutSIDValidation(input InputFormat) error {
+// translateCreateSRPolicyError converts gRPC errors into CLI-friendly messages.
+func translateCreateSRPolicyError(err error) error {
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	if st.Code() == codes.FailedPrecondition {
+		return fmt.Errorf("%s\n  hint: use --no-sid-validate to provision without validation", st.Message())
+	}
+	return errors.New(st.Message())
+}
+
+func addSRPolicyWithEndpointAddr(input InputFormat, noSIDValidate bool) error {
+	if input.SRPolicy.Type != "" && input.SRPolicy.Type != "explicit" {
+		return fmt.Errorf("the srcAddr / dstAddr form supports `type: explicit` only, got %q", input.SRPolicy.Type)
+	}
+	if input.SRPolicy.Metric != "" || len(input.SRPolicy.Waypoints) > 0 {
+		return errors.New("`metric` and `waypoints` require a dynamic path, which the srcAddr / dstAddr form does not support")
+	}
+
 	if !input.SRPolicy.PCEPSessionAddr.IsValid() || input.SRPolicy.Color == 0 || !input.SRPolicy.SrcAddr.IsValid() || !input.SRPolicy.DstAddr.IsValid() || len(input.SRPolicy.SegmentList) == 0 {
 		sampleInput := "srPolicy:\n" +
 			"  pcepSessionAddr: 192.0.2.1\n" +
@@ -127,7 +159,9 @@ func addSRPolicyWithoutSIDValidation(input InputFormat) error {
 
 		errMsg := "invalid input\n" +
 			"input example is below\n\n" +
-			sampleInput
+			sampleInput +
+			"or, to resolve endpoints from the TED by router ID instead,\n" +
+			"use the srcRouterID / dstRouterID form\n"
 		return errors.New(errMsg)
 	}
 
@@ -148,21 +182,19 @@ func addSRPolicyWithoutSIDValidation(input InputFormat) error {
 		SegmentList:     segmentList,
 		Color:           input.SRPolicy.Color,
 		PolicyName:      input.SRPolicy.Name,
+		Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 	}
 
 	request := &pb.CreateSRPolicyRequest{
-		SrPolicy:    srPolicy,
-		Asn:         input.ASN,
-		SidValidate: true, // Current server behavior uses SidValidate=true for the manual/TED-less path.
+		SrPolicy:           srPolicy,
+		Asn:                input.ASN,
+		DisablePathCompute: true,
+		NoSidValidate:      noSIDValidate,
 	}
-	if err := grpc.CreateSRPolicy(client, request); err != nil {
-		return err
-	}
-
-	return nil
+	return grpc.CreateSRPolicy(client, request)
 }
 
-func addSRPolicyWithSIDValidation(input InputFormat) error {
+func addSRPolicyWithRouterID(input InputFormat, noSIDValidate bool) error {
 	sampleInputDynamic, sampleInputExplicit := sampleInputs()
 
 	if err := validateCommonInput(input, sampleInputDynamic, sampleInputExplicit); err != nil {
@@ -188,15 +220,12 @@ func addSRPolicyWithSIDValidation(input InputFormat) error {
 	}
 
 	req := &pb.CreateSRPolicyRequest{
-		SrPolicy: srPolicy,
-		Asn:      input.ASN,
+		SrPolicy:      srPolicy,
+		Asn:           input.ASN,
+		NoSidValidate: noSIDValidate,
 	}
 
-	if err := grpc.CreateSRPolicy(client, req); err != nil {
-		return fmt.Errorf("gRPC Server Error: %w", err)
-	}
-
-	return nil
+	return grpc.CreateSRPolicy(client, req)
 }
 
 func sampleInputs() (dynamic, explicit string) {
@@ -239,7 +268,8 @@ func validateCommonInput(input InputFormat, sampleDynamic, sampleExplicit string
 				"input example is below\n\n" +
 				sampleDynamic +
 				sampleExplicit +
-				"or, if create SR Policy without TED, then use `--no-sid-validate` flag\n",
+				"or, to specify endpoints directly instead of resolving router IDs from the TED,\n" +
+				"use the srcAddr / dstAddr form\n",
 		)
 	}
 	return nil

--- a/cmd/pola/ted.go
+++ b/cmd/pola/ted.go
@@ -91,7 +91,7 @@ func printTED(jsonFlag bool) error {
 				prefixMap := map[string]any{
 					"prefix": prefix.Prefix.String(),
 				}
-				if prefix.SidIndex != 0 {
+				if prefix.HasPrefixSID() {
 					prefixMap["sidIndex"] = prefix.SidIndex
 				}
 				prefixes = append(prefixes, prefixMap)

--- a/examples/containerlab/sr-mpls-explicit-path-l3vpn/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path-l3vpn/README.md
@@ -58,6 +58,7 @@ Prefix-SID labels 16002 (p01), 16004 (p02) and 16003 (pe02).
 
 ```bash
 root@pola:/pola# pola sr-policy add -f pe01-policy1.yaml --no-sid-validate
+warning: skipping SID validation (--no-sid-validate)
 success!
 root@pola:/pola# pola sr-policy list
 Session: 10.0.255.1

--- a/examples/containerlab/sr-mpls-explicit-path/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path/README.md
@@ -76,10 +76,13 @@ Prefix-SID labels are 16001 (pe01), 16002 (pe02) and 16003 (pe03).
 
 ```bash
 root@pola:/pola# pola sr-policy add -f pe01-policy1.yaml --no-sid-validate
+warning: skipping SID validation (--no-sid-validate)
 success!
 root@pola:/pola# pola sr-policy add -f pe02-policy1.yaml --no-sid-validate
+warning: skipping SID validation (--no-sid-validate)
 success!
 root@pola:/pola# pola sr-policy add -f pe03-policy1.yaml --no-sid-validate
+warning: skipping SID validation (--no-sid-validate)
 success!
 
 root@pola:/pola# pola sr-policy list

--- a/examples/containerlab/srv6-explicit-path-l3vpn/README.md
+++ b/examples/containerlab/srv6-explicit-path-l3vpn/README.md
@@ -70,11 +70,11 @@ and `fd00:ffff:4:0:1::` (p02).
 
 ```bash
 root@pola:/pola# pola sr-policy add -f pe01-policy1.yaml --no-sid-validate
+warning: skipping SID validation (--no-sid-validate)
 success!
-
 root@pola:/pola# pola sr-policy add -f pe02-policy1.yaml --no-sid-validate
+warning: skipping SID validation (--no-sid-validate)
 success!
-
 root@pola:/pola# pola sr-policy list
 Session: fd00::2
   PolicyName: pe02-policy1

--- a/internal/pkg/gobgp/interface.go
+++ b/internal/pkg/gobgp/interface.go
@@ -499,24 +499,29 @@ func getLsPrefixList(nlris []*api.NLRI, lsAttrPrefix *api.LsAttributePrefix) ([]
 	return lsPrefixList, nil
 }
 
+// algo0PrefixSID returns the algorithm 0 Prefix-SID index, if present.
+// The repeated field takes precedence when populated.
+func algo0PrefixSID(lsAttrPrefix *api.LsAttributePrefix) (uint32, bool) {
+	if sids := lsAttrPrefix.GetSrPrefixSids(); len(sids) > 0 {
+		for _, sid := range sids {
+			if sid.GetAlgorithm() == 0 {
+				return sid.GetSid(), true
+			}
+		}
+		return 0, false
+	}
+	if sid := lsAttrPrefix.GetSrPrefixSid(); sid != 0 {
+		return sid, true
+	}
+	return 0, false
+}
+
 func getLsPrefix(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrPrefix *api.LsAttributePrefix) (*table.LsPrefix, error) {
 	var localNodeID string
 	var localNodeAsn uint32
 	var prefix []string
 
-	// Prefix-SID index 0 is valid, so presence is determined from the TLV list.
-	sidIndex := lsAttrPrefix.GetSrPrefixSid()
-	hasSidIndex := sidIndex != 0
-	if !hasSidIndex {
-		for _, sid := range lsAttrPrefix.GetSrPrefixSids() {
-			if sid.GetAlgorithm() != 0 {
-				continue
-			}
-			sidIndex = sid.GetSid()
-			hasSidIndex = true
-			break
-		}
-	}
+	sidIndex, hasSidIndex := algo0PrefixSID(lsAttrPrefix)
 
 	switch prefNLRI := typedLinkStateNLRI.Nlri.Nlri.(type) {
 	case *api.LsAddrPrefix_LsNLRI_PrefixV4:

--- a/internal/pkg/gobgp/interface.go
+++ b/internal/pkg/gobgp/interface.go
@@ -503,12 +503,19 @@ func getLsPrefix(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrPrefix *api.LsAttri
 	var localNodeID string
 	var localNodeAsn uint32
 	var prefix []string
-	var sidIndex uint32
 
-	if lsAttrPrefix.GetSrPrefixSid() != 0 {
-		sidIndex = lsAttrPrefix.GetSrPrefixSid()
-	} else {
-		sidIndex = 0
+	// Prefix-SID index 0 is valid, so presence is determined from the TLV list.
+	sidIndex := lsAttrPrefix.GetSrPrefixSid()
+	hasSidIndex := sidIndex != 0
+	if !hasSidIndex {
+		for _, sid := range lsAttrPrefix.GetSrPrefixSids() {
+			if sid.GetAlgorithm() != 0 {
+				continue
+			}
+			sidIndex = sid.GetSid()
+			hasSidIndex = true
+			break
+		}
 	}
 
 	switch prefNLRI := typedLinkStateNLRI.Nlri.Nlri.(type) {
@@ -527,6 +534,7 @@ func getLsPrefix(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrPrefix *api.LsAttri
 	localNode := table.NewLsNode(localNodeAsn, localNodeID)
 	lsPrefix := table.NewLsPrefix(localNode)
 	lsPrefix.SidIndex = sidIndex
+	lsPrefix.HasSidIndex = hasSidIndex
 
 	if len(prefix) != 1 {
 		return nil, errors.New("invalid prefix length: expected 1 prefix")

--- a/internal/pkg/gobgp/interface_test.go
+++ b/internal/pkg/gobgp/interface_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package gobgp
+
+import (
+	"testing"
+
+	api "github.com/osrg/gobgp/v4/api"
+)
+
+func testLsAddrPrefixV4(t *testing.T, prefix string) *api.LsAddrPrefix {
+	t.Helper()
+	return &api.LsAddrPrefix{
+		Nlri: &api.LsAddrPrefix_LsNLRI{
+			Nlri: &api.LsAddrPrefix_LsNLRI_PrefixV4{
+				PrefixV4: &api.LsPrefixV4NLRI{
+					LocalNode: &api.LsNodeDescriptor{
+						Asn:         65000,
+						IgpRouterId: "0000.0000.0001",
+					},
+					PrefixDescriptor: &api.LsPrefixDescriptor{
+						IpReachability: []string{prefix},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGetLsPrefix_SidIndex(t *testing.T) {
+	tests := []struct {
+		name            string
+		attr            *api.LsAttributePrefix
+		wantSidIndex    uint32
+		wantHasSidIndex bool
+	}{
+		{
+			name:            "no Prefix-SID",
+			attr:            &api.LsAttributePrefix{},
+			wantSidIndex:    0,
+			wantHasSidIndex: false,
+		},
+		{
+			name:            "singular Prefix-SID",
+			attr:            &api.LsAttributePrefix{SrPrefixSid: 3},
+			wantSidIndex:    3,
+			wantHasSidIndex: true,
+		},
+		{
+			name: "Prefix-SID index 0 advertised for algorithm 0",
+			attr: &api.LsAttributePrefix{
+				SrPrefixSids: []*api.LsAttributePrefixSID{
+					{Algorithm: 0, Sid: 0},
+				},
+			},
+			wantSidIndex:    0,
+			wantHasSidIndex: true,
+		},
+		{
+			name: "Prefix-SID index 0 only for a non-zero algorithm",
+			attr: &api.LsAttributePrefix{
+				SrPrefixSids: []*api.LsAttributePrefixSID{
+					{Algorithm: 128, Sid: 0},
+				},
+			},
+			wantSidIndex:    0,
+			wantHasSidIndex: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lsPrefix, err := getLsPrefix(testLsAddrPrefixV4(t, "10.0.0.1/32"), tt.attr)
+			if err != nil {
+				t.Fatalf("getLsPrefix() error = %v, want nil", err)
+			}
+			if lsPrefix.SidIndex != tt.wantSidIndex {
+				t.Errorf("SidIndex = %d, want %d", lsPrefix.SidIndex, tt.wantSidIndex)
+			}
+			if lsPrefix.HasSidIndex != tt.wantHasSidIndex {
+				t.Errorf("HasSidIndex = %v, want %v", lsPrefix.HasSidIndex, tt.wantHasSidIndex)
+			}
+		})
+	}
+}

--- a/internal/pkg/gobgp/interface_test.go
+++ b/internal/pkg/gobgp/interface_test.go
@@ -69,6 +69,40 @@ func TestGetLsPrefix_SidIndex(t *testing.T) {
 			wantSidIndex:    0,
 			wantHasSidIndex: false,
 		},
+		{
+			name: "singular field kept alongside an algorithm 0 index of 0",
+			attr: &api.LsAttributePrefix{
+				SrPrefixSid: 0,
+				SrPrefixSids: []*api.LsAttributePrefixSID{
+					{Algorithm: 0, Sid: 0},
+				},
+			},
+			wantSidIndex:    0,
+			wantHasSidIndex: true,
+		},
+		{
+			name: "singular field contradicts a list without algorithm 0",
+			attr: &api.LsAttributePrefix{
+				SrPrefixSid: 3,
+				SrPrefixSids: []*api.LsAttributePrefixSID{
+					{Algorithm: 128, Sid: 3},
+				},
+			},
+			wantSidIndex:    0,
+			wantHasSidIndex: false,
+		},
+		{
+			name: "algorithm 0 entry after a Flex-Algo entry wins over the singular field",
+			attr: &api.LsAttributePrefix{
+				SrPrefixSid: 3,
+				SrPrefixSids: []*api.LsAttributePrefixSID{
+					{Algorithm: 128, Sid: 3},
+					{Algorithm: 0, Sid: 16003},
+				},
+			},
+			wantSidIndex:    16003,
+			wantHasSidIndex: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -8,8 +8,8 @@ package version
 import "fmt"
 
 const Major uint = 1
-const Minor uint = 3
-const Patch uint = 2
+const Minor uint = 4
+const Patch uint = 0
 
 func Version() string {
 	return fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -22,6 +22,8 @@ import (
 	"github.com/nttcom/pola/pkg/table"
 	"go.uber.org/zap"
 	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type APIServer struct {
@@ -227,14 +229,18 @@ func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, segmentL
 }
 
 func (s *APIServer) CreateSRPolicy(ctx context.Context, req *pb.CreateSRPolicyRequest) (*pb.CreateSRPolicyResponse, error) {
-	sidvalidate := req.GetSidValidate()
-	if err := validateCreateSRPolicy(req, sidvalidate); err != nil {
+	disablePathCompute := req.GetDisablePathCompute()
+	if err := validateCreateSRPolicy(req, disablePathCompute); err != nil {
 		return nil, fmt.Errorf("failed to validate SR policy creation: %w", err)
 	}
 
-	segmentList, srcAddr, dstAddr, err := buildSegmentList(s, req, sidvalidate)
+	segmentList, srcAddr, dstAddr, err := buildSegmentList(s, req, disablePathCompute)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build segment list: %w", err)
+	}
+
+	if err := s.validateSIDs(req, segmentList); err != nil {
+		return nil, err
 	}
 
 	if err := sendSRPolicyRequest(s, req, segmentList, srcAddr, dstAddr); err != nil {
@@ -242,6 +248,45 @@ func (s *APIServer) CreateSRPolicy(ctx context.Context, req *pb.CreateSRPolicyRe
 	}
 
 	return &pb.CreateSRPolicyResponse{IsSuccess: true}, nil
+}
+
+func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []table.Segment) error {
+	policy := req.GetSrPolicy()
+
+	if req.GetNoSidValidate() {
+		s.logger.Warn("skipping SID validation: no_sid_validate specified",
+			zap.String("policyName", policy.GetPolicyName()),
+			zap.Uint32("color", policy.GetColor()),
+		)
+		return nil
+	}
+
+	// Skip validation for TED-computed dynamic paths.
+	if policy.GetType() == pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC && !req.GetDisablePathCompute() {
+		return nil
+	}
+
+	ted := s.pce.ted
+	if ted == nil {
+		return status.Errorf(codes.FailedPrecondition,
+			"TED is not enabled, SID validation cannot be performed")
+	}
+	if len(ted.Nodes) == 0 {
+		return status.Errorf(codes.FailedPrecondition,
+			"TED is enabled but empty (not yet synchronized), SID validation cannot be performed")
+	}
+
+	missingSegments := table.MissingSegments(ted, segmentList)
+	if len(missingSegments) == 0 {
+		return nil
+	}
+
+	descriptions := make([]string, 0, len(missingSegments))
+	for _, m := range missingSegments {
+		descriptions = append(descriptions, m.String())
+	}
+	return status.Errorf(codes.InvalidArgument,
+		"SID validation failed, the following SIDs are not found in TED: %s", strings.Join(descriptions, ", "))
 }
 
 func (s *APIServer) DeleteSRPolicy(ctx context.Context, input *pb.DeleteSRPolicyRequest) (*pb.DeleteSRPolicyResponse, error) {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -266,6 +266,14 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []ta
 		return nil
 	}
 
+	if table.HasUnknownSegmentType(segmentList) {
+		return status.Errorf(codes.InvalidArgument, "segment list contains a segment with an unrecognized SID family")
+	}
+
+	if table.HasMixedSegmentTypes(segmentList) {
+		return status.Errorf(codes.InvalidArgument, "segment list contains mixed SR-MPLS and SRv6 SIDs")
+	}
+
 	ted := s.pce.ted
 	if ted == nil {
 		return status.Errorf(codes.FailedPrecondition,

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -24,6 +24,7 @@ import (
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 type APIServer struct {
@@ -253,17 +254,15 @@ func (s *APIServer) CreateSRPolicy(ctx context.Context, req *pb.CreateSRPolicyRe
 func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []table.Segment) error {
 	policy := req.GetSrPolicy()
 
-	if req.GetNoSidValidate() {
-		s.logger.Warn("skipping SID validation: no_sid_validate specified",
-			zap.String("policyName", policy.GetPolicyName()),
-			zap.Uint32("color", policy.GetColor()),
-		)
-		return nil
-	}
-
-	// Skip validation for TED-computed dynamic paths.
-	if policy.GetType() == pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC && !req.GetDisablePathCompute() {
-		return nil
+	// Reject out-of-range labels before the validation skip paths.
+	if invalid := table.OutOfRangeSRMPLSLabels(segmentList); len(invalid) > 0 {
+		descriptions := make([]string, 0, len(invalid))
+		for _, s := range invalid {
+			descriptions = append(descriptions, s.String())
+		}
+		return status.Errorf(codes.InvalidArgument,
+			"segment list contains SR-MPLS labels outside the valid range 0-%d: %s",
+			table.MPLSLabelMax, strings.Join(descriptions, ", "))
 	}
 
 	if table.HasUnknownSegmentType(segmentList) {
@@ -272,6 +271,19 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []ta
 
 	if table.HasMixedSegmentTypes(segmentList) {
 		return status.Errorf(codes.InvalidArgument, "segment list contains mixed SR-MPLS and SRv6 SIDs")
+	}
+
+	// Skip TED lookup for dynamically computed paths.
+	if policy.GetType() == pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC && !req.GetDisablePathCompute() {
+		return nil
+	}
+
+	if req.GetNoSidValidate() {
+		s.logger.Warn("skipping SID validation: no_sid_validate specified",
+			zap.String("policyName", policy.GetPolicyName()),
+			zap.Uint32("color", policy.GetColor()),
+		)
+		return nil
 	}
 
 	ted := s.pce.ted
@@ -399,6 +411,9 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 	ValidationAddDisablePathCompute: func(policy *pb.SRPolicy, asn uint32) error {
 		if policy.PcepSessionAddr == nil {
 			return errors.New("policy.PCEP session address must not be nil")
+		}
+		if policy.Color == 0 {
+			return errors.New("policy.Color must not be zero")
 		}
 		if len(policy.SrcAddr) == 0 {
 			return errors.New("policy.SrcAddr must not be empty")
@@ -671,7 +686,12 @@ func convertLsPrefixes(prefixes []*table.LsPrefix) []*pb.LsPrefix {
 	result := make([]*pb.LsPrefix, 0, len(prefixes))
 	for _, p := range prefixes {
 		if p != nil {
-			result = append(result, &pb.LsPrefix{Prefix: p.Prefix.String(), SidIndex: p.SidIndex})
+			pbPrefix := &pb.LsPrefix{Prefix: p.Prefix.String()}
+			// Preserve Prefix-SID presence, including index 0.
+			if p.HasPrefixSID() {
+				pbPrefix.SidIndex = proto.Uint32(p.SidIndex)
+			}
+			result = append(result, pbPrefix)
 		}
 	}
 	return result

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -9,10 +9,14 @@ import (
 	"bytes"
 	"net/netip"
 	"slices"
+	"strings"
 	"testing"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/table"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // localAddr / remoteAddr from the gRPC message must land on the SR-MPLS segment.
@@ -156,5 +160,179 @@ func TestCreateEroFromSegmentListWithNAI(t *testing.T) {
 	}
 	if want := seg.LocalAddr.AsSlice(); !bytes.Equal(raw[8:12], want) {
 		t.Errorf("NAI: got %v, want %v", raw[8:12], want)
+	}
+}
+
+func newTestAPIServer(ted *table.LsTED) *APIServer {
+	return &APIServer{
+		pce:    &Server{ted: ted},
+		logger: zap.NewNop(),
+	}
+}
+
+func explicitPolicyRequest(noSIDValidate bool, sid string) *pb.CreateSRPolicyRequest {
+	return &pb.CreateSRPolicyRequest{
+		SrPolicy: &pb.SRPolicy{
+			Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+			PolicyName:  "test",
+			Color:       100,
+			SegmentList: []*pb.Segment{{Sid: sid}},
+		},
+		NoSidValidate: noSIDValidate,
+	}
+}
+
+func dynamicPolicyRequest() *pb.CreateSRPolicyRequest {
+	return &pb.CreateSRPolicyRequest{
+		SrPolicy: &pb.SRPolicy{
+			Type:       pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
+			PolicyName: "test",
+			Color:      100,
+		},
+	}
+}
+
+func TestValidateSIDs_NoSidValidateSkipsCheck(t *testing.T) {
+	s := newTestAPIServer(nil)
+	req := explicitPolicyRequest(true, "16099")
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
+
+	if err := s.validateSIDs(req, segmentList); err != nil {
+		t.Errorf("expected no_sid_validate to skip the check even with no TED, got: %v", err)
+	}
+}
+
+func TestValidateSIDs_DynamicPathSkipsCheck(t *testing.T) {
+	s := newTestAPIServer(nil)
+	req := dynamicPolicyRequest()
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
+
+	if err := s.validateSIDs(req, segmentList); err != nil {
+		t.Errorf("expected a dynamic path to skip the check, got: %v", err)
+	}
+}
+
+func TestValidateSIDs_DynamicWithDisablePathComputeIsStillValidated(t *testing.T) {
+	node := &table.LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+		},
+	}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
+	s := newTestAPIServer(ted)
+
+	req := dynamicPolicyRequest()
+	req.DisablePathCompute = true
+	req.SrPolicy.SegmentList = []*pb.Segment{{Sid: "16099"}}
+	req.SrPolicy.SrcAddr = netip.MustParseAddr("10.0.0.1").AsSlice()
+	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
+
+	err := s.validateSIDs(req, segmentList)
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+	}
+}
+
+func TestValidateSIDs_NoTED(t *testing.T) {
+	s := newTestAPIServer(nil)
+	req := explicitPolicyRequest(false, "16003")
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
+
+	err := s.validateSIDs(req, segmentList)
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.FailedPrecondition {
+		t.Fatalf("expected codes.FailedPrecondition, got: %v", err)
+	}
+	if !strings.Contains(st.Message(), "TED is not enabled") {
+		t.Errorf("unexpected message: %s", st.Message())
+	}
+}
+
+func TestValidateSIDs_TEDEmpty(t *testing.T) {
+	s := newTestAPIServer(&table.LsTED{Nodes: map[string]*table.LsNode{}})
+	req := explicitPolicyRequest(false, "16003")
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
+
+	err := s.validateSIDs(req, segmentList)
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.FailedPrecondition {
+		t.Fatalf("expected codes.FailedPrecondition, got: %v", err)
+	}
+	if !strings.Contains(st.Message(), "not yet synchronized") {
+		t.Errorf("expected a distinct message for an empty-but-enabled TED, got: %s", st.Message())
+	}
+}
+
+func TestValidateSIDs_MissingSID(t *testing.T) {
+	node := &table.LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+		},
+	}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
+	s := newTestAPIServer(ted)
+
+	req := explicitPolicyRequest(false, "16099")
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
+
+	err := s.validateSIDs(req, segmentList)
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+	}
+	if !strings.Contains(st.Message(), "hop 1") {
+		t.Errorf("expected the missing hop to be listed, got: %s", st.Message())
+	}
+}
+
+func TestValidateSIDs_EndpointFormIsStillValidated(t *testing.T) {
+	node := &table.LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+		},
+	}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
+	s := newTestAPIServer(ted)
+
+	req := explicitPolicyRequest(false, "16099")
+	req.DisablePathCompute = true
+	req.SrPolicy.SrcAddr = netip.MustParseAddr("10.0.0.1").AsSlice()
+	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
+
+	err := s.validateSIDs(req, segmentList)
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+	}
+	if !strings.Contains(st.Message(), "hop 1") {
+		t.Errorf("expected the missing hop to be listed, got: %s", st.Message())
+	}
+}
+
+func TestValidateSIDs_AllKnownSucceeds(t *testing.T) {
+	node := &table.LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+		},
+	}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
+	s := newTestAPIServer(ted)
+
+	req := explicitPolicyRequest(false, "16003")
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
+
+	if err := s.validateSIDs(req, segmentList); err != nil {
+		t.Errorf("expected no error, got: %v", err)
 	}
 }

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"net/netip"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -318,6 +319,34 @@ func TestValidateSIDs_EndpointFormIsStillValidated(t *testing.T) {
 	}
 }
 
+func TestValidateSIDs_LabelOutOfRangeIsRejectedEvenWithNoSidValidate(t *testing.T) {
+	s := newTestAPIServer(nil)
+	req := explicitPolicyRequest(true, "1048576")
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(1048576)}
+
+	err := s.validateSIDs(req, segmentList)
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+	}
+	if !strings.Contains(st.Message(), "0-1048575") || !strings.Contains(st.Message(), "hop 1") {
+		t.Errorf("unexpected message: %s", st.Message())
+	}
+}
+
+func TestValidateSIDs_LabelBoundsAreAccepted(t *testing.T) {
+	s := newTestAPIServer(nil)
+
+	for _, label := range []uint32{0, 1048575} {
+		req := explicitPolicyRequest(true, strconv.FormatUint(uint64(label), 10))
+		segmentList := []table.Segment{table.NewSegmentSRMPLS(label)}
+
+		if err := s.validateSIDs(req, segmentList); err != nil {
+			t.Errorf("expected label %d to be in range, got: %v", label, err)
+		}
+	}
+}
+
 func TestValidateSIDs_AllKnownSucceeds(t *testing.T) {
 	node := &table.LsNode{
 		RouterID:  "0000.0000.0001",
@@ -334,5 +363,47 @@ func TestValidateSIDs_AllKnownSucceeds(t *testing.T) {
 
 	if err := s.validateSIDs(req, segmentList); err != nil {
 		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestConvertLsPrefixes_SidIndexPresence(t *testing.T) {
+	tests := []struct {
+		name         string
+		prefix       *table.LsPrefix
+		wantSet      bool
+		wantSidIndex uint32
+	}{
+		{
+			name:    "no Prefix-SID",
+			prefix:  &table.LsPrefix{Prefix: netip.MustParsePrefix("10.0.0.1/32")},
+			wantSet: false,
+		},
+		{
+			name:         "Prefix-SID index 0",
+			prefix:       &table.LsPrefix{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 0, HasSidIndex: true},
+			wantSet:      true,
+			wantSidIndex: 0,
+		},
+		{
+			name:         "Prefix-SID index 16000",
+			prefix:       &table.LsPrefix{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 16000, HasSidIndex: true},
+			wantSet:      true,
+			wantSidIndex: 16000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertLsPrefixes([]*table.LsPrefix{tt.prefix})
+			if len(got) != 1 {
+				t.Fatalf("convertLsPrefixes() returned %d prefixes, want 1", len(got))
+			}
+			if (got[0].SidIndex != nil) != tt.wantSet {
+				t.Fatalf("sid_index set = %v, want %v", got[0].SidIndex != nil, tt.wantSet)
+			}
+			if tt.wantSet && got[0].GetSidIndex() != tt.wantSidIndex {
+				t.Errorf("sid_index = %d, want %d", got[0].GetSidIndex(), tt.wantSidIndex)
+			}
+		})
 	}
 }

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -218,7 +218,7 @@ func TestValidateSIDs_DynamicWithDisablePathComputeIsStillValidated(t *testing.T
 		RouterID:  "0000.0000.0001",
 		SrgbBegin: 16000,
 		Prefixes: []*table.LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
 		},
 	}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
@@ -273,7 +273,7 @@ func TestValidateSIDs_MissingSID(t *testing.T) {
 		RouterID:  "0000.0000.0001",
 		SrgbBegin: 16000,
 		Prefixes: []*table.LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
 		},
 	}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
@@ -297,7 +297,7 @@ func TestValidateSIDs_EndpointFormIsStillValidated(t *testing.T) {
 		RouterID:  "0000.0000.0001",
 		SrgbBegin: 16000,
 		Prefixes: []*table.LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
 		},
 	}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
@@ -352,7 +352,7 @@ func TestValidateSIDs_AllKnownSucceeds(t *testing.T) {
 		RouterID:  "0000.0000.0001",
 		SrgbBegin: 16000,
 		Prefixes: []*table.LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
 		},
 	}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -58,10 +58,26 @@ func (idx *SIDIndex) addNodePrefixSIDs(node *LsNode) {
 		return
 	}
 	for _, p := range node.Prefixes {
-		if p.HasPrefixSID() {
-			idx.mplsSIDs[node.SrgbBegin+p.SidIndex] = struct{}{}
+		if !p.HasPrefixSID() {
+			continue
+		}
+		if label, ok := srgbLabel(node, p.SidIndex); ok {
+			idx.mplsSIDs[label] = struct{}{}
 		}
 	}
+}
+
+// srgbLabel converts a Prefix-SID index to an MPLS label within the SRGB.
+// It returns false if the resulting label is out of range.
+func srgbLabel(node *LsNode, sidIndex uint32) (uint32, bool) {
+	label := uint64(node.SrgbBegin) + uint64(sidIndex)
+	if label > uint64(MPLSLabelMax) {
+		return 0, false
+	}
+	if node.SrgbEnd > node.SrgbBegin && label >= uint64(node.SrgbEnd) {
+		return 0, false
+	}
+	return uint32(label), true
 }
 
 // addLinkSIDs registers adjacency SIDs and SRv6 End.X SIDs.

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -10,6 +10,9 @@ import (
 	"net/netip"
 )
 
+// MPLSLabelMax is the maximum 20-bit MPLS label value.
+const MPLSLabelMax uint32 = 0xFFFFF
+
 // SIDIndex is a lookup structure over the SIDs advertised by the TED.
 type SIDIndex struct {
 	mplsSIDs     map[uint32]struct{}       // prefix SIDs and adjacency SIDs
@@ -50,8 +53,12 @@ func NewSIDIndex(ted *LsTED) *SIDIndex {
 
 // addNodePrefixSIDs registers SR-MPLS prefix SIDs.
 func (idx *SIDIndex) addNodePrefixSIDs(node *LsNode) {
+	// Without an SRGB, a Prefix-SID index cannot be converted to a label.
+	if node.SrgbBegin == 0 {
+		return
+	}
 	for _, p := range node.Prefixes {
-		if p != nil && p.SidIndex > FirstSIDIndex {
+		if p.HasPrefixSID() {
 			idx.mplsSIDs[node.SrgbBegin+p.SidIndex] = struct{}{}
 		}
 	}
@@ -116,6 +123,9 @@ func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
 	if _, ok := idx.srv6SIDs[s.Sid]; ok {
 		return true
 	}
+	if !s.USid {
+		return false
+	}
 	// Fall back to locator containment for uSID containers.
 	locBits := 0
 	if len(s.Structure) == 4 {
@@ -150,13 +160,26 @@ func MissingSegments(ted *LsTED, segmentList []Segment) []MissingSegment {
 	return missing
 }
 
-// HasUnknownSegmentType reports whether segmentList contains a segment with an unknown family.
-func HasUnknownSegmentType(segmentList []Segment) bool {
-	for _, seg := range segmentList {
-		if seg == nil {
+// OutOfRangeSRMPLSLabels reports SR-MPLS segments with labels outside the 20-bit range.
+func OutOfRangeSRMPLSLabels(segmentList []Segment) []MissingSegment {
+	var invalid []MissingSegment
+	for i, segment := range segmentList {
+		seg, ok := segment.(SegmentSRMPLS)
+		if !ok || seg.Sid <= MPLSLabelMax {
 			continue
 		}
-		if seg.GetFamily() == SegmentUnknown {
+		invalid = append(invalid, MissingSegment{Hop: i + 1, SID: seg.SidString()})
+	}
+	return invalid
+}
+
+// HasUnknownSegmentType reports whether segmentList contains a segment with an unknown family.
+func HasUnknownSegmentType(segmentList []Segment) bool {
+	for _, segment := range segmentList {
+		if segment == nil {
+			continue
+		}
+		if segmentFamily(segment) == SegmentUnknown {
 			return true
 		}
 	}
@@ -165,20 +188,27 @@ func HasUnknownSegmentType(segmentList []Segment) bool {
 
 // HasMixedSegmentTypes reports whether segmentList contains both SRv6 and SR-MPLS segments.
 func HasMixedSegmentTypes(segmentList []Segment) bool {
-	var hasSRv6, hasSRMPLS bool
-	for _, seg := range segmentList {
-		if seg == nil {
+	var family SegmentFamily
+
+	for _, segment := range segmentList {
+		if segment == nil {
 			continue
 		}
-		switch seg.GetFamily() {
-		case SegmentSRv6Family:
-			hasSRv6 = true
-		case SegmentSRMPLSFamily:
-			hasSRMPLS = true
+
+		current := segmentFamily(segment)
+		if current == SegmentUnknown {
+			continue
 		}
-		if hasSRv6 && hasSRMPLS {
+
+		if family == SegmentUnknown {
+			family = current
+			continue
+		}
+
+		if family != current {
 			return true
 		}
 	}
+
 	return false
 }

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -149,3 +149,36 @@ func MissingSegments(ted *LsTED, segmentList []Segment) []MissingSegment {
 	}
 	return missing
 }
+
+// HasUnknownSegmentType reports whether segmentList contains a segment with an unknown family.
+func HasUnknownSegmentType(segmentList []Segment) bool {
+	for _, seg := range segmentList {
+		if seg == nil {
+			continue
+		}
+		if seg.GetFamily() == SegmentUnknown {
+			return true
+		}
+	}
+	return false
+}
+
+// HasMixedSegmentTypes reports whether segmentList contains both SRv6 and SR-MPLS segments.
+func HasMixedSegmentTypes(segmentList []Segment) bool {
+	var hasSRv6, hasSRMPLS bool
+	for _, seg := range segmentList {
+		if seg == nil {
+			continue
+		}
+		switch seg.GetFamily() {
+		case SegmentSRv6Family:
+			hasSRv6 = true
+		case SegmentSRMPLSFamily:
+			hasSRMPLS = true
+		}
+		if hasSRv6 && hasSRMPLS {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package table
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+// SIDIndex is a lookup structure over the SIDs advertised by the TED.
+type SIDIndex struct {
+	mplsSIDs     map[uint32]struct{}       // prefix SIDs and adjacency SIDs
+	srv6SIDs     map[netip.Addr]struct{}   // End / End.X SIDs, matched exactly
+	srv6Locators map[netip.Prefix]struct{} // locator prefixes derived from SID structures
+}
+
+// MissingSegment identifies one segment the TED does not know about.
+type MissingSegment struct {
+	Hop int // 1-origin position in the segment list
+	SID string
+}
+
+func (m MissingSegment) String() string {
+	return fmt.Sprintf("hop %d (%s)", m.Hop, m.SID)
+}
+
+// NewSIDIndex builds a SIDIndex from the TED.
+func NewSIDIndex(ted *LsTED) *SIDIndex {
+	idx := &SIDIndex{
+		mplsSIDs:     map[uint32]struct{}{},
+		srv6SIDs:     map[netip.Addr]struct{}{},
+		srv6Locators: map[netip.Prefix]struct{}{},
+	}
+	if ted == nil {
+		return idx
+	}
+	for _, node := range ted.Nodes {
+		if node == nil {
+			continue
+		}
+		idx.addNodePrefixSIDs(node)
+		idx.addLinkSIDs(node)
+		idx.addSRv6NodeSIDs(node)
+	}
+	return idx
+}
+
+// addNodePrefixSIDs registers SR-MPLS prefix SIDs.
+func (idx *SIDIndex) addNodePrefixSIDs(node *LsNode) {
+	for _, p := range node.Prefixes {
+		if p != nil && p.SidIndex > FirstSIDIndex {
+			idx.mplsSIDs[node.SrgbBegin+p.SidIndex] = struct{}{}
+		}
+	}
+}
+
+// addLinkSIDs registers adjacency SIDs and SRv6 End.X SIDs.
+func (idx *SIDIndex) addLinkSIDs(node *LsNode) {
+	for _, l := range node.Links {
+		if l == nil {
+			continue
+		}
+		if l.AdjSid != 0 {
+			idx.mplsSIDs[l.AdjSid] = struct{}{}
+		}
+		if l.Srv6EndXSID != nil {
+			idx.addSRv6(l.Srv6EndXSID.Sids, l.Srv6EndXSID.Srv6SIDStructure)
+		}
+	}
+}
+
+// addSRv6NodeSIDs registers the SRv6 End SIDs a node advertises.
+func (idx *SIDIndex) addSRv6NodeSIDs(node *LsNode) {
+	for _, s := range node.SRv6SIDs {
+		if s != nil {
+			idx.addSRv6(s.Sids, s.SIDStructure)
+		}
+	}
+}
+
+// addSRv6 registers exact SIDs and their locator prefixes.
+func (idx *SIDIndex) addSRv6(sids []string, st SIDStructure) {
+	locBits := int(st.LocalBlock) + int(st.LocalNode)
+	for _, s := range sids {
+		addr, err := netip.ParseAddr(s)
+		if err != nil || !addr.Is6() {
+			continue
+		}
+		idx.srv6SIDs[addr] = struct{}{}
+		if locBits <= 0 || locBits > SRv6SIDBitLength {
+			continue
+		}
+		if p, err := addr.Prefix(locBits); err == nil {
+			idx.srv6Locators[p] = struct{}{}
+		}
+	}
+}
+
+// Has reports whether the TED knows about seg.
+func (idx *SIDIndex) Has(seg Segment) bool {
+	switch s := seg.(type) {
+	case SegmentSRMPLS:
+		_, ok := idx.mplsSIDs[s.Sid]
+		return ok
+	case SegmentSRv6:
+		return idx.hasSRv6(s)
+	}
+	return false
+}
+
+func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
+	// End / End.X SIDs are advertised verbatim, so prefer the exact match.
+	if _, ok := idx.srv6SIDs[s.Sid]; ok {
+		return true
+	}
+	// Fall back to locator containment for uSID containers.
+	locBits := 0
+	if len(s.Structure) == 4 {
+		locBits = int(s.Structure[0]) + int(s.Structure[1])
+	}
+	for loc := range idx.srv6Locators {
+		if !loc.Contains(s.Sid) {
+			continue
+		}
+		// Reject a request whose declared locator is shorter than the TED's.
+		if locBits > 0 && loc.Bits() > locBits {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// MissingSegments reports the segments not found in the TED.
+func MissingSegments(ted *LsTED, segmentList []Segment) []MissingSegment {
+	idx := NewSIDIndex(ted)
+	var missing []MissingSegment
+	for i, seg := range segmentList {
+		if seg == nil || !idx.Has(seg) {
+			sid := "<nil>"
+			if seg != nil {
+				sid = seg.SidString()
+			}
+			missing = append(missing, MissingSegment{Hop: i + 1, SID: sid})
+		}
+	}
+	return missing
+}

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -51,17 +51,68 @@ func TestSIDIndexHas_SRMPLS(t *testing.T) {
 }
 
 func TestSIDIndexHas_SRMPLS_SrgbBeginZero(t *testing.T) {
-	// A node that hasn't advertised its SRGB yet registers the raw SidIndex
-	// value as-is; this is a known limitation, not a correctness guarantee.
+	// Without an SRGB, a Prefix-SID index cannot be converted to a label.
 	node := &LsNode{
 		RouterID: "0000.0000.0001",
 		Prefixes: []*LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 16003},
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 16003, HasSidIndex: true},
 		},
 	}
 	idx := NewSIDIndex(newTestTED(node))
-	if !idx.Has(NewSegmentSRMPLS(16003)) {
-		t.Errorf("expected SidIndex to be registered verbatim when SrgbBegin is 0")
+	if idx.Has(NewSegmentSRMPLS(16003)) {
+		t.Errorf("expected SidIndex not to be registered when SrgbBegin is unavailable")
+	}
+}
+
+func TestSIDIndexHas_SRMPLS_PrefixSIDIndexZero(t *testing.T) {
+	// Prefix-SID index 0 is a valid index: SRGB begin + 0 must be registered
+	// when the Prefix-SID TLV was actually advertised.
+	node := &LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 0, HasSidIndex: true},
+		},
+	}
+	idx := NewSIDIndex(newTestTED(node))
+	if !idx.Has(NewSegmentSRMPLS(16000)) {
+		t.Errorf("expected Prefix-SID index 0 to be registered as label 16000")
+	}
+}
+
+func TestSIDIndexHas_SRMPLS_NoPrefixSID(t *testing.T) {
+	// A prefix without a Prefix-SID TLV must not register the SRGB begin label.
+	node := &LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32")},
+		},
+	}
+	idx := NewSIDIndex(newTestTED(node))
+	if idx.Has(NewSegmentSRMPLS(16000)) {
+		t.Errorf("expected no MPLS SID for a prefix without a Prefix-SID")
+	}
+}
+
+func TestLsPrefixHasPrefixSID(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix *LsPrefix
+		want   bool
+	}{
+		{"nil prefix", nil, false},
+		{"no Prefix-SID", &LsPrefix{}, false},
+		{"advertised index 0", &LsPrefix{HasSidIndex: true}, true},
+		{"advertised non-zero index", &LsPrefix{SidIndex: 3, HasSidIndex: true}, true},
+		{"non-zero index without flag", &LsPrefix{SidIndex: 3}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.prefix.HasPrefixSID(); got != tt.want {
+				t.Errorf("HasPrefixSID() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -118,6 +169,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 
 	t.Run("structure present, container within locator", func(t *testing.T) {
 		seg := NewSegmentSRv6(container)
+		seg.USid = true
 		seg.Structure = []uint8{32, 16, 16, 0}
 		if !NewSIDIndex(ted).Has(seg) {
 			t.Errorf("expected uSID container to be accepted via locator containment")
@@ -126,6 +178,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 
 	t.Run("no structure, falls back to containment", func(t *testing.T) {
 		seg := NewSegmentSRv6(container)
+		seg.USid = true
 		if !NewSIDIndex(ted).Has(seg) {
 			t.Errorf("expected uSID container without structure to be accepted via containment fallback")
 		}
@@ -133,6 +186,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 
 	t.Run("declared locator shorter than TED advertised", func(t *testing.T) {
 		seg := NewSegmentSRv6(container)
+		seg.USid = true
 		// Declares a /32 locator (block=24,node=8), which contradicts the /48
 		// the TED actually advertises.
 		seg.Structure = []uint8{24, 8, 16, 0}
@@ -143,8 +197,16 @@ func TestSIDIndexHas_USID(t *testing.T) {
 
 	t.Run("outside any known locator", func(t *testing.T) {
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:ffff::"))
+		seg.USid = true
 		if NewSIDIndex(ted).Has(seg) {
 			t.Errorf("expected mismatch for a SID outside any known locator")
+		}
+	})
+
+	t.Run("non-uSID segment does not fall back to locator containment", func(t *testing.T) {
+		seg := NewSegmentSRv6(container)
+		if NewSIDIndex(ted).Has(seg) {
+			t.Errorf("expected non-uSID segment to require an exact SID match")
 		}
 	})
 }
@@ -239,6 +301,57 @@ func TestHasUnknownSegmentType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := HasUnknownSegmentType(tt.segs); got != tt.want {
 				t.Errorf("HasUnknownSegmentType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutOfRangeSRMPLSLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		segs []Segment
+		want []MissingSegment
+	}{
+		{
+			name: "lower bound is valid",
+			segs: []Segment{NewSegmentSRMPLS(0)},
+		},
+		{
+			name: "upper bound is valid",
+			segs: []Segment{NewSegmentSRMPLS(1048575)},
+		},
+		{
+			name: "one past the upper bound is rejected",
+			segs: []Segment{NewSegmentSRMPLS(1048576)},
+			want: []MissingSegment{{Hop: 1, SID: "1048576"}},
+		},
+		{
+			name: "reports the offending hop only",
+			segs: []Segment{
+				NewSegmentSRMPLS(16001),
+				NewSegmentSRMPLS(1048576),
+			},
+			want: []MissingSegment{{Hop: 2, SID: "1048576"}},
+		},
+		{
+			name: "SRv6 and nil segments are ignored",
+			segs: []Segment{nil, NewSegmentSRv6(netip.MustParseAddr("2001:db8::1"))},
+		},
+		{
+			name: "empty list",
+			segs: []Segment{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := OutOfRangeSRMPLSLabels(tt.segs)
+			if len(got) != len(tt.want) {
+				t.Fatalf("OutOfRangeSRMPLSLabels() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("OutOfRangeSRMPLSLabels()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
 			}
 		})
 	}

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package table
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func newTestTED(nodes ...*LsNode) *LsTED {
+	m := make(map[string]*LsNode, len(nodes))
+	for _, n := range nodes {
+		m[n.RouterID] = n
+	}
+	return &LsTED{Nodes: m}
+}
+
+func TestSIDIndexHas_SRMPLS(t *testing.T) {
+	node := &LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+		},
+		Links: []*LsLink{
+			{AdjSid: 24001},
+		},
+	}
+	ted := newTestTED(node)
+
+	tests := []struct {
+		name string
+		seg  Segment
+		want bool
+	}{
+		{"prefix SID match", NewSegmentSRMPLS(16003), true},
+		{"adj SID match", NewSegmentSRMPLS(24001), true},
+		{"unknown label", NewSegmentSRMPLS(16099), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := NewSIDIndex(ted)
+			if got := idx.Has(tt.seg); got != tt.want {
+				t.Errorf("Has(%v) = %v, want %v", tt.seg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSIDIndexHas_SRMPLS_SrgbBeginZero(t *testing.T) {
+	// A node that hasn't advertised its SRGB yet registers the raw SidIndex
+	// value as-is; this is a known limitation, not a correctness guarantee.
+	node := &LsNode{
+		RouterID: "0000.0000.0001",
+		Prefixes: []*LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 16003},
+		},
+	}
+	idx := NewSIDIndex(newTestTED(node))
+	if !idx.Has(NewSegmentSRMPLS(16003)) {
+		t.Errorf("expected SidIndex to be registered verbatim when SrgbBegin is 0")
+	}
+}
+
+func TestSIDIndexHas_SRv6Exact(t *testing.T) {
+	node := &LsNode{
+		RouterID: "0000.0000.0001",
+		SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"2001:db8:1::"}, SIDStructure: SIDStructure{}},
+		},
+		Links: []*LsLink{
+			{
+				Srv6EndXSID: &Srv6EndXSID{
+					Sids:             []string{"2001:db8:1::1"},
+					Srv6SIDStructure: SIDStructure{},
+				},
+			},
+		},
+	}
+	ted := newTestTED(node)
+
+	tests := []struct {
+		name string
+		seg  Segment
+		want bool
+	}{
+		{"End SID exact match", NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::")), true},
+		{"End.X SID exact match", NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::1")), true},
+		{"unknown SID", NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::99")), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := NewSIDIndex(ted)
+			if got := idx.Has(tt.seg); got != tt.want {
+				t.Errorf("Has(%v) = %v, want %v", tt.seg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSIDIndexHas_USID(t *testing.T) {
+	// TED advertises a locator of block=32, node=16 bits -> fcbb:bb00:0100::/48.
+	node := &LsNode{
+		RouterID: "0000.0000.0001",
+		SRv6SIDs: []*LsSrv6SID{
+			{
+				Sids:         []string{"fcbb:bb00:0100::"},
+				SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
+			},
+		},
+	}
+	ted := newTestTED(node)
+
+	container := netip.MustParseAddr("fcbb:bb00:0100:0200:0300::")
+
+	t.Run("structure present, container within locator", func(t *testing.T) {
+		seg := NewSegmentSRv6(container)
+		seg.Structure = []uint8{32, 16, 16, 0}
+		if !NewSIDIndex(ted).Has(seg) {
+			t.Errorf("expected uSID container to be accepted via locator containment")
+		}
+	})
+
+	t.Run("no structure, falls back to containment", func(t *testing.T) {
+		seg := NewSegmentSRv6(container)
+		if !NewSIDIndex(ted).Has(seg) {
+			t.Errorf("expected uSID container without structure to be accepted via containment fallback")
+		}
+	})
+
+	t.Run("declared locator shorter than TED advertised", func(t *testing.T) {
+		seg := NewSegmentSRv6(container)
+		// Declares a /32 locator (block=24,node=8), which contradicts the /48
+		// the TED actually advertises.
+		seg.Structure = []uint8{24, 8, 16, 0}
+		if NewSIDIndex(ted).Has(seg) {
+			t.Errorf("expected mismatch when declared locator is shorter than TED advertised")
+		}
+	})
+
+	t.Run("outside any known locator", func(t *testing.T) {
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:ffff::"))
+		if NewSIDIndex(ted).Has(seg) {
+			t.Errorf("expected mismatch for a SID outside any known locator")
+		}
+	})
+}
+
+func TestSIDIndexHas_EmptyTED(t *testing.T) {
+	tests := []struct {
+		name string
+		ted  *LsTED
+	}{
+		{"nil TED", nil},
+		{"TED with no nodes", newTestTED()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := NewSIDIndex(tt.ted)
+			if idx.Has(NewSegmentSRMPLS(16003)) {
+				t.Errorf("expected no match against an empty TED")
+			}
+			if idx.Has(NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::"))) {
+				t.Errorf("expected no match against an empty TED")
+			}
+		})
+	}
+}
+
+func TestMissingSegments(t *testing.T) {
+	node := &LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+		},
+	}
+	ted := newTestTED(node)
+
+	segmentList := []Segment{
+		NewSegmentSRMPLS(16003),
+		NewSegmentSRMPLS(16099),
+		NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::99")),
+	}
+
+	missing := MissingSegments(ted, segmentList)
+	if len(missing) != 2 {
+		t.Fatalf("expected 2 missing segments, got %d: %v", len(missing), missing)
+	}
+	if missing[0].Hop != 2 || missing[0].SID != "16099" {
+		t.Errorf("unexpected first missing segment: %+v", missing[0])
+	}
+	if missing[1].Hop != 3 || missing[1].SID != "2001:db8:1::99" {
+		t.Errorf("unexpected second missing segment: %+v", missing[1])
+	}
+}

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -23,7 +23,7 @@ func TestSIDIndexHas_SRMPLS(t *testing.T) {
 		RouterID:  "0000.0000.0001",
 		SrgbBegin: 16000,
 		Prefixes: []*LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
 		},
 		Links: []*LsLink{
 			{AdjSid: 24001},
@@ -95,6 +95,79 @@ func TestSIDIndexHas_SRMPLS_NoPrefixSID(t *testing.T) {
 	}
 }
 
+func TestSIDIndexHas_SRMPLS_PrefixSIDRanges(t *testing.T) {
+	tests := []struct {
+		name  string
+		node  *LsNode
+		label uint32
+		want  bool
+	}{
+		{
+			name: "index inside the SRGB",
+			node: &LsNode{
+				RouterID: "0000.0000.0001", SrgbBegin: 16000, SrgbEnd: 24000,
+				Prefixes: []*LsPrefix{{SidIndex: 3, HasSidIndex: true}},
+			},
+			label: 16003,
+			want:  true,
+		},
+		{
+			name: "last index of the SRGB (SrgbEnd is exclusive)",
+			node: &LsNode{
+				RouterID: "0000.0000.0001", SrgbBegin: 16000, SrgbEnd: 24000,
+				Prefixes: []*LsPrefix{{SidIndex: 7999, HasSidIndex: true}},
+			},
+			label: 23999,
+			want:  true,
+		},
+		{
+			name: "index at SrgbEnd is outside the SRGB",
+			node: &LsNode{
+				RouterID: "0000.0000.0001", SrgbBegin: 16000, SrgbEnd: 24000,
+				Prefixes: []*LsPrefix{{SidIndex: 8000, HasSidIndex: true}},
+			},
+			label: 24000,
+			want:  false,
+		},
+		{
+			name: "index beyond the SRGB",
+			node: &LsNode{
+				RouterID: "0000.0000.0001", SrgbBegin: 16000, SrgbEnd: 24000,
+				Prefixes: []*LsPrefix{{SidIndex: 100000, HasSidIndex: true}},
+			},
+			label: 116000,
+			want:  false,
+		},
+		{
+			name: "label beyond the 20-bit MPLS range without an SRGB end",
+			node: &LsNode{
+				RouterID: "0000.0000.0001", SrgbBegin: 1000000,
+				Prefixes: []*LsPrefix{{SidIndex: 100000, HasSidIndex: true}},
+			},
+			label: 1100000,
+			want:  false,
+		},
+		{
+			name: "index that would overflow uint32",
+			node: &LsNode{
+				RouterID: "0000.0000.0001", SrgbBegin: 16000,
+				Prefixes: []*LsPrefix{{SidIndex: 0xFFFFFFFF, HasSidIndex: true}},
+			},
+			label: 15999, // 16000 + 0xFFFFFFFF wrapped around
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := NewSIDIndex(newTestTED(tt.node))
+			if got := idx.Has(NewSegmentSRMPLS(tt.label)); got != tt.want {
+				t.Errorf("Has(%d) = %v, want %v", tt.label, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLsPrefixHasPrefixSID(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -105,7 +178,6 @@ func TestLsPrefixHasPrefixSID(t *testing.T) {
 		{"no Prefix-SID", &LsPrefix{}, false},
 		{"advertised index 0", &LsPrefix{HasSidIndex: true}, true},
 		{"advertised non-zero index", &LsPrefix{SidIndex: 3, HasSidIndex: true}, true},
-		{"non-zero index without flag", &LsPrefix{SidIndex: 3}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -237,7 +309,7 @@ func TestMissingSegments(t *testing.T) {
 		RouterID:  "0000.0000.0001",
 		SrgbBegin: 16000,
 		Prefixes: []*LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3},
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
 		},
 	}
 	ted := newTestTED(node)

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -197,3 +197,120 @@ func TestMissingSegments(t *testing.T) {
 		t.Errorf("unexpected second missing segment: %+v", missing[1])
 	}
 }
+
+type fakeUnknownSegment struct{}
+
+func (fakeUnknownSegment) SidString() string        { return "unknown" }
+func (fakeUnknownSegment) GetFamily() SegmentFamily { return SegmentUnknown }
+
+func TestHasUnknownSegmentType(t *testing.T) {
+	tests := []struct {
+		name string
+		segs []Segment
+		want bool
+	}{
+		{
+			name: "all known, SR-MPLS",
+			segs: []Segment{NewSegmentSRMPLS(16001), NewSegmentSRMPLS(16002)},
+			want: false,
+		},
+		{
+			name: "all known, SRv6",
+			segs: []Segment{NewSegmentSRv6(netip.MustParseAddr("2001:db8::1"))},
+			want: false,
+		},
+		{
+			name: "contains nil only",
+			segs: []Segment{nil, nil},
+			want: false,
+		},
+		{
+			name: "empty list",
+			segs: []Segment{},
+			want: false,
+		},
+		{
+			name: "contains unknown family",
+			segs: []Segment{NewSegmentSRMPLS(16001), fakeUnknownSegment{}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasUnknownSegmentType(tt.segs); got != tt.want {
+				t.Errorf("HasUnknownSegmentType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasMixedSegmentTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		segs []Segment
+		want bool
+	}{
+		{
+			name: "all SRv6",
+			segs: []Segment{
+				NewSegmentSRv6(netip.MustParseAddr("2001:db8::1")),
+				NewSegmentSRv6(netip.MustParseAddr("2001:db8::2")),
+			},
+			want: false,
+		},
+
+		{
+			name: "all SR-MPLS",
+			segs: []Segment{NewSegmentSRMPLS(16001), NewSegmentSRMPLS(16002)},
+			want: false,
+		},
+		{
+			name: "mixed SRv6 then SR-MPLS",
+			segs: []Segment{
+				NewSegmentSRv6(netip.MustParseAddr("2001:db8::1")),
+				NewSegmentSRMPLS(16001),
+			},
+			want: true,
+		},
+
+		{
+			name: "mixed SR-MPLS then SRv6",
+			segs: []Segment{
+				NewSegmentSRMPLS(16001),
+				NewSegmentSRv6(netip.MustParseAddr("2001:db8::1")),
+			},
+			want: true,
+		},
+		{
+			name: "SRv6 with unknown family",
+			segs: []Segment{
+				NewSegmentSRv6(netip.MustParseAddr("2001:db8::1")),
+				fakeUnknownSegment{},
+			},
+			want: false,
+		},
+		{
+			name: "SR-MPLS with unknown family",
+			segs: []Segment{NewSegmentSRMPLS(16001), fakeUnknownSegment{}},
+			want: false,
+		},
+
+		{
+			name: "empty list",
+			segs: []Segment{},
+			want: false,
+		},
+		{
+			name: "single SR-MPLS",
+			segs: []Segment{NewSegmentSRMPLS(16001)},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasMixedSegmentTypes(tt.segs); got != tt.want {
+				t.Errorf("HasMixedSegmentTypes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -90,7 +90,17 @@ const SRv6SIDBitLength = 128
 
 type Segment interface {
 	SidString() string
-	GetFamily() SegmentFamily
+}
+
+func segmentFamily(segment Segment) SegmentFamily {
+	switch segment.(type) {
+	case SegmentSRv6:
+		return SegmentSRv6Family
+	case SegmentSRMPLS:
+		return SegmentSRMPLSFamily
+	default:
+		return SegmentUnknown
+	}
 }
 
 func NewSegment(sid string) (Segment, error) {
@@ -144,9 +154,6 @@ type SegmentSRv6 struct {
 
 func (seg SegmentSRv6) SidString() string {
 	return seg.Sid.String()
-}
-func (seg SegmentSRv6) GetFamily() SegmentFamily {
-	return SegmentSRv6Family
 }
 
 func (seg SegmentSRv6) Behavior() (uint16, error) {
@@ -228,10 +235,6 @@ func NewSegmentSRMPLS(sid uint32) SegmentSRMPLS {
 	return SegmentSRMPLS{
 		Sid: sid,
 	}
-}
-
-func (seg SegmentSRMPLS) GetFamily() SegmentFamily {
-	return SegmentSRMPLSFamily
 }
 
 // Equal for SegmentSRv6

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -90,6 +90,7 @@ const SRv6SIDBitLength = 128
 
 type Segment interface {
 	SidString() string
+	GetFamily() SegmentFamily
 }
 
 func NewSegment(sid string) (Segment, error) {
@@ -143,6 +144,9 @@ type SegmentSRv6 struct {
 
 func (seg SegmentSRv6) SidString() string {
 	return seg.Sid.String()
+}
+func (seg SegmentSRv6) GetFamily() SegmentFamily {
+	return SegmentSRv6Family
 }
 
 func (seg SegmentSRv6) Behavior() (uint16, error) {
@@ -226,6 +230,10 @@ func NewSegmentSRMPLS(sid uint32) SegmentSRMPLS {
 	}
 }
 
+func (seg SegmentSRMPLS) GetFamily() SegmentFamily {
+	return SegmentSRMPLSFamily
+}
+
 // Equal for SegmentSRv6
 func (seg SegmentSRv6) Equal(other SegmentSRv6) bool {
 	// Compare SID, LocalAddr, and RemoteAddr
@@ -260,3 +268,11 @@ type Waypoint struct {
 	RouterID string
 	SID      string // optional: fixed SID override
 }
+
+type SegmentFamily int
+
+const (
+	SegmentUnknown SegmentFamily = iota
+	SegmentSRv6Family
+	SegmentSRMPLSFamily
+)

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -68,7 +68,7 @@ func printNodePrefixes(node *LsNode) {
 			continue
 		}
 		fmt.Printf("    %s\n", prefix.Prefix.String())
-		if prefix.SidIndex != 0 {
+		if prefix.HasPrefixSID() {
 			fmt.Printf("      index: %d\n", prefix.SidIndex)
 		}
 	}
@@ -180,7 +180,7 @@ func NewLsNode(asn uint32, nodeID string) *LsNode {
 func (n *LsNode) NodeSegment() (Segment, error) {
 	// for SR-MPLS Segment
 	for _, prefix := range n.Prefixes {
-		if prefix.SidIndex > FirstSIDIndex {
+		if prefix.HasPrefixSID() {
 			sid := strconv.Itoa(int(n.SrgbBegin + prefix.SidIndex))
 			seg, err := NewSegment(sid)
 			if err != nil {
@@ -295,6 +295,16 @@ type LsPrefix struct {
 	LocalNode *LsNode      // primary key, in MP_REACH_NLRI Attr
 	Prefix    netip.Prefix // in MP_REACH_NLRI Attr
 	SidIndex  uint32       // in BGP-LS Attr (only for Lo Address Prefix)
+	// HasSidIndex reports whether a Prefix-SID TLV is present.
+	HasSidIndex bool
+}
+
+// HasPrefixSID reports whether this prefix has a Prefix-SID.
+func (lp *LsPrefix) HasPrefixSID() bool {
+	if lp == nil {
+		return false
+	}
+	return lp.HasSidIndex || lp.SidIndex != 0
 }
 
 func NewLsPrefix(localNode *LsNode) *LsPrefix {

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -301,10 +301,7 @@ type LsPrefix struct {
 
 // HasPrefixSID reports whether this prefix has a Prefix-SID.
 func (lp *LsPrefix) HasPrefixSID() bool {
-	if lp == nil {
-		return false
-	}
-	return lp.HasSidIndex || lp.SidIndex != 0
+	return lp != nil && lp.HasSidIndex
 }
 
 func NewLsPrefix(localNode *LsNode) *LsPrefix {

--- a/pkg/table/ted_test.go
+++ b/pkg/table/ted_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package table
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestLsNodeNodeSegment_PrefixSIDIndexZero(t *testing.T) {
+	node := &LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 0, HasSidIndex: true},
+		},
+	}
+
+	seg, err := node.NodeSegment()
+	if err != nil {
+		t.Fatalf("NodeSegment() error = %v, want nil", err)
+	}
+	if got, want := seg.SidString(), "16000"; got != want {
+		t.Errorf("NodeSegment() = %s, want %s", got, want)
+	}
+}
+
+func TestLsNodeNodeSegment_NoPrefixSID(t *testing.T) {
+	node := &LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32")},
+		},
+	}
+
+	if _, err := node.NodeSegment(); err == nil {
+		t.Errorf("NodeSegment() error = nil, want error for a node without a Node SID")
+	}
+}

--- a/test/helpers/wait.py
+++ b/test/helpers/wait.py
@@ -87,6 +87,32 @@ def wait_until_command_success(
         time.sleep(interval)
 
 
+def wait_until_command_output_contains(
+    cmd: str,
+    expected: str,
+    timeout: int = 300,
+    interval: int = 5,
+) -> subprocess.CompletedProcess:
+    """Wait until the stdout of a command contains the expected text."""
+
+    start = time.time()
+
+    while True:
+        result = run_command(cmd)
+
+        if expected in result.stdout:
+            return result
+
+        if time.time() - start > timeout:
+            raise TimeoutError(
+                f"Timeout waiting for {expected!r} in the output of {cmd!r}\n"
+                f"Last output:\n{result.stdout}"
+            )
+
+        print(f"Waiting for {expected!r} in the output of {cmd!r}...")
+        time.sleep(interval)
+
+
 def get_ted(pola_container: str) -> dict:
     """Get current TED JSON. Raises RuntimeError/JSONDecodeError on failure."""
 

--- a/test/scenario-test/explicit-path/README.md
+++ b/test/scenario-test/explicit-path/README.md
@@ -8,6 +8,7 @@ The tests verify:
 - Explicit-path SR Policy installation via `pola sr-policy add --no-sid-validate` (without TED)
 - The Node/Adjacency Identifier (NAI) built from the `localAddr` of each SID (RFC8664 4.3.1)
 - Segment lists without `localAddr`, which must keep the NAI absent
+- Installing without `--no-sid-validate` is refused when there is no TED
 
 ## Topology
 
@@ -50,9 +51,11 @@ The scenario tests perform the following steps:
 
 1. Deploy the Containerlab topology
 2. Wait for the PCEP session establishment of all three PCCs
-3. Install explicit-path SR Policies via `pola sr-policy add --no-sid-validate`
-4. Verify that each PCC installs the policy and that the SR-ERO label stack matches the input
-5. Verify the NAI of each SR-ERO hop on the PCC that reports it
+3. Verify that installing a policy without `--no-sid-validate` is refused,
+   since this lab runs with TED disabled
+4. Install explicit-path SR Policies via `pola sr-policy add --no-sid-validate`
+5. Verify that each PCC installs the policy and that the SR-ERO label stack matches the input
+6. Verify the NAI of each SR-ERO hop on the PCC that reports it
 
 ## Test Cases
 

--- a/test/scenario-test/explicit-path/test_explicit_path.py
+++ b/test/scenario-test/explicit-path/test_explicit_path.py
@@ -10,6 +10,7 @@ import pytest
 from helpers.wait import (
     run_command,
     wait_for_ssh,
+    wait_until_command_output_contains,
     wait_until_command_success,
     wait_until_lsp_up,
     wait_until_ssh_output_contains,
@@ -129,9 +130,9 @@ class TestExplicitPathSRMPLS:
     def _assert_frr_policy(self):
         """Verify the SR Policy installed on the FRRouting PCC."""
 
-        result = wait_until_command_success(
-            f"docker exec clab-{LAB}-pe03 vtysh -c 'show sr-te policy detail' "
-            f"| grep 'Name: pe03-policy1'"
+        result = wait_until_command_output_contains(
+            f"docker exec clab-{LAB}-pe03 vtysh -c 'show sr-te policy detail'",
+            "Status: Active",
         )
 
-        assert "Status: Active" in result.stdout, result.stdout
+        assert "Name: pe03-policy1" in result.stdout, result.stdout

--- a/test/scenario-test/explicit-path/test_explicit_path.py
+++ b/test/scenario-test/explicit-path/test_explicit_path.py
@@ -34,6 +34,24 @@ def add_sr_policy(policy_file: str) -> None:
     assert "success" in result.stdout.lower(), (
         f"failed to add {policy_file}\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
+    assert "skipping SID validation" in result.stderr, (
+        f"--no-sid-validate must always warn on stderr\nstderr: {result.stderr}"
+    )
+
+
+def add_sr_policy_expecting_ted_error(policy_file: str) -> None:
+    """Installing without --no-sid-validate must be refused when there is no TED."""
+
+    result = run_command(
+        f"docker exec {POLA} /bin/pola sr-policy add -f {policy_file} -p {GRPC_PORT}"
+    )
+
+    assert result.returncode != 0, (
+        f"expected {policy_file} to be refused\nstdout: {result.stdout}"
+    )
+    combined = result.stdout + result.stderr
+    assert "TED is not enabled" in combined, combined
+    assert "--no-sid-validate" in combined, combined
 
 
 class TestExplicitPathSRMPLS:
@@ -45,6 +63,7 @@ class TestExplicitPathSRMPLS:
     - The Node/Adjacency Identifier (NAI) built from the `localAddr` of each SID
       (RFC8664 4.3.1) is accepted by the PCC and shown in the installed SR-ERO
     - Segment lists without `localAddr` still install with the NAI absent
+    - Installing without --no-sid-validate is refused when there is no TED
     """
 
     TEST_EXPLICIT_PATH_DIR = os.path.join(
@@ -64,6 +83,8 @@ class TestExplicitPathSRMPLS:
                 f"docker exec {POLA} /bin/pola session -p {GRPC_PORT} "
                 f"| grep '{pcc_addr}'"
             )
+
+        add_sr_policy_expecting_ted_error("/pe01-policy1.yaml")
 
         add_sr_policy("/pe01-policy1.yaml")
         add_sr_policy("/pe02-policy1.yaml")

--- a/tools/grpc/go/add-sr-policy-no-ls/add_sr-policy_no_ls.go
+++ b/tools/grpc/go/add-sr-policy-no-ls/add_sr-policy_no_ls.go
@@ -56,7 +56,8 @@ func main() {
 				{Sid: "16004"},
 			},
 		},
-		SidValidate: false,
+		DisablePathCompute: true,
+		NoSidValidate:      true,
 	})
 	if err != nil {
 		log.Fatalf("c.CreateSRPolicy error: %v", err)

--- a/tools/grpc/go/add-sr-policy/add_sr-policy.go
+++ b/tools/grpc/go/add-sr-policy/add_sr-policy.go
@@ -52,7 +52,6 @@ func main() {
 			Type:            pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
 			Metric:          pb.MetricType_METRIC_TYPE_TE,
 		},
-		SidValidate: true,
 	})
 	if err != nil {
 		log.Fatalf("c.CreateSRPolicy error: %v", err)


### PR DESCRIPTION
## Description

This PR refactors SR Policy creation and adds server-side explicit SID validation.

The main changes are:

- Replace the old `sid_validate` behavior with:
  - `disable_path_compute`
  - `no_sid_validate`
- Move explicit SID validation into the server.
- Add support for creating explicit-path SR Policies using endpoint addresses (`srcAddr`/`dstAddr`) without TED-based endpoint resolution or path computation.
- Improve CLI error messages and warnings.
- Update JSON schemas and CLI documentation.
- Add unit tests and scenario tests covering SID validation behavior.

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactoring
- [x] Documentation
- [ ] Build / CI

## How was this tested?

- `make test-scenario`
- Verified the following Containerlab examples:
  - `examples/containerlab/sr-mpls-explicit-path`
  - `examples/containerlab/sr-mpls-explicit-path-l3vpn`
  - `examples/containerlab/srv6-explicit-path-l3vpn`
  - `examples/containerlab/srv6-usid-dynamic-path`
  - `examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed