### PR TITLE
Wait for FRR SR Policy to become active

### DIFF
--- a/test/helpers/wait.py
+++ b/test/helpers/wait.py
@@ -87,6 +87,32 @@ def wait_until_command_success(
         time.sleep(interval)
 
 
+def wait_until_command_output_contains(
+    cmd: str,
+    expected: str,
+    timeout: int = 300,
+    interval: int = 5,
+) -> subprocess.CompletedProcess:
+    """Wait until the stdout of a command contains the expected text."""
+
+    start = time.time()
+
+    while True:
+        result = run_command(cmd)
+
+        if expected in result.stdout:
+            return result
+
+        if time.time() - start > timeout:
+            raise TimeoutError(
+                f"Timeout waiting for {expected!r} in the output of {cmd!r}\n"
+                f"Last output:\n{result.stdout}"
+            )
+
+        print(f"Waiting for {expected!r} in the output of {cmd!r}...")
+        time.sleep(interval)
+
+
 def get_ted(pola_container: str) -> dict:
     """Get current TED JSON. Raises RuntimeError/JSONDecodeError on failure."""
 

--- a/test/scenario-test/explicit-path/test_explicit_path.py
+++ b/test/scenario-test/explicit-path/test_explicit_path.py
@@ -10,6 +10,7 @@ import pytest
 from helpers.wait import (
     run_command,
     wait_for_ssh,
+    wait_until_command_output_contains,
     wait_until_command_success,
     wait_until_lsp_up,
     wait_until_ssh_output_contains,
@@ -129,9 +130,9 @@ class TestExplicitPathSRMPLS:
     def _assert_frr_policy(self):
         """Verify the SR Policy installed on the FRRouting PCC."""
 
-        result = wait_until_command_success(
-            f"docker exec clab-{LAB}-pe03 vtysh -c 'show sr-te policy detail' "
-            f"| grep 'Name: pe03-policy1'"
+        result = wait_until_command_output_contains(
+            f"docker exec clab-{LAB}-pe03 vtysh -c 'show sr-te policy detail'",
+            "Status: Active",
         )
 
-        assert "Status: Active" in result.stdout, result.stdout
+        assert "Name: pe03-policy1" in result.stdout, result.stdout


### PR DESCRIPTION
## Description

Add a helper to wait until command output contains the expected text.

Use it in the FRRouting explicit-path test to wait until the SR Policy becomes `Active` before asserting the result.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

- `make test-scenario`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed