### PR TITLE
 Preserve received PCC capabilities

### DIFF
--- a/pkg/packet/pcep/capability.go
+++ b/pkg/packet/pcep/capability.go
@@ -10,6 +10,7 @@ type CapabilityInterface interface {
 	CapStrings() []string
 }
 
+// PolaCapability converts received capabilities to those advertised by Pola.
 func PolaCapability(caps []CapabilityInterface) []CapabilityInterface {
 	polaCaps := []CapabilityInterface{}
 	for _, cap := range caps {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -553,7 +553,7 @@ func (s *APIServer) GetSessionList(ctx context.Context, _ *pb.GetSessionListRequ
 			Caps:     []string{},
 			IsSynced: pcepSession.isSynced,
 		}
-		for _, cap := range pcepSession.pccCapabilities {
+		for _, cap := range pcepSession.advertisedCapabilities {
 			ss.Caps = append(ss.Caps, cap.CapStrings()...)
 		}
 		ss.Caps = slices.Compact(ss.Caps)

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"time"
 
 	"github.com/nttcom/pola/pkg/cspf"
@@ -20,18 +21,19 @@ import (
 )
 
 type Session struct {
-	sessionID       uint8
-	peerAddr        netip.Addr
-	tcpConn         *net.TCPConn
-	isSynced        bool
-	srpIDHead       uint32 // 0x00000000 and 0xFFFFFFFF are reserved.
-	srPolicies      []*table.SRPolicy
-	logger          *zap.Logger
-	keepAlive       uint8
-	pccType         pcep.PccType
-	pccCapabilities []pcep.CapabilityInterface
-	ted             *table.LsTED
-	asn             uint32
+	sessionID               uint8
+	peerAddr                netip.Addr
+	tcpConn                 *net.TCPConn
+	isSynced                bool
+	srpIDHead               uint32 // 0x00000000 and 0xFFFFFFFF are reserved.
+	srPolicies              []*table.SRPolicy
+	logger                  *zap.Logger
+	keepAlive               uint8
+	pccType                 pcep.PccType
+	advertisedCapabilities  []pcep.CapabilityInterface // Capabilities Pola advertises to the PCC.
+	receivedPccCapabilities []pcep.CapabilityInterface // Capabilities received from the PCC.
+	ted                     *table.LsTED
+	asn                     uint32
 }
 
 func NewSession(sessionID uint8, peerAddr netip.Addr, tcpConn *net.TCPConn, logger *zap.Logger, ted *table.LsTED, asn uint32) *Session {
@@ -144,11 +146,12 @@ func (ss *Session) ReceiveOpen() error {
 		return err
 	}
 
-	ss.pccCapabilities = pcep.PolaCapability(openMessage.OpenObject.Caps)
+	ss.receivedPccCapabilities = slices.Clone(openMessage.OpenObject.Caps)
+	ss.advertisedCapabilities = pcep.PolaCapability(openMessage.OpenObject.Caps)
 
 	// pccType detection
 	// * FRRouting cannot be detected from the open message, so it is treated as an RFC compliant
-	ss.pccType = pcep.DeterminePccType(ss.pccCapabilities)
+	ss.pccType = pcep.DeterminePccType(ss.receivedPccCapabilities)
 	ss.logger.Debug("Determine PCC Type", zap.Int("pcc-type", int(ss.pccType)))
 	ss.keepAlive = openMessage.OpenObject.Keepalive
 
@@ -496,7 +499,7 @@ func (ss *Session) RequestSRPolicyCreated(srPolicy table.SRPolicy) error {
 }
 
 func (ss *Session) SendOpen() error {
-	openMessage, err := pcep.NewOpenMessage(ss.sessionID, ss.keepAlive, ss.pccCapabilities)
+	openMessage, err := pcep.NewOpenMessage(ss.sessionID, ss.keepAlive, ss.advertisedCapabilities)
 	if err != nil {
 		return err
 	}
@@ -558,7 +561,7 @@ func (ss *Session) resolveColorPreference(sr *pcep.StateReport) (uint32, uint32)
 	} else {
 		// Check if PCC supports color capability
 		hasColor := false
-		for _, cap := range ss.pccCapabilities {
+		for _, cap := range ss.receivedPccCapabilities {
 			if c, ok := cap.(*pcep.StatefulPCECapability); ok && c.ColorCapability {
 				hasColor = true
 				break

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -6,7 +6,9 @@
 package server
 
 import (
+	"net"
 	"net/netip"
+	"reflect"
 	"testing"
 
 	"go.uber.org/zap"
@@ -14,6 +16,46 @@ import (
 	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/nttcom/pola/pkg/table"
 )
+
+// newTCPConnPair returns a connected TCP connection pair over loopback.
+func newTCPConnPair(t *testing.T) (server, client *net.TCPConn) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := ln.Close(); err != nil {
+			t.Errorf("failed to close listener: %v", err)
+		}
+	})
+
+	serverCh := make(chan *net.TCPConn, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		serverCh <- conn.(*net.TCPConn)
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	select {
+	case server := <-serverCh:
+		return server, clientConn.(*net.TCPConn)
+	case err := <-errCh:
+		t.Fatalf("failed to accept connection: %v", err)
+		return nil, clientConn.(*net.TCPConn)
+	}
+}
 
 // newTestStateReport builds a PCRpt state report for an SR-MPLS policy with an explicit path.
 func newTestStateReport(t *testing.T, plspID uint32, srpID uint32) *pcep.StateReport {
@@ -81,5 +123,68 @@ func TestHandleStateReportRemove(t *testing.T) {
 
 	if _, found := ss.SearchSRPolicy(sr.LSPObject.PlspID); found {
 		t.Error("SR Policy is still registered after being reported as removed")
+	}
+}
+
+func TestReceiveOpenSeparatesPccAndPolaCapabilities(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("failed to close server connection: %v", err)
+		}
+	})
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close client connection: %v", err)
+		}
+	})
+
+	// The PCC advertises Color Capability support but not LSP Update Capability.
+	pccCaps := []pcep.CapabilityInterface{
+		&pcep.StatefulPCECapability{
+			LSPUpdateCapability: false,
+			ColorCapability:     true,
+		},
+	}
+	openMessage, err := pcep.NewOpenMessage(1, 30, pccCaps)
+	if err != nil {
+		t.Fatalf("failed to create open message: %v", err)
+	}
+	byteOpenMessage, err := openMessage.Serialize()
+	if err != nil {
+		t.Fatalf("failed to serialize open message: %v", err)
+	}
+	if _, err := client.Write(byteOpenMessage); err != nil {
+		t.Fatalf("failed to write open message: %v", err)
+	}
+
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	if err := ss.ReceiveOpen(); err != nil {
+		t.Fatalf("ReceiveOpen returned an error: %v", err)
+	}
+
+	if !reflect.DeepEqual(ss.receivedPccCapabilities, pccCaps) {
+		t.Errorf("receivedPccCapabilities: got %+v, want %+v", ss.receivedPccCapabilities, pccCaps)
+	}
+
+	wantPolaCaps := pcep.PolaCapability(pccCaps)
+	if !reflect.DeepEqual(ss.advertisedCapabilities, wantPolaCaps) {
+		t.Errorf("advertisedCapabilities: got %+v, want %+v", ss.advertisedCapabilities, wantPolaCaps)
+	}
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.LSPObject.TLVs = append(sr.LSPObject.TLVs, &pcep.Color{Color: 100})
+	color, _ := ss.resolveColorPreference(sr)
+	if color != 100 {
+		t.Errorf("resolveColorPreference did not detect Color Capability from receivedPccCapabilities: got color %d, want 100", color)
+	}
+
+	receivedCap := ss.receivedPccCapabilities[0].(*pcep.StatefulPCECapability)
+	polaCap := ss.advertisedCapabilities[0].(*pcep.StatefulPCECapability)
+	if receivedCap == polaCap {
+		t.Error("receivedPccCapabilities and advertisedCapabilities share the same StatefulPCECapability instance")
+	}
+	if receivedCap.LSPUpdateCapability == polaCap.LSPUpdateCapability {
+		t.Error("expected received and advertised StatefulPCECapability to diverge, got identical LSPUpdateCapability")
 	}
 }


### PR DESCRIPTION
## Description

Keep PCC capabilities received in the Open message separately from Pola's advertised capabilities.

This ensures internal logic uses the actual capabilities advertised by the PCC.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Refactoring
* [ ] Documentation
* [ ] Build / CI

## How was this tested?

* Added a test for separating PCC and Pola capabilities.

## Checklist

* [x] `make ci` passes locally
* [x] Tests added or updated if needed
* [ ] Documentation updated if needed