### PR TITLE
Validate listen configuration and improve gRPC server handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ RUFF_VERSION          ?= latest
 	test-scenario \
 	test-scenario-parallel \
 	ci \
+	release \
 	clean
 
 .DEFAULT_GOAL := build
@@ -151,6 +152,26 @@ test-scenario-parallel: PYTEST_ARGS = -s -n 4 --dist loadgroup
 test-scenario-parallel: test-scenario ## Run containerlab scenario tests, one lab per worker
 
 ci: check-proto lint build test ## Run the same checks as CI
+
+release: ## Cut a release: make release VERSION=X.Y.Z
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=X.Y.Z"; exit 1; fi
+	@if ! echo "$(VERSION)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then echo "VERSION must be in X.Y.Z format: $(VERSION)"; exit 1; fi
+	@if [ -n "$$(git status --porcelain)" ]; then echo "Working tree is not clean"; exit 1; fi
+	@if [ "$$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then echo "Must be on main branch"; exit 1; fi
+	@git fetch origin main develop --tags
+	@if git rev-parse -q --verify "refs/tags/v$(VERSION)" >/dev/null; then \
+		echo "Tag v$(VERSION) already exists"; exit 1; \
+	fi
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/main)" ]; then echo "Local main is out of sync with origin/main"; exit 1; fi
+	@if [ -n "$$(git log origin/main..origin/develop --oneline)" ]; then \
+		echo "develop has commits not yet merged into main:"; \
+		git log origin/main..origin/develop --oneline; \
+		exit 1; \
+	fi
+	$(MAKE) ci
+	$(MAKE) test-race
+	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
+	git push origin "v$(VERSION)"
 
 clean: ## Remove generated files
 	$(RM) -r bin $(TEST_BIN_DIR)

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -60,7 +60,7 @@ JSON formatted response
 ]
 ```
 
-### pola session del *Address* \[-j\]
+### pola session delete *Address* \[-j\]
 
 Deletes the specified session.
 

--- a/cmd/pola/session.go
+++ b/cmd/pola/session.go
@@ -24,7 +24,7 @@ func newSessionCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newSessionDelCmd())
+	cmd.AddCommand(newSessionDeleteCmd())
 	return cmd
 }
 

--- a/cmd/pola/session_delete.go
+++ b/cmd/pola/session_delete.go
@@ -14,19 +14,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSessionDelCmd() *cobra.Command {
+func newSessionDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:          "del",
+		Use:          "delete",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("requires session address\nUsage: pola session del [session address]")
+				return fmt.Errorf("requires session address\nUsage: pola session delete [session address]")
 			}
 			ssAddr, err := netip.ParseAddr(args[0])
 			if err != nil {
-				return fmt.Errorf("invalid input\nUsage: pola session del [session address]")
+				return fmt.Errorf("invalid input\nUsage: pola session delete [session address]")
 			}
-			if err := delSession(ssAddr, jsonFmt); err != nil {
+			if err := deleteSession(ssAddr, jsonFmt); err != nil {
 				return err
 			}
 			return nil
@@ -34,7 +34,7 @@ func newSessionDelCmd() *cobra.Command {
 	}
 }
 
-func delSession(session netip.Addr, jsonFlag bool) error {
+func deleteSession(session netip.Addr, jsonFlag bool) error {
 	request := &pb.DeleteSessionRequest{
 		Addr: session.AsSlice(),
 	}

--- a/cmd/polad/main.go
+++ b/cmd/polad/main.go
@@ -44,6 +44,9 @@ func main() {
 	if err != nil {
 		log.Panicf("failed to read config file: %v", err)
 	}
+	if err := c.Validate(); err != nil {
+		log.Panicf("invalid config file: %v", err)
+	}
 
 	// Create log directory if it does not exist
 	if err := os.MkdirAll(c.Global.Log.Path, 0755); err != nil {

--- a/docs/schemas/server/polad_config.json
+++ b/docs/schemas/server/polad_config.json
@@ -26,7 +26,8 @@
                     "required": [
                         "address",
                         "port"
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "grpcServer": {
                     "type": "object",
@@ -49,7 +50,8 @@
                     "required": [
                         "address",
                         "port"
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "log": {
                     "type": "object",
@@ -67,7 +69,8 @@
                     "required": [
                         "path",
                         "name"
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "ted": {
                     "type": "object",
@@ -89,7 +92,8 @@
                     },
                     "required": [
                         "enable"
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "gobgp": {
                     "type": "object",
@@ -115,12 +119,14 @@
                             "required": [
                                 "address",
                                 "port"
-                            ]
+                            ],
+                            "additionalProperties": false
                         }
                     },
                     "required": [
                         "grpcClient"
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "usidMode": {
                     "type": "boolean",
@@ -132,7 +138,8 @@
                 "grpcServer",
                 "log",
                 "ted"
-            ]
+            ],
+            "additionalProperties": false
         }
     },
     "required": [

--- a/docs/sources/getting-started.md
+++ b/docs/sources/getting-started.md
@@ -35,6 +35,7 @@ See the [Docker page](../../build/package/README.md).
 ## Configuration
 
 Specify the IP address and port number for each PCEP and gRPC.
+`address` must be a literal IPv4 or IPv6 address; hostnames are not resolved.
 See [JSON schema](../schemas/server/polad_config.json) for config details.
 
 ### case: TED disable

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -69,8 +70,54 @@ func ReadConfigFile(configFile string) (Config, error) {
 		}
 	}()
 
-	if err := yaml.NewDecoder(f).Decode(c); err != nil {
-		return *c, err
+	dec := yaml.NewDecoder(f)
+	dec.KnownFields(true)
+	if err := dec.Decode(c); err != nil {
+		return *c, fmt.Errorf("failed to parse config file %q: %w", configFile, err)
 	}
 	return *c, nil
+}
+
+// Validate checks required configuration fields.
+func (c *Config) Validate() error {
+	var errs []error
+
+	if c.Global.PCEP.Address == "" {
+		errs = append(errs, errors.New("global.pcep.address is required"))
+	}
+	if c.Global.PCEP.Port == "" {
+		errs = append(errs, errors.New("global.pcep.port is required"))
+	}
+	if c.Global.GRPCServer.Address == "" {
+		errs = append(errs, errors.New("global.grpcServer.address is required"))
+	}
+	if c.Global.GRPCServer.Port == "" {
+		errs = append(errs, errors.New("global.grpcServer.port is required"))
+	}
+	if c.Global.Log.Path == "" {
+		errs = append(errs, errors.New("global.log.path is required"))
+	}
+	if c.Global.Log.Name == "" {
+		errs = append(errs, errors.New("global.log.name is required"))
+	}
+	if c.Global.TED == nil {
+		errs = append(errs, errors.New("global.ted is required"))
+	} else if c.Global.TED.Enable {
+		if c.Global.TED.Source == "" {
+			errs = append(errs, errors.New("global.ted.source is required when global.ted.enable is true"))
+		}
+		if c.Global.TED.ASN == 0 {
+			errs = append(errs, errors.New("global.ted.asn is required when global.ted.enable is true"))
+		}
+		if c.Global.TED.Source == "gobgp" {
+			if c.Global.GoBGP.GRPCClient.Address == "" {
+				errs = append(errs, errors.New("global.gobgp.grpcClient.address is required when global.ted.source is gobgp"))
+			}
+			if c.Global.GoBGP.GRPCClient.Port == "" {
+				errs = append(errs, errors.New("global.gobgp.grpcClient.port is required when global.ted.source is gobgp"))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "polad.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	return path
+}
+
+const validConfig = `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: true
+    source: "gobgp"
+    asn: 65000
+  gobgp:
+    grpcClient:
+      address: "127.0.0.1"
+      port: 50051
+  usidMode: true
+`
+
+func TestReadConfigFile_Valid(t *testing.T) {
+	path := writeConfig(t, validConfig)
+
+	c, err := ReadConfigFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Global.GRPCServer.Address != "127.0.0.1" || c.Global.GRPCServer.Port != "50052" {
+		t.Errorf("unexpected GRPCServer: %+v", c.Global.GRPCServer)
+	}
+	if c.Global.TED == nil || !c.Global.TED.Enable || c.Global.TED.ASN != 65000 {
+		t.Errorf("unexpected TED: %+v", c.Global.TED)
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("unexpected validation error: %v", err)
+	}
+}
+
+// Regression test: v1.3.0 configs used kebab-case keys (grpc-server, usid-mode,
+// grpc-client), which were renamed to camelCase. These must now fail loudly
+// instead of silently decoding to empty values.
+func TestReadConfigFile_LegacyKebabCaseKeysRejected(t *testing.T) {
+	legacyConfig := `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+  grpc-server:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  usid-mode: true
+`
+	path := writeConfig(t, legacyConfig)
+
+	_, err := ReadConfigFile(path)
+	if err == nil {
+		t.Fatal("expected error for legacy kebab-case config, got nil")
+	}
+	if !strings.Contains(err.Error(), "grpc-server") {
+		t.Errorf("expected error to mention the offending key \"grpc-server\", got: %v", err)
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr bool
+	}{
+		{
+			name:   "valid, TED enabled",
+			config: validConfig,
+		},
+		{
+			name: "valid, TED disabled without source/asn",
+			config: `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`,
+		},
+		{
+			name: "missing grpcServer.address",
+			config: `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+  grpcServer:
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`,
+			wantErr: true,
+		},
+		{
+			name: "missing grpcServer section entirely",
+			config: `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`,
+			wantErr: true,
+		},
+		{
+			name: "missing ted section",
+			config: `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+`,
+			wantErr: true,
+		},
+		{
+			name: "ted enabled without asn",
+			config: `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: true
+    source: "gobgp"
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConfig(t, tt.config)
+			c, err := ReadConfigFile(path)
+			if err != nil {
+				t.Fatalf("unexpected read error: %v", err)
+			}
+			err = c.Validate()
+			if tt.wantErr && err == nil {
+				t.Error("expected validation error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
+// yaml.v3 decodes an unquoted integer scalar into a string field without
+// error; pin this behavior since Port is typed as string.
+func TestReadConfigFile_UnquotedIntegerPort(t *testing.T) {
+	path := writeConfig(t, validConfig)
+
+	c, err := ReadConfigFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Global.GRPCServer.Port != "50052" {
+		t.Errorf("expected Port %q, got %q", "50052", c.Global.GRPCServer.Port)
+	}
+}

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1454,7 +1454,8 @@ func (tlv *PathSetupTypeCapability) MarshalLogObject(enc zapcore.ObjectEncoder) 
 
 	subTLVTypes := make([]string, len(tlv.SubTLVs))
 	for i, stlv := range tlv.SubTLVs {
-		subTLVTypes[i] = fmt.Sprintf("0x%x (%s)", stlv.Type(), stlv.Type().String())
+		// TLVType implements Stringer; use uint16 for numeric formatting.
+		subTLVTypes[i] = fmt.Sprintf("0x%04x (%s)", uint16(stlv.Type()), stlv.Type())
 	}
 	_ = enc.AddArray("subTLVs", zapcore.ArrayMarshalerFunc(func(ae zapcore.ArrayEncoder) error {
 		for _, s := range subTLVTypes {
@@ -1897,7 +1898,7 @@ func (tlv *UnknownTLV) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		return nil
 	}
 
-	enc.AddString("type", fmt.Sprintf("0x%04x", tlv.Typ))
+	enc.AddString("type", fmt.Sprintf("0x%04x", uint16(tlv.Typ)))
 	enc.AddUint16("length", tlv.Length)
 	return nil
 }

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1094,7 +1094,7 @@ func TestPathSetupTypeCapability_MarshalLogObject(t *testing.T) {
 				"pathSetupTypes": []any{
 					"Traffic engineering path is set up using Segment Routing (RFC8664)",
 				},
-				"subTLVs": []any{"0x53522d5043452d4341504142494c49545920285246433836363429 (SR-PCE-CAPABILITY (RFC8664))"},
+				"subTLVs": []any{"0x001a (SR-PCE-CAPABILITY (RFC8664))"},
 			},
 		},
 		"NilTLV": {
@@ -1986,14 +1986,14 @@ func TestUnknownTLV_MarshalLogObject(t *testing.T) {
 		"StandardTLV": {
 			testUnknownTLV,
 			map[string]any{
-				"type":   fmt.Sprintf("0x%04x", testUnknownTLV.Typ),
+				"type":   "0xffff",
 				"length": testUnknownTLV.Length,
 			},
 		},
 		"OddLength": {
 			testUnknownTLVOddLength,
 			map[string]any{
-				"type":   fmt.Sprintf("0x%04x", testUnknownTLVOddLength.Typ),
+				"type":   "0xffff",
 				"length": testUnknownTLVOddLength.Length,
 			},
 		},
@@ -2011,6 +2011,21 @@ func TestUnknownTLV_MarshalLogObject(t *testing.T) {
 			assert.Equal(t, tt.expected, enc.Fields, "unexpected fields for '%s'", name)
 		})
 	}
+}
+
+// Ensure TLVType is not formatted as ASCII hex via its String() method.
+func TestMarshalLogObject_TLVTypeHexFormatting(t *testing.T) {
+	enc := zapcore.NewMapObjectEncoder()
+	err := testPathSetupTypeCapabilityWithSubTLV.MarshalLogObject(enc)
+	assert.NoError(t, err)
+	subTLVs, ok := enc.Fields["subTLVs"].([]any)
+	assert.True(t, ok)
+	assert.Equal(t, []any{"0x001a (SR-PCE-CAPABILITY (RFC8664))"}, subTLVs)
+
+	enc = zapcore.NewMapObjectEncoder()
+	err = testUnknownTLV.MarshalLogObject(enc)
+	assert.NoError(t, err)
+	assert.Equal(t, "0xffff", enc.Fields["type"])
 }
 
 func TestUnknownTLV_Len(t *testing.T) {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/netip"
 	"slices"
@@ -47,12 +48,24 @@ func NewAPIServer(pce *Server, grpcServer *grpc.Server, usidMode bool, logger *z
 }
 
 func (s *APIServer) Serve(address string, port string) error {
-	listenInfo := net.JoinHostPort(address, port)
-	s.logger.Info("Start listening on gRPC port", zap.String("listenInfo", listenInfo))
-	grpcListener, err := net.Listen("tcp", listenInfo)
+	a, err := netip.ParseAddr(address)
 	if err != nil {
-		return fmt.Errorf("failed to listen: %w", err)
+		return fmt.Errorf("failed to parse gRPC address %q: %w", address, err)
 	}
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("failed to convert gRPC port %q: %w", port, err)
+	}
+	if p < 0 || p > math.MaxUint16 {
+		return errors.New("invalid gRPC listen port")
+	}
+	localAddr := netip.AddrPortFrom(a, uint16(p))
+
+	grpcListener, err := net.Listen("tcp", localAddr.String())
+	if err != nil {
+		return fmt.Errorf("failed to listen on gRPC port %s: %w", localAddr.String(), err)
+	}
+	s.logger.Info("Start listening on gRPC port", zap.String("listenInfo", grpcListener.Addr().String()))
 	return s.grpcServer.Serve(grpcListener)
 }
 

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -6,16 +6,19 @@
 package server
 
 import (
-	"bytes"
 	"net/netip"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -60,25 +63,15 @@ func TestNewEnrichedSegmentSRMPLS(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			seg, err := newEnrichedSegment(tt.segment, false)
 			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected an error, got none")
-				}
+				require.Error(t, err)
 				return
 			}
-			if err != nil {
-				t.Fatalf("newEnrichedSegment returned an error: %v", err)
-			}
+			require.NoError(t, err)
 
 			mplsSeg, ok := seg.(table.SegmentSRMPLS)
-			if !ok {
-				t.Fatalf("segment type: got %T, want table.SegmentSRMPLS", seg)
-			}
-			if got := addrString(mplsSeg.LocalAddr); got != tt.wantLocal {
-				t.Errorf("LocalAddr: got %q, want %q", got, tt.wantLocal)
-			}
-			if got := addrString(mplsSeg.RemoteAddr); got != tt.wantRemote {
-				t.Errorf("RemoteAddr: got %q, want %q", got, tt.wantRemote)
-			}
+			require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", seg)
+			assert.Equal(t, tt.wantLocal, addrString(mplsSeg.LocalAddr), "LocalAddr")
+			assert.Equal(t, tt.wantRemote, addrString(mplsSeg.RemoteAddr), "RemoteAddr")
 		})
 	}
 }
@@ -95,36 +88,21 @@ func TestNewEnrichedSegmentSRv6(t *testing.T) {
 
 	for _, usidMode := range []bool{false, true} {
 		seg, err := newEnrichedSegment(segment, usidMode)
-		if err != nil {
-			t.Fatalf("newEnrichedSegment returned an error: %v", err)
-		}
+		require.NoError(t, err)
 
 		srv6Seg, ok := seg.(table.SegmentSRv6)
-		if !ok {
-			t.Fatalf("segment type: got %T, want table.SegmentSRv6", seg)
-		}
-		if got := srv6Seg.Sid.String(); got != "2001:db8:1005::" {
-			t.Errorf("Sid: got %q, want %q", got, "2001:db8:1005::")
-		}
-		if got := addrString(srv6Seg.LocalAddr); got != "2001:db8::5" {
-			t.Errorf("LocalAddr: got %q, want %q", got, "2001:db8::5")
-		}
-		if got := addrString(srv6Seg.RemoteAddr); got != "2001:db8::6" {
-			t.Errorf("RemoteAddr: got %q, want %q", got, "2001:db8::6")
-		}
-		if want := []uint8{32, 16, 0, 80}; !slices.Equal(srv6Seg.Structure, want) {
-			t.Errorf("Structure: got %v, want %v", srv6Seg.Structure, want)
-		}
-		if srv6Seg.USid != usidMode {
-			t.Errorf("USid with usidMode=%v: got %v", usidMode, srv6Seg.USid)
-		}
+		require.Truef(t, ok, "segment type: got %T, want table.SegmentSRv6", seg)
+		assert.Equal(t, "2001:db8:1005::", srv6Seg.Sid.String(), "Sid")
+		assert.Equal(t, "2001:db8::5", addrString(srv6Seg.LocalAddr), "LocalAddr")
+		assert.Equal(t, "2001:db8::6", addrString(srv6Seg.RemoteAddr), "RemoteAddr")
+		assert.Equal(t, []uint8{32, 16, 0, 80}, srv6Seg.Structure, "Structure")
+		assert.Equalf(t, usidMode, srv6Seg.USid, "USid with usidMode=%v", usidMode)
 	}
 }
 
 func TestNewEnrichedSegmentInvalidSID(t *testing.T) {
-	if _, err := newEnrichedSegment(&pb.Segment{Sid: "not-a-sid"}, false); err == nil {
-		t.Error("expected an error for an unparsable SID, got none")
-	}
+	_, err := newEnrichedSegment(&pb.Segment{Sid: "not-a-sid"}, false)
+	assert.Error(t, err, "expected an error for an unparsable SID")
 }
 
 func addrString(addr netip.Addr) string {
@@ -141,27 +119,17 @@ func TestCreateEroFromSegmentListWithNAI(t *testing.T) {
 	seg.LocalAddr = netip.MustParseAddr("10.255.0.2")
 
 	ero := createEroFromSegmentList([]table.Segment{seg})
-	if len(ero.EroSubobjects) != 1 {
-		t.Fatalf("ERO subobject count: got %d, want 1", len(ero.EroSubobjects))
-	}
+	require.Len(t, ero.EroSubobjects, 1)
 
 	raw, err := ero.EroSubobjects[0].Serialize()
-	if err != nil {
-		t.Fatalf("Serialize returned an error: %v", err)
-	}
+	require.NoError(t, err)
 	// Type, Length, NT/Flags (4byte) + SID (4byte) + NAI (4byte)
-	if len(raw) != 12 {
-		t.Fatalf("serialized size: got %d, want 12", len(raw))
-	}
-	if nt := raw[2] >> 4; nt != 0x01 {
-		t.Errorf("NAI type: got 0x%02x, want 0x01 (IPv4 node ID)", nt)
-	}
-	if raw[3]&0x08 != 0 {
-		t.Error("F flag is set even though the NAI is present")
-	}
-	if want := seg.LocalAddr.AsSlice(); !bytes.Equal(raw[8:12], want) {
-		t.Errorf("NAI: got %v, want %v", raw[8:12], want)
-	}
+	require.Len(t, raw, 12)
+
+	nt := raw[2] >> 4
+	assert.Equalf(t, uint8(0x01), nt, "NAI type: got 0x%02x, want 0x01 (IPv4 node ID)", nt)
+	assert.Zero(t, raw[3]&0x08, "F flag is set even though the NAI is present")
+	assert.Equal(t, seg.LocalAddr.AsSlice(), raw[8:12], "NAI")
 }
 
 func newTestAPIServer(ted *table.LsTED) *APIServer {
@@ -198,9 +166,8 @@ func TestValidateSIDs_NoSidValidateSkipsCheck(t *testing.T) {
 	req := explicitPolicyRequest(true, "16099")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	if err := s.validateSIDs(req, segmentList); err != nil {
-		t.Errorf("expected no_sid_validate to skip the check even with no TED, got: %v", err)
-	}
+	err := s.validateSIDs(req, segmentList)
+	assert.NoError(t, err, "expected no_sid_validate to skip the check even with no TED")
 }
 
 func TestValidateSIDs_DynamicPathSkipsCheck(t *testing.T) {
@@ -208,9 +175,8 @@ func TestValidateSIDs_DynamicPathSkipsCheck(t *testing.T) {
 	req := dynamicPolicyRequest()
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	if err := s.validateSIDs(req, segmentList); err != nil {
-		t.Errorf("expected a dynamic path to skip the check, got: %v", err)
-	}
+	err := s.validateSIDs(req, segmentList)
+	assert.NoError(t, err, "expected a dynamic path to skip the check")
 }
 
 func TestValidateSIDs_DynamicWithDisablePathComputeIsStillValidated(t *testing.T) {
@@ -233,9 +199,8 @@ func TestValidateSIDs_DynamicWithDisablePathComputeIsStillValidated(t *testing.T
 
 	err := s.validateSIDs(req, segmentList)
 	st, ok := status.FromError(err)
-	if !ok || st.Code() != codes.InvalidArgument {
-		t.Fatalf("expected codes.InvalidArgument, got: %v", err)
-	}
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
 }
 
 func TestValidateSIDs_NoTED(t *testing.T) {
@@ -245,12 +210,9 @@ func TestValidateSIDs_NoTED(t *testing.T) {
 
 	err := s.validateSIDs(req, segmentList)
 	st, ok := status.FromError(err)
-	if !ok || st.Code() != codes.FailedPrecondition {
-		t.Fatalf("expected codes.FailedPrecondition, got: %v", err)
-	}
-	if !strings.Contains(st.Message(), "TED is not enabled") {
-		t.Errorf("unexpected message: %s", st.Message())
-	}
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "TED is not enabled")
 }
 
 func TestValidateSIDs_TEDEmpty(t *testing.T) {
@@ -260,12 +222,9 @@ func TestValidateSIDs_TEDEmpty(t *testing.T) {
 
 	err := s.validateSIDs(req, segmentList)
 	st, ok := status.FromError(err)
-	if !ok || st.Code() != codes.FailedPrecondition {
-		t.Fatalf("expected codes.FailedPrecondition, got: %v", err)
-	}
-	if !strings.Contains(st.Message(), "not yet synchronized") {
-		t.Errorf("expected a distinct message for an empty-but-enabled TED, got: %s", st.Message())
-	}
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "not yet synchronized", "expected a distinct message for an empty-but-enabled TED")
 }
 
 func TestValidateSIDs_MissingSID(t *testing.T) {
@@ -284,12 +243,9 @@ func TestValidateSIDs_MissingSID(t *testing.T) {
 
 	err := s.validateSIDs(req, segmentList)
 	st, ok := status.FromError(err)
-	if !ok || st.Code() != codes.InvalidArgument {
-		t.Fatalf("expected codes.InvalidArgument, got: %v", err)
-	}
-	if !strings.Contains(st.Message(), "hop 1") {
-		t.Errorf("expected the missing hop to be listed, got: %s", st.Message())
-	}
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "hop 1", "expected the missing hop to be listed")
 }
 
 func TestValidateSIDs_EndpointFormIsStillValidated(t *testing.T) {
@@ -311,12 +267,9 @@ func TestValidateSIDs_EndpointFormIsStillValidated(t *testing.T) {
 
 	err := s.validateSIDs(req, segmentList)
 	st, ok := status.FromError(err)
-	if !ok || st.Code() != codes.InvalidArgument {
-		t.Fatalf("expected codes.InvalidArgument, got: %v", err)
-	}
-	if !strings.Contains(st.Message(), "hop 1") {
-		t.Errorf("expected the missing hop to be listed, got: %s", st.Message())
-	}
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "hop 1", "expected the missing hop to be listed")
 }
 
 func TestValidateSIDs_LabelOutOfRangeIsRejectedEvenWithNoSidValidate(t *testing.T) {
@@ -361,9 +314,44 @@ func TestValidateSIDs_AllKnownSucceeds(t *testing.T) {
 	req := explicitPolicyRequest(false, "16003")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	if err := s.validateSIDs(req, segmentList); err != nil {
-		t.Errorf("expected no error, got: %v", err)
-	}
+	err := s.validateSIDs(req, segmentList)
+	assert.NoError(t, err)
+}
+
+func TestServe_InvalidAddress(t *testing.T) {
+	s := &APIServer{grpcServer: grpc.NewServer(), logger: zap.NewNop()}
+	require.Error(t, s.Serve("", "50052"))
+}
+
+func TestServe_InvalidPort(t *testing.T) {
+	s := &APIServer{grpcServer: grpc.NewServer(), logger: zap.NewNop()}
+	require.Error(t, s.Serve("127.0.0.1", "notaport"))
+}
+
+func TestServe_PortOutOfRange(t *testing.T) {
+	s := &APIServer{grpcServer: grpc.NewServer(), logger: zap.NewNop()}
+	require.Error(t, s.Serve("127.0.0.1", "70000"))
+}
+
+func TestServe_ListensAndLogsActualAddr(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	s := &APIServer{grpcServer: grpc.NewServer(), logger: zap.New(core)}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve("127.0.0.1", "0") }()
+
+	require.Eventually(t, func() bool {
+		return len(logs.FilterMessage("Start listening on gRPC port").All()) > 0
+	}, 2*time.Second, 10*time.Millisecond, "expected listenInfo to be logged")
+
+	s.grpcServer.GracefulStop()
+	require.NoError(t, <-errCh)
+
+	entries := logs.FilterMessage("Start listening on gRPC port").All()
+	require.Len(t, entries, 1)
+	listenInfo, _ := entries[0].ContextMap()["listenInfo"].(string)
+	require.NotEmpty(t, listenInfo, "expected listenInfo to be logged")
+	assert.False(t, strings.HasSuffix(listenInfo, ":0"), "expected the actual bound port, got %s", listenInfo)
 }
 
 func TestConvertLsPrefixes_SidIndexPresence(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -95,7 +95,7 @@ func (s *Server) Serve(address string, port string, usidMode bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to convert port %s: %w", port, err)
 	}
-	if p > math.MaxUint16 {
+	if p < 0 || p > math.MaxUint16 {
 		return errors.New("invalid PCEP listen port")
 	}
 	localAddr := netip.AddrPortFrom(a, uint16(p))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package server
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// Regression test: strconv.Atoi accepts negative numbers, which used to
+// wrap around to a valid uint16 (e.g. -1 -> 65535) instead of being rejected.
+func TestServer_Serve_NegativePortRejected(t *testing.T) {
+	s := &Server{logger: zap.NewNop()}
+	if err := s.Serve("127.0.0.1", "-1", false); err == nil {
+		t.Fatal("expected error for negative port")
+	}
+}
+
+func TestServer_Serve_PortOutOfRange(t *testing.T) {
+	s := &Server{logger: zap.NewNop()}
+	if err := s.Serve("127.0.0.1", "70000", false); err == nil {
+		t.Fatal("expected error for out-of-range port")
+	}
+}


### PR DESCRIPTION
## Description

Validate server configuration and listen parameters to prevent invalid startup settings.
Improve gRPC/PCEP server tests and ensure actual listen addresses are logged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

- Added unit tests for invalid configuration and listen parameters
- Verified with `go test ./...`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed