### PR TITLE
Rename session del command to delete

### DIFF
--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -60,7 +60,7 @@ JSON formatted response
 ]
 ```
 
-### pola session del *Address* \[-j\]
+### pola session delete *Address* \[-j\]
 
 Deletes the specified session.
 

--- a/cmd/pola/session.go
+++ b/cmd/pola/session.go
@@ -24,7 +24,7 @@ func newSessionCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newSessionDelCmd())
+	cmd.AddCommand(newSessionDeleteCmd())
 	return cmd
 }
 

--- a/cmd/pola/session_delete.go
+++ b/cmd/pola/session_delete.go
@@ -14,19 +14,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSessionDelCmd() *cobra.Command {
+func newSessionDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:          "del",
+		Use:          "delete",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("requires session address\nUsage: pola session del [session address]")
+				return fmt.Errorf("requires session address\nUsage: pola session delete [session address]")
 			}
 			ssAddr, err := netip.ParseAddr(args[0])
 			if err != nil {
-				return fmt.Errorf("invalid input\nUsage: pola session del [session address]")
+				return fmt.Errorf("invalid input\nUsage: pola session delete [session address]")
 			}
-			if err := delSession(ssAddr, jsonFmt); err != nil {
+			if err := deleteSession(ssAddr, jsonFmt); err != nil {
 				return err
 			}
 			return nil
@@ -34,7 +34,7 @@ func newSessionDelCmd() *cobra.Command {
 	}
 }
 
-func delSession(session netip.Addr, jsonFlag bool) error {
+func deleteSession(session netip.Addr, jsonFlag bool) error {
 	request := &pb.DeleteSessionRequest{
 		Addr: session.AsSlice(),
 	}


### PR DESCRIPTION
## Description

Rename `pola session del` to `pola session delete` for consistent CLI naming.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

- Verified CLI help and references for the renamed command.
- `make scenario-test-parallel`

## Checklist

- [x] `make ci` passes locally
- [ ] Tests added or updated if needed
- [x] Documentation updated if needed