### PR TITLE
Add `make release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ RUFF_VERSION          ?= latest
 	test-scenario \
 	test-scenario-parallel \
 	ci \
+	release \
 	clean
 
 .DEFAULT_GOAL := build
@@ -151,6 +152,26 @@ test-scenario-parallel: PYTEST_ARGS = -s -n 4 --dist loadgroup
 test-scenario-parallel: test-scenario ## Run containerlab scenario tests, one lab per worker
 
 ci: check-proto lint build test ## Run the same checks as CI
+
+release: ## Cut a release: make release VERSION=X.Y.Z
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=X.Y.Z"; exit 1; fi
+	@if ! echo "$(VERSION)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then echo "VERSION must be in X.Y.Z format: $(VERSION)"; exit 1; fi
+	@if [ -n "$$(git status --porcelain)" ]; then echo "Working tree is not clean"; exit 1; fi
+	@if [ "$$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then echo "Must be on main branch"; exit 1; fi
+	@git fetch origin main develop --tags
+	@if git rev-parse -q --verify "refs/tags/v$(VERSION)" >/dev/null; then \
+		echo "Tag v$(VERSION) already exists"; exit 1; \
+	fi
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/main)" ]; then echo "Local main is out of sync with origin/main"; exit 1; fi
+	@if [ -n "$$(git log origin/main..origin/develop --oneline)" ]; then \
+		echo "develop has commits not yet merged into main:"; \
+		git log origin/main..origin/develop --oneline; \
+		exit 1; \
+	fi
+	$(MAKE) ci
+	$(MAKE) test-race
+	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
+	git push origin "v$(VERSION)"
 
 clean: ## Remove generated files
 	$(RM) -r bin $(TEST_BIN_DIR)

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -60,7 +60,7 @@ JSON formatted response
 ]
 ```
 
-### pola session del *Address* \[-j\]
+### pola session delete *Address* \[-j\]
 
 Deletes the specified session.
 

--- a/cmd/pola/session.go
+++ b/cmd/pola/session.go
@@ -24,7 +24,7 @@ func newSessionCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newSessionDelCmd())
+	cmd.AddCommand(newSessionDeleteCmd())
 	return cmd
 }
 

--- a/cmd/pola/session_delete.go
+++ b/cmd/pola/session_delete.go
@@ -14,19 +14,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSessionDelCmd() *cobra.Command {
+func newSessionDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:          "del",
+		Use:          "delete",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("requires session address\nUsage: pola session del [session address]")
+				return fmt.Errorf("requires session address\nUsage: pola session delete [session address]")
 			}
 			ssAddr, err := netip.ParseAddr(args[0])
 			if err != nil {
-				return fmt.Errorf("invalid input\nUsage: pola session del [session address]")
+				return fmt.Errorf("invalid input\nUsage: pola session delete [session address]")
 			}
-			if err := delSession(ssAddr, jsonFmt); err != nil {
+			if err := deleteSession(ssAddr, jsonFmt); err != nil {
 				return err
 			}
 			return nil
@@ -34,7 +34,7 @@ func newSessionDelCmd() *cobra.Command {
 	}
 }
 
-func delSession(session netip.Addr, jsonFlag bool) error {
+func deleteSession(session netip.Addr, jsonFlag bool) error {
 	request := &pb.DeleteSessionRequest{
 		Addr: session.AsSlice(),
 	}


### PR DESCRIPTION
## Description

Add `make release` target to automate release preparation and tag creation.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [x] Build / CI

## How was this tested?

- `make ci`
- `make test-race`

## Checklist

- [x] `make ci` passes locally
- [ ] Tests added or updated if needed
- [ ] Documentation updated if needed