### PR TITLE
Support typed Juniper vendor-specific Association TLVs

### DIFF
--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -121,3 +121,58 @@ func TestNewPCInitiateMessage_OriginatorASNReachesWire(t *testing.T) {
 		})
 	}
 }
+
+// Verify object selection for each PccType.
+func TestNewPCInitiateMessage_VendorObjectSelection(t *testing.T) {
+	t.Parallel()
+
+	srcAddr := netip.MustParseAddr("192.0.2.1")
+	dstAddr := netip.MustParseAddr("192.0.2.2")
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16001)}
+
+	cases := map[string]struct {
+		pccType         PccType
+		wantAssociation bool
+		wantAssocType   AssocType
+		wantVendorInfo  bool
+	}{
+		"JuniperLegacy": {
+			pccType:         JuniperLegacy,
+			wantAssociation: true,
+			wantAssocType:   AssociationTypeSRPolicyAssociationJuniper,
+		},
+		"CiscoLegacy": {
+			pccType:        CiscoLegacy,
+			wantVendorInfo: true,
+		},
+		"RFCCompliant": {
+			pccType:         RFCCompliant,
+			wantAssociation: true,
+			wantAssocType:   AssociationTypeSRPolicyAssociation,
+			wantVendorInfo:  true,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m, err := NewPCInitiateMessage(1, "policy1", false, 0, segmentList, 100, 200, srcAddr, dstAddr, VendorSpecific(tt.pccType))
+			require.NoError(t, err, "NewPCInitiateMessage failed")
+
+			if tt.wantAssociation {
+				require.NotNil(t, m.AssociationObject, "AssociationObject should be set")
+				assert.Equal(t, tt.wantAssocType, m.AssociationObject.AssocType, "unexpected AssocType")
+			} else {
+				assert.Nil(t, m.AssociationObject, "AssociationObject should not be set")
+			}
+
+			if tt.wantVendorInfo {
+				require.NotNil(t, m.VendorInformationObject, "VendorInformationObject should be set")
+				assert.Equal(t, EnterpriseNumberCisco, m.VendorInformationObject.EnterpriseNumber, "unexpected EnterpriseNumber")
+			} else {
+				assert.Nil(t, m.VendorInformationObject, "VendorInformationObject should not be set")
+			}
+		})
+	}
+}

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1700,6 +1700,9 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 		AssocSrc:   srcAddr,
 	}
 	if opts.pccType == JuniperLegacy {
+		if !dstAddr.Is4() {
+			return nil, fmt.Errorf("invalid endpoint address for JuniperLegacy (NewAssociationObject): only IPv4 is supported, got dst=%v", dstAddr)
+		}
 		o.AssocID = 0
 		o.AssocType = AssociationTypeSRPolicyAssociationJuniper
 		associationObjectTLVs := []TLVInterface{
@@ -1710,11 +1713,12 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 				},
 			},
 			&SRPolicyCandidatePathIdentifierJuniper{
+				// Juniper legacy CPATH-ID TLV uses a zero-filled IPv4 Originator Address.
 				SRPolicyCandidatePathIdentifier: SRPolicyCandidatePathIdentifier{
 					ProtocolOrigin: ProtocolOriginPCEP,
 					OriginatorASN:  opts.originatorASN,
-					// Preserve Juniper legacy CPATH-ID TLV wire format with zero-filled Originator Address.
-					Discriminator: 1,
+					OriginatorAddr: netip.IPv4Unspecified(),
+					Discriminator:  1,
 				},
 			},
 			&SRPolicyCandidatePathPreferenceJuniper{

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1710,18 +1710,12 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 					Uint32ToByteSlice(color), dstAddr.AsSlice(),
 				),
 			},
-			&UndefinedTLV{
-				Typ:    TLVSRPolicyCPathIDJuniper,
-				Length: TLVSRPolicyCPathIDValueLength,
-				Value: AppendByteSlices(
-					[]uint8{
-						ProtocolOriginPCEP, // protocol origin
-						0x00, 0x00, 0x00,   // mbz
-					},
-					Uint32ToByteSlice(opts.originatorASN), // Originator ASN
-					make([]uint8, 16),                     // Originator Address
-					make([]uint8, 4),                      // discriminator
-				),
+			&SRPolicyCandidatePathIdentifierJuniper{
+				SRPolicyCandidatePathIdentifier: SRPolicyCandidatePathIdentifier{
+					OriginatorASN:  opts.originatorASN,
+					OriginatorAddr: dstAddr,
+					Discriminator:  1,
+				},
 			},
 			&UndefinedTLV{
 				Typ:    TLVSRPolicyCPathPreferenceJuniper,

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1751,7 +1751,7 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 func (o *AssociationObject) Color() uint32 {
 	for _, tlv := range o.TLVs {
 		switch t := tlv.(type) {
-		case *UndefinedTLV:
+		case *UnknownTLV:
 			if t.Type() == TLVExtendedAssociationIDIPv4Juniper {
 				return uint32(binary.BigEndian.Uint32(t.Value[:4]))
 			}
@@ -1768,7 +1768,7 @@ func (o *AssociationObject) Color() uint32 {
 func (o *AssociationObject) Preference() uint32 {
 	for _, tlv := range o.TLVs {
 		switch t := tlv.(type) {
-		case *UndefinedTLV:
+		case *UnknownTLV:
 			if t.Type() == TLVSRPolicyCPathPreferenceJuniper {
 				return uint32(binary.BigEndian.Uint32(t.Value))
 			}
@@ -1856,12 +1856,12 @@ func NewVendorInformationObject(vendor PccType, color uint32, preference uint32)
 	if vendor == CiscoLegacy {
 		o.EnterpriseNumber = EnterpriseNumberCisco
 		vendorInformationObjectTLVs := []TLVInterface{
-			&UndefinedTLV{
+			&UnknownTLV{
 				Typ:    SubTLVColorCisco,
 				Length: SubTLVColorCiscoValueLength, // TODO: 20 if ipv6 endpoint
 				Value:  Uint32ToByteSlice(color),
 			},
-			&UndefinedTLV{
+			&UnknownTLV{
 				Typ:    SubTLVPreferenceCisco,
 				Length: SubTLVPreferenceCiscoValueLength,
 				Value:  Uint32ToByteSlice(preference),
@@ -1886,7 +1886,7 @@ func (o *VendorInformationObject) Preference() uint32 {
 // or 0 if it is absent or too short to hold one.
 func (o *VendorInformationObject) subTLVUint32(typ TLVType) uint32 {
 	for _, tlv := range o.TLVs {
-		t, ok := tlv.(*UndefinedTLV)
+		t, ok := tlv.(*UnknownTLV)
 		if !ok || t.Type() != typ {
 			continue
 		}

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1711,9 +1711,10 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 			},
 			&SRPolicyCandidatePathIdentifierJuniper{
 				SRPolicyCandidatePathIdentifier: SRPolicyCandidatePathIdentifier{
+					ProtocolOrigin: ProtocolOriginPCEP,
 					OriginatorASN:  opts.originatorASN,
-					OriginatorAddr: dstAddr,
-					Discriminator:  1,
+					// Preserve Juniper legacy CPATH-ID TLV wire format with zero-filled Originator Address.
+					Discriminator: 1,
 				},
 			},
 			&SRPolicyCandidatePathPreferenceJuniper{
@@ -1751,14 +1752,16 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 func (o *AssociationObject) Color() uint32 {
 	for _, tlv := range o.TLVs {
 		switch t := tlv.(type) {
-		case *UnknownTLV:
-			if t.Type() == TLVExtendedAssociationIDIPv4Juniper {
-				return uint32(binary.BigEndian.Uint32(t.Value[:4]))
-			}
 		case *ExtendedAssociationIDIPv4Juniper:
 			return t.Color
+
 		case *ExtendedAssociationID:
 			return t.Color
+
+		case *UnknownTLV:
+			if t.Type() == TLVExtendedAssociationIDIPv4Juniper && len(t.Value) >= 4 {
+				return uint32(binary.BigEndian.Uint32(t.Value[:4]))
+			}
 		}
 	}
 	return 0
@@ -1768,14 +1771,16 @@ func (o *AssociationObject) Color() uint32 {
 func (o *AssociationObject) Preference() uint32 {
 	for _, tlv := range o.TLVs {
 		switch t := tlv.(type) {
-		case *UnknownTLV:
-			if t.Type() == TLVSRPolicyCPathPreferenceJuniper {
-				return uint32(binary.BigEndian.Uint32(t.Value))
-			}
 		case *SRPolicyCandidatePathPreferenceJuniper:
 			return t.Preference
+
 		case *SRPolicyCandidatePathPreference:
 			return t.Preference
+
+		case *UnknownTLV:
+			if t.Type() == TLVSRPolicyCPathPreferenceJuniper && len(t.Value) >= 4 {
+				return uint32(binary.BigEndian.Uint32(t.Value))
+			}
 		}
 	}
 	return 0

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1703,12 +1703,11 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 		o.AssocID = 0
 		o.AssocType = AssociationTypeSRPolicyAssociationJuniper
 		associationObjectTLVs := []TLVInterface{
-			&UndefinedTLV{
-				Typ:    TLVExtendedAssociationIDIPv4Juniper,
-				Length: TLVExtendedAssociationIDIPv4ValueLength, // JuniperLegacy has only IPv4 implementation
-				Value: AppendByteSlices(
-					Uint32ToByteSlice(color), dstAddr.AsSlice(),
-				),
+			&ExtendedAssociationIDIPv4Juniper{
+				ExtendedAssociationID: ExtendedAssociationID{
+					Color:    color,
+					Endpoint: dstAddr, // JuniperLegacy has only IPv4 implementation
+				},
 			},
 			&SRPolicyCandidatePathIdentifierJuniper{
 				SRPolicyCandidatePathIdentifier: SRPolicyCandidatePathIdentifier{
@@ -1717,10 +1716,10 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 					Discriminator:  1,
 				},
 			},
-			&UndefinedTLV{
-				Typ:    TLVSRPolicyCPathPreferenceJuniper,
-				Length: TLVSRPolicyCPathPreferenceValueLength,
-				Value:  Uint32ToByteSlice(preference),
+			&SRPolicyCandidatePathPreferenceJuniper{
+				SRPolicyCandidatePathPreference: SRPolicyCandidatePathPreference{
+					Preference: preference,
+				},
 			},
 		}
 		o.TLVs = append(o.TLVs, associationObjectTLVs...)
@@ -1751,14 +1750,16 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 // (I.D. pce-segment-routing-policy-cp-08 5.1)
 func (o *AssociationObject) Color() uint32 {
 	for _, tlv := range o.TLVs {
-		if t, ok := tlv.(*UndefinedTLV); ok {
+		switch t := tlv.(type) {
+		case *UndefinedTLV:
 			if t.Type() == TLVExtendedAssociationIDIPv4Juniper {
 				return uint32(binary.BigEndian.Uint32(t.Value[:4]))
 			}
-		} else if t, ok := tlv.(*ExtendedAssociationID); ok {
+		case *ExtendedAssociationIDIPv4Juniper:
+			return t.Color
+		case *ExtendedAssociationID:
 			return t.Color
 		}
-
 	}
 	return 0
 }
@@ -1766,11 +1767,14 @@ func (o *AssociationObject) Color() uint32 {
 // (I.D. pce-segment-routing-policy-cp-08 5.1)
 func (o *AssociationObject) Preference() uint32 {
 	for _, tlv := range o.TLVs {
-		if t, ok := tlv.(*UndefinedTLV); ok {
+		switch t := tlv.(type) {
+		case *UndefinedTLV:
 			if t.Type() == TLVSRPolicyCPathPreferenceJuniper {
 				return uint32(binary.BigEndian.Uint32(t.Value))
 			}
-		} else if t, ok := tlv.(*SRPolicyCandidatePathPreference); ok {
+		case *SRPolicyCandidatePathPreferenceJuniper:
+			return t.Preference
+		case *SRPolicyCandidatePathPreference:
 			return t.Preference
 		}
 	}
@@ -1779,7 +1783,10 @@ func (o *AssociationObject) Preference() uint32 {
 
 func (o *AssociationObject) Endpoint() netip.Addr {
 	for _, tlv := range o.TLVs {
-		if t, ok := tlv.(*ExtendedAssociationID); ok {
+		switch t := tlv.(type) {
+		case *ExtendedAssociationIDIPv4Juniper:
+			return t.Endpoint
+		case *ExtendedAssociationID:
 			return t.Endpoint
 		}
 	}

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -1072,15 +1072,15 @@ func TestAssociationObject_ColorPreferenceFromTLVs(t *testing.T) {
 			},
 			wantColor: 100, wantPreference: 200,
 		},
-		// UndefinedTLV fallback path must still work for vendor TLVs that are not decoded as typed TLVs.
-		"UndefinedTLVDecodePath": {
+		// UnknownTLV fallback path must still work for vendor TLVs that are not decoded as typed TLVs.
+		"UnknownTLVDecodePath": {
 			object: &AssociationObject{
 				TLVs: []TLVInterface{
-					&UndefinedTLV{
+					&UnknownTLV{
 						Typ:   TLVExtendedAssociationIDIPv4Juniper,
 						Value: AppendByteSlices(Uint32ToByteSlice(100), dstAddr.AsSlice()),
 					},
-					&UndefinedTLV{
+					&UnknownTLV{
 						Typ:   TLVSRPolicyCPathPreferenceJuniper,
 						Value: Uint32ToByteSlice(200),
 					},
@@ -1121,7 +1121,7 @@ func TestVendorInformationObject_DecodeFromBytes(t *testing.T) {
 				ObjectType:       ObjectTypeVendorSpecificConstraints,
 				EnterpriseNumber: EnterpriseNumberCisco,
 				TLVs: []TLVInterface{
-					&UndefinedTLV{Typ: SubTLVColorCisco, Length: 4, Value: []uint8{0x00, 0x00, 0x00, 0x64}},
+					&UnknownTLV{Typ: SubTLVColorCisco, Length: 4, Value: []uint8{0x00, 0x00, 0x00, 0x64}},
 				},
 			},
 		},
@@ -1133,7 +1133,7 @@ func TestVendorInformationObject_DecodeFromBytes(t *testing.T) {
 				ObjectType:       ObjectTypeVendorSpecificConstraints,
 				EnterpriseNumber: EnterpriseNumberCisco,
 				TLVs: []TLVInterface{
-					&UndefinedTLV{Typ: TLVVendorInformation, Length: 2, Value: []uint8{0xde, 0xad}},
+					&UnknownTLV{Typ: TLVVendorInformation, Length: 2, Value: []uint8{0xde, 0xad}},
 				},
 			},
 		},
@@ -1175,8 +1175,8 @@ func TestVendorInformationObject_ColorPreference(t *testing.T) {
 			object: &VendorInformationObject{
 				EnterpriseNumber: EnterpriseNumberCisco,
 				TLVs: []TLVInterface{
-					&UndefinedTLV{Typ: SubTLVColorCisco, Length: 4, Value: Uint32ToByteSlice(100)},
-					&UndefinedTLV{Typ: SubTLVPreferenceCisco, Length: 4, Value: Uint32ToByteSlice(200)},
+					&UnknownTLV{Typ: SubTLVColorCisco, Length: 4, Value: Uint32ToByteSlice(100)},
+					&UnknownTLV{Typ: SubTLVPreferenceCisco, Length: 4, Value: Uint32ToByteSlice(200)},
 				},
 			},
 			wantColor: 100, wantPreference: 200,
@@ -1186,8 +1186,8 @@ func TestVendorInformationObject_ColorPreference(t *testing.T) {
 			object: &VendorInformationObject{
 				EnterpriseNumber: EnterpriseNumberCisco,
 				TLVs: []TLVInterface{
-					&UndefinedTLV{Typ: SubTLVColorCisco, Length: 0, Value: []uint8{}},
-					&UndefinedTLV{Typ: SubTLVPreferenceCisco, Length: 2, Value: []uint8{0x00, 0x01}},
+					&UnknownTLV{Typ: SubTLVColorCisco, Length: 0, Value: []uint8{}},
+					&UnknownTLV{Typ: SubTLVPreferenceCisco, Length: 2, Value: []uint8{0x00, 0x01}},
 				},
 			},
 			wantColor: 0, wantPreference: 0,
@@ -1216,7 +1216,7 @@ func TestVendorInformationObject_RoundTrip(t *testing.T) {
 			ObjectType:       ObjectTypeVendorSpecificConstraints,
 			EnterpriseNumber: EnterpriseNumberCisco,
 			TLVs: []TLVInterface{
-				&UndefinedTLV{
+				&UnknownTLV{
 					Typ:    SubTLVColorCisco,
 					Length: SubTLVColorCiscoValueLength,
 					Value:  Uint32ToByteSlice(100),
@@ -1227,12 +1227,12 @@ func TestVendorInformationObject_RoundTrip(t *testing.T) {
 			ObjectType:       ObjectTypeVendorSpecificConstraints,
 			EnterpriseNumber: EnterpriseNumberCisco,
 			TLVs: []TLVInterface{
-				&UndefinedTLV{
+				&UnknownTLV{
 					Typ:    SubTLVColorCisco,
 					Length: SubTLVColorCiscoValueLength,
 					Value:  Uint32ToByteSlice(100),
 				},
-				&UndefinedTLV{
+				&UnknownTLV{
 					Typ:    SubTLVPreferenceCisco,
 					Length: SubTLVPreferenceCiscoValueLength,
 					Value:  Uint32ToByteSlice(200),
@@ -1243,12 +1243,12 @@ func TestVendorInformationObject_RoundTrip(t *testing.T) {
 			ObjectType:       ObjectTypeVendorSpecificConstraints,
 			EnterpriseNumber: EnterpriseNumberCisco,
 			TLVs: []TLVInterface{
-				&UndefinedTLV{
+				&UnknownTLV{
 					Typ:    SubTLVColorCisco,
 					Length: SubTLVColorCiscoValueLength,
 					Value:  Uint32ToByteSlice(0),
 				},
-				&UndefinedTLV{
+				&UnknownTLV{
 					Typ:    SubTLVPreferenceCisco,
 					Length: SubTLVPreferenceCiscoValueLength,
 					Value:  Uint32ToByteSlice(0),

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -6,7 +6,6 @@
 package pcep
 
 import (
-	"bytes"
 	"net/netip"
 	"testing"
 
@@ -907,13 +906,12 @@ func TestNewAssociationObject_DefaultCandidatePathIdentifier(t *testing.T) {
 	assert.Equal(t, expected, raw, "AssociationObject wire bytes changed")
 }
 
-// Verifies Juniper legacy AssociationObject serialization and CP-ID TLV handling.
-func TestNewAssociationObject_JuniperLegacy(t *testing.T) {
+// Verifies the Originator ASN option is reflected in the Juniper CP-ID TLV.
+func TestNewAssociationObject_JuniperLegacy_OriginatorASN(t *testing.T) {
 	t.Parallel()
 
 	srcAddr := netip.MustParseAddr("192.0.2.1")
 	dstAddr := netip.MustParseAddr("192.0.2.2")
-	originatorAddr := dstAddr.As16()
 
 	cases := map[string]struct {
 		opts        []Opt
@@ -941,31 +939,21 @@ func TestNewAssociationObject_JuniperLegacy(t *testing.T) {
 			cpID, ok := o.TLVs[1].(*SRPolicyCandidatePathIdentifierJuniper)
 			require.True(t, ok, "CP-ID TLV must be represented as SRPolicyCandidatePathIdentifierJuniper")
 
-			assert.Equal(t, uint32(tt.expectedASN), cpID.OriginatorASN)
-
-			raw, err := o.Serialize()
-			require.NoError(t, err)
-
-			expectedTLV := AppendByteSlices(
-				[]byte{0xff, 0xe4, 0x00, 0x1c},
-				[]byte{byte(ProtocolOriginPCEP), 0x00, 0x00, 0x00},
-				Uint32ToByteSlice(tt.expectedASN),
-				originatorAddr[:],
-				[]byte{0x00, 0x00, 0x00, 0x01},
-			)
-
-			require.True(t, bytes.Contains(raw, expectedTLV),
-				"serialized object does not contain expected Juniper SRPOLICY-CPATH-ID TLV with ASN %d",
-				tt.expectedASN,
-			)
+			assert.Equal(t, tt.expectedASN, cpID.OriginatorASN)
 		})
 	}
+}
 
-	// Ensure typed TLV conversion preserves the existing Juniper wire format.
+// Verifies Juniper vendor-specific TLVs preserve typed fields and legacy wire format.
+func TestNewAssociationObject_JuniperLegacy_TypedTLV(t *testing.T) {
+	t.Parallel()
+
+	srcAddr := netip.MustParseAddr("192.0.2.1")
+	dstAddr := netip.MustParseAddr("192.0.2.2")
+
 	o, err := NewAssociationObject(srcAddr, dstAddr, 100, 200, VendorSpecific(JuniperLegacy))
 	require.NoError(t, err, "NewAssociationObject failed")
 
-	// Verify vendor-specific TLVs are represented by their typed implementations.
 	require.Len(t, o.TLVs, 3)
 	require.IsType(t, &ExtendedAssociationIDIPv4Juniper{}, o.TLVs[0])
 
@@ -976,31 +964,39 @@ func TestNewAssociationObject_JuniperLegacy(t *testing.T) {
 
 	assert.Equal(t, uint8(ProtocolOriginPCEP), cpID.ProtocolOrigin)
 	assert.Equal(t, uint32(0), cpID.OriginatorASN)
-	assert.Equal(t, dstAddr, cpID.OriginatorAddr)
+	assert.Equal(t, netip.IPv4Unspecified(), cpID.OriginatorAddr)
 	assert.Equal(t, uint32(1), cpID.Discriminator)
+}
 
-	expected := AppendByteSlices(
-		[]byte{
-			0x28, 0x10, 0x00, 0x44, // common object header: class=ASSOCIATION, type=1, length=0x44
-			0x00, 0x00, 0x00, 0x00, // reserved + flags
-			0xff, 0xe1, 0x00, 0x00, // assoc type=0xffe1 (SRPolicyAssociationJuniper), assoc id=0
-			0xc0, 0x00, 0x02, 0x01, // assoc source=192.0.2.1
+// Ensures typed TLV conversion preserves the existing Juniper wire format byte-for-byte.
+func TestNewAssociationObject_JuniperLegacy_WireFormat(t *testing.T) {
+	t.Parallel()
 
-			0xff, 0xe3, 0x00, 0x08, // ExtendedAssociationID TLV (Juniper): type=0xffe3, length=8
-			0x00, 0x00, 0x00, 0x64, // color=100
-			0xc0, 0x00, 0x02, 0x02, // endpoint=192.0.2.2
+	srcAddr := netip.MustParseAddr("192.0.2.1")
+	dstAddr := netip.MustParseAddr("192.0.2.2")
 
-			0xff, 0xe4, 0x00, 0x1c, // SRPOLICY-CPATH-ID TLV (Juniper): type=0xffe4, length=28
-			byte(ProtocolOriginPCEP), 0x00, 0x00, 0x00, // protocol origin + MBZ
-			0x00, 0x00, 0x00, 0x00, // ASN=0
-		},
-		originatorAddr[:], // originator address: IPv4 represented as IPv4-mapped IPv6 address
-		[]byte{
-			0x00, 0x00, 0x00, 0x01, // discriminator=1
-			0xff, 0xe5, 0x00, 0x04, // SRPOLICY-CPATH-PREFERENCE TLV (Juniper): type=0xffe5, length=4
-			0x00, 0x00, 0x00, 0xc8, // preference=200
-		},
-	)
+	o, err := NewAssociationObject(srcAddr, dstAddr, 100, 200, VendorSpecific(JuniperLegacy))
+	require.NoError(t, err, "NewAssociationObject failed")
+
+	expected := []byte{
+		0x28, 0x10, 0x00, 0x44, // common object header: class=ASSOCIATION, type=1, length=0x44
+		0x00, 0x00, 0x00, 0x00, // reserved + flags
+		0xff, 0xe1, 0x00, 0x00, // assoc type=0xffe1 (SRPolicyAssociationJuniper), assoc id=0
+		0xc0, 0x00, 0x02, 0x01, // assoc source=192.0.2.1
+
+		0xff, 0xe3, 0x00, 0x08, // ExtendedAssociationID TLV (Juniper): type=0xffe3, length=8
+		0x00, 0x00, 0x00, 0x64, // color=100
+		0xc0, 0x00, 0x02, 0x02, // endpoint=192.0.2.2
+
+		0xff, 0xe4, 0x00, 0x1c, // SRPOLICY-CPATH-ID TLV (Juniper): type=0xffe4, length=28
+		byte(ProtocolOriginPCEP), 0x00, 0x00, 0x00, // protocol origin + MBZ
+		0x00, 0x00, 0x00, 0x00, // ASN=0
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // originator address: zero-filled (Juniper wire format)
+		0x00, 0x00, 0x00, 0x01, // discriminator=1
+
+		0xff, 0xe5, 0x00, 0x04, // SRPOLICY-CPATH-PREFERENCE TLV (Juniper): type=0xffe5, length=4
+		0x00, 0x00, 0x00, 0xc8, // preference=200
+	}
 
 	raw, err := o.Serialize()
 	require.NoError(t, err, "Serialize failed")
@@ -1040,7 +1036,7 @@ func TestAssociationObject_JuniperLegacyRoundTrip(t *testing.T) {
 
 	assert.Equal(t, uint8(ProtocolOriginPCEP), cpID.ProtocolOrigin)
 	assert.Equal(t, uint32(0), cpID.OriginatorASN)
-	assert.Equal(t, dstAddr, cpID.OriginatorAddr)
+	assert.Equal(t, netip.IPv4Unspecified(), cpID.OriginatorAddr)
 	assert.Equal(t, uint32(1), cpID.Discriminator)
 }
 

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -1108,6 +1108,36 @@ func TestAssociationObject_ColorPreferenceFromTLVs(t *testing.T) {
 	}
 }
 
+func TestNewVendorInformationObject(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CiscoLegacy", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := NewVendorInformationObject(CiscoLegacy, 100, 200)
+		require.NoError(t, err, "NewVendorInformationObject failed")
+
+		want := &VendorInformationObject{
+			ObjectType:       ObjectTypeVendorSpecificConstraints,
+			EnterpriseNumber: EnterpriseNumberCisco,
+			TLVs: []TLVInterface{
+				&UnknownTLV{Typ: SubTLVColorCisco, Length: SubTLVColorCiscoValueLength, Value: Uint32ToByteSlice(100)},
+				&UnknownTLV{Typ: SubTLVPreferenceCisco, Length: SubTLVPreferenceCiscoValueLength, Value: Uint32ToByteSlice(200)},
+			},
+		}
+		assert.Equal(t, want, got, "unexpected VendorInformationObject")
+		assert.Equal(t, uint32(100), got.Color(), "Color mismatch")
+		assert.Equal(t, uint32(200), got.Preference(), "Preference mismatch")
+	})
+
+	t.Run("UnknownVendor", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewVendorInformationObject(JuniperLegacy, 100, 200)
+		assert.Error(t, err, "expected error for unsupported vendor")
+	})
+}
+
 func TestVendorInformationObject_DecodeFromBytes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -907,19 +907,26 @@ func TestNewAssociationObject_DefaultCandidatePathIdentifier(t *testing.T) {
 	assert.Equal(t, expected, raw, "AssociationObject wire bytes changed")
 }
 
-// Verify OriginatorASN is propagated to the Juniper SRPOLICY-CPATH-ID TLV.
-func TestNewAssociationObject_JuniperLegacyOriginatorASN(t *testing.T) {
+// Verifies Juniper CP-ID TLV serialization, including OriginatorASN propagation and wire format stability.
+func TestNewAssociationObject_JuniperLegacyCandidatePathIdentifier(t *testing.T) {
 	t.Parallel()
 
 	srcAddr := netip.MustParseAddr("192.0.2.1")
 	dstAddr := netip.MustParseAddr("192.0.2.2")
+	originatorAddr := dstAddr.As16()
 
 	cases := map[string]struct {
 		opts        []Opt
 		expectedASN uint32
 	}{
-		"OriginatorASNSet":     {opts: []Opt{VendorSpecific(JuniperLegacy), OriginatorASN(65001)}, expectedASN: 65001},
-		"OriginatorASNOmitted": {opts: []Opt{VendorSpecific(JuniperLegacy)}, expectedASN: 0},
+		"OriginatorASNSet": {
+			opts:        []Opt{VendorSpecific(JuniperLegacy), OriginatorASN(65001)},
+			expectedASN: 65001,
+		},
+		"OriginatorASNOmitted": {
+			opts:        []Opt{VendorSpecific(JuniperLegacy)},
+			expectedASN: 0,
+		},
 	}
 
 	for name, tt := range cases {
@@ -933,15 +940,49 @@ func TestNewAssociationObject_JuniperLegacyOriginatorASN(t *testing.T) {
 			require.NoError(t, err, "Serialize failed")
 
 			expectedTLV := AppendByteSlices(
-				[]byte{0xff, 0xe4, 0x00, 0x1c},                     // SRPOLICY-CPATH-ID TLV (Juniper): type=0xffe4, len=28
-				[]byte{byte(ProtocolOriginPCEP), 0x00, 0x00, 0x00}, // protocol origin + mbz
+				[]byte{0xff, 0xe4, 0x00, 0x1c},
+				[]byte{byte(ProtocolOriginPCEP), 0x00, 0x00, 0x00},
 				Uint32ToByteSlice(tt.expectedASN),
-				make([]byte, 16), // originator address
-				make([]byte, 4),  // discriminator
+				originatorAddr[:],
+				[]byte{0x00, 0x00, 0x00, 0x01},
 			)
-			assert.True(t, bytes.Contains(raw, expectedTLV), "serialized object does not carry ASN %d in the Juniper SRPOLICY-CPATH-ID TLV", tt.expectedASN)
+
+			assert.True(t, bytes.Contains(raw, expectedTLV),
+				"serialized object does not contain expected Juniper SRPOLICY-CPATH-ID TLV with ASN %d",
+				tt.expectedASN,
+			)
 		})
 	}
+
+	// Ensure the Juniper AssociationObject preserves the legacy wire format after typed TLV conversion.
+	o, err := NewAssociationObject(srcAddr, dstAddr, 100, 200, VendorSpecific(JuniperLegacy))
+	require.NoError(t, err, "NewAssociationObject failed")
+
+	expected := AppendByteSlices(
+		[]byte{
+			0x28, 0x10, 0x00, 0x44, // common object header: class=ASSOCIATION, type=1, length=0x44
+			0x00, 0x00, 0x00, 0x00, // reserved + flags
+			0xff, 0xe1, 0x00, 0x00, // assoc type=0xffe1 (SRPolicyAssociationJuniper), assoc id=0
+			0xc0, 0x00, 0x02, 0x01, // assoc source=192.0.2.1
+
+			0xff, 0xe3, 0x00, 0x08, // ExtendedAssociationID TLV (Juniper)
+			0x00, 0x00, 0x00, 0x64, // color=100
+			0xc0, 0x00, 0x02, 0x02, // endpoint=192.0.2.2
+
+			0xff, 0xe4, 0x00, 0x1c, // SRPOLICY-CPATH-ID TLV (Juniper), length=28
+			byte(ProtocolOriginPCEP), 0x00, 0x00, 0x00, // protocol origin + MBZ
+			0x00, 0x00, 0x00, 0x00, // ASN=0
+		},
+		originatorAddr[:], // originator address field (IPv4 represented as IPv4-mapped IPv6)
+		[]byte{
+			0x00, 0x00, 0x00, 0x01, // discriminator=1
+			0xff, 0xe5, 0x00, 0x04, // SRPOLICY-CPATH-PREFERENCE TLV (Juniper)
+			0x00, 0x00, 0x00, 0xc8, // preference=200
+		},
+	)
+	raw, err := o.Serialize()
+	require.NoError(t, err, "Serialize failed")
+	assert.Equal(t, expected, raw, "AssociationObject wire bytes changed")
 }
 
 func TestVendorInformationObject_DecodeFromBytes(t *testing.T) {

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -907,8 +907,8 @@ func TestNewAssociationObject_DefaultCandidatePathIdentifier(t *testing.T) {
 	assert.Equal(t, expected, raw, "AssociationObject wire bytes changed")
 }
 
-// Verifies Juniper CP-ID TLV serialization, including OriginatorASN propagation and wire format stability.
-func TestNewAssociationObject_JuniperLegacyCandidatePathIdentifier(t *testing.T) {
+// Verifies Juniper legacy AssociationObject serialization and CP-ID TLV handling.
+func TestNewAssociationObject_JuniperLegacy(t *testing.T) {
 	t.Parallel()
 
 	srcAddr := netip.MustParseAddr("192.0.2.1")
@@ -934,10 +934,17 @@ func TestNewAssociationObject_JuniperLegacyCandidatePathIdentifier(t *testing.T)
 			t.Parallel()
 
 			o, err := NewAssociationObject(srcAddr, dstAddr, 100, 200, tt.opts...)
-			require.NoError(t, err, "NewAssociationObject failed")
+			require.NoError(t, err)
+
+			require.Len(t, o.TLVs, 3)
+
+			cpID, ok := o.TLVs[1].(*SRPolicyCandidatePathIdentifierJuniper)
+			require.True(t, ok, "CP-ID TLV must be represented as SRPolicyCandidatePathIdentifierJuniper")
+
+			assert.Equal(t, uint32(tt.expectedASN), cpID.OriginatorASN)
 
 			raw, err := o.Serialize()
-			require.NoError(t, err, "Serialize failed")
+			require.NoError(t, err)
 
 			expectedTLV := AppendByteSlices(
 				[]byte{0xff, 0xe4, 0x00, 0x1c},
@@ -947,16 +954,30 @@ func TestNewAssociationObject_JuniperLegacyCandidatePathIdentifier(t *testing.T)
 				[]byte{0x00, 0x00, 0x00, 0x01},
 			)
 
-			assert.True(t, bytes.Contains(raw, expectedTLV),
+			require.True(t, bytes.Contains(raw, expectedTLV),
 				"serialized object does not contain expected Juniper SRPOLICY-CPATH-ID TLV with ASN %d",
 				tt.expectedASN,
 			)
 		})
 	}
 
-	// Ensure the Juniper AssociationObject preserves the legacy wire format after typed TLV conversion.
+	// Ensure typed TLV conversion preserves the existing Juniper wire format.
 	o, err := NewAssociationObject(srcAddr, dstAddr, 100, 200, VendorSpecific(JuniperLegacy))
 	require.NoError(t, err, "NewAssociationObject failed")
+
+	// Verify vendor-specific TLVs are represented by their typed implementations.
+	require.Len(t, o.TLVs, 3)
+	require.IsType(t, &ExtendedAssociationIDIPv4Juniper{}, o.TLVs[0])
+
+	cpID, ok := o.TLVs[1].(*SRPolicyCandidatePathIdentifierJuniper)
+	require.True(t, ok, "CP-ID TLV must be represented as SRPolicyCandidatePathIdentifierJuniper")
+
+	require.IsType(t, &SRPolicyCandidatePathPreferenceJuniper{}, o.TLVs[2])
+
+	assert.Equal(t, uint8(ProtocolOriginPCEP), cpID.ProtocolOrigin)
+	assert.Equal(t, uint32(0), cpID.OriginatorASN)
+	assert.Equal(t, dstAddr, cpID.OriginatorAddr)
+	assert.Equal(t, uint32(1), cpID.Discriminator)
 
 	expected := AppendByteSlices(
 		[]byte{
@@ -965,24 +986,118 @@ func TestNewAssociationObject_JuniperLegacyCandidatePathIdentifier(t *testing.T)
 			0xff, 0xe1, 0x00, 0x00, // assoc type=0xffe1 (SRPolicyAssociationJuniper), assoc id=0
 			0xc0, 0x00, 0x02, 0x01, // assoc source=192.0.2.1
 
-			0xff, 0xe3, 0x00, 0x08, // ExtendedAssociationID TLV (Juniper)
+			0xff, 0xe3, 0x00, 0x08, // ExtendedAssociationID TLV (Juniper): type=0xffe3, length=8
 			0x00, 0x00, 0x00, 0x64, // color=100
 			0xc0, 0x00, 0x02, 0x02, // endpoint=192.0.2.2
 
-			0xff, 0xe4, 0x00, 0x1c, // SRPOLICY-CPATH-ID TLV (Juniper), length=28
+			0xff, 0xe4, 0x00, 0x1c, // SRPOLICY-CPATH-ID TLV (Juniper): type=0xffe4, length=28
 			byte(ProtocolOriginPCEP), 0x00, 0x00, 0x00, // protocol origin + MBZ
 			0x00, 0x00, 0x00, 0x00, // ASN=0
 		},
-		originatorAddr[:], // originator address field (IPv4 represented as IPv4-mapped IPv6)
+		originatorAddr[:], // originator address: IPv4 represented as IPv4-mapped IPv6 address
 		[]byte{
 			0x00, 0x00, 0x00, 0x01, // discriminator=1
-			0xff, 0xe5, 0x00, 0x04, // SRPOLICY-CPATH-PREFERENCE TLV (Juniper)
+			0xff, 0xe5, 0x00, 0x04, // SRPOLICY-CPATH-PREFERENCE TLV (Juniper): type=0xffe5, length=4
 			0x00, 0x00, 0x00, 0xc8, // preference=200
 		},
 	)
+
 	raw, err := o.Serialize()
 	require.NoError(t, err, "Serialize failed")
 	assert.Equal(t, expected, raw, "AssociationObject wire bytes changed")
+}
+
+// Ensures Juniper legacy AssociationObject round-trips through serialization and decoding with typed TLVs.
+func TestAssociationObject_JuniperLegacyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	srcAddr := netip.MustParseAddr("192.0.2.1")
+	dstAddr := netip.MustParseAddr("192.0.2.2")
+
+	o, err := NewAssociationObject(srcAddr, dstAddr, 100, 200, VendorSpecific(JuniperLegacy))
+	require.NoError(t, err, "NewAssociationObject failed")
+
+	raw, err := o.Serialize()
+	require.NoError(t, err, "Serialize failed")
+
+	var got AssociationObject
+	err = got.DecodeFromBytes(ObjectTypeAssociationIPv4, raw[commonObjectHeaderLength:])
+	require.NoError(t, err, "DecodeFromBytes failed")
+
+	require.Len(t, got.TLVs, 3)
+
+	// Verify Juniper vendor TLVs survive decoding as typed TLVs.
+	require.IsType(t, &ExtendedAssociationIDIPv4Juniper{}, got.TLVs[0])
+
+	cpID, ok := got.TLVs[1].(*SRPolicyCandidatePathIdentifierJuniper)
+	require.True(t, ok, "CP-ID TLV must be represented as SRPolicyCandidatePathIdentifierJuniper")
+
+	require.IsType(t, &SRPolicyCandidatePathPreferenceJuniper{}, got.TLVs[2])
+
+	assert.Equal(t, uint32(100), got.Color())
+	assert.Equal(t, uint32(200), got.Preference())
+	assert.Equal(t, dstAddr, got.Endpoint())
+
+	assert.Equal(t, uint8(ProtocolOriginPCEP), cpID.ProtocolOrigin)
+	assert.Equal(t, uint32(0), cpID.OriginatorASN)
+	assert.Equal(t, dstAddr, cpID.OriginatorAddr)
+	assert.Equal(t, uint32(1), cpID.Discriminator)
+}
+
+func TestAssociationObject_ColorPreferenceFromTLVs(t *testing.T) {
+	t.Parallel()
+
+	dstAddr := netip.MustParseAddr("192.0.2.2")
+
+	cases := map[string]struct {
+		object         *AssociationObject
+		wantColor      uint32
+		wantPreference uint32
+	}{
+		"RFCTypedTLV": {
+			object: &AssociationObject{
+				TLVs: []TLVInterface{
+					&ExtendedAssociationID{Color: 100, Endpoint: dstAddr},
+					&SRPolicyCandidatePathPreference{Preference: 200},
+				},
+			},
+			wantColor: 100, wantPreference: 200,
+		},
+		"JuniperTypedTLV": {
+			object: &AssociationObject{
+				TLVs: []TLVInterface{
+					&ExtendedAssociationIDIPv4Juniper{ExtendedAssociationID: ExtendedAssociationID{Color: 100, Endpoint: dstAddr}},
+					&SRPolicyCandidatePathPreferenceJuniper{SRPolicyCandidatePathPreference: SRPolicyCandidatePathPreference{Preference: 200}},
+				},
+			},
+			wantColor: 100, wantPreference: 200,
+		},
+		// UndefinedTLV fallback path must still work for vendor TLVs that are not decoded as typed TLVs.
+		"UndefinedTLVDecodePath": {
+			object: &AssociationObject{
+				TLVs: []TLVInterface{
+					&UndefinedTLV{
+						Typ:   TLVExtendedAssociationIDIPv4Juniper,
+						Value: AppendByteSlices(Uint32ToByteSlice(100), dstAddr.AsSlice()),
+					},
+					&UndefinedTLV{
+						Typ:   TLVSRPolicyCPathPreferenceJuniper,
+						Value: Uint32ToByteSlice(200),
+					},
+				},
+			},
+			wantColor: 100, wantPreference: 200,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.wantColor, tt.object.Color(), "color mismatch for '%s'", name)
+			assert.Equal(t, tt.wantPreference, tt.object.Preference(), "preference mismatch for '%s'", name)
+		})
+	}
 }
 
 func TestVendorInformationObject_DecodeFromBytes(t *testing.T) {

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -944,6 +944,18 @@ func TestNewAssociationObject_JuniperLegacy_OriginatorASN(t *testing.T) {
 	}
 }
 
+// JuniperLegacy uses the IPv4 Extended Association ID TLV format.
+// IPv6 endpoints must be rejected during object construction.
+func TestNewAssociationObject_JuniperLegacy_RejectsIPv6(t *testing.T) {
+	t.Parallel()
+
+	srcAddr := netip.MustParseAddr("2001:db8::1")
+	dstAddr := netip.MustParseAddr("2001:db8::2")
+
+	_, err := NewAssociationObject(srcAddr, dstAddr, 100, 200, VendorSpecific(JuniperLegacy))
+	assert.Error(t, err)
+}
+
 // Verifies Juniper vendor-specific TLVs preserve typed fields and legacy wire format.
 func TestNewAssociationObject_JuniperLegacy_TypedTLV(t *testing.T) {
 	t.Parallel()

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1835,16 +1835,16 @@ func (tlv *Color) Len() uint16 {
 	return TLVValueOffset + TLVColorValueLength
 }
 
-type UndefinedTLV struct {
+type UnknownTLV struct {
 	Typ    TLVType
 	Length uint16
 	Value  []byte
 }
 
-func (tlv *UndefinedTLV) DecodeFromBytes(data []byte) error {
+func (tlv *UnknownTLV) DecodeFromBytes(data []byte) error {
 	valueLen, err := decodeTLVLength(data, true)
 	if err != nil {
-		return fmt.Errorf("UndefinedTLV: %w", err)
+		return fmt.Errorf("UnknownTLV: %w", err)
 	}
 
 	tlv.Typ = TLVType(binary.BigEndian.Uint16(data[TLVTypeOffset:TLVLengthOffset]))
@@ -1854,7 +1854,7 @@ func (tlv *UndefinedTLV) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (tlv *UndefinedTLV) Serialize() []byte {
+func (tlv *UnknownTLV) Serialize() []byte {
 	padding := (TLVAlignment - (tlv.Length % TLVAlignment)) % TLVAlignment
 
 	return AppendByteSlices(
@@ -1865,7 +1865,7 @@ func (tlv *UndefinedTLV) Serialize() []byte {
 	)
 }
 
-func (tlv *UndefinedTLV) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+func (tlv *UnknownTLV) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	if tlv == nil {
 		return nil
 	}
@@ -1875,11 +1875,11 @@ func (tlv *UndefinedTLV) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-func (tlv *UndefinedTLV) Type() TLVType {
+func (tlv *UnknownTLV) Type() TLVType {
 	return tlv.Typ
 }
 
-func (tlv *UndefinedTLV) Len() uint16 {
+func (tlv *UnknownTLV) Len() uint16 {
 	padding := uint16(0)
 	if tlv.Length%4 != 0 {
 		padding = (4 - tlv.Length%4)
@@ -1889,7 +1889,7 @@ func (tlv *UndefinedTLV) Len() uint16 {
 
 // CapStrings reports the registered TLV name even when no decoder exists.
 // Unknown TLV types fall back to "unknown_type_<n>".
-func (tlv *UndefinedTLV) CapStrings() []string {
+func (tlv *UnknownTLV) CapStrings() []string {
 	if desc, ok := tlvDescriptions[tlv.Typ]; ok {
 		return []string{desc.Description}
 	}
@@ -1897,7 +1897,7 @@ func (tlv *UndefinedTLV) CapStrings() []string {
 	return []string{capStr}
 }
 
-func (tlv *UndefinedTLV) SetLength() {
+func (tlv *UnknownTLV) SetLength() {
 	tlv.Length = uint16(len(tlv.Value))
 }
 
@@ -1913,7 +1913,7 @@ func DecodeTLV(data []byte) (TLVInterface, error) {
 func decodeTLV(data []byte, tlvType TLVType) (TLVInterface, error) {
 	createTLV, found := tlvMap[tlvType]
 	if !found {
-		return decodeUndefinedTLV(data, tlvType)
+		return decodeUnknownTLV(data, tlvType)
 	}
 
 	tlv := createTLV()
@@ -1924,11 +1924,11 @@ func decodeTLV(data []byte, tlvType TLVType) (TLVInterface, error) {
 	return tlv, nil
 }
 
-// decodeUndefinedTLV decodes a single TLV without consulting tlvMap, keeping its value as raw bytes.
-func decodeUndefinedTLV(data []byte, tlvType TLVType) (TLVInterface, error) {
-	tlv := &UndefinedTLV{}
+// decodeUnknownTLV decodes a single TLV without consulting tlvMap, keeping its value as raw bytes.
+func decodeUnknownTLV(data []byte, tlvType TLVType) (TLVInterface, error) {
+	tlv := &UnknownTLV{}
 	if err := tlv.DecodeFromBytes(data); err != nil {
-		return nil, fmt.Errorf("error decoding undefined TLV type %x: %w", uint16(tlvType), err)
+		return nil, fmt.Errorf("error decoding unknown TLV type %x: %w", uint16(tlvType), err)
 	}
 
 	return tlv, nil
@@ -1939,11 +1939,9 @@ func DecodeTLVs(data []byte) ([]TLVInterface, error) {
 	return decodeTLVSequence(data, decodeTLV)
 }
 
-// DecodeVendorTLVs decodes a sequence of TLVs carried in a VENDOR-INFORMATION Object (RFC7470 4).
-// Their type space is enterprise-specific and may collide with the standard one, so every TLV is
-// kept as an UndefinedTLV instead of being matched against tlvMap.
+// DecodeVendorTLVs decodes vendor-specific TLVs as UnknownTLV.
 func DecodeVendorTLVs(data []byte) ([]TLVInterface, error) {
-	return decodeTLVSequence(data, decodeUndefinedTLV)
+	return decodeTLVSequence(data, decodeUnknownTLV)
 }
 
 func decodeTLVSequence(data []byte, decode func([]byte, TLVType) (TLVInterface, error)) ([]TLVInterface, error) {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1298,17 +1298,44 @@ func NewExtendedAssociationID(color uint32, endpoint netip.Addr) *ExtendedAssoci
 }
 
 // ExtendedAssociationIDIPv4Juniper is the Juniper vendor-specific
-// Extended Association ID TLV (0xffe3). JuniperLegacy has only an IPv4 implementation.
+// Extended Association ID TLV (0xffe3). Juniper devices always use the
+// IPv4 zero-padded wire format for this TLV, even on IPv6 PCEP sessions,
+// so the IPv6 wire format (value length 20) is rejected here.
 type ExtendedAssociationIDIPv4Juniper struct {
 	ExtendedAssociationID
 }
 
+func (tlv *ExtendedAssociationIDIPv4Juniper) DecodeFromBytes(data []byte) error {
+	valueLen, err := decodeTLVLength(data, false)
+	if err != nil {
+		return fmt.Errorf("ExtendedAssociationIDIPv4Juniper: %w", err)
+	}
+
+	if valueLen != int(TLVExtendedAssociationIDIPv4ValueLength) {
+		return fmt.Errorf("ExtendedAssociationIDIPv4Juniper: invalid value length %d", valueLen)
+	}
+
+	return tlv.ExtendedAssociationID.DecodeFromBytes(data)
+}
+
 func (tlv *ExtendedAssociationIDIPv4Juniper) Serialize() []byte {
+	if !tlv.Endpoint.Is4() {
+		return nil
+	}
+
 	return tlv.serialize(tlv.Type())
 }
 
 func (tlv *ExtendedAssociationIDIPv4Juniper) Type() TLVType {
 	return TLVExtendedAssociationIDIPv4Juniper
+}
+
+func (tlv *ExtendedAssociationIDIPv4Juniper) Len() uint16 {
+	if !tlv.Endpoint.Is4() {
+		return 0
+	}
+
+	return TLVValueOffset + TLVExtendedAssociationIDIPv4ValueLength
 }
 
 type PathSetupTypeCapability struct {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -263,6 +263,11 @@ var tlvMap = map[TLVType]func() TLVInterface{
 	TLVSRPolicyCPathID:         func() TLVInterface { return &SRPolicyCandidatePathIdentifier{} },
 	TLVSRPolicyCPathPreference: func() TLVInterface { return &SRPolicyCandidatePathPreference{} },
 	TLVColor:                   func() TLVInterface { return &Color{} },
+
+	// Juniper vendor-specific Association TLVs.
+	TLVExtendedAssociationIDIPv4Juniper: func() TLVInterface { return &ExtendedAssociationIDIPv4Juniper{} },
+	TLVSRPolicyCPathIDJuniper:           func() TLVInterface { return &SRPolicyCandidatePathIdentifierJuniper{} },
+	TLVSRPolicyCPathPreferenceJuniper:   func() TLVInterface { return &SRPolicyCandidatePathPreferenceJuniper{} },
 }
 
 // VendorInformation represents the VENDOR-INFORMATION TLV (RFC7470 4).
@@ -1225,6 +1230,10 @@ func (tlv *ExtendedAssociationID) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *ExtendedAssociationID) Serialize() []byte {
+	return tlv.serialize(tlv.Type())
+}
+
+func (tlv *ExtendedAssociationID) serialize(typ TLVType) []byte {
 	if !tlv.Endpoint.IsValid() {
 		return nil
 	}
@@ -1243,7 +1252,7 @@ func (tlv *ExtendedAssociationID) Serialize() []byte {
 	copy(value[ExtendedAssociationIDEndpointOffset:], tlv.Endpoint.AsSlice())
 
 	return AppendByteSlices(
-		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(typ),
 		Uint16ToByteSlice(length),
 		value,
 	)
@@ -1286,6 +1295,20 @@ func NewExtendedAssociationID(color uint32, endpoint netip.Addr) *ExtendedAssoci
 		Color:    color,
 		Endpoint: endpoint,
 	}
+}
+
+// ExtendedAssociationIDIPv4Juniper is the Juniper vendor-specific
+// Extended Association ID TLV (0xffe3). JuniperLegacy has only an IPv4 implementation.
+type ExtendedAssociationIDIPv4Juniper struct {
+	ExtendedAssociationID
+}
+
+func (tlv *ExtendedAssociationIDIPv4Juniper) Serialize() []byte {
+	return tlv.serialize(tlv.Type())
+}
+
+func (tlv *ExtendedAssociationIDIPv4Juniper) Type() TLVType {
+	return TLVExtendedAssociationIDIPv4Juniper
 }
 
 type PathSetupTypeCapability struct {
@@ -1711,6 +1734,10 @@ func (tlv *SRPolicyCandidatePathPreference) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *SRPolicyCandidatePathPreference) Serialize() []byte {
+	return tlv.serialize(tlv.Type())
+}
+
+func (tlv *SRPolicyCandidatePathPreference) serialize(typ TLVType) []byte {
 	value := make([]byte, TLVSRPolicyCPathPreferenceValueLength)
 
 	binary.BigEndian.PutUint32(
@@ -1719,7 +1746,7 @@ func (tlv *SRPolicyCandidatePathPreference) Serialize() []byte {
 	)
 
 	return AppendByteSlices(
-		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(typ),
 		Uint16ToByteSlice(TLVSRPolicyCPathPreferenceValueLength),
 		value,
 	)
@@ -1740,6 +1767,20 @@ func (tlv *SRPolicyCandidatePathPreference) Type() TLVType {
 
 func (tlv *SRPolicyCandidatePathPreference) Len() uint16 {
 	return TLVValueOffset + TLVSRPolicyCPathPreferenceValueLength
+}
+
+// SRPolicyCandidatePathPreferenceJuniper is the Juniper vendor-specific
+// SR Policy candidate path preference TLV (0xffe5).
+type SRPolicyCandidatePathPreferenceJuniper struct {
+	SRPolicyCandidatePathPreference
+}
+
+func (tlv *SRPolicyCandidatePathPreferenceJuniper) Serialize() []byte {
+	return tlv.serialize(tlv.Type())
+}
+
+func (tlv *SRPolicyCandidatePathPreferenceJuniper) Type() TLVType {
+	return TLVSRPolicyCPathPreferenceJuniper
 }
 
 type Color struct {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1607,6 +1607,10 @@ func (tlv *SRPolicyCandidatePathIdentifier) DecodeFromBytes(data []byte) error {
 }
 
 func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
+	return tlv.serialize(tlv.Type())
+}
+
+func (tlv *SRPolicyCandidatePathIdentifier) serialize(typ TLVType) []byte {
 
 	value := make([]byte, TLVSRPolicyCPathIDValueLength)
 
@@ -1646,7 +1650,7 @@ func (tlv *SRPolicyCandidatePathIdentifier) Serialize() []byte {
 	)
 
 	return AppendByteSlices(
-		Uint16ToByteSlice(tlv.Type()),
+		Uint16ToByteSlice(typ),
 		Uint16ToByteSlice(TLVSRPolicyCPathIDValueLength),
 		value,
 	)
@@ -1670,6 +1674,20 @@ func (tlv *SRPolicyCandidatePathIdentifier) Type() TLVType {
 
 func (tlv *SRPolicyCandidatePathIdentifier) Len() uint16 {
 	return TLVValueOffset + TLVSRPolicyCPathIDValueLength
+}
+
+// SRPolicyCandidatePathIdentifierJuniper is the Juniper vendor-specific
+// SR Policy candidate path identifier TLV (0xffe4).
+type SRPolicyCandidatePathIdentifierJuniper struct {
+	SRPolicyCandidatePathIdentifier
+}
+
+func (tlv *SRPolicyCandidatePathIdentifierJuniper) Serialize() []byte {
+	return tlv.serialize(tlv.Type())
+}
+
+func (tlv *SRPolicyCandidatePathIdentifierJuniper) Type() TLVType {
+	return TLVSRPolicyCPathIDJuniper
 }
 
 type SRPolicyCandidatePathPreference struct {

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1903,65 +1903,65 @@ func TestColor_Len(t *testing.T) {
 	runTLVLenTests(t, cases)
 }
 
-// Test data for UndefinedTLV.
+// Test data for UnknownTLV.
 var (
-	// Standard 4-byte UndefinedTLV
-	testUndefinedTLV = &UndefinedTLV{
+	// Standard 4-byte UnknownTLV
+	testUnknownTLV = &UnknownTLV{
 		Typ:    TLVType(0xffff),
 		Length: 4,
 		Value:  []byte{0xde, 0xad, 0xbe, 0xef},
 	}
 	// 3-byte value (odd → 1 byte padding required)
-	testUndefinedTLVOddLength = &UndefinedTLV{
+	testUnknownTLVOddLength = &UnknownTLV{
 		Typ:    TLVType(0xffff),
 		Length: 3,
 		Value:  []byte{0x01, 0x02, 0x03},
 	}
 
 	// Serialized TLV bytes
-	testUndefinedTLVBytes           = []byte{0xff, 0xff, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef}
-	testUndefinedTLVOddLengthBytes  = []byte{0xff, 0xff, 0x00, 0x03, 0x01, 0x02, 0x03, 0x00}
-	testUndefinedTLVTruncatedHeader = []byte{0xff, 0xff, 0x00}
-	testUndefinedTLVTruncatedValue  = []byte{0xff, 0xff, 0x00, 0x08, 0x01, 0x02}
+	testUnknownTLVBytes           = []byte{0xff, 0xff, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef}
+	testUnknownTLVOddLengthBytes  = []byte{0xff, 0xff, 0x00, 0x03, 0x01, 0x02, 0x03, 0x00}
+	testUnknownTLVTruncatedHeader = []byte{0xff, 0xff, 0x00}
+	testUnknownTLVTruncatedValue  = []byte{0xff, 0xff, 0x00, 0x08, 0x01, 0x02}
 )
 
-func TestUndefinedTLV_DecodeFromBytes(t *testing.T) {
+func TestUnknownTLV_DecodeFromBytes(t *testing.T) {
 	cases := map[string]TLVTestCase{
-		"ValidUndefinedTLV": {testUndefinedTLVBytes, testUndefinedTLV, false},
-		"TruncatedHeader":   {testUndefinedTLVTruncatedHeader, nil, true},
-		"TruncatedValue":    {testUndefinedTLVTruncatedValue, nil, true},
+		"ValidUnknownTLV": {testUnknownTLVBytes, testUnknownTLV, false},
+		"TruncatedHeader": {testUnknownTLVTruncatedHeader, nil, true},
+		"TruncatedValue":  {testUnknownTLVTruncatedValue, nil, true},
 	}
-	runTLVDecodeTests(t, cases, func() TLVInterface { return &UndefinedTLV{} })
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &UnknownTLV{} })
 }
 
-func TestUndefinedTLV_Serialize(t *testing.T) {
+func TestUnknownTLV_Serialize(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
 		expected []byte
 	}{
-		"AlignedValue":   {testUndefinedTLV, testUndefinedTLVBytes},
-		"UnalignedValue": {testUndefinedTLVOddLength, testUndefinedTLVOddLengthBytes},
+		"AlignedValue":   {testUnknownTLV, testUnknownTLVBytes},
+		"UnalignedValue": {testUnknownTLVOddLength, testUnknownTLVOddLengthBytes},
 	}
 	runTLVSerializeTests(t, cases)
 }
 
-func TestUndefinedTLV_MarshalLogObject(t *testing.T) {
+func TestUnknownTLV_MarshalLogObject(t *testing.T) {
 	cases := map[string]struct {
-		input    *UndefinedTLV
+		input    *UnknownTLV
 		expected map[string]any
 	}{
 		"StandardTLV": {
-			testUndefinedTLV,
+			testUnknownTLV,
 			map[string]any{
-				"type":   fmt.Sprintf("0x%04x", testUndefinedTLV.Typ),
-				"length": testUndefinedTLV.Length,
+				"type":   fmt.Sprintf("0x%04x", testUnknownTLV.Typ),
+				"length": testUnknownTLV.Length,
 			},
 		},
 		"OddLength": {
-			testUndefinedTLVOddLength,
+			testUnknownTLVOddLength,
 			map[string]any{
-				"type":   fmt.Sprintf("0x%04x", testUndefinedTLVOddLength.Typ),
-				"length": testUndefinedTLVOddLength.Length,
+				"type":   fmt.Sprintf("0x%04x", testUnknownTLVOddLength.Typ),
+				"length": testUnknownTLVOddLength.Length,
 			},
 		},
 		"NilTLV": {
@@ -1980,18 +1980,18 @@ func TestUndefinedTLV_MarshalLogObject(t *testing.T) {
 	}
 }
 
-func TestUndefinedTLV_Len(t *testing.T) {
+func TestUnknownTLV_Len(t *testing.T) {
 	cases := map[string]struct {
 		input    TLVInterface
 		expected uint16
 	}{
-		"AlignedLen":   {testUndefinedTLV, TLVValueOffset + 4},          // 4-byte value
-		"UnalignedLen": {testUndefinedTLVOddLength, TLVValueOffset + 4}, // 3-byte value + 1 pad = 4
+		"AlignedLen":   {testUnknownTLV, TLVValueOffset + 4},          // 4-byte value
+		"UnalignedLen": {testUnknownTLVOddLength, TLVValueOffset + 4}, // 3-byte value + 1 pad = 4
 	}
 	runTLVLenTests(t, cases)
 }
 
-func TestUndefinedTLV_CapStrings(t *testing.T) {
+func TestUnknownTLV_CapStrings(t *testing.T) {
 	cases := map[string]struct {
 		input    CapStringsInterface
 		expected []string
@@ -1999,16 +1999,16 @@ func TestUndefinedTLV_CapStrings(t *testing.T) {
 		// Registered in tlvDescriptions but with no dedicated decoder: reported
 		// under its registry name rather than as unknown_type_<n>.
 		"RegisteredWithoutDecoder": {
-			input:    &UndefinedTLV{Typ: TLVSRP2MPPolicyCapability},
+			input:    &UnknownTLV{Typ: TLVSRP2MPPolicyCapability},
 			expected: []string{"SR-P2MP-POLICY-CAPABILITY"},
 		},
 		"RegisteredVendorSpecific": {
-			input:    &UndefinedTLV{Typ: TLVSRPolicyCPathPreferenceJuniper},
+			input:    &UnknownTLV{Typ: TLVSRPolicyCPathPreferenceJuniper},
 			expected: []string{"SRPOLICY-CPATH-PREFERENCE (Juniper)"},
 		},
 		// Absent from the registry: falls back to the numeric form.
 		"UnregisteredType": {
-			input:    &UndefinedTLV{Typ: TLVType(0x1234)},
+			input:    &UnknownTLV{Typ: TLVType(0x1234)},
 			expected: []string{"unknown_type_4660"},
 		},
 	}
@@ -2016,8 +2016,8 @@ func TestUndefinedTLV_CapStrings(t *testing.T) {
 	runCapStringsTests(t, cases)
 }
 
-func TestUndefinedTLV_SetLength(t *testing.T) {
-	tlv := &UndefinedTLV{Value: []byte{0x01, 0x02, 0x03}}
+func TestUnknownTLV_SetLength(t *testing.T) {
+	tlv := &UnknownTLV{Value: []byte{0x01, 0x02, 0x03}}
 	tlv.SetLength()
 	assert.Equal(t, uint16(3), tlv.Length, "SetLength() should set Length to len(Value)")
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1285,21 +1285,40 @@ func TestExtendedAssociationIDIPv4Juniper_Type(t *testing.T) {
 }
 
 func TestExtendedAssociationIDIPv4Juniper_Serialize(t *testing.T) {
-	tlv := &ExtendedAssociationIDIPv4Juniper{
-		ExtendedAssociationID: *testIPv4ExtendedAssociationID,
+	expectedIPv4 := append([]byte(nil), testIPv4ExtendedAssociationIDBytes...)
+	expectedIPv4[0], expectedIPv4[1] = 0xff, 0xe3 // type=0xffe3, value layout unchanged
+
+	cases := map[string]struct {
+		input    TLVInterface
+		expected []byte
+	}{
+		"IPv4": {
+			&ExtendedAssociationIDIPv4Juniper{ExtendedAssociationID: *testIPv4ExtendedAssociationID},
+			expectedIPv4,
+		},
+		"IPv6Rejected": {
+			&ExtendedAssociationIDIPv4Juniper{ExtendedAssociationID: *testIPv6ExtendedAssociationID},
+			nil,
+		},
 	}
-
-	expected := append([]byte(nil), testIPv4ExtendedAssociationIDBytes...)
-	expected[0], expected[1] = 0xff, 0xe3 // type=0xffe3, value layout unchanged
-
-	assert.Equal(t, expected, tlv.Serialize())
+	runTLVSerializeTests(t, cases)
 }
 
 func TestExtendedAssociationIDIPv4Juniper_Len(t *testing.T) {
-	tlv := &ExtendedAssociationIDIPv4Juniper{
-		ExtendedAssociationID: *testIPv4ExtendedAssociationID,
+	cases := map[string]struct {
+		input    TLVInterface
+		expected uint16
+	}{
+		"IPv4": {
+			&ExtendedAssociationIDIPv4Juniper{ExtendedAssociationID: *testIPv4ExtendedAssociationID},
+			testIPv4ExtendedAssociationID.Len(),
+		},
+		"IPv6Rejected": {
+			&ExtendedAssociationIDIPv4Juniper{ExtendedAssociationID: *testIPv6ExtendedAssociationID},
+			0,
+		},
 	}
-	assert.Equal(t, testIPv4ExtendedAssociationID.Len(), tlv.Len())
+	runTLVLenTests(t, cases)
 }
 
 // Verifies Juniper vendor TLVs preserve structured logging fields.
@@ -1317,6 +1336,15 @@ func TestExtendedAssociationIDIPv4Juniper_MarshalLogObject(t *testing.T) {
 	}, enc.Fields)
 }
 
+// testExtendedAssociationIDIPv4JuniperIPv6Bytes is the IPv6 wire format (value length 20) with
+// the Juniper TLV type. Juniper devices always send the IPv4 zero-padded format, even over IPv6
+// PCEP sessions, so this layout must be rejected.
+var testExtendedAssociationIDIPv4JuniperIPv6Bytes = func() []byte {
+	b := append([]byte(nil), testIPv6ExtendedAssociationIDBytes...)
+	b[0], b[1] = 0xff, 0xe3 // type=0xffe3, IPv6 value layout (length 20)
+	return b
+}()
+
 func TestExtendedAssociationIDIPv4Juniper_DecodeFromBytes(t *testing.T) {
 	t.Parallel()
 
@@ -1328,6 +1356,11 @@ func TestExtendedAssociationIDIPv4Juniper_DecodeFromBytes(t *testing.T) {
 			input,
 			&ExtendedAssociationIDIPv4Juniper{ExtendedAssociationID: *testIPv4ExtendedAssociationID},
 			false,
+		},
+		"IPv6Rejected": {
+			testExtendedAssociationIDIPv4JuniperIPv6Bytes,
+			nil,
+			true,
 		},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &ExtendedAssociationIDIPv4Juniper{} })
@@ -2087,6 +2120,9 @@ func TestDecodeTLVs(t *testing.T) {
 		"TruncatedTLVPadding": {testDecodeTruncatedPadding, true, 0, "truncated TLV padding"},
 		"InvalidKnownTLVBody": {append(tlvHeader(TLVStatefulPCECapability, 4), 0x00, 0x00, 0x00, 0x00), false, 1, ""},
 		"InvalidPadding":      {invalidPaddingBytes, true, 0, "invalid TLV padding"},
+		"JuniperExtendedAssociationIDIPv6Rejected": {
+			testExtendedAssociationIDIPv4JuniperIPv6Bytes, true, 0, "invalid value length",
+		},
 	}
 
 	for name, tt := range cases {

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -54,6 +54,10 @@ func TestTLVMap(t *testing.T) {
 		"SRPolicyCPathID":         {TLVSRPolicyCPathID, &SRPolicyCandidatePathIdentifier{}},
 		"SRPolicyCPathPreference": {TLVSRPolicyCPathPreference, &SRPolicyCandidatePathPreference{}},
 		"Color":                   {TLVColor, &Color{}},
+
+		"ExtendedAssociationIDIPv4Juniper": {TLVExtendedAssociationIDIPv4Juniper, &ExtendedAssociationIDIPv4Juniper{}},
+		"SRPolicyCPathIDJuniper":           {TLVSRPolicyCPathIDJuniper, &SRPolicyCandidatePathIdentifierJuniper{}},
+		"SRPolicyCPathPreferenceJuniper":   {TLVSRPolicyCPathPreferenceJuniper, &SRPolicyCandidatePathPreferenceJuniper{}},
 	}
 
 	for name, tt := range cases {
@@ -1273,6 +1277,62 @@ func TestExtendedAssociationID_Len(t *testing.T) {
 	runTLVLenTests(t, cases)
 }
 
+func TestExtendedAssociationIDIPv4Juniper_Type(t *testing.T) {
+	t.Parallel()
+
+	tlv := &ExtendedAssociationIDIPv4Juniper{}
+	assert.Equal(t, TLVExtendedAssociationIDIPv4Juniper, tlv.Type())
+}
+
+func TestExtendedAssociationIDIPv4Juniper_Serialize(t *testing.T) {
+	tlv := &ExtendedAssociationIDIPv4Juniper{
+		ExtendedAssociationID: *testIPv4ExtendedAssociationID,
+	}
+
+	expected := append([]byte(nil), testIPv4ExtendedAssociationIDBytes...)
+	expected[0], expected[1] = 0xff, 0xe3 // type=0xffe3, value layout unchanged
+
+	assert.Equal(t, expected, tlv.Serialize())
+}
+
+func TestExtendedAssociationIDIPv4Juniper_Len(t *testing.T) {
+	tlv := &ExtendedAssociationIDIPv4Juniper{
+		ExtendedAssociationID: *testIPv4ExtendedAssociationID,
+	}
+	assert.Equal(t, testIPv4ExtendedAssociationID.Len(), tlv.Len())
+}
+
+// Verifies Juniper vendor TLVs preserve structured logging fields.
+func TestExtendedAssociationIDIPv4Juniper_MarshalLogObject(t *testing.T) {
+	t.Parallel()
+
+	tlv := &ExtendedAssociationIDIPv4Juniper{ExtendedAssociationID: *testIPv4ExtendedAssociationID}
+
+	enc := zapcore.NewMapObjectEncoder()
+	err := tlv.MarshalLogObject(enc)
+	assert.NoError(t, err, "unexpected error during MarshalLogObject")
+	assert.Equal(t, map[string]any{
+		"color":    testIPv4ExtendedAssociationID.Color,
+		"ipv4Addr": testIPv4ExtendedAssociationID.Endpoint.String(),
+	}, enc.Fields)
+}
+
+func TestExtendedAssociationIDIPv4Juniper_DecodeFromBytes(t *testing.T) {
+	t.Parallel()
+
+	input := append([]byte(nil), testIPv4ExtendedAssociationIDBytes...)
+	input[0], input[1] = 0xff, 0xe3 // type=0xffe3, value layout unchanged
+
+	cases := map[string]TLVTestCase{
+		"IPv4Juniper": {
+			input,
+			&ExtendedAssociationIDIPv4Juniper{ExtendedAssociationID: *testIPv4ExtendedAssociationID},
+			false,
+		},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &ExtendedAssociationIDIPv4Juniper{} })
+}
+
 // Test data for AssocTypeList.
 var (
 	// AssocTypeList with two entries.
@@ -1613,6 +1673,23 @@ func TestSRPolicyCandidatePathIdentifierJuniper_Len(t *testing.T) {
 	assert.Equal(t, testSRPolicyCPathIDIPv4.Len(), tlv.Len())
 }
 
+// Verifies Juniper vendor TLVs preserve structured logging fields.
+func TestSRPolicyCandidatePathIdentifierJuniper_MarshalLogObject(t *testing.T) {
+	t.Parallel()
+
+	tlv := &SRPolicyCandidatePathIdentifierJuniper{SRPolicyCandidatePathIdentifier: *testSRPolicyCPathIDIPv4}
+
+	enc := zapcore.NewMapObjectEncoder()
+	err := tlv.MarshalLogObject(enc)
+	assert.NoError(t, err, "unexpected error during MarshalLogObject")
+	assert.Equal(t, map[string]any{
+		"protocolOrigin": testSRPolicyCPathIDIPv4.ProtocolOrigin,
+		"originatorAsn":  testSRPolicyCPathIDIPv4.OriginatorASN,
+		"originatorAddr": testSRPolicyCPathIDIPv4.OriginatorAddr.String(),
+		"discriminator":  testSRPolicyCPathIDIPv4.Discriminator,
+	}, enc.Fields)
+}
+
 // Test data for SRPolicyCandidatePathPreference.
 var (
 	testSRPolicyCPathPreference = &SRPolicyCandidatePathPreference{Preference: 100}
@@ -1687,6 +1764,61 @@ func TestSRPolicyCandidatePathPreference_Len(t *testing.T) {
 		"ValidLen": {testSRPolicyCPathPreference, TLVValueOffset + TLVSRPolicyCPathPreferenceValueLength},
 	}
 	runTLVLenTests(t, cases)
+}
+
+func TestSRPolicyCandidatePathPreferenceJuniper_Type(t *testing.T) {
+	t.Parallel()
+
+	tlv := &SRPolicyCandidatePathPreferenceJuniper{}
+	assert.Equal(t, TLVSRPolicyCPathPreferenceJuniper, tlv.Type())
+}
+
+func TestSRPolicyCandidatePathPreferenceJuniper_Serialize(t *testing.T) {
+	tlv := &SRPolicyCandidatePathPreferenceJuniper{
+		SRPolicyCandidatePathPreference: *testSRPolicyCPathPreference,
+	}
+
+	expected := append([]byte(nil), testSRPolicyCPathPreferenceBytes...)
+	expected[0], expected[1] = 0xff, 0xe5 // type=0xffe5, value layout unchanged
+
+	assert.Equal(t, expected, tlv.Serialize())
+}
+
+func TestSRPolicyCandidatePathPreferenceJuniper_Len(t *testing.T) {
+	tlv := &SRPolicyCandidatePathPreferenceJuniper{
+		SRPolicyCandidatePathPreference: *testSRPolicyCPathPreference,
+	}
+	assert.Equal(t, testSRPolicyCPathPreference.Len(), tlv.Len())
+}
+
+// Verifies Juniper vendor TLVs preserve structured logging fields.
+func TestSRPolicyCandidatePathPreferenceJuniper_MarshalLogObject(t *testing.T) {
+	t.Parallel()
+
+	tlv := &SRPolicyCandidatePathPreferenceJuniper{SRPolicyCandidatePathPreference: *testSRPolicyCPathPreference}
+
+	enc := zapcore.NewMapObjectEncoder()
+	err := tlv.MarshalLogObject(enc)
+	assert.NoError(t, err, "unexpected error during MarshalLogObject")
+	assert.Equal(t, map[string]any{
+		"preference": testSRPolicyCPathPreference.Preference,
+	}, enc.Fields)
+}
+
+func TestSRPolicyCandidatePathPreferenceJuniper_DecodeFromBytes(t *testing.T) {
+	t.Parallel()
+
+	input := append([]byte(nil), testSRPolicyCPathPreferenceBytes...)
+	input[0], input[1] = 0xff, 0xe5 // type=0xffe5, value layout unchanged
+
+	cases := map[string]TLVTestCase{
+		"PreferenceJuniper": {
+			input,
+			&SRPolicyCandidatePathPreferenceJuniper{SRPolicyCandidatePathPreference: *testSRPolicyCPathPreference},
+			false,
+		},
+	}
+	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRPolicyCandidatePathPreferenceJuniper{} })
 }
 
 // Test data for Color.

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1588,6 +1588,31 @@ func TestSRPolicyCandidatePathIdentifier_ProtocolOriginRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSRPolicyCandidatePathIdentifierJuniper_Type(t *testing.T) {
+	t.Parallel()
+
+	tlv := &SRPolicyCandidatePathIdentifierJuniper{}
+	assert.Equal(t, TLVSRPolicyCPathIDJuniper, tlv.Type())
+}
+
+func TestSRPolicyCandidatePathIdentifierJuniper_Serialize(t *testing.T) {
+	tlv := &SRPolicyCandidatePathIdentifierJuniper{
+		SRPolicyCandidatePathIdentifier: *testSRPolicyCPathIDIPv4,
+	}
+
+	expected := append([]byte(nil), testSRPolicyCPathIDIPv4Bytes...)
+	expected[0], expected[1] = 0xff, 0xe4 // type=0xffe4, value layout unchanged
+
+	assert.Equal(t, expected, tlv.Serialize())
+}
+
+func TestSRPolicyCandidatePathIdentifierJuniper_Len(t *testing.T) {
+	tlv := &SRPolicyCandidatePathIdentifierJuniper{
+		SRPolicyCandidatePathIdentifier: *testSRPolicyCPathIDIPv4,
+	}
+	assert.Equal(t, testSRPolicyCPathIDIPv4.Len(), tlv.Len())
+}
+
 // Test data for SRPolicyCandidatePathPreference.
 var (
 	testSRPolicyCPathPreference = &SRPolicyCandidatePathPreference{Preference: 100}


### PR DESCRIPTION
## Description
<!-- What does this PR change, and why is it needed? -->

This PR adds typed decoding support for Juniper vendor-specific Association TLVs.

Juniper legacy Association TLVs are now decoded as typed TLVs. 
`UndefinedTLV` is renamed to `UnknownTLV`.


## Type of change
<!-- Check all that apply. -->
- [x] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?
<!-- Commands run (e.g. `make test`, `make test-scenario`), and/or
example topologies verified.
-->
* `make test`
* Added/updated unit tests for:
  * Typed decoding of Juniper vendor-specific Association TLVs
  * Unknown TLV preservation
  * Vendor Information object round-trip behavior

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed
