### PR TITLE
Add SR Policy CPATH-ID metadata support

### DIFF
--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -562,7 +562,7 @@ func NewPCInitiateMessage(srpID uint32, lspName string, lspDelete bool, plspID u
 
 	switch opts.pccType {
 	case JuniperLegacy:
-		if m.AssociationObject, err = NewAssociationObject(srcAddr, dstAddr, color, preference, VendorSpecific(opts.pccType)); err != nil {
+		if m.AssociationObject, err = NewAssociationObject(srcAddr, dstAddr, color, preference, VendorSpecific(opts.pccType), OriginatorASN(opts.originatorASN)); err != nil {
 			return nil, err
 		}
 	case CiscoLegacy:
@@ -570,7 +570,7 @@ func NewPCInitiateMessage(srpID uint32, lspName string, lspDelete bool, plspID u
 			return nil, err
 		}
 	case RFCCompliant:
-		if m.AssociationObject, err = NewAssociationObject(srcAddr, dstAddr, color, preference); err != nil {
+		if m.AssociationObject, err = NewAssociationObject(srcAddr, dstAddr, color, preference, OriginatorASN(opts.originatorASN)); err != nil {
 			return nil, err
 		}
 		// FRRouting is considered RFC compliant

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -6,8 +6,11 @@
 package pcep
 
 import (
+	"bytes"
+	"net/netip"
 	"testing"
 
+	"github.com/nttcom/pola/pkg/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,6 +69,55 @@ func TestPCErrMessage_RoundTrip(t *testing.T) {
 			raw2, err := got.Serialize()
 			require.NoError(t, err, "re-Serialize failed")
 			assert.Equal(t, raw, raw2, "re-serialized bytes differ")
+		})
+	}
+}
+
+// Verify OriginatorASN is propagated to the SRPOLICY-CPATH-ID TLV.
+func TestNewPCInitiateMessage_OriginatorASNReachesWire(t *testing.T) {
+	t.Parallel()
+
+	srcAddr := netip.MustParseAddr("192.0.2.1")
+	dstAddr := netip.MustParseAddr("192.0.2.2")
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16001)}
+
+	cases := map[string]struct {
+		opts        []Opt
+		expectedASN uint32
+	}{
+		"OriginatorASNSet":     {opts: []Opt{VendorSpecific(RFCCompliant), OriginatorASN(65000)}, expectedASN: 65000},
+		"OriginatorASNOmitted": {opts: []Opt{VendorSpecific(RFCCompliant)}, expectedASN: 0},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m, err := NewPCInitiateMessage(1, "policy1", false, 0, segmentList, 100, 200, srcAddr, dstAddr, tt.opts...)
+			require.NoError(t, err, "NewPCInitiateMessage failed")
+			require.NotNil(t, m.AssociationObject, "RFC compliant PCInitiate must carry an ASSOCIATION object")
+
+			var cpathID *SRPolicyCandidatePathIdentifier
+			for _, tlv := range m.AssociationObject.TLVs {
+				if id, ok := tlv.(*SRPolicyCandidatePathIdentifier); ok {
+					cpathID = id
+					break
+				}
+			}
+			require.NotNil(t, cpathID, "SRPOLICY-CPATH-ID TLV missing from ASSOCIATION object")
+			assert.Equal(t, tt.expectedASN, cpathID.OriginatorASN, "OriginatorASN not propagated to the TLV")
+
+			raw, err := m.Serialize()
+			require.NoError(t, err, "Serialize failed")
+
+			expectedTLV := AppendByteSlices(
+				[]uint8{0x00, 0x39, 0x00, 0x1c}, // SRPOLICY-CPATH-ID TLV: type=0x0039, len=28
+				[]uint8{0x0a, 0x00, 0x00, 0x00}, // protocol origin + mbz
+				Uint32ToByteSlice(tt.expectedASN),
+				make([]uint8, 12), dstAddr.AsSlice(), // originator address (IPv4 in the 16 byte field)
+				[]uint8{0x00, 0x00, 0x00, 0x01}, // discriminator
+			)
+			assert.True(t, bytes.Contains(raw, expectedTLV), "serialized message does not carry ASN %d in the SRPOLICY-CPATH-ID TLV", tt.expectedASN)
 		})
 	}
 }

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1737,7 +1737,7 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 				Endpoint: dstAddr,
 			},
 			&SRPolicyCandidatePathIdentifier{
-				OriginatorASN:  0, // TODO: set PCE ASN
+				OriginatorASN:  opts.originatorASN,
 				OriginatorAddr: dstAddr,
 				Discriminator:  1, // keep existing wire value
 			},
@@ -1895,7 +1895,8 @@ func (o *VendorInformationObject) subTLVUint32(typ TLVType) uint32 {
 }
 
 type optParams struct {
-	pccType PccType
+	pccType       PccType
+	originatorASN uint32
 }
 
 type Opt func(*optParams)
@@ -1903,5 +1904,11 @@ type Opt func(*optParams)
 func VendorSpecific(pt PccType) Opt {
 	return func(op *optParams) {
 		op.pccType = pt
+	}
+}
+
+func OriginatorASN(asn uint32) Opt {
+	return func(op *optParams) {
+		op.originatorASN = asn
 	}
 }

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1713,13 +1713,15 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 			&UndefinedTLV{
 				Typ:    TLVSRPolicyCPathIDJuniper,
 				Length: TLVSRPolicyCPathIDValueLength,
-				Value: []uint8{
-					0x00,             // protocol origin
-					0x00, 0x00, 0x00, // mbz
-					0x00, 0x00, 0x00, 0x00, // Originator ASN
-					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Originator Address
-					0x00, 0x00, 0x00, 0x00, //discriminator
-				},
+				Value: AppendByteSlices(
+					[]uint8{
+						ProtocolOriginPCEP, // protocol origin
+						0x00, 0x00, 0x00,   // mbz
+					},
+					Uint32ToByteSlice(opts.originatorASN), // Originator ASN
+					make([]uint8, 16),                     // Originator Address
+					make([]uint8, 4),                      // discriminator
+				),
 			},
 			&UndefinedTLV{
 				Typ:    TLVSRPolicyCPathPreferenceJuniper,

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1737,6 +1737,7 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 				Endpoint: dstAddr,
 			},
 			&SRPolicyCandidatePathIdentifier{
+				ProtocolOrigin: ProtocolOriginPCEP, // this PCE originates the candidate path
 				OriginatorASN:  opts.originatorASN,
 				OriginatorAddr: dstAddr,
 				Discriminator:  1, // keep existing wire value

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1737,7 +1737,9 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 				Endpoint: dstAddr,
 			},
 			&SRPolicyCandidatePathIdentifier{
+				OriginatorASN:  0, // TODO: set PCE ASN
 				OriginatorAddr: dstAddr,
+				Discriminator:  1, // keep existing wire value
 			},
 			&SRPolicyCandidatePathPreference{
 				Preference: preference,

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -821,7 +821,9 @@ func TestAssociationObject_RoundTrip(t *testing.T) {
 					Endpoint: v4Endpoint,
 				},
 				&SRPolicyCandidatePathIdentifier{
+					OriginatorASN:  65000,
 					OriginatorAddr: v4Endpoint,
+					Discriminator:  7,
 				},
 				&SRPolicyCandidatePathPreference{
 					Preference: 200,
@@ -871,6 +873,36 @@ func TestAssociationObject_RoundTrip(t *testing.T) {
 			assert.Equal(t, raw, raw2, "re-serialized bytes differ")
 		})
 	}
+}
+
+// Ensures NewAssociationObject preserves the existing wire format.
+func TestNewAssociationObject_WireCompatibility(t *testing.T) {
+	t.Parallel()
+
+	srcAddr := netip.MustParseAddr("192.0.2.1")
+	dstAddr := netip.MustParseAddr("192.0.2.2")
+
+	o, err := NewAssociationObject(srcAddr, dstAddr, 100, 200)
+	require.NoError(t, err, "NewAssociationObject failed")
+
+	expected := []byte{
+		0x28, 0x10, 0x00, 0x44, // common object header: class=ASSOCIATION, type=1, length=0x44
+		0x00, 0x00, 0x00, 0x00, // reserved + flags
+		0x00, 0x06, 0x00, 0x01, // assoc type=6 (SRPolicyAssociation), assoc id=1
+		0xc0, 0x00, 0x02, 0x01, // assoc source=192.0.2.1
+		0x00, 0x1f, 0x00, 0x08, 0x00, 0x00, 0x00, 0x64, 0xc0, 0x00, 0x02, 0x02, // ExtendedAssociationID TLV: color=100, endpoint=192.0.2.2
+		0x00, 0x39, 0x00, 0x1c, // SRPOLICY-CPATH-ID TLV: type=0x0039, len=28
+		0x0a, 0x00, 0x00, 0x00, // protocol=0x0a + mbz
+		0x00, 0x00, 0x00, 0x00, // ASN=0
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // originator addr padding
+		0xc0, 0x00, 0x02, 0x02, // dstAddr=192.0.2.2
+		0x00, 0x00, 0x00, 0x01, // discriminator=1
+		0x00, 0x3b, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, // SRPOLICY-CPATH-PREFERENCE TLV: preference=200
+	}
+
+	raw, err := o.Serialize()
+	require.NoError(t, err, "Serialize failed")
+	assert.Equal(t, expected, raw, "AssociationObject wire bytes changed")
 }
 
 func TestVendorInformationObject_DecodeFromBytes(t *testing.T) {

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -6,6 +6,7 @@
 package pcep
 
 import (
+	"bytes"
 	"net/netip"
 	"testing"
 
@@ -904,6 +905,43 @@ func TestNewAssociationObject_DefaultCandidatePathIdentifier(t *testing.T) {
 	raw, err := o.Serialize()
 	require.NoError(t, err, "Serialize failed")
 	assert.Equal(t, expected, raw, "AssociationObject wire bytes changed")
+}
+
+// Verify OriginatorASN is propagated to the Juniper SRPOLICY-CPATH-ID TLV.
+func TestNewAssociationObject_JuniperLegacyOriginatorASN(t *testing.T) {
+	t.Parallel()
+
+	srcAddr := netip.MustParseAddr("192.0.2.1")
+	dstAddr := netip.MustParseAddr("192.0.2.2")
+
+	cases := map[string]struct {
+		opts        []Opt
+		expectedASN uint32
+	}{
+		"OriginatorASNSet":     {opts: []Opt{VendorSpecific(JuniperLegacy), OriginatorASN(65001)}, expectedASN: 65001},
+		"OriginatorASNOmitted": {opts: []Opt{VendorSpecific(JuniperLegacy)}, expectedASN: 0},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			o, err := NewAssociationObject(srcAddr, dstAddr, 100, 200, tt.opts...)
+			require.NoError(t, err, "NewAssociationObject failed")
+
+			raw, err := o.Serialize()
+			require.NoError(t, err, "Serialize failed")
+
+			expectedTLV := AppendByteSlices(
+				[]byte{0xff, 0xe4, 0x00, 0x1c},                     // SRPOLICY-CPATH-ID TLV (Juniper): type=0xffe4, len=28
+				[]byte{byte(ProtocolOriginPCEP), 0x00, 0x00, 0x00}, // protocol origin + mbz
+				Uint32ToByteSlice(tt.expectedASN),
+				make([]byte, 16), // originator address
+				make([]byte, 4),  // discriminator
+			)
+			assert.True(t, bytes.Contains(raw, expectedTLV), "serialized object does not carry ASN %d in the Juniper SRPOLICY-CPATH-ID TLV", tt.expectedASN)
+		})
+	}
 }
 
 func TestVendorInformationObject_DecodeFromBytes(t *testing.T) {

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -821,6 +821,7 @@ func TestAssociationObject_RoundTrip(t *testing.T) {
 					Endpoint: v4Endpoint,
 				},
 				&SRPolicyCandidatePathIdentifier{
+					ProtocolOrigin: ProtocolOriginPCEP,
 					OriginatorASN:  65000,
 					OriginatorAddr: v4Endpoint,
 					Discriminator:  7,

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -876,7 +876,7 @@ func TestAssociationObject_RoundTrip(t *testing.T) {
 }
 
 // Ensures NewAssociationObject preserves the existing wire format.
-func TestNewAssociationObject_WireCompatibility(t *testing.T) {
+func TestNewAssociationObject_DefaultCandidatePathIdentifier(t *testing.T) {
 	t.Parallel()
 
 	srcAddr := netip.MustParseAddr("192.0.2.1")

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1553,19 +1553,21 @@ func (tlv *AssocTypeList) CapStrings() []string {
 }
 
 type SRPolicyCandidatePathIdentifier struct {
+	ProtocolOrigin uint8 // Protocol that originated the candidate path.
 	OriginatorASN  uint32
 	OriginatorAddr netip.Addr // Decoded IPv4 addresses are stored as native IPv4.
 	Discriminator  uint32
 }
 
 const (
-	SRPolicyCPathIDASNOffset           = 4
-	SRPolicyCPathIDAddrOffset          = 8
-	SRPolicyCPathIDIPv4Offset          = 12 // offset within Originator Address field
-	SRPolicyCPathIDDiscriminatorOffset = 24
-	SRPolicyCPathIDASNLen              = 4
-	SRPolicyCPathIDDiscriminatorLen    = 4
-	ProtocolOriginPCEP                 = 0x0a
+	SRPolicyCPathIDProtocolOriginOffset = 0
+	SRPolicyCPathIDASNOffset            = 4
+	SRPolicyCPathIDAddrOffset           = 8
+	SRPolicyCPathIDIPv4Offset           = 12 // offset within Originator Address field
+	SRPolicyCPathIDDiscriminatorOffset  = 24
+	SRPolicyCPathIDASNLen               = 4
+	SRPolicyCPathIDDiscriminatorLen     = 4
+	ProtocolOriginPCEP                  = 0x0a
 )
 
 func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
@@ -1578,6 +1580,8 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 	if len(value) != int(TLVSRPolicyCPathIDValueLength) {
 		return fmt.Errorf("SRPolicyCandidatePathIdentifier: invalid value length, expected %d, got %d", TLVSRPolicyCPathIDValueLength, len(value))
 	}
+
+	tlv.ProtocolOrigin = value[SRPolicyCPathIDProtocolOriginOffset]
 
 	tlv.OriginatorASN = binary.BigEndian.Uint32(
 		value[SRPolicyCPathIDASNOffset : SRPolicyCPathIDASNOffset+SRPolicyCPathIDASNLen],
@@ -1606,7 +1610,7 @@ func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 
 	value := make([]byte, TLVSRPolicyCPathIDValueLength)
 
-	value[0] = ProtocolOriginPCEP
+	value[SRPolicyCPathIDProtocolOriginOffset] = tlv.ProtocolOrigin
 
 	binary.BigEndian.PutUint32(
 		value[SRPolicyCPathIDASNOffset:SRPolicyCPathIDASNOffset+SRPolicyCPathIDASNLen],
@@ -1653,6 +1657,7 @@ func (tlv *SRPolicyCandidatePathIdentifier) MarshalLogObject(enc zapcore.ObjectE
 		return nil
 	}
 
+	enc.AddUint8("protocolOrigin", tlv.ProtocolOrigin)
 	enc.AddUint32("originatorAsn", tlv.OriginatorASN)
 	enc.AddString("originatorAddr", tlv.OriginatorAddr.String())
 	enc.AddUint32("discriminator", tlv.Discriminator)

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1553,15 +1553,19 @@ func (tlv *AssocTypeList) CapStrings() []string {
 }
 
 type SRPolicyCandidatePathIdentifier struct {
-	OriginatorAddr netip.Addr // After DecodeFromBytes, IPv4 addresses are stored as native IPv4 (upper 12 bytes zero), not IPv4-mapped IPv6
+	OriginatorASN  uint32
+	OriginatorAddr netip.Addr // Decoded IPv4 addresses are stored as native IPv4.
+	Discriminator  uint32
 }
 
 const (
-	SRPolicyCPathIDASNOffset  = 4
-	SRPolicyCPathIDAddrOffset = 8
-	SRPolicyCPathIDIPv4Offset = 12
-	DiscriminatorLen          = 4
-	ProtocolOriginPCEP        = 0x0a
+	SRPolicyCPathIDASNOffset           = 4
+	SRPolicyCPathIDAddrOffset          = 8
+	SRPolicyCPathIDIPv4Offset          = 12 // offset within Originator Address field
+	SRPolicyCPathIDDiscriminatorOffset = 24
+	SRPolicyCPathIDASNLen              = 4
+	SRPolicyCPathIDDiscriminatorLen    = 4
+	ProtocolOriginPCEP                 = 0x0a
 )
 
 func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
@@ -1575,6 +1579,10 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 		return fmt.Errorf("SRPolicyCandidatePathIdentifier: invalid value length, expected %d, got %d", TLVSRPolicyCPathIDValueLength, len(value))
 	}
 
+	tlv.OriginatorASN = binary.BigEndian.Uint32(
+		value[SRPolicyCPathIDASNOffset : SRPolicyCPathIDASNOffset+SRPolicyCPathIDASNLen],
+	)
+
 	addrBytes := value[SRPolicyCPathIDAddrOffset : SRPolicyCPathIDAddrOffset+IPv6AddrLen]
 
 	if isIPv4Bytes(addrBytes) {
@@ -1587,6 +1595,10 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 		tlv.OriginatorAddr = netip.AddrFrom16(addr16)
 	}
 
+	tlv.Discriminator = binary.BigEndian.Uint32(
+		value[SRPolicyCPathIDDiscriminatorOffset : SRPolicyCPathIDDiscriminatorOffset+SRPolicyCPathIDDiscriminatorLen],
+	)
+
 	return nil
 }
 
@@ -1595,6 +1607,11 @@ func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 	value := make([]byte, TLVSRPolicyCPathIDValueLength)
 
 	value[0] = ProtocolOriginPCEP
+
+	binary.BigEndian.PutUint32(
+		value[SRPolicyCPathIDASNOffset:SRPolicyCPathIDASNOffset+SRPolicyCPathIDASNLen],
+		tlv.OriginatorASN,
+	)
 
 	addr := tlv.OriginatorAddr
 
@@ -1620,8 +1637,8 @@ func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 	}
 
 	binary.BigEndian.PutUint32(
-		value[SRPolicyCPathIDAddrOffset+IPv6AddrLen:SRPolicyCPathIDAddrOffset+IPv6AddrLen+DiscriminatorLen],
-		1, // TODO: set discriminator properly if needed
+		value[SRPolicyCPathIDDiscriminatorOffset:SRPolicyCPathIDDiscriminatorOffset+SRPolicyCPathIDDiscriminatorLen],
+		tlv.Discriminator,
 	)
 
 	return AppendByteSlices(
@@ -1636,7 +1653,9 @@ func (tlv *SRPolicyCandidatePathIdentifier) MarshalLogObject(enc zapcore.ObjectE
 		return nil
 	}
 
+	enc.AddUint32("originatorAsn", tlv.OriginatorASN)
 	enc.AddString("originatorAddr", tlv.OriginatorAddr.String())
+	enc.AddUint32("discriminator", tlv.Discriminator)
 	return nil
 }
 

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1421,11 +1421,13 @@ func TestAssocTypeList_CapStrings(t *testing.T) {
 // Test data for SRPolicyCandidatePathIdentifier.
 var (
 	testSRPolicyCPathIDIPv4 = &SRPolicyCandidatePathIdentifier{
+		ProtocolOrigin: ProtocolOriginPCEP,
 		OriginatorASN:  65000,
 		OriginatorAddr: netip.AddrFrom4([4]byte{192, 0, 2, 1}), // IPv4 originator
 		Discriminator:  1,
 	}
 	testSRPolicyCPathIDIPv6 = &SRPolicyCandidatePathIdentifier{
+		ProtocolOrigin: ProtocolOriginPCEP,
 		OriginatorASN:  65000,
 		OriginatorAddr: netip.MustParseAddr("2001:db8::1"), // IPv6 originator
 		Discriminator:  2,
@@ -1452,6 +1454,7 @@ var (
 	testSRPolicyCPathIDTruncatedHeader = []byte{0x00, 0x39, 0x00}                                                                   // Truncated header (less than 4 bytes)
 
 	testSRPolicyCPathIDInvalid = &SRPolicyCandidatePathIdentifier{
+		ProtocolOrigin: ProtocolOriginPCEP,
 		OriginatorAddr: netip.Addr{}, // zero value, IsValid() == false
 		Discriminator:  1,
 	}
@@ -1465,14 +1468,31 @@ var (
 		0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x01, // discriminator
 	}
+
+	// Protocol-Origin other than PCEP must survive decode and re-serialize unchanged.
+	testSRPolicyCPathIDNonPCEP = &SRPolicyCandidatePathIdentifier{
+		ProtocolOrigin: 0x14, // BGP SR Policy origin defined by RFC
+		OriginatorASN:  65001,
+		OriginatorAddr: netip.AddrFrom4([4]byte{192, 0, 2, 3}),
+		Discriminator:  3,
+	}
+	testSRPolicyCPathIDNonPCEPBytes = []byte{
+		0x00, 0x39, 0x00, 0x1c, // type=0x0039, len=28
+		0x14, 0x00, 0x00, 0x00, // protocol origin=0x14 + mbz
+		0x00, 0x00, 0xfd, 0xe9, // ASN=65001
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // originator addr padding
+		0xc0, 0x00, 0x02, 0x03, // IPv4 addr
+		0x00, 0x00, 0x00, 0x03, // discriminator=3
+	}
 )
 
 func TestSRPolicyCandidatePathIdentifier_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
-		"ValidIPv4":       {testSRPolicyCPathIDIPv4Bytes, testSRPolicyCPathIDIPv4, false},
-		"ValidIPv6":       {testSRPolicyCPathIDIPv6Bytes, testSRPolicyCPathIDIPv6, false},
-		"TooShort":        {testSRPolicyCPathIDTooShort, nil, true},
-		"TruncatedHeader": {testSRPolicyCPathIDTruncatedHeader, nil, true},
+		"ValidIPv4":             {testSRPolicyCPathIDIPv4Bytes, testSRPolicyCPathIDIPv4, false},
+		"ValidIPv6":             {testSRPolicyCPathIDIPv6Bytes, testSRPolicyCPathIDIPv6, false},
+		"NonPCEPProtocolOrigin": {testSRPolicyCPathIDNonPCEPBytes, testSRPolicyCPathIDNonPCEP, false},
+		"TooShort":              {testSRPolicyCPathIDTooShort, nil, true},
+		"TruncatedHeader":       {testSRPolicyCPathIDTruncatedHeader, nil, true},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRPolicyCandidatePathIdentifier{} })
 }
@@ -1482,8 +1502,9 @@ func TestSRPolicyCandidatePathIdentifier_Serialize(t *testing.T) {
 		input    TLVInterface
 		expected []byte
 	}{
-		"SerializeIPv4": {testSRPolicyCPathIDIPv4, testSRPolicyCPathIDIPv4Bytes},
-		"SerializeIPv6": {testSRPolicyCPathIDIPv6, testSRPolicyCPathIDIPv6Bytes},
+		"SerializeIPv4":                  {testSRPolicyCPathIDIPv4, testSRPolicyCPathIDIPv4Bytes},
+		"SerializeIPv6":                  {testSRPolicyCPathIDIPv6, testSRPolicyCPathIDIPv6Bytes},
+		"SerializeNonPCEPProtocolOrigin": {testSRPolicyCPathIDNonPCEP, testSRPolicyCPathIDNonPCEPBytes},
 	}
 	runTLVSerializeTests(t, cases)
 }
@@ -1506,6 +1527,7 @@ func TestSRPolicyCandidatePathIdentifier_MarshalLogObject(t *testing.T) {
 		"IPv4": {
 			testSRPolicyCPathIDIPv4,
 			map[string]any{
+				"protocolOrigin": testSRPolicyCPathIDIPv4.ProtocolOrigin,
 				"originatorAsn":  testSRPolicyCPathIDIPv4.OriginatorASN,
 				"originatorAddr": testSRPolicyCPathIDIPv4.OriginatorAddr.String(),
 				"discriminator":  testSRPolicyCPathIDIPv4.Discriminator,
@@ -1514,6 +1536,7 @@ func TestSRPolicyCandidatePathIdentifier_MarshalLogObject(t *testing.T) {
 		"IPv6": {
 			testSRPolicyCPathIDIPv6,
 			map[string]any{
+				"protocolOrigin": testSRPolicyCPathIDIPv6.ProtocolOrigin,
 				"originatorAsn":  testSRPolicyCPathIDIPv6.OriginatorASN,
 				"originatorAddr": testSRPolicyCPathIDIPv6.OriginatorAddr.String(),
 				"discriminator":  testSRPolicyCPathIDIPv6.Discriminator,
@@ -1543,6 +1566,26 @@ func TestSRPolicyCandidatePathIdentifier_Len(t *testing.T) {
 		"ValidLen": {testSRPolicyCPathIDIPv4, TLVValueOffset + TLVSRPolicyCPathIDValueLength},
 	}
 	runTLVLenTests(t, cases)
+}
+
+// Protocol-Origin must survive Decode -> Serialize without being rewritten to PCEP.
+func TestSRPolicyCandidatePathIdentifier_ProtocolOriginRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, origin := range []uint8{0x00, 0x0a, 0x14, 0x1e, 0xff} {
+		t.Run(fmt.Sprintf("Origin_0x%02x", origin), func(t *testing.T) {
+			t.Parallel()
+
+			raw := append([]byte(nil), testSRPolicyCPathIDIPv4Bytes...)
+			raw[TLVValueOffset+SRPolicyCPathIDProtocolOriginOffset] = origin
+
+			var got SRPolicyCandidatePathIdentifier
+			require.NoError(t, got.DecodeFromBytes(raw), "DecodeFromBytes failed")
+			assert.Equal(t, origin, got.ProtocolOrigin, "ProtocolOrigin not preserved on decode")
+
+			assert.Equal(t, raw, got.Serialize(), "re-serialized bytes differ")
+		})
+	}
 }
 
 // Test data for SRPolicyCandidatePathPreference.

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1420,24 +1420,32 @@ func TestAssocTypeList_CapStrings(t *testing.T) {
 
 // Test data for SRPolicyCandidatePathIdentifier.
 var (
-	testSRPolicyCPathIDIPv4 = &SRPolicyCandidatePathIdentifier{OriginatorAddr: netip.AddrFrom4([4]byte{192, 0, 2, 1})} // IPv4 originator
-	testSRPolicyCPathIDIPv6 = &SRPolicyCandidatePathIdentifier{OriginatorAddr: netip.MustParseAddr("2001:db8::1")}     // IPv6 originator
+	testSRPolicyCPathIDIPv4 = &SRPolicyCandidatePathIdentifier{
+		OriginatorASN:  65000,
+		OriginatorAddr: netip.AddrFrom4([4]byte{192, 0, 2, 1}), // IPv4 originator
+		Discriminator:  1,
+	}
+	testSRPolicyCPathIDIPv6 = &SRPolicyCandidatePathIdentifier{
+		OriginatorASN:  65000,
+		OriginatorAddr: netip.MustParseAddr("2001:db8::1"), // IPv6 originator
+		Discriminator:  2,
+	}
 
 	testSRPolicyCPathIDIPv4Bytes = []byte{
 		0x00, 0x39, 0x00, 0x1c, // type=0x0039, len=28
 		0x0a, 0x00, 0x00, 0x00, // protocol=0x0a + mbz
-		0x00, 0x00, 0x00, 0x00, // ASN=0
+		0x00, 0x00, 0xfd, 0xe8, // ASN=65000
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // originator addr padding
 		0xc0, 0x00, 0x02, 0x01, // IPv4 addr
-		0x00, 0x00, 0x00, 0x01, // discriminator
+		0x00, 0x00, 0x00, 0x01, // discriminator=1
 	}
 
 	testSRPolicyCPathIDIPv6Bytes = []byte{
 		0x00, 0x39, 0x00, 0x1c, // type=0x0039, len=28
 		0x0a, 0x00, 0x00, 0x00, // protocol + mbz
-		0x00, 0x00, 0x00, 0x00, // ASN
+		0x00, 0x00, 0xfd, 0xe8, // ASN=65000
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // IPv6 addr
-		0x00, 0x00, 0x00, 0x01, // discriminator
+		0x00, 0x00, 0x00, 0x02, // discriminator=2
 	}
 
 	testSRPolicyCPathIDTooShort        = []byte{0x00, 0x39, 0x00, 0x0a, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} // Less than 16 bytes for OriginatorAddr
@@ -1445,6 +1453,7 @@ var (
 
 	testSRPolicyCPathIDInvalid = &SRPolicyCandidatePathIdentifier{
 		OriginatorAddr: netip.Addr{}, // zero value, IsValid() == false
+		Discriminator:  1,
 	}
 	testSRPolicyCPathIDInvalidBytes = []byte{
 		0x00, 0x39, 0x00, 0x1c, // type + length
@@ -1497,13 +1506,17 @@ func TestSRPolicyCandidatePathIdentifier_MarshalLogObject(t *testing.T) {
 		"IPv4": {
 			testSRPolicyCPathIDIPv4,
 			map[string]any{
+				"originatorAsn":  testSRPolicyCPathIDIPv4.OriginatorASN,
 				"originatorAddr": testSRPolicyCPathIDIPv4.OriginatorAddr.String(),
+				"discriminator":  testSRPolicyCPathIDIPv4.Discriminator,
 			},
 		},
 		"IPv6": {
 			testSRPolicyCPathIDIPv6,
 			map[string]any{
+				"originatorAsn":  testSRPolicyCPathIDIPv6.OriginatorASN,
 				"originatorAddr": testSRPolicyCPathIDIPv6.OriginatorAddr.String(),
+				"discriminator":  testSRPolicyCPathIDIPv6.Discriminator,
 			},
 		},
 		"NilTLV": {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	sessionList []*Session
 	ted         *table.LsTED
 	logger      *zap.Logger
+	asn         uint32
 }
 
 type PCEOptions struct {
@@ -36,7 +37,10 @@ type PCEOptions struct {
 }
 
 func NewPCE(o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem) Error {
-	s := &Server{logger: logger}
+	s := &Server{
+		logger: logger,
+		asn:    o.ASN,
+	}
 	if o.TEDEnable {
 		s.ted = &table.LsTED{
 			Nodes: map[string]*table.LsNode{},
@@ -117,7 +121,7 @@ func (s *Server) Serve(address string, port string, usidMode bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse remote address %s: %w", tcpConn.RemoteAddr().String(), err)
 		}
-		ss := NewSession(sessionID, peerAddrPort.Addr(), tcpConn, s.logger, s.ted)
+		ss := NewSession(sessionID, peerAddrPort.Addr(), tcpConn, s.logger, s.ted, s.asn)
 		ss.logger.Info("start PCEP session")
 
 		s.sessionList = append(s.sessionList, ss)

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -31,9 +31,10 @@ type Session struct {
 	pccType         pcep.PccType
 	pccCapabilities []pcep.CapabilityInterface
 	ted             *table.LsTED
+	asn             uint32
 }
 
-func NewSession(sessionID uint8, peerAddr netip.Addr, tcpConn *net.TCPConn, logger *zap.Logger, ted *table.LsTED) *Session {
+func NewSession(sessionID uint8, peerAddr netip.Addr, tcpConn *net.TCPConn, logger *zap.Logger, ted *table.LsTED, asn uint32) *Session {
 	return &Session{
 		sessionID: sessionID,
 		isSynced:  false,
@@ -43,6 +44,7 @@ func NewSession(sessionID uint8, peerAddr netip.Addr, tcpConn *net.TCPConn, logg
 		peerAddr:  peerAddr,
 		tcpConn:   tcpConn,
 		ted:       ted,
+		asn:       asn,
 	}
 }
 
@@ -503,7 +505,7 @@ func (ss *Session) SendOpen() error {
 }
 
 func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error {
-	pcinitiateMessage, err := pcep.NewPCInitiateMessage(ss.srpIDHead, srPolicy.Name, lspDelete, srPolicy.PlspID, srPolicy.SegmentList, srPolicy.Color, srPolicy.Preference, srPolicy.SrcAddr, srPolicy.DstAddr, pcep.VendorSpecific(ss.pccType))
+	pcinitiateMessage, err := pcep.NewPCInitiateMessage(ss.srpIDHead, srPolicy.Name, lspDelete, srPolicy.PlspID, srPolicy.SegmentList, srPolicy.Color, srPolicy.Preference, srPolicy.SrcAddr, srPolicy.DstAddr, pcep.VendorSpecific(ss.pccType), pcep.OriginatorASN(ss.asn))
 	if err != nil {
 		return err
 	}

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -46,7 +46,7 @@ func newTestStateReport(t *testing.T, plspID uint32, srpID uint32) *pcep.StateRe
 // With the TED disabled the PCE cannot compute anything, but that must not fail the state report:
 // doing so used to tear down the PCEP session and made the PCC reconnect in a loop.
 func TestHandleStateReportWithoutTED(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil)
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
@@ -67,7 +67,7 @@ func TestHandleStateReportWithoutTED(t *testing.T) {
 
 // The same report with the R-Flag set removes the SR Policy instead of registering it.
 func TestHandleStateReportRemove(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil)
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {

--- a/test/helpers/wait.py
+++ b/test/helpers/wait.py
@@ -68,7 +68,7 @@ def wait_for_ssh(
 
 def wait_until_command_success(
     cmd: str,
-    timeout: int = 600,
+    timeout: int = 1200,
     interval: int = 5,
 ) -> subprocess.CompletedProcess:
     """Wait until command exits successfully."""


### PR DESCRIPTION
## Description

This PR adds support for ASN and discriminator fields in the SR Policy Candidate Path Identifier (CPATH-ID) TLV.
The CPATH-ID TLV now supports:
* Originator ASN
* Protocol Origin
* Discriminator

## Type of change
<!-- Check all that apply. -->
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?
<!-- Commands run (e.g. `make test`, `make test-scenario`), and/or
example topologies verified.
-->

* `make test`
* Added unit tests for:
  * CPATH-ID TLV serialization/deserialization with ASN and discriminator
  * PCInitiate message generation with configured PCE ASN

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed
