### PR TITLE
Improve PCEP capability reporting

### DIFF
--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -886,12 +886,14 @@ func (tlv *SRPCECapability) Len() uint16 {
 }
 
 func (tlv *SRPCECapability) CapStrings() []string {
-	var ret []string
+	ret := []string{"SR"}
 	if tlv.HasUnlimitedMaxSIDDepth {
 		ret = append(ret, "Unlimited-SID-Depth")
+	} else {
+		ret = append(ret, fmt.Sprintf("MSD=%d", tlv.MaximumSidDepth))
 	}
 	if tlv.IsNAISupported {
-		ret = append(ret, "NAI-Supported")
+		ret = append(ret, "SR-NAI-Supported")
 	}
 	return ret
 }
@@ -969,7 +971,7 @@ func (tlv *SRv6PCECapability) Len() uint16 {
 func (tlv *SRv6PCECapability) CapStrings() []string {
 	ret := []string{"SRv6"}
 	if tlv.IsNAISupported {
-		ret = append(ret, "NAI-Supported")
+		ret = append(ret, "SRv6-NAI-Supported")
 	}
 	return ret
 }
@@ -1072,7 +1074,20 @@ func (tlv *MultipathCapability) Len() uint16 {
 }
 
 func (tlv *MultipathCapability) CapStrings() []string {
-	return []string{"Multipath"}
+	ret := []string{"Multipath", fmt.Sprintf("MaxMultipaths=%d", tlv.MaxMultipaths)}
+	if tlv.IsWeightedSupported {
+		ret = append(ret, "Weighted")
+	}
+	if tlv.IsOppositeDirSupported {
+		ret = append(ret, "OppositeDir")
+	}
+	if tlv.IsForwardClassSupported {
+		ret = append(ret, "ForwardClass")
+	}
+	if tlv.IsCompositePathSupported {
+		ret = append(ret, "CompositePath")
+	}
+	return ret
 }
 
 func NewMultipathCapability(maxMultipaths uint16, isWeightedSupported, isOppositeDirSupported, isForwardClassSupported, isCompositePathSupported bool) *MultipathCapability {
@@ -1600,7 +1615,11 @@ func (tlv *AssocTypeList) Len() uint16 {
 }
 
 func (tlv *AssocTypeList) CapStrings() []string {
-	return []string{}
+	ret := make([]string, 0, len(tlv.AssocTypes))
+	for _, at := range tlv.AssocTypes {
+		ret = append(ret, "AssocType:"+at.String())
+	}
+	return ret
 }
 
 type SRPolicyCandidatePathIdentifier struct {
@@ -1915,11 +1934,10 @@ func (tlv *UnknownTLV) Len() uint16 {
 	return TLVValueOffset + tlv.Length + padding
 }
 
-// CapStrings reports the registered TLV name even when no decoder exists.
-// Unknown TLV types fall back to "unknown_type_<n>".
+// Registered TLVs are reported with their identifier and name.
 func (tlv *UnknownTLV) CapStrings() []string {
-	if desc, ok := tlvDescriptions[tlv.Typ]; ok {
-		return []string{desc.Description}
+	if _, ok := tlvDescriptions[tlv.Typ]; ok {
+		return []string{fmt.Sprintf("0x%04x (%s)", uint16(tlv.Typ), tlv.Typ)}
 	}
 	capStr := "unknown_type_" + strconv.FormatInt(int64(tlv.Typ), 10)
 	return []string{capStr}

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -734,10 +734,12 @@ var (
 	testSRPCECapabilityUnlimitedOnly  = &SRPCECapability{HasUnlimitedMaxSIDDepth: true}
 	testSRPCECapabilityNAIOnly        = &SRPCECapability{IsNAISupported: true}
 	testSRPCECapabilityNoneEnabled    = &SRPCECapability{}
-	testSRPCECapabilityAllEnabledStrs = []string{"Unlimited-SID-Depth", "NAI-Supported"}
-	testSRPCECapabilityUnlimitedStrs  = []string{"Unlimited-SID-Depth"}
-	testSRPCECapabilityNAIStrs        = []string{"NAI-Supported"}
-	testSRPCECapabilityNoneStrs       = []string(nil)
+	testSRPCECapabilityAllEnabledStrs = []string{"SR", "Unlimited-SID-Depth", "SR-NAI-Supported"}
+	testSRPCECapabilityUnlimitedStrs  = []string{"SR", "Unlimited-SID-Depth"}
+	testSRPCECapabilityNAIStrs        = []string{"SR", "MSD=0", "SR-NAI-Supported"}
+	testSRPCECapabilityMSDOnly        = &SRPCECapability{MaximumSidDepth: 10}
+	testSRPCECapabilityMSDOnlyStrs    = []string{"SR", "MSD=10"}
+	testSRPCECapabilityNoneStrs       = []string{"SR", "MSD=0"}
 )
 
 func TestSRPCECapability_DecodeFromBytes(t *testing.T) {
@@ -829,6 +831,7 @@ func TestSRPCECapability_CapStrings(t *testing.T) {
 		"OnlyUnlimitedMaxSIDDepthEnabled": {testSRPCECapabilityUnlimitedOnly, testSRPCECapabilityUnlimitedStrs},
 		"OnlyNAISupportedEnabled":         {testSRPCECapabilityNAIOnly, testSRPCECapabilityNAIStrs},
 		"NoCapabilitiesEnabled":           {testSRPCECapabilityNoneEnabled, testSRPCECapabilityNoneStrs},
+		"WithNonZeroMSD":                  {testSRPCECapabilityMSDOnly, testSRPCECapabilityMSDOnlyStrs},
 	}
 	runCapStringsTests(t, cases)
 }
@@ -1507,6 +1510,17 @@ func TestAssocTypeList_CapStrings(t *testing.T) {
 		expected []string
 	}{
 		"EmptyList": {&AssocTypeList{}, []string{}},
+		"TwoEntries": {
+			testAssocTypeList,
+			[]string{
+				"AssocType:Path Protection Association",
+				"AssocType:SR Policy Association",
+			},
+		},
+		"SingleEntry": {
+			testAssocTypeListSingle,
+			[]string{"AssocType:Path Protection Association"},
+		},
 	}
 	runCapStringsTests(t, cases)
 }
@@ -2045,14 +2059,14 @@ func TestUnknownTLV_CapStrings(t *testing.T) {
 		expected []string
 	}{
 		// Registered in tlvDescriptions but with no dedicated decoder: reported
-		// under its registry name rather than as unknown_type_<n>.
+		// as its TLV identifier plus registry name rather than as unknown_type_<n>.
 		"RegisteredWithoutDecoder": {
 			input:    &UnknownTLV{Typ: TLVSRP2MPPolicyCapability},
-			expected: []string{"SR-P2MP-POLICY-CAPABILITY"},
+			expected: []string{"0x0049 (SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11))"},
 		},
 		"RegisteredVendorSpecific": {
 			input:    &UnknownTLV{Typ: TLVSRPolicyCPathPreferenceJuniper},
-			expected: []string{"SRPOLICY-CPATH-PREFERENCE (Juniper)"},
+			expected: []string{"0xffe5 (SRPOLICY-CPATH-PREFERENCE (Juniper) (vendor-specific))"},
 		},
 		// Absent from the registry: falls back to the numeric form.
 		"UnregisteredType": {
@@ -2195,7 +2209,7 @@ var (
 	testSRv6PCECapabilityShortLength = append(tlvHeader(TLVSRv6PCECapability, 3), 0x00, 0x00, 0x00)
 	testSRv6PCECapabilityTruncated   = append(tlvHeader(TLVSRv6PCECapability, 4), 0x00, 0x00)
 	testSRv6PCECapabilityNoNAI       = &SRv6PCECapability{}
-	testSRv6PCECapabilityNAIStrs     = []string{"SRv6", "NAI-Supported"}
+	testSRv6PCECapabilityNAIStrs     = []string{"SRv6", "SRv6-NAI-Supported"}
 	testSRv6PCECapabilityNoNAIStrs   = []string{"SRv6"}
 )
 
@@ -2304,12 +2318,13 @@ func TestSRv6PCECapability_RoundTrip(t *testing.T) {
 var (
 	testMultipathCapability = NewMultipathCapability(8, true, true, true, true)
 	// MaxMultipaths=8 (0x0008), Flags=W|O|F|C = 0x001D
-	testMultipathCapabilityBytes        = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x08, 0x00, 0x1d)
-	testMultipathCapabilityNoFlags      = NewMultipathCapability(1, false, false, false, false)
-	testMultipathCapabilityNoFlagsBytes = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x01, 0x00, 0x00)
-	testMultipathCapabilityTruncated    = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x08)
-	testMultipathCapabilityInvalidLen   = append(tlvHeader(TLVMultipathCap, 8), 0x00, 0x08, 0x00, 0x0f, 0xde, 0xad, 0xbe, 0xef)
-	testMultipathCapabilityCapStrs      = []string{"Multipath"}
+	testMultipathCapabilityBytes          = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x08, 0x00, 0x1d)
+	testMultipathCapabilityNoFlags        = NewMultipathCapability(1, false, false, false, false)
+	testMultipathCapabilityNoFlagsBytes   = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x01, 0x00, 0x00)
+	testMultipathCapabilityTruncated      = append(tlvHeader(TLVMultipathCap, 4), 0x00, 0x08)
+	testMultipathCapabilityInvalidLen     = append(tlvHeader(TLVMultipathCap, 8), 0x00, 0x08, 0x00, 0x0f, 0xde, 0xad, 0xbe, 0xef)
+	testMultipathCapabilityCapStrs        = []string{"Multipath", "MaxMultipaths=8", "Weighted", "OppositeDir", "ForwardClass", "CompositePath"}
+	testMultipathCapabilityNoFlagsCapStrs = []string{"Multipath", "MaxMultipaths=1"}
 )
 
 func TestMultipathCapability_DecodeFromBytes(t *testing.T) {
@@ -2387,7 +2402,7 @@ func TestMultipathCapability_CapStrings(t *testing.T) {
 		expected []string
 	}{
 		"AllFlagsEnabled": {testMultipathCapability, testMultipathCapabilityCapStrs},
-		"NoFlagsEnabled":  {testMultipathCapabilityNoFlags, testMultipathCapabilityCapStrs},
+		"NoFlagsEnabled":  {testMultipathCapabilityNoFlags, testMultipathCapabilityNoFlagsCapStrs},
 	}
 	runCapStringsTests(t, cases)
 }

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -13,7 +13,6 @@ import (
 	"math"
 	"net"
 	"net/netip"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -553,10 +552,16 @@ func (s *APIServer) GetSessionList(ctx context.Context, _ *pb.GetSessionListRequ
 			Caps:     []string{},
 			IsSynced: pcepSession.isSynced,
 		}
+		seenCaps := make(map[string]struct{})
 		for _, cap := range pcepSession.advertisedCapabilities {
-			ss.Caps = append(ss.Caps, cap.CapStrings()...)
+			for _, capStr := range cap.CapStrings() {
+				if _, ok := seenCaps[capStr]; ok {
+					continue
+				}
+				seenCaps[capStr] = struct{}{}
+				ss.Caps = append(ss.Caps, capStr)
+			}
 		}
-		ss.Caps = slices.Compact(ss.Caps)
 		sessions = append(sessions, ss)
 	}
 

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -6,6 +6,7 @@
 package server
 
 import (
+	"context"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
+	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/nttcom/pola/pkg/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -394,4 +396,29 @@ func TestConvertLsPrefixes_SidIndexPresence(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSessionList_DeduplicatesNonAdjacentCaps(t *testing.T) {
+	session := &Session{
+		peerAddr: netip.MustParseAddr("10.0.0.1"),
+		isSynced: true,
+		advertisedCapabilities: []pcep.CapabilityInterface{
+			&pcep.SRPCECapability{IsNAISupported: true},
+			&pcep.SRv6PCECapability{IsNAISupported: true},
+			&pcep.SRPCECapability{IsNAISupported: true},
+		},
+	}
+	s := &APIServer{
+		pce:    &Server{sessionList: []*Session{session}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+
+	assert.Equal(t, []string{
+		"SR", "MSD=0", "SR-NAI-Supported",
+		"SRv6", "SRv6-NAI-Supported",
+	}, resp.Sessions[0].Caps)
 }


### PR DESCRIPTION
## Description

Improve PCEP capability output and deduplicate non-adjacent capabilities.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

- Added capability formatting and deduplication tests
- `make ci`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed