### PR TITLE
Redesign per-session views for capabilities and SR policies

### DIFF
--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -581,13 +581,17 @@ func (x *SRPolicy) GetState() SRPolicyState {
 }
 
 type CreateSRPolicyRequest struct {
-	state              protoimpl.MessageState `protogen:"open.v1"`
-	SrPolicy           *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
-	Asn                uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
-	DisablePathCompute bool                   `protobuf:"varint,4,opt,name=disable_path_compute,json=disablePathCompute,proto3" json:"disable_path_compute,omitempty"`
-	NoSidValidate      bool                   `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	SrPolicy *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
+	// Not required when disable_path_compute is true.
+	Asn uint32 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
+	// Use endpoints and segments provided in the request without TED lookup
+	// or path computation (no CSPF or router-ID resolution).
+	DisablePathCompute bool `protobuf:"varint,4,opt,name=disable_path_compute,json=disablePathCompute,proto3" json:"disable_path_compute,omitempty"`
+	// Skip checking that explicit SIDs exist in the TED.
+	NoSidValidate bool `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateSRPolicyRequest) Reset() {

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -75,6 +75,61 @@ func (SRPolicyType) EnumDescriptor() ([]byte, []int) {
 	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{0}
 }
 
+type SRPolicyState int32
+
+const (
+	SRPolicyState_SR_POLICY_STATE_UNSPECIFIED SRPolicyState = 0
+	SRPolicyState_SR_POLICY_STATE_DOWN        SRPolicyState = 1
+	SRPolicyState_SR_POLICY_STATE_UP          SRPolicyState = 2
+	SRPolicyState_SR_POLICY_STATE_ACTIVE      SRPolicyState = 3
+	SRPolicyState_SR_POLICY_STATE_UNKNOWN     SRPolicyState = 4
+)
+
+// Enum value maps for SRPolicyState.
+var (
+	SRPolicyState_name = map[int32]string{
+		0: "SR_POLICY_STATE_UNSPECIFIED",
+		1: "SR_POLICY_STATE_DOWN",
+		2: "SR_POLICY_STATE_UP",
+		3: "SR_POLICY_STATE_ACTIVE",
+		4: "SR_POLICY_STATE_UNKNOWN",
+	}
+	SRPolicyState_value = map[string]int32{
+		"SR_POLICY_STATE_UNSPECIFIED": 0,
+		"SR_POLICY_STATE_DOWN":        1,
+		"SR_POLICY_STATE_UP":          2,
+		"SR_POLICY_STATE_ACTIVE":      3,
+		"SR_POLICY_STATE_UNKNOWN":     4,
+	}
+)
+
+func (x SRPolicyState) Enum() *SRPolicyState {
+	p := new(SRPolicyState)
+	*p = x
+	return p
+}
+
+func (x SRPolicyState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SRPolicyState) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_pola_v1_pola_proto_enumTypes[1].Descriptor()
+}
+
+func (SRPolicyState) Type() protoreflect.EnumType {
+	return &file_api_pola_v1_pola_proto_enumTypes[1]
+}
+
+func (x SRPolicyState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SRPolicyState.Descriptor instead.
+func (SRPolicyState) EnumDescriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{1}
+}
+
 type SessionState int32
 
 const (
@@ -108,11 +163,11 @@ func (x SessionState) String() string {
 }
 
 func (SessionState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[1].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[2].Descriptor()
 }
 
 func (SessionState) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[1]
+	return &file_api_pola_v1_pola_proto_enumTypes[2]
 }
 
 func (x SessionState) Number() protoreflect.EnumNumber {
@@ -121,7 +176,77 @@ func (x SessionState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SessionState.Descriptor instead.
 func (SessionState) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{1}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
+}
+
+type CapabilityType int32
+
+const (
+	CapabilityType_CAPABILITY_TYPE_UNSPECIFIED        CapabilityType = 0
+	CapabilityType_CAPABILITY_TYPE_STATEFUL           CapabilityType = 1
+	CapabilityType_CAPABILITY_TYPE_SR                 CapabilityType = 2
+	CapabilityType_CAPABILITY_TYPE_SRV6               CapabilityType = 3
+	CapabilityType_CAPABILITY_TYPE_PATH_SETUP_TYPE    CapabilityType = 4
+	CapabilityType_CAPABILITY_TYPE_ASSOC_TYPE_LIST    CapabilityType = 5
+	CapabilityType_CAPABILITY_TYPE_LSP_DB_VERSION     CapabilityType = 6
+	CapabilityType_CAPABILITY_TYPE_MULTIPATH          CapabilityType = 7
+	CapabilityType_CAPABILITY_TYPE_VENDOR_INFORMATION CapabilityType = 8
+	CapabilityType_CAPABILITY_TYPE_UNKNOWN            CapabilityType = 9
+)
+
+// Enum value maps for CapabilityType.
+var (
+	CapabilityType_name = map[int32]string{
+		0: "CAPABILITY_TYPE_UNSPECIFIED",
+		1: "CAPABILITY_TYPE_STATEFUL",
+		2: "CAPABILITY_TYPE_SR",
+		3: "CAPABILITY_TYPE_SRV6",
+		4: "CAPABILITY_TYPE_PATH_SETUP_TYPE",
+		5: "CAPABILITY_TYPE_ASSOC_TYPE_LIST",
+		6: "CAPABILITY_TYPE_LSP_DB_VERSION",
+		7: "CAPABILITY_TYPE_MULTIPATH",
+		8: "CAPABILITY_TYPE_VENDOR_INFORMATION",
+		9: "CAPABILITY_TYPE_UNKNOWN",
+	}
+	CapabilityType_value = map[string]int32{
+		"CAPABILITY_TYPE_UNSPECIFIED":        0,
+		"CAPABILITY_TYPE_STATEFUL":           1,
+		"CAPABILITY_TYPE_SR":                 2,
+		"CAPABILITY_TYPE_SRV6":               3,
+		"CAPABILITY_TYPE_PATH_SETUP_TYPE":    4,
+		"CAPABILITY_TYPE_ASSOC_TYPE_LIST":    5,
+		"CAPABILITY_TYPE_LSP_DB_VERSION":     6,
+		"CAPABILITY_TYPE_MULTIPATH":          7,
+		"CAPABILITY_TYPE_VENDOR_INFORMATION": 8,
+		"CAPABILITY_TYPE_UNKNOWN":            9,
+	}
+)
+
+func (x CapabilityType) Enum() *CapabilityType {
+	p := new(CapabilityType)
+	*p = x
+	return p
+}
+
+func (x CapabilityType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CapabilityType) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_pola_v1_pola_proto_enumTypes[3].Descriptor()
+}
+
+func (CapabilityType) Type() protoreflect.EnumType {
+	return &file_api_pola_v1_pola_proto_enumTypes[3]
+}
+
+func (x CapabilityType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CapabilityType.Descriptor instead.
+func (CapabilityType) EnumDescriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
 }
 
 type MetricType int32
@@ -163,11 +288,11 @@ func (x MetricType) String() string {
 }
 
 func (MetricType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[2].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[4].Descriptor()
 }
 
 func (MetricType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[2]
+	return &file_api_pola_v1_pola_proto_enumTypes[4]
 }
 
 func (x MetricType) Number() protoreflect.EnumNumber {
@@ -176,7 +301,7 @@ func (x MetricType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use MetricType.Descriptor instead.
 func (MetricType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
 }
 
 type Segment struct {
@@ -313,6 +438,9 @@ type SRPolicy struct {
 	SegmentList     []*Segment             `protobuf:"bytes,10,rep,name=segment_list,json=segmentList,proto3" json:"segment_list,omitempty"`
 	Metric          MetricType             `protobuf:"varint,11,opt,name=metric,proto3,enum=api.pola.v1.MetricType" json:"metric,omitempty"`
 	Waypoints       []*Waypoint            `protobuf:"bytes,12,rep,name=waypoints,proto3" json:"waypoints,omitempty"`
+	PlspId          uint32                 `protobuf:"varint,13,opt,name=plsp_id,json=plspId,proto3" json:"plsp_id,omitempty"`
+	LspId           uint32                 `protobuf:"varint,14,opt,name=lsp_id,json=lspId,proto3" json:"lsp_id,omitempty"`
+	State           SRPolicyState          `protobuf:"varint,15,opt,name=state,proto3,enum=api.pola.v1.SRPolicyState" json:"state,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -431,18 +559,35 @@ func (x *SRPolicy) GetWaypoints() []*Waypoint {
 	return nil
 }
 
+func (x *SRPolicy) GetPlspId() uint32 {
+	if x != nil {
+		return x.PlspId
+	}
+	return 0
+}
+
+func (x *SRPolicy) GetLspId() uint32 {
+	if x != nil {
+		return x.LspId
+	}
+	return 0
+}
+
+func (x *SRPolicy) GetState() SRPolicyState {
+	if x != nil {
+		return x.State
+	}
+	return SRPolicyState_SR_POLICY_STATE_UNSPECIFIED
+}
+
 type CreateSRPolicyRequest struct {
-	state    protoimpl.MessageState `protogen:"open.v1"`
-	SrPolicy *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
-	// Not required when disable_path_compute is true.
-	Asn uint32 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
-	// Use endpoints and segments provided in the request without TED lookup
-	// or path computation (no CSPF or router-ID resolution).
-	DisablePathCompute bool `protobuf:"varint,4,opt,name=disable_path_compute,json=disablePathCompute,proto3" json:"disable_path_compute,omitempty"`
-	// Skip checking that explicit SIDs exist in the TED.
-	NoSidValidate bool `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	SrPolicy           *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
+	Asn                uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
+	DisablePathCompute bool                   `protobuf:"varint,4,opt,name=disable_path_compute,json=disablePathCompute,proto3" json:"disable_path_compute,omitempty"`
+	NoSidValidate      bool                   `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *CreateSRPolicyRequest) Reset() {
@@ -643,19 +788,715 @@ func (x *DeleteSRPolicyResponse) GetIsSuccess() bool {
 	return false
 }
 
-type Session struct {
+type StatefulCapability struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	LspUpdate            bool                   `protobuf:"varint,1,opt,name=lsp_update,json=lspUpdate,proto3" json:"lsp_update,omitempty"`
+	IncludeDbVersion     bool                   `protobuf:"varint,2,opt,name=include_db_version,json=includeDbVersion,proto3" json:"include_db_version,omitempty"`
+	LspInstantiation     bool                   `protobuf:"varint,3,opt,name=lsp_instantiation,json=lspInstantiation,proto3" json:"lsp_instantiation,omitempty"`
+	TriggeredResync      bool                   `protobuf:"varint,4,opt,name=triggered_resync,json=triggeredResync,proto3" json:"triggered_resync,omitempty"`
+	DeltaLspSync         bool                   `protobuf:"varint,5,opt,name=delta_lsp_sync,json=deltaLspSync,proto3" json:"delta_lsp_sync,omitempty"`
+	TriggeredInitialSync bool                   `protobuf:"varint,6,opt,name=triggered_initial_sync,json=triggeredInitialSync,proto3" json:"triggered_initial_sync,omitempty"`
+	Color                bool                   `protobuf:"varint,7,opt,name=color,proto3" json:"color,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *StatefulCapability) Reset() {
+	*x = StatefulCapability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StatefulCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StatefulCapability) ProtoMessage() {}
+
+func (x *StatefulCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StatefulCapability.ProtoReflect.Descriptor instead.
+func (*StatefulCapability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *StatefulCapability) GetLspUpdate() bool {
+	if x != nil {
+		return x.LspUpdate
+	}
+	return false
+}
+
+func (x *StatefulCapability) GetIncludeDbVersion() bool {
+	if x != nil {
+		return x.IncludeDbVersion
+	}
+	return false
+}
+
+func (x *StatefulCapability) GetLspInstantiation() bool {
+	if x != nil {
+		return x.LspInstantiation
+	}
+	return false
+}
+
+func (x *StatefulCapability) GetTriggeredResync() bool {
+	if x != nil {
+		return x.TriggeredResync
+	}
+	return false
+}
+
+func (x *StatefulCapability) GetDeltaLspSync() bool {
+	if x != nil {
+		return x.DeltaLspSync
+	}
+	return false
+}
+
+func (x *StatefulCapability) GetTriggeredInitialSync() bool {
+	if x != nil {
+		return x.TriggeredInitialSync
+	}
+	return false
+}
+
+func (x *StatefulCapability) GetColor() bool {
+	if x != nil {
+		return x.Color
+	}
+	return false
+}
+
+type SrCapability struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Addr          []byte                 `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	State         SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
-	Caps          []string               `protobuf:"bytes,3,rep,name=caps,proto3" json:"caps,omitempty"`
-	IsSynced      bool                   `protobuf:"varint,4,opt,name=is_synced,json=isSynced,proto3" json:"is_synced,omitempty"`
+	UnlimitedMsd  bool                   `protobuf:"varint,1,opt,name=unlimited_msd,json=unlimitedMsd,proto3" json:"unlimited_msd,omitempty"`
+	NaiSupported  bool                   `protobuf:"varint,2,opt,name=nai_supported,json=naiSupported,proto3" json:"nai_supported,omitempty"`
+	Msd           uint32                 `protobuf:"varint,3,opt,name=msd,proto3" json:"msd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SrCapability) Reset() {
+	*x = SrCapability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SrCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SrCapability) ProtoMessage() {}
+
+func (x *SrCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SrCapability.ProtoReflect.Descriptor instead.
+func (*SrCapability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SrCapability) GetUnlimitedMsd() bool {
+	if x != nil {
+		return x.UnlimitedMsd
+	}
+	return false
+}
+
+func (x *SrCapability) GetNaiSupported() bool {
+	if x != nil {
+		return x.NaiSupported
+	}
+	return false
+}
+
+func (x *SrCapability) GetMsd() uint32 {
+	if x != nil {
+		return x.Msd
+	}
+	return 0
+}
+
+type Srv6Capability struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	NaiSupported  bool                   `protobuf:"varint,1,opt,name=nai_supported,json=naiSupported,proto3" json:"nai_supported,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Srv6Capability) Reset() {
+	*x = Srv6Capability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Srv6Capability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Srv6Capability) ProtoMessage() {}
+
+func (x *Srv6Capability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Srv6Capability.ProtoReflect.Descriptor instead.
+func (*Srv6Capability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *Srv6Capability) GetNaiSupported() bool {
+	if x != nil {
+		return x.NaiSupported
+	}
+	return false
+}
+
+type PathSetupTypeCapability struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	PathSetupTypes []uint32               `protobuf:"varint,1,rep,packed,name=path_setup_types,json=pathSetupTypes,proto3" json:"path_setup_types,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *PathSetupTypeCapability) Reset() {
+	*x = PathSetupTypeCapability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PathSetupTypeCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PathSetupTypeCapability) ProtoMessage() {}
+
+func (x *PathSetupTypeCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PathSetupTypeCapability.ProtoReflect.Descriptor instead.
+func (*PathSetupTypeCapability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *PathSetupTypeCapability) GetPathSetupTypes() []uint32 {
+	if x != nil {
+		return x.PathSetupTypes
+	}
+	return nil
+}
+
+type AssocTypeListCapability struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AssocTypes    []uint32               `protobuf:"varint,1,rep,packed,name=assoc_types,json=assocTypes,proto3" json:"assoc_types,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssocTypeListCapability) Reset() {
+	*x = AssocTypeListCapability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssocTypeListCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssocTypeListCapability) ProtoMessage() {}
+
+func (x *AssocTypeListCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssocTypeListCapability.ProtoReflect.Descriptor instead.
+func (*AssocTypeListCapability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *AssocTypeListCapability) GetAssocTypes() []uint32 {
+	if x != nil {
+		return x.AssocTypes
+	}
+	return nil
+}
+
+type LspDbVersionCapability struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	VersionNumber uint64                 `protobuf:"varint,1,opt,name=version_number,json=versionNumber,proto3" json:"version_number,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LspDbVersionCapability) Reset() {
+	*x = LspDbVersionCapability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LspDbVersionCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LspDbVersionCapability) ProtoMessage() {}
+
+func (x *LspDbVersionCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LspDbVersionCapability.ProtoReflect.Descriptor instead.
+func (*LspDbVersionCapability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *LspDbVersionCapability) GetVersionNumber() uint64 {
+	if x != nil {
+		return x.VersionNumber
+	}
+	return 0
+}
+
+type MultipathCapability struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	MaxMultipaths uint32                 `protobuf:"varint,1,opt,name=max_multipaths,json=maxMultipaths,proto3" json:"max_multipaths,omitempty"`
+	Weighted      bool                   `protobuf:"varint,2,opt,name=weighted,proto3" json:"weighted,omitempty"`
+	OppositeDir   bool                   `protobuf:"varint,3,opt,name=opposite_dir,json=oppositeDir,proto3" json:"opposite_dir,omitempty"`
+	ForwardClass  bool                   `protobuf:"varint,4,opt,name=forward_class,json=forwardClass,proto3" json:"forward_class,omitempty"`
+	CompositePath bool                   `protobuf:"varint,5,opt,name=composite_path,json=compositePath,proto3" json:"composite_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MultipathCapability) Reset() {
+	*x = MultipathCapability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MultipathCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MultipathCapability) ProtoMessage() {}
+
+func (x *MultipathCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MultipathCapability.ProtoReflect.Descriptor instead.
+func (*MultipathCapability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *MultipathCapability) GetMaxMultipaths() uint32 {
+	if x != nil {
+		return x.MaxMultipaths
+	}
+	return 0
+}
+
+func (x *MultipathCapability) GetWeighted() bool {
+	if x != nil {
+		return x.Weighted
+	}
+	return false
+}
+
+func (x *MultipathCapability) GetOppositeDir() bool {
+	if x != nil {
+		return x.OppositeDir
+	}
+	return false
+}
+
+func (x *MultipathCapability) GetForwardClass() bool {
+	if x != nil {
+		return x.ForwardClass
+	}
+	return false
+}
+
+func (x *MultipathCapability) GetCompositePath() bool {
+	if x != nil {
+		return x.CompositePath
+	}
+	return false
+}
+
+type VendorInformationCapability struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	EnterpriseNumber uint32                 `protobuf:"varint,1,opt,name=enterprise_number,json=enterpriseNumber,proto3" json:"enterprise_number,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *VendorInformationCapability) Reset() {
+	*x = VendorInformationCapability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VendorInformationCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VendorInformationCapability) ProtoMessage() {}
+
+func (x *VendorInformationCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VendorInformationCapability.ProtoReflect.Descriptor instead.
+func (*VendorInformationCapability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *VendorInformationCapability) GetEnterpriseNumber() uint32 {
+	if x != nil {
+		return x.EnterpriseNumber
+	}
+	return 0
+}
+
+type UnknownCapability struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TlvType       uint32                 `protobuf:"varint,1,opt,name=tlv_type,json=tlvType,proto3" json:"tlv_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnknownCapability) Reset() {
+	*x = UnknownCapability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnknownCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnknownCapability) ProtoMessage() {}
+
+func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnknownCapability.ProtoReflect.Descriptor instead.
+func (*UnknownCapability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *UnknownCapability) GetTlvType() uint32 {
+	if x != nil {
+		return x.TlvType
+	}
+	return 0
+}
+
+type Capability struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Type  CapabilityType         `protobuf:"varint,1,opt,name=type,proto3,enum=api.pola.v1.CapabilityType" json:"type,omitempty"`
+	// Types that are valid to be assigned to Detail:
+	//
+	//	*Capability_Stateful
+	//	*Capability_Sr
+	//	*Capability_Srv6
+	//	*Capability_PathSetupType
+	//	*Capability_AssocTypeList
+	//	*Capability_LspDbVersion
+	//	*Capability_Multipath
+	//	*Capability_VendorInformation
+	//	*Capability_Unknown
+	Detail        isCapability_Detail `protobuf_oneof:"detail"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Capability) Reset() {
+	*x = Capability{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Capability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Capability) ProtoMessage() {}
+
+func (x *Capability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Capability.ProtoReflect.Descriptor instead.
+func (*Capability) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *Capability) GetType() CapabilityType {
+	if x != nil {
+		return x.Type
+	}
+	return CapabilityType_CAPABILITY_TYPE_UNSPECIFIED
+}
+
+func (x *Capability) GetDetail() isCapability_Detail {
+	if x != nil {
+		return x.Detail
+	}
+	return nil
+}
+
+func (x *Capability) GetStateful() *StatefulCapability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_Stateful); ok {
+			return x.Stateful
+		}
+	}
+	return nil
+}
+
+func (x *Capability) GetSr() *SrCapability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_Sr); ok {
+			return x.Sr
+		}
+	}
+	return nil
+}
+
+func (x *Capability) GetSrv6() *Srv6Capability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_Srv6); ok {
+			return x.Srv6
+		}
+	}
+	return nil
+}
+
+func (x *Capability) GetPathSetupType() *PathSetupTypeCapability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_PathSetupType); ok {
+			return x.PathSetupType
+		}
+	}
+	return nil
+}
+
+func (x *Capability) GetAssocTypeList() *AssocTypeListCapability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_AssocTypeList); ok {
+			return x.AssocTypeList
+		}
+	}
+	return nil
+}
+
+func (x *Capability) GetLspDbVersion() *LspDbVersionCapability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_LspDbVersion); ok {
+			return x.LspDbVersion
+		}
+	}
+	return nil
+}
+
+func (x *Capability) GetMultipath() *MultipathCapability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_Multipath); ok {
+			return x.Multipath
+		}
+	}
+	return nil
+}
+
+func (x *Capability) GetVendorInformation() *VendorInformationCapability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_VendorInformation); ok {
+			return x.VendorInformation
+		}
+	}
+	return nil
+}
+
+func (x *Capability) GetUnknown() *UnknownCapability {
+	if x != nil {
+		if x, ok := x.Detail.(*Capability_Unknown); ok {
+			return x.Unknown
+		}
+	}
+	return nil
+}
+
+type isCapability_Detail interface {
+	isCapability_Detail()
+}
+
+type Capability_Stateful struct {
+	Stateful *StatefulCapability `protobuf:"bytes,2,opt,name=stateful,proto3,oneof"`
+}
+
+type Capability_Sr struct {
+	Sr *SrCapability `protobuf:"bytes,3,opt,name=sr,proto3,oneof"`
+}
+
+type Capability_Srv6 struct {
+	Srv6 *Srv6Capability `protobuf:"bytes,4,opt,name=srv6,proto3,oneof"`
+}
+
+type Capability_PathSetupType struct {
+	PathSetupType *PathSetupTypeCapability `protobuf:"bytes,5,opt,name=path_setup_type,json=pathSetupType,proto3,oneof"`
+}
+
+type Capability_AssocTypeList struct {
+	AssocTypeList *AssocTypeListCapability `protobuf:"bytes,6,opt,name=assoc_type_list,json=assocTypeList,proto3,oneof"`
+}
+
+type Capability_LspDbVersion struct {
+	LspDbVersion *LspDbVersionCapability `protobuf:"bytes,7,opt,name=lsp_db_version,json=lspDbVersion,proto3,oneof"`
+}
+
+type Capability_Multipath struct {
+	Multipath *MultipathCapability `protobuf:"bytes,8,opt,name=multipath,proto3,oneof"`
+}
+
+type Capability_VendorInformation struct {
+	VendorInformation *VendorInformationCapability `protobuf:"bytes,9,opt,name=vendor_information,json=vendorInformation,proto3,oneof"`
+}
+
+type Capability_Unknown struct {
+	Unknown *UnknownCapability `protobuf:"bytes,10,opt,name=unknown,proto3,oneof"`
+}
+
+func (*Capability_Stateful) isCapability_Detail() {}
+
+func (*Capability_Sr) isCapability_Detail() {}
+
+func (*Capability_Srv6) isCapability_Detail() {}
+
+func (*Capability_PathSetupType) isCapability_Detail() {}
+
+func (*Capability_AssocTypeList) isCapability_Detail() {}
+
+func (*Capability_LspDbVersion) isCapability_Detail() {}
+
+func (*Capability_Multipath) isCapability_Detail() {}
+
+func (*Capability_VendorInformation) isCapability_Detail() {}
+
+func (*Capability_Unknown) isCapability_Detail() {}
+
+type Session struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Addr         []byte                 `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	State        SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
+	IsSynced     bool                   `protobuf:"varint,4,opt,name=is_synced,json=isSynced,proto3" json:"is_synced,omitempty"`
+	Capabilities []*Capability          `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	// Populated by GetSRPolicyList; empty when returned from GetSessionList.
+	SrPolicies    []*SRPolicy `protobuf:"bytes,6,rep,name=sr_policies,json=srPolicies,proto3" json:"sr_policies,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Session) Reset() {
 	*x = Session{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[7]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -667,7 +1508,7 @@ func (x *Session) String() string {
 func (*Session) ProtoMessage() {}
 
 func (x *Session) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[7]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -680,7 +1521,7 @@ func (x *Session) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Session.ProtoReflect.Descriptor instead.
 func (*Session) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Session) GetAddr() []byte {
@@ -697,13 +1538,6 @@ func (x *Session) GetState() SessionState {
 	return SessionState_SESSION_STATE_UNSPECIFIED
 }
 
-func (x *Session) GetCaps() []string {
-	if x != nil {
-		return x.Caps
-	}
-	return nil
-}
-
 func (x *Session) GetIsSynced() bool {
 	if x != nil {
 		return x.IsSynced
@@ -711,88 +1545,14 @@ func (x *Session) GetIsSynced() bool {
 	return false
 }
 
-type SessionList struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Sessions      []*Session             `protobuf:"bytes,1,rep,name=sessions,proto3" json:"sessions,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *SessionList) Reset() {
-	*x = SessionList{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[8]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *SessionList) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SessionList) ProtoMessage() {}
-
-func (x *SessionList) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[8]
+func (x *Session) GetCapabilities() []*Capability {
 	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use SessionList.ProtoReflect.Descriptor instead.
-func (*SessionList) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{8}
-}
-
-func (x *SessionList) GetSessions() []*Session {
-	if x != nil {
-		return x.Sessions
+		return x.Capabilities
 	}
 	return nil
 }
 
-type SRPolicyList struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SrPolicies    []*SRPolicy            `protobuf:"bytes,1,rep,name=sr_policies,json=srPolicies,proto3" json:"sr_policies,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *SRPolicyList) Reset() {
-	*x = SRPolicyList{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *SRPolicyList) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SRPolicyList) ProtoMessage() {}
-
-func (x *SRPolicyList) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use SRPolicyList.ProtoReflect.Descriptor instead.
-func (*SRPolicyList) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{9}
-}
-
-func (x *SRPolicyList) GetSrPolicies() []*SRPolicy {
+func (x *Session) GetSrPolicies() []*SRPolicy {
 	if x != nil {
 		return x.SrPolicies
 	}
@@ -810,7 +1570,7 @@ type EndpointBehavior struct {
 
 func (x *EndpointBehavior) Reset() {
 	*x = EndpointBehavior{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -822,7 +1582,7 @@ func (x *EndpointBehavior) String() string {
 func (*EndpointBehavior) ProtoMessage() {}
 
 func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -835,7 +1595,7 @@ func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointBehavior.ProtoReflect.Descriptor instead.
 func (*EndpointBehavior) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{10}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *EndpointBehavior) GetBehavior() uint32 {
@@ -871,7 +1631,7 @@ type SidStructure struct {
 
 func (x *SidStructure) Reset() {
 	*x = SidStructure{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -883,7 +1643,7 @@ func (x *SidStructure) String() string {
 func (*SidStructure) ProtoMessage() {}
 
 func (x *SidStructure) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -896,7 +1656,7 @@ func (x *SidStructure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidStructure.ProtoReflect.Descriptor instead.
 func (*SidStructure) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{11}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SidStructure) GetLocalBlock() uint32 {
@@ -936,7 +1696,7 @@ type SID struct {
 
 func (x *SID) Reset() {
 	*x = SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -948,7 +1708,7 @@ func (x *SID) String() string {
 func (*SID) ProtoMessage() {}
 
 func (x *SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -961,7 +1721,7 @@ func (x *SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SID.ProtoReflect.Descriptor instead.
 func (*SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{12}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SID) GetSid() string {
@@ -980,7 +1740,7 @@ type MultiTopoID struct {
 
 func (x *MultiTopoID) Reset() {
 	*x = MultiTopoID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -992,7 +1752,7 @@ func (x *MultiTopoID) String() string {
 func (*MultiTopoID) ProtoMessage() {}
 
 func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1005,7 +1765,7 @@ func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultiTopoID.ProtoReflect.Descriptor instead.
 func (*MultiTopoID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{13}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *MultiTopoID) GetMultiTopoId() uint32 {
@@ -1027,7 +1787,7 @@ type LsSrv6SID struct {
 
 func (x *LsSrv6SID) Reset() {
 	*x = LsSrv6SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1039,7 +1799,7 @@ func (x *LsSrv6SID) String() string {
 func (*LsSrv6SID) ProtoMessage() {}
 
 func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1052,7 +1812,7 @@ func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6SID.ProtoReflect.Descriptor instead.
 func (*LsSrv6SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{14}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *LsSrv6SID) GetSids() []*SID {
@@ -1093,7 +1853,7 @@ type LsPrefix struct {
 
 func (x *LsPrefix) Reset() {
 	*x = LsPrefix{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1105,7 +1865,7 @@ func (x *LsPrefix) String() string {
 func (*LsPrefix) ProtoMessage() {}
 
 func (x *LsPrefix) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1118,7 +1878,7 @@ func (x *LsPrefix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsPrefix.ProtoReflect.Descriptor instead.
 func (*LsPrefix) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{15}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *LsPrefix) GetPrefix() string {
@@ -1145,7 +1905,7 @@ type Metric struct {
 
 func (x *Metric) Reset() {
 	*x = Metric{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1157,7 +1917,7 @@ func (x *Metric) String() string {
 func (*Metric) ProtoMessage() {}
 
 func (x *Metric) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1170,7 +1930,7 @@ func (x *Metric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metric.ProtoReflect.Descriptor instead.
 func (*Metric) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{16}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Metric) GetType() MetricType {
@@ -1198,7 +1958,7 @@ type Srv6EndXSID struct {
 
 func (x *Srv6EndXSID) Reset() {
 	*x = Srv6EndXSID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1210,7 +1970,7 @@ func (x *Srv6EndXSID) String() string {
 func (*Srv6EndXSID) ProtoMessage() {}
 
 func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1223,7 +1983,7 @@ func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Srv6EndXSID.ProtoReflect.Descriptor instead.
 func (*Srv6EndXSID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{17}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Srv6EndXSID) GetEndpointBehavior() uint32 {
@@ -1264,7 +2024,7 @@ type LsLink struct {
 
 func (x *LsLink) Reset() {
 	*x = LsLink{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1276,7 +2036,7 @@ func (x *LsLink) String() string {
 func (*LsLink) ProtoMessage() {}
 
 func (x *LsLink) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1289,7 +2049,7 @@ func (x *LsLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsLink.ProtoReflect.Descriptor instead.
 func (*LsLink) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{18}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *LsLink) GetLocalRouterId() string {
@@ -1372,7 +2132,7 @@ type LsNode struct {
 
 func (x *LsNode) Reset() {
 	*x = LsNode{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1384,7 +2144,7 @@ func (x *LsNode) String() string {
 func (*LsNode) ProtoMessage() {}
 
 func (x *LsNode) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1397,7 +2157,7 @@ func (x *LsNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsNode.ProtoReflect.Descriptor instead.
 func (*LsNode) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LsNode) GetAsn() uint32 {
@@ -1473,7 +2233,7 @@ type TED struct {
 
 func (x *TED) Reset() {
 	*x = TED{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1485,7 +2245,7 @@ func (x *TED) String() string {
 func (*TED) ProtoMessage() {}
 
 func (x *TED) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1498,7 +2258,7 @@ func (x *TED) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TED.ProtoReflect.Descriptor instead.
 func (*TED) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TED) GetEnable() bool {
@@ -1523,7 +2283,7 @@ type GetSessionListRequest struct {
 
 func (x *GetSessionListRequest) Reset() {
 	*x = GetSessionListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1535,7 +2295,7 @@ func (x *GetSessionListRequest) String() string {
 func (*GetSessionListRequest) ProtoMessage() {}
 
 func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1548,7 +2308,7 @@ func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListRequest.ProtoReflect.Descriptor instead.
 func (*GetSessionListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
 }
 
 type GetSessionListResponse struct {
@@ -1560,7 +2320,7 @@ type GetSessionListResponse struct {
 
 func (x *GetSessionListResponse) Reset() {
 	*x = GetSessionListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1572,7 +2332,7 @@ func (x *GetSessionListResponse) String() string {
 func (*GetSessionListResponse) ProtoMessage() {}
 
 func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1585,7 +2345,7 @@ func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListResponse.ProtoReflect.Descriptor instead.
 func (*GetSessionListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetSessionListResponse) GetSessions() []*Session {
@@ -1596,14 +2356,16 @@ func (x *GetSessionListResponse) GetSessions() []*Session {
 }
 
 type GetSRPolicyListRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional filter: only return policies for the PCEP session with this peer address.
+	SessionAddr   []byte `protobuf:"bytes,1,opt,name=session_addr,json=sessionAddr,proto3" json:"session_addr,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetSRPolicyListRequest) Reset() {
 	*x = GetSRPolicyListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1615,7 +2377,7 @@ func (x *GetSRPolicyListRequest) String() string {
 func (*GetSRPolicyListRequest) ProtoMessage() {}
 
 func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1628,19 +2390,26 @@ func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListRequest.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *GetSRPolicyListRequest) GetSessionAddr() []byte {
+	if x != nil {
+		return x.SessionAddr
+	}
+	return nil
 }
 
 type GetSRPolicyListResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	SrPolicies    []*SRPolicy            `protobuf:"bytes,1,rep,name=sr_policies,json=srPolicies,proto3" json:"sr_policies,omitempty"`
+	Sessions      []*Session             `protobuf:"bytes,2,rep,name=sessions,proto3" json:"sessions,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetSRPolicyListResponse) Reset() {
 	*x = GetSRPolicyListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1652,7 +2421,7 @@ func (x *GetSRPolicyListResponse) String() string {
 func (*GetSRPolicyListResponse) ProtoMessage() {}
 
 func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1665,12 +2434,12 @@ func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListResponse.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
 }
 
-func (x *GetSRPolicyListResponse) GetSrPolicies() []*SRPolicy {
+func (x *GetSRPolicyListResponse) GetSessions() []*Session {
 	if x != nil {
-		return x.SrPolicies
+		return x.Sessions
 	}
 	return nil
 }
@@ -1683,7 +2452,7 @@ type GetTEDRequest struct {
 
 func (x *GetTEDRequest) Reset() {
 	*x = GetTEDRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1695,7 +2464,7 @@ func (x *GetTEDRequest) String() string {
 func (*GetTEDRequest) ProtoMessage() {}
 
 func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1708,7 +2477,7 @@ func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDRequest.ProtoReflect.Descriptor instead.
 func (*GetTEDRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
 }
 
 type GetTEDResponse struct {
@@ -1721,7 +2490,7 @@ type GetTEDResponse struct {
 
 func (x *GetTEDResponse) Reset() {
 	*x = GetTEDResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1733,7 +2502,7 @@ func (x *GetTEDResponse) String() string {
 func (*GetTEDResponse) ProtoMessage() {}
 
 func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1746,7 +2515,7 @@ func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDResponse.ProtoReflect.Descriptor instead.
 func (*GetTEDResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetTEDResponse) GetEnable() bool {
@@ -1772,7 +2541,7 @@ type DeleteSessionRequest struct {
 
 func (x *DeleteSessionRequest) Reset() {
 	*x = DeleteSessionRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1784,7 +2553,7 @@ func (x *DeleteSessionRequest) String() string {
 func (*DeleteSessionRequest) ProtoMessage() {}
 
 func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1797,7 +2566,7 @@ func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DeleteSessionRequest) GetAddr() []byte {
@@ -1816,7 +2585,7 @@ type DeleteSessionResponse struct {
 
 func (x *DeleteSessionResponse) Reset() {
 	*x = DeleteSessionResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1828,7 +2597,7 @@ func (x *DeleteSessionResponse) String() string {
 func (*DeleteSessionResponse) ProtoMessage() {}
 
 func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1841,7 +2610,7 @@ func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *DeleteSessionResponse) GetIsSuccess() bool {
@@ -1865,7 +2634,7 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"remoteAddr\"9\n" +
 	"\bWaypoint\x12\x1b\n" +
 	"\trouter_id\x18\x01 \x01(\tR\brouterId\x12\x10\n" +
-	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xd9\x03\n" +
+	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xbb\x04\n" +
 	"\bSRPolicy\x12*\n" +
 	"\x11pcep_session_addr\x18\x01 \x01(\fR\x0fpcepSessionAddr\x12\x19\n" +
 	"\bsrc_addr\x18\x02 \x01(\fR\asrcAddr\x12\x19\n" +
@@ -1882,7 +2651,10 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\fsegment_list\x18\n" +
 	" \x03(\v2\x14.api.pola.v1.SegmentR\vsegmentList\x12/\n" +
 	"\x06metric\x18\v \x01(\x0e2\x17.api.pola.v1.MetricTypeR\x06metric\x123\n" +
-	"\twaypoints\x18\f \x03(\v2\x15.api.pola.v1.WaypointR\twaypoints\"\xcb\x01\n" +
+	"\twaypoints\x18\f \x03(\v2\x15.api.pola.v1.WaypointR\twaypoints\x12\x17\n" +
+	"\aplsp_id\x18\r \x01(\rR\x06plspId\x12\x15\n" +
+	"\x06lsp_id\x18\x0e \x01(\rR\x05lspId\x120\n" +
+	"\x05state\x18\x0f \x01(\x0e2\x1a.api.pola.v1.SRPolicyStateR\x05state\"\xcb\x01\n" +
 	"\x15CreateSRPolicyRequest\x122\n" +
 	"\tsr_policy\x18\x01 \x01(\v2\x15.api.pola.v1.SRPolicyR\bsrPolicy\x12\x10\n" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\x120\n" +
@@ -1896,17 +2668,60 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\"7\n" +
 	"\x16DeleteSRPolicyResponse\x12\x1d\n" +
 	"\n" +
-	"is_success\x18\x01 \x01(\bR\tisSuccess\"\x7f\n" +
+	"is_success\x18\x01 \x01(\bR\tisSuccess\"\xab\x02\n" +
+	"\x12StatefulCapability\x12\x1d\n" +
+	"\n" +
+	"lsp_update\x18\x01 \x01(\bR\tlspUpdate\x12,\n" +
+	"\x12include_db_version\x18\x02 \x01(\bR\x10includeDbVersion\x12+\n" +
+	"\x11lsp_instantiation\x18\x03 \x01(\bR\x10lspInstantiation\x12)\n" +
+	"\x10triggered_resync\x18\x04 \x01(\bR\x0ftriggeredResync\x12$\n" +
+	"\x0edelta_lsp_sync\x18\x05 \x01(\bR\fdeltaLspSync\x124\n" +
+	"\x16triggered_initial_sync\x18\x06 \x01(\bR\x14triggeredInitialSync\x12\x14\n" +
+	"\x05color\x18\a \x01(\bR\x05color\"j\n" +
+	"\fSrCapability\x12#\n" +
+	"\runlimited_msd\x18\x01 \x01(\bR\funlimitedMsd\x12#\n" +
+	"\rnai_supported\x18\x02 \x01(\bR\fnaiSupported\x12\x10\n" +
+	"\x03msd\x18\x03 \x01(\rR\x03msd\"5\n" +
+	"\x0eSrv6Capability\x12#\n" +
+	"\rnai_supported\x18\x01 \x01(\bR\fnaiSupported\"C\n" +
+	"\x17PathSetupTypeCapability\x12(\n" +
+	"\x10path_setup_types\x18\x01 \x03(\rR\x0epathSetupTypes\":\n" +
+	"\x17AssocTypeListCapability\x12\x1f\n" +
+	"\vassoc_types\x18\x01 \x03(\rR\n" +
+	"assocTypes\"?\n" +
+	"\x16LspDbVersionCapability\x12%\n" +
+	"\x0eversion_number\x18\x01 \x01(\x04R\rversionNumber\"\xc7\x01\n" +
+	"\x13MultipathCapability\x12%\n" +
+	"\x0emax_multipaths\x18\x01 \x01(\rR\rmaxMultipaths\x12\x1a\n" +
+	"\bweighted\x18\x02 \x01(\bR\bweighted\x12!\n" +
+	"\fopposite_dir\x18\x03 \x01(\bR\voppositeDir\x12#\n" +
+	"\rforward_class\x18\x04 \x01(\bR\fforwardClass\x12%\n" +
+	"\x0ecomposite_path\x18\x05 \x01(\bR\rcompositePath\"J\n" +
+	"\x1bVendorInformationCapability\x12+\n" +
+	"\x11enterprise_number\x18\x01 \x01(\rR\x10enterpriseNumber\".\n" +
+	"\x11UnknownCapability\x12\x19\n" +
+	"\btlv_type\x18\x01 \x01(\rR\atlvType\"\xac\x05\n" +
+	"\n" +
+	"Capability\x12/\n" +
+	"\x04type\x18\x01 \x01(\x0e2\x1b.api.pola.v1.CapabilityTypeR\x04type\x12=\n" +
+	"\bstateful\x18\x02 \x01(\v2\x1f.api.pola.v1.StatefulCapabilityH\x00R\bstateful\x12+\n" +
+	"\x02sr\x18\x03 \x01(\v2\x19.api.pola.v1.SrCapabilityH\x00R\x02sr\x121\n" +
+	"\x04srv6\x18\x04 \x01(\v2\x1b.api.pola.v1.Srv6CapabilityH\x00R\x04srv6\x12N\n" +
+	"\x0fpath_setup_type\x18\x05 \x01(\v2$.api.pola.v1.PathSetupTypeCapabilityH\x00R\rpathSetupType\x12N\n" +
+	"\x0fassoc_type_list\x18\x06 \x01(\v2$.api.pola.v1.AssocTypeListCapabilityH\x00R\rassocTypeList\x12K\n" +
+	"\x0elsp_db_version\x18\a \x01(\v2#.api.pola.v1.LspDbVersionCapabilityH\x00R\flspDbVersion\x12@\n" +
+	"\tmultipath\x18\b \x01(\v2 .api.pola.v1.MultipathCapabilityH\x00R\tmultipath\x12Y\n" +
+	"\x12vendor_information\x18\t \x01(\v2(.api.pola.v1.VendorInformationCapabilityH\x00R\x11vendorInformation\x12:\n" +
+	"\aunknown\x18\n" +
+	" \x01(\v2\x1e.api.pola.v1.UnknownCapabilityH\x00R\aunknownB\b\n" +
+	"\x06detail\"\xec\x01\n" +
 	"\aSession\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\fR\x04addr\x12/\n" +
-	"\x05state\x18\x02 \x01(\x0e2\x19.api.pola.v1.SessionStateR\x05state\x12\x12\n" +
-	"\x04caps\x18\x03 \x03(\tR\x04caps\x12\x1b\n" +
-	"\tis_synced\x18\x04 \x01(\bR\bisSynced\"?\n" +
-	"\vSessionList\x120\n" +
-	"\bsessions\x18\x01 \x03(\v2\x14.api.pola.v1.SessionR\bsessions\"F\n" +
-	"\fSRPolicyList\x126\n" +
-	"\vsr_policies\x18\x01 \x03(\v2\x15.api.pola.v1.SRPolicyR\n" +
-	"srPolicies\"b\n" +
+	"\x05state\x18\x02 \x01(\x0e2\x19.api.pola.v1.SessionStateR\x05state\x12\x1b\n" +
+	"\tis_synced\x18\x04 \x01(\bR\bisSynced\x12;\n" +
+	"\fcapabilities\x18\x05 \x03(\v2\x17.api.pola.v1.CapabilityR\fcapabilities\x126\n" +
+	"\vsr_policies\x18\x06 \x03(\v2\x15.api.pola.v1.SRPolicyR\n" +
+	"srPoliciesJ\x04\b\x03\x10\x04R\x04caps\"b\n" +
 	"\x10EndpointBehavior\x12\x1a\n" +
 	"\bbehavior\x18\x01 \x01(\rR\bbehavior\x12\x14\n" +
 	"\x05flags\x18\x02 \x01(\rR\x05flags\x12\x1c\n" +
@@ -1970,11 +2785,11 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\bls_nodes\x18\x02 \x03(\v2\x13.api.pola.v1.LsNodeR\alsNodes\"\x17\n" +
 	"\x15GetSessionListRequest\"J\n" +
 	"\x16GetSessionListResponse\x120\n" +
-	"\bsessions\x18\x01 \x03(\v2\x14.api.pola.v1.SessionR\bsessions\"\x18\n" +
-	"\x16GetSRPolicyListRequest\"Q\n" +
-	"\x17GetSRPolicyListResponse\x126\n" +
-	"\vsr_policies\x18\x01 \x03(\v2\x15.api.pola.v1.SRPolicyR\n" +
-	"srPolicies\"\x0f\n" +
+	"\bsessions\x18\x01 \x03(\v2\x14.api.pola.v1.SessionR\bsessions\";\n" +
+	"\x16GetSRPolicyListRequest\x12!\n" +
+	"\fsession_addr\x18\x01 \x01(\fR\vsessionAddr\"^\n" +
+	"\x17GetSRPolicyListResponse\x120\n" +
+	"\bsessions\x18\x02 \x03(\v2\x14.api.pola.v1.SessionR\bsessionsJ\x04\b\x01\x10\x02R\vsr_policies\"\x0f\n" +
 	"\rGetTEDRequest\"X\n" +
 	"\x0eGetTEDResponse\x12\x16\n" +
 	"\x06enable\x18\x01 \x01(\bR\x06enable\x12.\n" +
@@ -1987,11 +2802,28 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\fSRPolicyType\x12\x1e\n" +
 	"\x1aSR_POLICY_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17SR_POLICY_TYPE_EXPLICIT\x10\x01\x12\x1a\n" +
-	"\x16SR_POLICY_TYPE_DYNAMIC\x10\x02*[\n" +
+	"\x16SR_POLICY_TYPE_DYNAMIC\x10\x02*\x9b\x01\n" +
+	"\rSRPolicyState\x12\x1f\n" +
+	"\x1bSR_POLICY_STATE_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14SR_POLICY_STATE_DOWN\x10\x01\x12\x16\n" +
+	"\x12SR_POLICY_STATE_UP\x10\x02\x12\x1a\n" +
+	"\x16SR_POLICY_STATE_ACTIVE\x10\x03\x12\x1b\n" +
+	"\x17SR_POLICY_STATE_UNKNOWN\x10\x04*[\n" +
 	"\fSessionState\x12\x1d\n" +
 	"\x19SESSION_STATE_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12SESSION_STATE_DOWN\x10\x01\x12\x14\n" +
-	"\x10SESSION_STATE_UP\x10\x02*\x83\x01\n" +
+	"\x10SESSION_STATE_UP\x10\x02*\xd3\x02\n" +
+	"\x0eCapabilityType\x12\x1f\n" +
+	"\x1bCAPABILITY_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
+	"\x18CAPABILITY_TYPE_STATEFUL\x10\x01\x12\x16\n" +
+	"\x12CAPABILITY_TYPE_SR\x10\x02\x12\x18\n" +
+	"\x14CAPABILITY_TYPE_SRV6\x10\x03\x12#\n" +
+	"\x1fCAPABILITY_TYPE_PATH_SETUP_TYPE\x10\x04\x12#\n" +
+	"\x1fCAPABILITY_TYPE_ASSOC_TYPE_LIST\x10\x05\x12\"\n" +
+	"\x1eCAPABILITY_TYPE_LSP_DB_VERSION\x10\x06\x12\x1d\n" +
+	"\x19CAPABILITY_TYPE_MULTIPATH\x10\a\x12&\n" +
+	"\"CAPABILITY_TYPE_VENDOR_INFORMATION\x10\b\x12\x1b\n" +
+	"\x17CAPABILITY_TYPE_UNKNOWN\x10\t*\x83\x01\n" +
 	"\n" +
 	"MetricType\x12\x1b\n" +
 	"\x17METRIC_TYPE_UNSPECIFIED\x10\x00\x12\x13\n" +
@@ -2020,85 +2852,106 @@ func file_api_pola_v1_pola_proto_rawDescGZIP() []byte {
 	return file_api_pola_v1_pola_proto_rawDescData
 }
 
-var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_api_pola_v1_pola_proto_goTypes = []any{
-	(SRPolicyType)(0),               // 0: api.pola.v1.SRPolicyType
-	(SessionState)(0),               // 1: api.pola.v1.SessionState
-	(MetricType)(0),                 // 2: api.pola.v1.MetricType
-	(*Segment)(nil),                 // 3: api.pola.v1.Segment
-	(*Waypoint)(nil),                // 4: api.pola.v1.Waypoint
-	(*SRPolicy)(nil),                // 5: api.pola.v1.SRPolicy
-	(*CreateSRPolicyRequest)(nil),   // 6: api.pola.v1.CreateSRPolicyRequest
-	(*CreateSRPolicyResponse)(nil),  // 7: api.pola.v1.CreateSRPolicyResponse
-	(*DeleteSRPolicyRequest)(nil),   // 8: api.pola.v1.DeleteSRPolicyRequest
-	(*DeleteSRPolicyResponse)(nil),  // 9: api.pola.v1.DeleteSRPolicyResponse
-	(*Session)(nil),                 // 10: api.pola.v1.Session
-	(*SessionList)(nil),             // 11: api.pola.v1.SessionList
-	(*SRPolicyList)(nil),            // 12: api.pola.v1.SRPolicyList
-	(*EndpointBehavior)(nil),        // 13: api.pola.v1.EndpointBehavior
-	(*SidStructure)(nil),            // 14: api.pola.v1.SidStructure
-	(*SID)(nil),                     // 15: api.pola.v1.SID
-	(*MultiTopoID)(nil),             // 16: api.pola.v1.MultiTopoID
-	(*LsSrv6SID)(nil),               // 17: api.pola.v1.LsSrv6SID
-	(*LsPrefix)(nil),                // 18: api.pola.v1.LsPrefix
-	(*Metric)(nil),                  // 19: api.pola.v1.Metric
-	(*Srv6EndXSID)(nil),             // 20: api.pola.v1.Srv6EndXSID
-	(*LsLink)(nil),                  // 21: api.pola.v1.LsLink
-	(*LsNode)(nil),                  // 22: api.pola.v1.LsNode
-	(*TED)(nil),                     // 23: api.pola.v1.TED
-	(*GetSessionListRequest)(nil),   // 24: api.pola.v1.GetSessionListRequest
-	(*GetSessionListResponse)(nil),  // 25: api.pola.v1.GetSessionListResponse
-	(*GetSRPolicyListRequest)(nil),  // 26: api.pola.v1.GetSRPolicyListRequest
-	(*GetSRPolicyListResponse)(nil), // 27: api.pola.v1.GetSRPolicyListResponse
-	(*GetTEDRequest)(nil),           // 28: api.pola.v1.GetTEDRequest
-	(*GetTEDResponse)(nil),          // 29: api.pola.v1.GetTEDResponse
-	(*DeleteSessionRequest)(nil),    // 30: api.pola.v1.DeleteSessionRequest
-	(*DeleteSessionResponse)(nil),   // 31: api.pola.v1.DeleteSessionResponse
+	(SRPolicyType)(0),                   // 0: api.pola.v1.SRPolicyType
+	(SRPolicyState)(0),                  // 1: api.pola.v1.SRPolicyState
+	(SessionState)(0),                   // 2: api.pola.v1.SessionState
+	(CapabilityType)(0),                 // 3: api.pola.v1.CapabilityType
+	(MetricType)(0),                     // 4: api.pola.v1.MetricType
+	(*Segment)(nil),                     // 5: api.pola.v1.Segment
+	(*Waypoint)(nil),                    // 6: api.pola.v1.Waypoint
+	(*SRPolicy)(nil),                    // 7: api.pola.v1.SRPolicy
+	(*CreateSRPolicyRequest)(nil),       // 8: api.pola.v1.CreateSRPolicyRequest
+	(*CreateSRPolicyResponse)(nil),      // 9: api.pola.v1.CreateSRPolicyResponse
+	(*DeleteSRPolicyRequest)(nil),       // 10: api.pola.v1.DeleteSRPolicyRequest
+	(*DeleteSRPolicyResponse)(nil),      // 11: api.pola.v1.DeleteSRPolicyResponse
+	(*StatefulCapability)(nil),          // 12: api.pola.v1.StatefulCapability
+	(*SrCapability)(nil),                // 13: api.pola.v1.SrCapability
+	(*Srv6Capability)(nil),              // 14: api.pola.v1.Srv6Capability
+	(*PathSetupTypeCapability)(nil),     // 15: api.pola.v1.PathSetupTypeCapability
+	(*AssocTypeListCapability)(nil),     // 16: api.pola.v1.AssocTypeListCapability
+	(*LspDbVersionCapability)(nil),      // 17: api.pola.v1.LspDbVersionCapability
+	(*MultipathCapability)(nil),         // 18: api.pola.v1.MultipathCapability
+	(*VendorInformationCapability)(nil), // 19: api.pola.v1.VendorInformationCapability
+	(*UnknownCapability)(nil),           // 20: api.pola.v1.UnknownCapability
+	(*Capability)(nil),                  // 21: api.pola.v1.Capability
+	(*Session)(nil),                     // 22: api.pola.v1.Session
+	(*EndpointBehavior)(nil),            // 23: api.pola.v1.EndpointBehavior
+	(*SidStructure)(nil),                // 24: api.pola.v1.SidStructure
+	(*SID)(nil),                         // 25: api.pola.v1.SID
+	(*MultiTopoID)(nil),                 // 26: api.pola.v1.MultiTopoID
+	(*LsSrv6SID)(nil),                   // 27: api.pola.v1.LsSrv6SID
+	(*LsPrefix)(nil),                    // 28: api.pola.v1.LsPrefix
+	(*Metric)(nil),                      // 29: api.pola.v1.Metric
+	(*Srv6EndXSID)(nil),                 // 30: api.pola.v1.Srv6EndXSID
+	(*LsLink)(nil),                      // 31: api.pola.v1.LsLink
+	(*LsNode)(nil),                      // 32: api.pola.v1.LsNode
+	(*TED)(nil),                         // 33: api.pola.v1.TED
+	(*GetSessionListRequest)(nil),       // 34: api.pola.v1.GetSessionListRequest
+	(*GetSessionListResponse)(nil),      // 35: api.pola.v1.GetSessionListResponse
+	(*GetSRPolicyListRequest)(nil),      // 36: api.pola.v1.GetSRPolicyListRequest
+	(*GetSRPolicyListResponse)(nil),     // 37: api.pola.v1.GetSRPolicyListResponse
+	(*GetTEDRequest)(nil),               // 38: api.pola.v1.GetTEDRequest
+	(*GetTEDResponse)(nil),              // 39: api.pola.v1.GetTEDResponse
+	(*DeleteSessionRequest)(nil),        // 40: api.pola.v1.DeleteSessionRequest
+	(*DeleteSessionResponse)(nil),       // 41: api.pola.v1.DeleteSessionResponse
 }
 var file_api_pola_v1_pola_proto_depIdxs = []int32{
 	0,  // 0: api.pola.v1.SRPolicy.type:type_name -> api.pola.v1.SRPolicyType
-	3,  // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
-	2,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
-	4,  // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
-	5,  // 4: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	5,  // 5: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	1,  // 6: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
-	10, // 7: api.pola.v1.SessionList.sessions:type_name -> api.pola.v1.Session
-	5,  // 8: api.pola.v1.SRPolicyList.sr_policies:type_name -> api.pola.v1.SRPolicy
-	15, // 9: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
-	13, // 10: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
-	14, // 11: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
-	16, // 12: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
-	2,  // 13: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
-	15, // 14: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
-	14, // 15: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	19, // 16: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	20, // 17: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
-	21, // 18: api.pola.v1.LsNode.ls_links:type_name -> api.pola.v1.LsLink
-	18, // 19: api.pola.v1.LsNode.ls_prefixes:type_name -> api.pola.v1.LsPrefix
-	17, // 20: api.pola.v1.LsNode.ls_srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	22, // 21: api.pola.v1.TED.ls_nodes:type_name -> api.pola.v1.LsNode
-	10, // 22: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	5,  // 23: api.pola.v1.GetSRPolicyListResponse.sr_policies:type_name -> api.pola.v1.SRPolicy
-	22, // 24: api.pola.v1.GetTEDResponse.ls_nodes:type_name -> api.pola.v1.LsNode
-	6,  // 25: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	8,  // 26: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	24, // 27: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	26, // 28: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	28, // 29: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	30, // 30: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	7,  // 31: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	9,  // 32: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	25, // 33: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	27, // 34: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	29, // 35: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	31, // 36: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	31, // [31:37] is the sub-list for method output_type
-	25, // [25:31] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	5,  // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
+	4,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
+	6,  // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
+	1,  // 4: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
+	7,  // 5: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	7,  // 6: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	3,  // 7: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
+	12, // 8: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
+	13, // 9: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
+	14, // 10: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
+	15, // 11: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
+	16, // 12: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
+	17, // 13: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
+	18, // 14: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
+	19, // 15: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
+	20, // 16: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
+	2,  // 17: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
+	21, // 18: api.pola.v1.Session.capabilities:type_name -> api.pola.v1.Capability
+	7,  // 19: api.pola.v1.Session.sr_policies:type_name -> api.pola.v1.SRPolicy
+	25, // 20: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
+	23, // 21: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	24, // 22: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
+	26, // 23: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
+	4,  // 24: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
+	25, // 25: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
+	24, // 26: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
+	29, // 27: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	30, // 28: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
+	31, // 29: api.pola.v1.LsNode.ls_links:type_name -> api.pola.v1.LsLink
+	28, // 30: api.pola.v1.LsNode.ls_prefixes:type_name -> api.pola.v1.LsPrefix
+	27, // 31: api.pola.v1.LsNode.ls_srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	32, // 32: api.pola.v1.TED.ls_nodes:type_name -> api.pola.v1.LsNode
+	22, // 33: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	22, // 34: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.Session
+	32, // 35: api.pola.v1.GetTEDResponse.ls_nodes:type_name -> api.pola.v1.LsNode
+	8,  // 36: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	10, // 37: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	34, // 38: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	36, // 39: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	38, // 40: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	40, // 41: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	9,  // 42: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	11, // 43: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	35, // 44: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	37, // 45: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	39, // 46: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	41, // 47: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	42, // [42:48] is the sub-list for method output_type
+	36, // [36:42] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }
@@ -2106,14 +2959,25 @@ func file_api_pola_v1_pola_proto_init() {
 	if File_api_pola_v1_pola_proto != nil {
 		return
 	}
-	file_api_pola_v1_pola_proto_msgTypes[15].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[16].OneofWrappers = []any{
+		(*Capability_Stateful)(nil),
+		(*Capability_Sr)(nil),
+		(*Capability_Srv6)(nil),
+		(*Capability_PathSetupType)(nil),
+		(*Capability_AssocTypeList)(nil),
+		(*Capability_LspDbVersion)(nil),
+		(*Capability_Multipath)(nil),
+		(*Capability_VendorInformation)(nil),
+		(*Capability_Unknown)(nil),
+	}
+	file_api_pola_v1_pola_proto_msgTypes[23].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_pola_v1_pola_proto_rawDesc), len(file_api_pola_v1_pola_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   29,
+			NumEnums:      5,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -36,6 +36,14 @@ message Waypoint {
   string sid = 2; // optional: explicit SID override
 }
 
+enum SRPolicyState {
+  SR_POLICY_STATE_UNSPECIFIED = 0;
+  SR_POLICY_STATE_DOWN = 1;
+  SR_POLICY_STATE_UP = 2;
+  SR_POLICY_STATE_ACTIVE = 3;
+  SR_POLICY_STATE_UNKNOWN = 4;
+}
+
 message SRPolicy {
   bytes pcep_session_addr = 1;
   bytes src_addr = 2;
@@ -49,22 +57,17 @@ message SRPolicy {
   repeated Segment segment_list = 10;
   MetricType metric = 11;
   repeated Waypoint waypoints = 12;
+  uint32 plsp_id = 13;
+  uint32 lsp_id = 14;
+  SRPolicyState state = 15;
 }
 
 message CreateSRPolicyRequest {
   SRPolicy sr_policy = 1;
-
-  // Not required when disable_path_compute is true.
   uint32 asn = 2;
-
   reserved 3;
   reserved "sid_validate";
-
-  // Use endpoints and segments provided in the request without TED lookup
-  // or path computation (no CSPF or router-ID resolution).
   bool disable_path_compute = 4;
-
-  // Skip checking that explicit SIDs exist in the TED.
   bool no_sid_validate = 5;
 }
 
@@ -87,19 +90,92 @@ enum SessionState {
   SESSION_STATE_UP = 2;
 }
 
+enum CapabilityType {
+  CAPABILITY_TYPE_UNSPECIFIED = 0;
+  CAPABILITY_TYPE_STATEFUL = 1;
+  CAPABILITY_TYPE_SR = 2;
+  CAPABILITY_TYPE_SRV6 = 3;
+  CAPABILITY_TYPE_PATH_SETUP_TYPE = 4;
+  CAPABILITY_TYPE_ASSOC_TYPE_LIST = 5;
+  CAPABILITY_TYPE_LSP_DB_VERSION = 6;
+  CAPABILITY_TYPE_MULTIPATH = 7;
+  CAPABILITY_TYPE_VENDOR_INFORMATION = 8;
+  CAPABILITY_TYPE_UNKNOWN = 9;
+}
+
+message StatefulCapability {
+  bool lsp_update = 1;
+  bool include_db_version = 2;
+  bool lsp_instantiation = 3;
+  bool triggered_resync = 4;
+  bool delta_lsp_sync = 5;
+  bool triggered_initial_sync = 6;
+  bool color = 7;
+}
+
+message SrCapability {
+  bool unlimited_msd = 1;
+  bool nai_supported = 2;
+  uint32 msd = 3;
+}
+
+message Srv6Capability {
+  bool nai_supported = 1;
+}
+
+message PathSetupTypeCapability {
+  repeated uint32 path_setup_types = 1;
+}
+
+message AssocTypeListCapability {
+  repeated uint32 assoc_types = 1;
+}
+
+message LspDbVersionCapability {
+  uint64 version_number = 1;
+}
+
+message MultipathCapability {
+  uint32 max_multipaths = 1;
+  bool weighted = 2;
+  bool opposite_dir = 3;
+  bool forward_class = 4;
+  bool composite_path = 5;
+}
+
+message VendorInformationCapability {
+  uint32 enterprise_number = 1;
+}
+
+message UnknownCapability {
+  uint32 tlv_type = 1;
+}
+
+message Capability {
+  CapabilityType type = 1;
+
+  oneof detail {
+    StatefulCapability stateful = 2;
+    SrCapability sr = 3;
+    Srv6Capability srv6 = 4;
+    PathSetupTypeCapability path_setup_type = 5;
+    AssocTypeListCapability assoc_type_list = 6;
+    LspDbVersionCapability lsp_db_version = 7;
+    MultipathCapability multipath = 8;
+    VendorInformationCapability vendor_information = 9;
+    UnknownCapability unknown = 10;
+  }
+}
+
 message Session {
   bytes addr = 1;
   SessionState state = 2;
-  repeated string caps = 3;
+  reserved 3;
+  reserved "caps";
   bool is_synced = 4;
-}
-
-message SessionList {
-  repeated Session sessions = 1;
-}
-
-message SRPolicyList {
-  repeated SRPolicy sr_policies = 1;
+  repeated Capability capabilities = 5;
+  // Populated by GetSRPolicyList; empty when returned from GetSessionList.
+  repeated SRPolicy sr_policies = 6;
 }
 
 message EndpointBehavior {
@@ -191,10 +267,14 @@ message GetSessionListResponse {
 }
 
 message GetSRPolicyListRequest {
+  // Optional filter: only return policies for the PCEP session with this peer address.
+  bytes session_addr = 1;
 }
 
 message GetSRPolicyListResponse {
-  repeated SRPolicy sr_policies = 1;
+  reserved 1;
+  reserved "sr_policies";
+  repeated Session sessions = 2;
 }
 
 message GetTEDRequest {

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -64,10 +64,18 @@ message SRPolicy {
 
 message CreateSRPolicyRequest {
   SRPolicy sr_policy = 1;
+
+  // Not required when disable_path_compute is true.
   uint32 asn = 2;
+
   reserved 3;
   reserved "sid_validate";
+
+  // Use endpoints and segments provided in the request without TED lookup
+  // or path computation (no CSPF or router-ID resolution).
   bool disable_path_compute = 4;
+
+  // Skip checking that explicit SIDs exist in the TED.
   bool no_sid_validate = 5;
 }
 

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -1,6 +1,6 @@
 # Pola CLI Tool
 
-## Instllation
+## Installation
 
 ### From Go Package
 
@@ -30,7 +30,7 @@ go install ./...
 
 ### pola session \[-j\]
 
-Displays the peer addresses of the active session.
+Displays the peer addresses of the active session, sorted by address.
 
 JSON formatted response
 
@@ -38,27 +38,38 @@ JSON formatted response
 [
   {
     "Addr": "192.0.2.1",
-    "State": "UP",
-    "Caps": [
-      "Stateful",
-      "Update",
-      "Initiate",
-      "SR-TE",
-    ]
-  },
-  {
-    "Addr": "192.0.2.2",
-    "State": "UP",
-    "Caps": [
-      "Stateful",
-      "Update",
-      "Initiate",
-      "SR-TE",
-      "SRv6-TE"
-    ]
+    "State": "SESSION_STATE_UP",
+    "Capabilities": [
+      {
+        "Type": "STATEFUL",
+        "Detail": {
+          "LSPUpdate": true,
+          "IncludeDBVersion": false,
+          "LSPInstantiation": true,
+          "TriggeredResync": false,
+          "DeltaLSPSync": false,
+          "TriggeredInitialSync": false,
+          "Color": false
+        }
+      },
+      {
+        "Type": "SR",
+        "Detail": {
+          "UnlimitedMSD": false,
+          "NAISupported": true,
+          "MSD": 10
+        }
+      }
+    ],
+    "IsSynced": true
   }
 ]
 ```
+
+`Capabilities` is the list of advertised capability TLVs, one entry per TLV.
+`Type` identifies the TLV, and `Detail` carries its type-specific fields
+(e.g. `MSD` for the SR capability, `VersionNumber` for LSP-DB-Version); it is
+omitted for TLVs with no fields beyond their type.
 
 ### pola session delete *Address* \[-j\]
 
@@ -72,99 +83,76 @@ JSON formatted response
 }
 ```
 
-### pola sr-policy list \[-j\]
+### pola sr-policy list \[-j\] \[--session *address*\]
 
-Displays the lsp list managed by polad.
+Displays the SR Policies managed by polad, grouped by PCEP session and sorted
+by session address. Pass `--session` to only show policies on the session
+with that peer address.
 
 JSON formatted response
 
 ```json
-{
-  "lsps": [
-    {
-      "color": 999,
-      "dstAddr": "192.0.2.1",
-      "segmentList": [
-        16003,
-        16001
-      ],
-      "peerAddr": "192.0.2.2",
-      "policyName": "sample_policy1",
-      "preference": 100,
-      "srcAddr": "192.0.2.2"
-    },
-    {
-      "color": 888,
-      "dstAddr": "192.0.2.2",
-      "segmentList": [
-        16003,
-        16002
-      ],
-      "peerAddr": "192.0.2.1",
-      "policyName": "sample_policy2",
-      "preference": 100,
-      "srcAddr": "192.0.2.1"
-    }
-  ]
-}
+[
+  {
+    "peerAddr": "192.0.2.2",
+    "srPolicies": [
+      {
+        "plspId": 1,
+        "policyName": "sample_policy1",
+        "segmentList": [
+          { "sid": 16003 },
+          { "sid": 16001 }
+        ],
+        "srcAddr": "192.0.2.2",
+        "dstAddr": "192.0.2.1",
+        "srcRouterId": "0000.0aff.0002",
+        "dstRouterId": "0000.0aff.0001",
+        "color": 999,
+        "preference": 100,
+        "lspId": 1,
+        "state": "up",
+        "type": "explicit"
+      }
+    ]
+  },
+  {
+    "peerAddr": "2001:0db8::1",
+    "srPolicies": [
+      {
+        "plspId": 1,
+        "policyName": "sample_policy2",
+        "segmentList": [
+          {
+            "sid": "2001:0db8:1005::",
+            "localAddr": "2001:0db8::5",
+            "sidStructure": "32,16,0,80"
+          }
+        ],
+        "srcAddr": "2001:0db8::1",
+        "dstAddr": "2001:0db8::2",
+        "color": 888,
+        "preference": 100,
+        "lspId": 1,
+        "state": "active",
+        "type": "dynamic",
+        "metric": "te"
+      }
+    ]
+  }
+]
 ```
 
-※ want to change to this format later.
+Notes:
 
-```json
-  "peers": [
-    {
-      "peerAddr": "192.0.2.1",
-      "lsps": [
-        {
-          "policyName": "sample_policy1",
-          "srcAddr": "192.0.2.1",
-          "dstAddr": "192.0.2.2",
-          "segmentList": [
-            16003,
-            16002
-          ]
-        },
-        {
-          "policyName": "sample_policy2",
-          "srcAddr": "192.0.2.1",
-          "dstAddr": "192.0.2.2",
-          "segmentList": [
-            16003,
-            16001,
-            16002
-          ]
-        }
-      ]
-    },
-    {
-      "peerAddr": "192.0.2.2",
-      "lsps": [
-        {
-          "policyName": "sample_policy3",
-          "srcAddr": "192.0.2.2",
-          "dstAddr": "192.0.2.1",
-          "segmentList": [
-            16003,
-            16001
-          ]
-        },
-        {
-          "policyName": "sample_policy4",
-          "srcAddr": "192.0.2.2",
-          "dstAddr": "192.0.2.1",
-          "segmentList": [
-            16003,
-            16002,
-            16001
-          ]
-        }
-      ]
-    }
-  ]
-}
-
-```
+- `plspId`, `lspId`, and `state` reflect the latest PCRpt received. They may
+  be omitted for newly created policies before the first report.
+- `srcRouterId`/`dstRouterId` are resolved from TED loopback addresses and are
+  omitted when no matching node is found.
+- `segmentList` entries include `localAddr`/`remoteAddr` when the SID carries
+  NAI information. SRv6 segments may also include `sidStructure`.
+- `type` and `metric` reflect the candidate-path settings used when the policy
+  was created by `pola sr-policy add`. They are omitted for policies discovered
+  from the router or after a polad restart.
 
 ### pola sr-policy add -f `filepath`
 
@@ -178,11 +166,11 @@ YAML input format
 asn: 65000
 srPolicy:
   pcepSessionAddr: 192.0.2.1
-  name: policy-name    
+  name: policy-name
   srcRouterID: 0000.0aff.0001
   dstRouterID: 0000.0aff.0004
   color: 100
-  type: dynamic 
+  type: dynamic
   metric: igp / te / delay
 ```
 
@@ -204,7 +192,7 @@ YAML input format
 asn: 65000
 srPolicy:
   pcepSessionAddr: 192.0.2.1
-  name: policy-name    
+  name: policy-name
   srcRouterID: 0000.0aff.0001
   dstRouterID: 0000.0aff.0004
   color: 100
@@ -263,7 +251,7 @@ srPolicy:
       sidStructure: "32,16,0,80"
 ```
 
-json formatted response
+JSON formatted response
 
 ```json
 {
@@ -291,7 +279,7 @@ Notes:
 
 ### pola ted \[-j\]
 
-Displays the ted managed by polad.
+Displays the TED managed by polad.
 
 JSON formatted response
 
@@ -442,21 +430,21 @@ JSON formatted response
 
 ## Completion
 
-## Bash
+### Bash
 
 ```bash
 pola completion bash | sudo tee -a /usr/share/bash-completion/completions/pola >/dev/null
 source /usr/share/bash-completion/completions/pola
 ```
 
-## Zsh
+### Zsh
 
 ```bash
 pola completion zsh > /usr/local/share/zsh/site-functions/_pola
 compinit
 ```
 
-## Fish
+### Fish
 
 ```bash
 pola completion fish > ~/.config/fish/completions/pola.fish

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -144,8 +144,9 @@ JSON formatted response
 
 Notes:
 
-- `plspId`, `lspId`, and `state` reflect the latest PCRpt received. They may
-  be omitted for newly created policies before the first report.
+- Policies appear in this list only after their first PCRpt is received.
+- `lspId` is omitted when the reported LSP-ID is zero. `plspId` and `state`
+  reflect the latest PCRpt received.
 - `srcRouterId`/`dstRouterId` are resolved from TED loopback addresses and are
   omitted when no matching node is found.
 - `segmentList` entries include `localAddr`/`remoteAddr` when the SID carries

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -189,7 +189,7 @@ type Capability struct {
 // Strings returns the human-readable flags for this capability's TLV.
 func (c Capability) Strings() []string {
 	if c.Detail == nil {
-		return nil
+		return []string{c.Type}
 	}
 	return c.Detail.Strings()
 }

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -8,7 +8,10 @@ package grpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/netip"
+	"strconv"
+	"strings"
 	"time"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
@@ -19,11 +22,236 @@ func withTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), time.Second)
 }
 
+// StatefulCapability holds the RFC 8231/8232 Stateful PCE capability flags.
+type StatefulCapability struct {
+	LSPUpdate            bool
+	IncludeDBVersion     bool
+	LSPInstantiation     bool
+	TriggeredResync      bool
+	DeltaLSPSync         bool
+	TriggeredInitialSync bool
+	Color                bool
+}
+
+func (c StatefulCapability) Strings() []string {
+	ret := []string{"Stateful"}
+	if c.LSPUpdate {
+		ret = append(ret, "Update")
+	}
+	if c.IncludeDBVersion {
+		ret = append(ret, "Include-DB-Ver")
+	}
+	if c.LSPInstantiation {
+		ret = append(ret, "Instantiation")
+	}
+	if c.TriggeredResync {
+		ret = append(ret, "Triggered-Resync")
+	}
+	if c.DeltaLSPSync {
+		ret = append(ret, "Delta-LSP-Sync")
+	}
+	if c.TriggeredInitialSync {
+		ret = append(ret, "Triggered-Initial-Sync")
+	}
+	if c.Color {
+		ret = append(ret, "Color")
+	}
+	return ret
+}
+
+// SRCapability holds the RFC 8664 SR-PCE capability flags.
+type SRCapability struct {
+	UnlimitedMSD bool
+	NAISupported bool
+	MSD          uint32
+}
+
+func (c SRCapability) Strings() []string {
+	ret := []string{"SR"}
+	if c.UnlimitedMSD {
+		ret = append(ret, "Unlimited-SID-Depth")
+	} else {
+		ret = append(ret, fmt.Sprintf("MSD=%d", c.MSD))
+	}
+	if c.NAISupported {
+		ret = append(ret, "SR-NAI-Supported")
+	}
+	return ret
+}
+
+// SRv6Capability holds the RFC 9603 SRv6-PCE capability flags.
+type SRv6Capability struct {
+	NAISupported bool
+}
+
+func (c SRv6Capability) Strings() []string {
+	ret := []string{"SRv6"}
+	if c.NAISupported {
+		ret = append(ret, "SRv6-NAI-Supported")
+	}
+	return ret
+}
+
+// PathSetupTypeCapability holds the raw PathSetupType values advertised by the peer.
+type PathSetupTypeCapability struct {
+	PathSetupTypes []uint32
+}
+
+func (c PathSetupTypeCapability) Strings() []string {
+	var ret []string
+	for _, pst := range c.PathSetupTypes {
+		switch pst {
+		case 1:
+			ret = append(ret, "SR-TE")
+		case 3:
+			ret = append(ret, "SRv6-TE")
+		}
+	}
+	return ret
+}
+
+// AssocTypeListCapability holds the raw Association types advertised by the peer.
+type AssocTypeListCapability struct {
+	AssocTypes []uint32
+}
+
+func (c AssocTypeListCapability) Strings() []string {
+	ret := make([]string, 0, len(c.AssocTypes))
+	for _, at := range c.AssocTypes {
+		ret = append(ret, fmt.Sprintf("AssocType:%d", at))
+	}
+	return ret
+}
+
+// LSPDBVersionCapability holds the LSP-DB version number advertised by the peer.
+type LSPDBVersionCapability struct {
+	VersionNumber uint64
+}
+
+func (c LSPDBVersionCapability) Strings() []string {
+	return []string{"LSP-DB-VERSION"}
+}
+
+// MultipathCapability holds the RFC 8751 multipath capability flags.
+type MultipathCapability struct {
+	MaxMultipaths uint32
+	Weighted      bool
+	OppositeDir   bool
+	ForwardClass  bool
+	CompositePath bool
+}
+
+func (c MultipathCapability) Strings() []string {
+	ret := []string{"Multipath", fmt.Sprintf("MaxMultipaths=%d", c.MaxMultipaths)}
+	if c.Weighted {
+		ret = append(ret, "Weighted")
+	}
+	if c.OppositeDir {
+		ret = append(ret, "OppositeDir")
+	}
+	if c.ForwardClass {
+		ret = append(ret, "ForwardClass")
+	}
+	if c.CompositePath {
+		ret = append(ret, "CompositePath")
+	}
+	return ret
+}
+
+// VendorInformationCapability holds the enterprise number of a vendor-specific capability TLV.
+type VendorInformationCapability struct {
+	EnterpriseNumber uint32
+}
+
+func (c VendorInformationCapability) Strings() []string {
+	return []string{fmt.Sprintf("Vendor-Info(%d)", c.EnterpriseNumber)}
+}
+
+// UnknownCapability holds the raw TLV type of a capability Pola does not recognize.
+type UnknownCapability struct {
+	TLVType uint32
+}
+
+func (c UnknownCapability) Strings() []string {
+	return []string{fmt.Sprintf("unknown_type_%d", c.TLVType)}
+}
+
+// capabilityDetail is implemented by every typed capability detail above.
+type capabilityDetail interface {
+	Strings() []string
+}
+
+type Capability struct {
+	Type   string
+	Detail capabilityDetail
+}
+
+// Strings returns the human-readable flags for this capability's TLV.
+func (c Capability) Strings() []string {
+	if c.Detail == nil {
+		return nil
+	}
+	return c.Detail.Strings()
+}
+
 type Session struct {
-	Addr     netip.Addr
-	State    string
-	Caps     []string
-	IsSynced bool
+	Addr         netip.Addr
+	State        string
+	Capabilities []Capability
+	IsSynced     bool
+}
+
+// CapStrings flattens the human-readable flags of all capabilities into a single list.
+func (s Session) CapStrings() []string {
+	var caps []string
+	for _, c := range s.Capabilities {
+		caps = append(caps, c.Strings()...)
+	}
+	return caps
+}
+
+// capabilityFromPB converts a gRPC Capability into its typed client-side representation.
+func capabilityFromPB(c *pb.Capability) Capability {
+	cap := Capability{Type: strings.TrimPrefix(c.GetType().String(), "CAPABILITY_TYPE_")}
+	switch detail := c.GetDetail().(type) {
+	case *pb.Capability_Stateful:
+		cap.Detail = StatefulCapability{
+			LSPUpdate:            detail.Stateful.GetLspUpdate(),
+			IncludeDBVersion:     detail.Stateful.GetIncludeDbVersion(),
+			LSPInstantiation:     detail.Stateful.GetLspInstantiation(),
+			TriggeredResync:      detail.Stateful.GetTriggeredResync(),
+			DeltaLSPSync:         detail.Stateful.GetDeltaLspSync(),
+			TriggeredInitialSync: detail.Stateful.GetTriggeredInitialSync(),
+			Color:                detail.Stateful.GetColor(),
+		}
+	case *pb.Capability_Sr:
+		cap.Detail = SRCapability{
+			UnlimitedMSD: detail.Sr.GetUnlimitedMsd(),
+			NAISupported: detail.Sr.GetNaiSupported(),
+			MSD:          detail.Sr.GetMsd(),
+		}
+	case *pb.Capability_Srv6:
+		cap.Detail = SRv6Capability{NAISupported: detail.Srv6.GetNaiSupported()}
+	case *pb.Capability_PathSetupType:
+		cap.Detail = PathSetupTypeCapability{PathSetupTypes: detail.PathSetupType.GetPathSetupTypes()}
+	case *pb.Capability_AssocTypeList:
+		cap.Detail = AssocTypeListCapability{AssocTypes: detail.AssocTypeList.GetAssocTypes()}
+	case *pb.Capability_LspDbVersion:
+		cap.Detail = LSPDBVersionCapability{VersionNumber: detail.LspDbVersion.GetVersionNumber()}
+	case *pb.Capability_Multipath:
+		cap.Detail = MultipathCapability{
+			MaxMultipaths: detail.Multipath.GetMaxMultipaths(),
+			Weighted:      detail.Multipath.GetWeighted(),
+			OppositeDir:   detail.Multipath.GetOppositeDir(),
+			ForwardClass:  detail.Multipath.GetForwardClass(),
+			CompositePath: detail.Multipath.GetCompositePath(),
+		}
+	case *pb.Capability_VendorInformation:
+		cap.Detail = VendorInformationCapability{EnterpriseNumber: detail.VendorInformation.GetEnterpriseNumber()}
+	case *pb.Capability_Unknown:
+		cap.Detail = UnknownCapability{TLVType: detail.Unknown.GetTlvType()}
+	}
+	return cap
 }
 
 func GetSessions(client pb.PCEServiceClient) ([]Session, error) {
@@ -37,14 +265,19 @@ func GetSessions(client pb.PCEServiceClient) ([]Session, error) {
 
 	var sessions []Session
 	for _, pbss := range ret.GetSessions() {
-		addr, _ := netip.AddrFromSlice(pbss.GetAddr())
+		addr, ok := netip.AddrFromSlice(pbss.GetAddr())
+		if !ok {
+			return nil, fmt.Errorf("invalid session address: %v", pbss.GetAddr())
+		}
+
 		ss := Session{
 			Addr:     addr,
 			State:    pbss.State.String(),
-			Caps:     []string{},
 			IsSynced: pbss.GetIsSynced(),
 		}
-		ss.Caps = append(ss.Caps, pbss.GetCaps()...)
+		for _, c := range pbss.GetCapabilities() {
+			ss.Capabilities = append(ss.Capabilities, capabilityFromPB(c))
+		}
 		sessions = append(sessions, ss)
 	}
 
@@ -62,41 +295,175 @@ func DeleteSession(client pb.PCEServiceClient, req *pb.DeleteSessionRequest) err
 	return nil
 }
 
-func GetSRPolicyList(client pb.PCEServiceClient) (map[netip.Addr][]table.SRPolicy, error) {
+// SessionSRPolicies groups the SR Policies managed over a single PCEP session.
+type SessionSRPolicies struct {
+	Addr       netip.Addr       `json:"peerAddr"`
+	SRPolicies []table.SRPolicy `json:"srPolicies"`
+}
+
+// GetSRPolicyList returns SR Policies grouped by PCEP session in stable order.
+// If sessionAddr is valid, only the matching session is returned.
+func GetSRPolicyList(client pb.PCEServiceClient, sessionAddr netip.Addr) ([]SessionSRPolicies, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
-	ret, err := client.GetSRPolicyList(ctx, &pb.GetSRPolicyListRequest{})
+	req := &pb.GetSRPolicyListRequest{}
+	if sessionAddr.IsValid() {
+		req.SessionAddr = sessionAddr.AsSlice()
+	}
+
+	ret, err := client.GetSRPolicyList(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
-	policies := make(map[netip.Addr][]table.SRPolicy, len(ret.GetSrPolicies()))
+	sessions := make([]SessionSRPolicies, 0, len(ret.GetSessions()))
+	for _, pbSession := range ret.GetSessions() {
+		peerAddr, ok := netip.AddrFromSlice(pbSession.GetAddr())
+		if !ok {
+			return nil, fmt.Errorf("invalid session address: %v", pbSession.GetAddr())
+		}
 
-	for _, p := range ret.GetSrPolicies() {
-		peerAddr, _ := netip.AddrFromSlice(p.PcepSessionAddr)
-		srcAddr, _ := netip.AddrFromSlice(p.SrcAddr)
-		dstAddr, _ := netip.AddrFromSlice(p.DstAddr)
-		var segmentList []table.Segment
-		for _, s := range p.SegmentList {
-			seg, err := table.NewSegment(s.Sid)
+		policies := make([]table.SRPolicy, 0, len(pbSession.GetSrPolicies()))
+		for _, p := range pbSession.GetSrPolicies() {
+			policy, err := convertSRPolicy(p)
 			if err != nil {
 				return nil, err
 			}
-			segmentList = append(segmentList, seg)
+			policies = append(policies, policy)
 		}
 
-		policies[peerAddr] = append(policies[peerAddr], table.SRPolicy{
-			Name:        p.PolicyName,
-			SegmentList: segmentList,
-			SrcAddr:     srcAddr,
-			DstAddr:     dstAddr,
-			Color:       p.Color,
-			Preference:  p.Preference,
-		})
+		sessions = append(sessions, SessionSRPolicies{Addr: peerAddr, SRPolicies: policies})
 	}
 
-	return policies, nil
+	return sessions, nil
+}
+
+func convertSRPolicy(p *pb.SRPolicy) (table.SRPolicy, error) {
+	srcAddr, ok := netip.AddrFromSlice(p.GetSrcAddr())
+	if !ok {
+		return table.SRPolicy{}, fmt.Errorf("invalid SR policy source address: %v", p.GetSrcAddr())
+	}
+
+	dstAddr, ok := netip.AddrFromSlice(p.GetDstAddr())
+	if !ok {
+		return table.SRPolicy{}, fmt.Errorf("invalid SR policy destination address: %v", p.GetDstAddr())
+	}
+
+	segmentList := make([]table.Segment, 0, len(p.GetSegmentList()))
+	for _, s := range p.GetSegmentList() {
+		seg, err := segmentFromPB(s)
+		if err != nil {
+			return table.SRPolicy{}, err
+		}
+		segmentList = append(segmentList, seg)
+	}
+
+	return table.SRPolicy{
+		PlspID:      p.GetPlspId(),
+		Name:        p.GetPolicyName(),
+		SegmentList: segmentList,
+		SrcAddr:     srcAddr,
+		DstAddr:     dstAddr,
+		SrcRouterID: p.GetSrcRouterId(),
+		DstRouterID: p.GetDstRouterId(),
+		Color:       p.GetColor(),
+		Preference:  p.GetPreference(),
+		LSPID:       uint16(p.GetLspId()),
+		State:       policyStateFromPB(p.GetState()),
+		Type:        policyTypeFromPB(p.GetType()),
+		Metric:      metricTypeFromPB(p.GetMetric()),
+	}, nil
+}
+
+func policyStateFromPB(state pb.SRPolicyState) table.PolicyState {
+	switch state {
+	case pb.SRPolicyState_SR_POLICY_STATE_DOWN:
+		return table.PolicyDown
+	case pb.SRPolicyState_SR_POLICY_STATE_UP:
+		return table.PolicyUp
+	case pb.SRPolicyState_SR_POLICY_STATE_ACTIVE:
+		return table.PolicyActive
+	case pb.SRPolicyState_SR_POLICY_STATE_UNKNOWN:
+		return table.PolicyUnknown
+	default:
+		return ""
+	}
+}
+
+func policyTypeFromPB(polType pb.SRPolicyType) table.PolicyType {
+	switch polType {
+	case pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT:
+		return table.PolicyTypeExplicit
+	case pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC:
+		return table.PolicyTypeDynamic
+	default:
+		return ""
+	}
+}
+
+func metricTypeFromPB(metricType pb.MetricType) table.MetricType {
+	switch metricType {
+	case pb.MetricType_METRIC_TYPE_IGP:
+		return table.IGPMetric
+	case pb.MetricType_METRIC_TYPE_TE:
+		return table.TEMetric
+	case pb.MetricType_METRIC_TYPE_DELAY:
+		return table.DelayMetric
+	case pb.MetricType_METRIC_TYPE_HOPCOUNT:
+		return table.HopcountMetric
+	default:
+		return table.UnspecifiedMetric
+	}
+}
+
+func segmentFromPB(s *pb.Segment) (table.Segment, error) {
+	seg, err := table.NewSegment(s.GetSid())
+	if err != nil {
+		return nil, err
+	}
+	switch v := seg.(type) {
+	case table.SegmentSRv6:
+		if la, err := netip.ParseAddr(s.GetLocalAddr()); err == nil {
+			v.LocalAddr = la
+		}
+		if ra, err := netip.ParseAddr(s.GetRemoteAddr()); err == nil {
+			v.RemoteAddr = ra
+		}
+		if structure := parseSidStructure(s.GetSidStructure()); structure != nil {
+			v.Structure = table.SIDStructureBytes(structure)
+		}
+		return v, nil
+	case table.SegmentSRMPLS:
+		if la, err := netip.ParseAddr(s.GetLocalAddr()); err == nil {
+			v.LocalAddr = la
+		}
+		if ra, err := netip.ParseAddr(s.GetRemoteAddr()); err == nil {
+			v.RemoteAddr = ra
+		}
+		return v, nil
+	}
+	return seg, nil
+}
+
+// parseSidStructure parses a comma-separated SID structure string (e.g. "32,16,0,80"), returning nil if malformed.
+func parseSidStructure(s string) []uint8 {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	if len(parts) != 4 {
+		return nil
+	}
+	result := make([]uint8, 4)
+	for i, p := range parts {
+		v, err := strconv.ParseUint(strings.TrimSpace(p), 10, 8)
+		if err != nil {
+			return nil
+		}
+		result[i] = uint8(v)
+	}
+	return result
 }
 
 func CreateSRPolicy(client pb.PCEServiceClient, req *pb.CreateSRPolicyRequest) error {
@@ -143,7 +510,7 @@ func GetTED(client pb.PCEServiceClient) (*table.LsTED, error) {
 	return ted, nil
 }
 
-// initializeLsNodes initializes LsNodes in the LsTED table using the given array of nodes
+// initializeLsNodes initializes LsNodes in the LsTED table.
 func initializeLsNodes(ted *table.LsTED, nodes []*pb.LsNode) {
 	for _, node := range nodes {
 		lsNode := table.NewLsNode(node.GetAsn(), node.GetRouterId())

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -271,9 +271,10 @@ func GetSessions(client pb.PCEServiceClient) ([]Session, error) {
 		}
 
 		ss := Session{
-			Addr:     addr,
-			State:    pbss.State.String(),
-			IsSynced: pbss.GetIsSynced(),
+			Addr:         addr,
+			State:        pbss.State.String(),
+			IsSynced:     pbss.GetIsSynced(),
+			Capabilities: []Capability{},
 		}
 		for _, c := range pbss.GetCapabilities() {
 			ss.Capabilities = append(ss.Capabilities, capabilityFromPB(c))

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -10,6 +10,8 @@ import (
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -59,4 +61,58 @@ func TestCreateLsPrefix_SidIndexPresence(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSegmentFromPB_SRMPLS(t *testing.T) {
+	tests := []struct {
+		name       string
+		localAddr  string
+		remoteAddr string
+	}{
+		{name: "localAddr only", localAddr: "192.0.2.1"},
+		{name: "remoteAddr only", remoteAddr: "192.0.2.2"},
+		{name: "localAddr and remoteAddr", localAddr: "192.0.2.1", remoteAddr: "192.0.2.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seg, err := segmentFromPB(&pb.Segment{
+				Sid:        "16003",
+				LocalAddr:  tt.localAddr,
+				RemoteAddr: tt.remoteAddr,
+			})
+			require.NoError(t, err)
+
+			mplsSeg, ok := seg.(table.SegmentSRMPLS)
+			require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", seg)
+			assert.Equal(t, "16003", mplsSeg.SidString())
+			if tt.localAddr == "" {
+				assert.False(t, mplsSeg.LocalAddr.IsValid())
+			} else {
+				assert.Equal(t, tt.localAddr, mplsSeg.LocalAddr.String())
+			}
+			if tt.remoteAddr == "" {
+				assert.False(t, mplsSeg.RemoteAddr.IsValid())
+			} else {
+				assert.Equal(t, tt.remoteAddr, mplsSeg.RemoteAddr.String())
+			}
+		})
+	}
+}
+
+func TestSegmentFromPB_SRv6(t *testing.T) {
+	seg, err := segmentFromPB(&pb.Segment{
+		Sid:          "2001:db8:1005::",
+		LocalAddr:    "2001:db8::5",
+		RemoteAddr:   "2001:db8::6",
+		SidStructure: "32,16,0,80",
+	})
+	require.NoError(t, err)
+
+	srv6Seg, ok := seg.(table.SegmentSRv6)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRv6", seg)
+	assert.Equal(t, "2001:db8:1005::", srv6Seg.SidString())
+	assert.Equal(t, "2001:db8::5", srv6Seg.LocalAddr.String())
+	assert.Equal(t, "2001:db8::6", srv6Seg.RemoteAddr.String())
+	assert.Equal(t, table.SIDStructureBytes{32, 16, 0, 80}, srv6Seg.Structure)
 }

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -6,12 +6,16 @@
 package grpc
 
 import (
+	"context"
+	"encoding/json"
+	"net/netip"
 	"testing"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -115,6 +119,38 @@ func TestSegmentFromPB_SRv6(t *testing.T) {
 	assert.Equal(t, "2001:db8::5", srv6Seg.LocalAddr.String())
 	assert.Equal(t, "2001:db8::6", srv6Seg.RemoteAddr.String())
 	assert.Equal(t, table.SIDStructureBytes{32, 16, 0, 80}, srv6Seg.Structure)
+}
+
+// fakeSessionListClient returns a fixed GetSessionListResponse.
+type fakeSessionListClient struct {
+	pb.PCEServiceClient
+	resp *pb.GetSessionListResponse
+}
+
+func (f *fakeSessionListClient) GetSessionList(ctx context.Context, in *pb.GetSessionListRequest, opts ...grpc.CallOption) (*pb.GetSessionListResponse, error) {
+	return f.resp, nil
+}
+
+func TestGetSessions_NoCapabilitiesIsEmptySlice(t *testing.T) {
+	client := &fakeSessionListClient{resp: &pb.GetSessionListResponse{
+		Sessions: []*pb.Session{
+			{
+				Addr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State: pb.SessionState_SESSION_STATE_UP,
+			},
+		},
+	}}
+
+	sessions, err := GetSessions(client)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+
+	require.NotNil(t, sessions[0].Capabilities)
+	assert.Empty(t, sessions[0].Capabilities)
+
+	marshaled, err := json.Marshal(sessions[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(marshaled), `"Capabilities":[]`)
 }
 
 func TestCapability_Strings(t *testing.T) {

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -116,3 +116,15 @@ func TestSegmentFromPB_SRv6(t *testing.T) {
 	assert.Equal(t, "2001:db8::6", srv6Seg.RemoteAddr.String())
 	assert.Equal(t, table.SIDStructureBytes{32, 16, 0, 80}, srv6Seg.Structure)
 }
+
+func TestCapability_Strings(t *testing.T) {
+	t.Run("nil Detail falls back to type token", func(t *testing.T) {
+		cap := Capability{Type: "VENDOR_INFORMATION"}
+		assert.Equal(t, []string{"VENDOR_INFORMATION"}, cap.Strings())
+	})
+
+	t.Run("typed Detail is unaffected", func(t *testing.T) {
+		cap := Capability{Type: "SR", Detail: SRCapability{MSD: 10}}
+		assert.Equal(t, []string{"SR", "MSD=10"}, cap.Strings())
+	})
+}

--- a/cmd/pola/session.go
+++ b/cmd/pola/session.go
@@ -8,6 +8,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
 	"github.com/spf13/cobra"
@@ -47,7 +48,7 @@ func showSession(jsonFlag bool) error {
 		for i, ss := range sessions {
 			fmt.Printf("sessionAddr(%d): %s\n", i, ss.Addr.String())
 			fmt.Printf("  State: %s\n", ss.State)
-			fmt.Printf("  Capabilities: %s\n", ss.Caps)
+			fmt.Printf("  Capabilities: %s\n", strings.Join(ss.CapStrings(), ", "))
 			fmt.Printf("  IsSynced: %t\n", ss.IsSynced)
 		}
 	}

--- a/cmd/pola/sr_policy_list.go
+++ b/cmd/pola/sr_policy_list.go
@@ -8,17 +8,21 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/netip"
 
 	"github.com/spf13/cobra"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
+	"github.com/nttcom/pola/pkg/table"
 )
 
 func newSRPolicyListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:  "list",
 		RunE: showSRPolicyList,
 	}
+	cmd.Flags().String("session", "", "filter by PCEP session peer address")
+	return cmd
 }
 
 func showSRPolicyList(cmd *cobra.Command, args []string) error {
@@ -27,29 +31,43 @@ func showSRPolicyList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to retrieve 'json' flag: %v", err)
 	}
 
-	srPolicies, err := grpc.GetSRPolicyList(client)
+	sessionAddr, err := sessionAddrFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	sessions, err := grpc.GetSRPolicyList(client, sessionAddr)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve SR policy list: %v", err)
 	}
 
 	if jsonFlag {
 		// Output in JSON format
-		outputJSON, err := json.Marshal(srPolicies)
+		outputJSON, err := json.Marshal(sessions)
 		if err != nil {
 			return fmt.Errorf("failed to marshal SR policy list to JSON: %v", err)
 		}
 		fmt.Println(string(outputJSON))
 	} else {
 		// Output in user-friendly format
-		if len(srPolicies) == 0 {
+		if len(sessions) == 0 {
 			fmt.Println("No SR Policies found.")
 		} else {
-			for sessionID, policies := range srPolicies {
-				fmt.Printf("Session: %s\n", sessionID)
-				for _, policy := range policies {
+			for _, session := range sessions {
+				fmt.Printf("Session: %s\n", session.Addr.String())
+				for _, policy := range session.SRPolicies {
 					fmt.Printf("  PolicyName: %s\n", policy.Name)
-					fmt.Printf("    SrcAddr: %s\n", policy.SrcAddr)
-					fmt.Printf("    DstAddr: %s\n", policy.DstAddr)
+					fmt.Printf("    PlspID: %d\n", policy.PlspID)
+					fmt.Printf("    LSPID: %d\n", policy.LSPID)
+					fmt.Printf("    State: %s\n", policy.State)
+					if policy.Type != "" {
+						fmt.Printf("    Type: %s\n", policy.Type)
+					}
+					if policy.Metric != table.UnspecifiedMetric {
+						fmt.Printf("    Metric: %s\n", policy.Metric.DisplayString())
+					}
+					fmt.Printf("    SrcAddr: %s\n", srcDstDisplay(policy.SrcAddr.String(), policy.SrcRouterID))
+					fmt.Printf("    DstAddr: %s\n", srcDstDisplay(policy.DstAddr.String(), policy.DstRouterID))
 					fmt.Printf("    Color: %d\n", policy.Color)
 					fmt.Printf("    Preference: %d\n", policy.Preference)
 					fmt.Printf("    SegmentList: ")
@@ -58,7 +76,7 @@ func showSRPolicyList(cmd *cobra.Command, args []string) error {
 						fmt.Println("None")
 					} else {
 						for j, segment := range policy.SegmentList {
-							fmt.Print(segment.SidString())
+							fmt.Print(segmentDisplayString(segment))
 							if j == len(policy.SegmentList)-1 {
 								fmt.Println()
 							} else {
@@ -72,4 +90,57 @@ func showSRPolicyList(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
+}
+
+func sessionAddrFlag(cmd *cobra.Command) (netip.Addr, error) {
+	flag, err := cmd.Flags().GetString("session")
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("failed to retrieve 'session' flag: %v", err)
+	}
+	if flag == "" {
+		return netip.Addr{}, nil
+	}
+	addr, err := netip.ParseAddr(flag)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("invalid --session address %q: %v", flag, err)
+	}
+	return addr, nil
+}
+
+func srcDstDisplay(addr, routerID string) string {
+	if routerID == "" {
+		return addr
+	}
+	return fmt.Sprintf("%s (%s)", addr, routerID)
+}
+
+func segmentDisplayString(seg table.Segment) string {
+	var localAddr, remoteAddr string
+	switch v := seg.(type) {
+	case table.SegmentSRv6:
+		if v.LocalAddr.IsValid() {
+			localAddr = v.LocalAddr.String()
+		}
+		if v.RemoteAddr.IsValid() {
+			remoteAddr = v.RemoteAddr.String()
+		}
+	case table.SegmentSRMPLS:
+		if v.LocalAddr.IsValid() {
+			localAddr = v.LocalAddr.String()
+		}
+		if v.RemoteAddr.IsValid() {
+			remoteAddr = v.RemoteAddr.String()
+		}
+	}
+
+	switch {
+	case localAddr == "" && remoteAddr == "":
+		return seg.SidString()
+	case remoteAddr == "":
+		return fmt.Sprintf("%s (local=%s)", seg.SidString(), localAddr)
+	case localAddr == "":
+		return fmt.Sprintf("%s (remote=%s)", seg.SidString(), remoteAddr)
+	default:
+		return fmt.Sprintf("%s (local=%s, remote=%s)", seg.SidString(), localAddr, remoteAddr)
+	}
 }

--- a/cmd/pola/sr_policy_list_test.go
+++ b/cmd/pola/sr_policy_list_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nttcom/pola/pkg/table"
+)
+
+func TestSessionAddrFlag_Unset(t *testing.T) {
+	cmd := newSRPolicyListCmd()
+
+	addr, err := sessionAddrFlag(cmd)
+	require.NoError(t, err)
+	assert.False(t, addr.IsValid())
+}
+
+func TestSessionAddrFlag_Valid(t *testing.T) {
+	cmd := newSRPolicyListCmd()
+	require.NoError(t, cmd.Flags().Set("session", "10.0.0.1"))
+
+	addr, err := sessionAddrFlag(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.1", addr.String())
+}
+
+func TestSessionAddrFlag_Invalid(t *testing.T) {
+	cmd := newSRPolicyListCmd()
+	require.NoError(t, cmd.Flags().Set("session", "not-an-address"))
+
+	_, err := sessionAddrFlag(cmd)
+	require.Error(t, err)
+}
+
+func TestSegmentDisplayString(t *testing.T) {
+	local := netip.MustParseAddr("192.0.2.1")
+	remote := netip.MustParseAddr("192.0.2.2")
+
+	tests := []struct {
+		name string
+		seg  table.SegmentSRMPLS
+		want string
+	}{
+		{
+			name: "no localAddr, no remoteAddr",
+			seg:  table.SegmentSRMPLS{Sid: 16003},
+			want: "16003",
+		},
+		{
+			name: "localAddr only",
+			seg:  table.SegmentSRMPLS{Sid: 16003, LocalAddr: local},
+			want: "16003 (local=192.0.2.1)",
+		},
+		{
+			name: "remoteAddr only",
+			seg:  table.SegmentSRMPLS{Sid: 16003, RemoteAddr: remote},
+			want: "16003 (remote=192.0.2.2)",
+		},
+		{
+			name: "localAddr and remoteAddr",
+			seg:  table.SegmentSRMPLS{Sid: 16003, LocalAddr: local, RemoteAddr: remote},
+			want: "16003 (local=192.0.2.1, remote=192.0.2.2)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, segmentDisplayString(tt.seg))
+		})
+	}
+}

--- a/examples/grpc/go/examples_test.go
+++ b/examples/grpc/go/examples_test.go
@@ -32,9 +32,9 @@ type fakeServer struct {
 
 	fail bool
 
-	sessions []*pb.Session
-	policies []*pb.SRPolicy
-	ted      *pb.GetTEDResponse
+	sessions         []*pb.Session
+	srPolicySessions []*pb.Session
+	ted              *pb.GetTEDResponse
 
 	mu         sync.Mutex
 	createReq  *pb.CreateSRPolicyRequest
@@ -83,7 +83,7 @@ func (f *fakeServer) GetSRPolicyList(_ context.Context, _ *pb.GetSRPolicyListReq
 	if f.fail {
 		return nil, errFake
 	}
-	return &pb.GetSRPolicyListResponse{SrPolicies: f.policies}, nil
+	return &pb.GetSRPolicyListResponse{Sessions: f.srPolicySessions}, nil
 }
 
 func (f *fakeServer) GetTED(_ context.Context, _ *pb.GetTEDRequest) (*pb.GetTEDResponse, error) {
@@ -495,9 +495,12 @@ func TestSessionList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeServer{sessions: []*pb.Session{
 			{
-				Addr:     addrBytes(t, "192.0.2.1"),
-				State:    pb.SessionState_SESSION_STATE_UP,
-				Caps:     []string{"Stateful", "SR"},
+				Addr:  addrBytes(t, "192.0.2.1"),
+				State: pb.SessionState_SESSION_STATE_UP,
+				Capabilities: []*pb.Capability{
+					{Type: pb.CapabilityType_CAPABILITY_TYPE_STATEFUL},
+					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
+				},
 				IsSynced: true,
 			},
 			// Invalid session address: the example should warn and skip the session.
@@ -507,7 +510,7 @@ func TestSessionList(t *testing.T) {
 		wantOutput(t, out, code,
 			"sessionAddr(0): 192.0.2.1",
 			"state: SESSION_STATE_UP",
-			"capabilities: Stateful, SR",
+			"capabilities: STATEFUL, SR(msd=10, unlimitedMsd=false, naiSupported=false)",
 			"isSynced: true",
 			"invalid address for session 1",
 		)
@@ -524,19 +527,23 @@ func TestSessionList(t *testing.T) {
 
 func TestSRPolicyList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		f := &fakeServer{policies: []*pb.SRPolicy{
+		f := &fakeServer{srPolicySessions: []*pb.Session{
 			{
-				PcepSessionAddr: addrBytes(t, "192.0.2.1"),
-				SrcAddr:         addrBytes(t, "192.0.2.1"),
-				DstAddr:         addrBytes(t, "192.0.2.2"),
-				PolicyName:      "with-segments",
-				Color:           100,
-				Preference:      200,
-				SegmentList:     []*pb.Segment{{Sid: "16002"}, {Sid: "16003"}},
+				Addr: addrBytes(t, "192.0.2.1"),
+				SrPolicies: []*pb.SRPolicy{{
+					SrcAddr:     addrBytes(t, "192.0.2.1"),
+					DstAddr:     addrBytes(t, "192.0.2.2"),
+					PolicyName:  "with-segments",
+					Color:       100,
+					Preference:  200,
+					SegmentList: []*pb.Segment{{Sid: "16002"}, {Sid: "16003"}},
+				}},
 			},
 			{
-				PcepSessionAddr: []byte{1, 2, 3},
-				PolicyName:      "no-segments",
+				Addr: []byte{1, 2, 3},
+				SrPolicies: []*pb.SRPolicy{{
+					PolicyName: "no-segments",
+				}},
 			},
 		}}
 		out, code := run(t, "sr-policy-list", serve(t, f))

--- a/examples/grpc/go/session-list/main.go
+++ b/examples/grpc/go/session-list/main.go
@@ -54,7 +54,27 @@ func main() {
 		}
 		fmt.Printf("sessionAddr(%d): %v\n", i, addr)
 		fmt.Printf("  state: %s\n", ss.GetState())
-		fmt.Printf("  capabilities: %s\n", strings.Join(ss.GetCaps(), ", "))
+		fmt.Printf("  capabilities: %s\n", strings.Join(capStrings(ss.GetCapabilities()), ", "))
 		fmt.Printf("  isSynced: %t\n", ss.GetIsSynced())
+	}
+}
+
+func capStrings(capabilities []*pb.Capability) []string {
+	var caps []string
+	for _, c := range capabilities {
+		caps = append(caps, capString(c))
+	}
+	return caps
+}
+
+func capString(c *pb.Capability) string {
+	typ := strings.TrimPrefix(c.GetType().String(), "CAPABILITY_TYPE_")
+	switch detail := c.GetDetail().(type) {
+	case *pb.Capability_Sr:
+		return fmt.Sprintf("%s(msd=%d, unlimitedMsd=%t, naiSupported=%t)", typ, detail.Sr.GetMsd(), detail.Sr.GetUnlimitedMsd(), detail.Sr.GetNaiSupported())
+	case *pb.Capability_LspDbVersion:
+		return fmt.Sprintf("%s(versionNumber=%d)", typ, detail.LspDbVersion.GetVersionNumber())
+	default:
+		return typ
 	}
 }

--- a/examples/grpc/go/sr-policy-list/main.go
+++ b/examples/grpc/go/sr-policy-list/main.go
@@ -46,15 +46,20 @@ func main() {
 		log.Fatalf("unable to get SR policy list from server: %v", err)
 	}
 
-	for i, srPolicy := range ret.GetSrPolicies() {
-		fmt.Printf("srPolicy(%d):\n", i)
-		fmt.Printf("  sessionAddr: %s\n", formatAddr(srPolicy.GetPcepSessionAddr()))
-		fmt.Printf("  policyName: %s\n", srPolicy.GetPolicyName())
-		fmt.Printf("  srcAddr: %s\n", formatAddr(srPolicy.GetSrcAddr()))
-		fmt.Printf("  dstAddr: %s\n", formatAddr(srPolicy.GetDstAddr()))
-		fmt.Printf("  color: %d\n", srPolicy.GetColor())
-		fmt.Printf("  preference: %d\n", srPolicy.GetPreference())
-		fmt.Printf("  path: %s\n", formatSegmentList(srPolicy.GetSegmentList()))
+	i := 0
+	for _, session := range ret.GetSessions() {
+		sessionAddr := formatAddr(session.GetAddr())
+		for _, srPolicy := range session.GetSrPolicies() {
+			fmt.Printf("srPolicy(%d):\n", i)
+			i++
+			fmt.Printf("  sessionAddr: %s\n", sessionAddr)
+			fmt.Printf("  policyName: %s\n", srPolicy.GetPolicyName())
+			fmt.Printf("  srcAddr: %s\n", formatAddr(srPolicy.GetSrcAddr()))
+			fmt.Printf("  dstAddr: %s\n", formatAddr(srPolicy.GetDstAddr()))
+			fmt.Printf("  color: %d\n", srPolicy.GetColor())
+			fmt.Printf("  preference: %d\n", srPolicy.GetPreference())
+			fmt.Printf("  path: %s\n", formatSegmentList(srPolicy.GetSegmentList()))
+		}
 	}
 }
 

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -382,14 +382,17 @@ func (s *APIServer) DeleteSRPolicy(ctx context.Context, input *pb.DeleteSRPolicy
 	var srcAddr, dstAddr netip.Addr
 	var segmentList []table.Segment
 
-	srcAddr, ok := netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
-	if !ok {
-		return &pb.DeleteSRPolicyResponse{
-			IsSuccess: false,
-		}, errors.New("invalid source address")
+	if len(inputSRPolicy.GetSrcAddr()) > 0 {
+		var ok bool
+		srcAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
+		if !ok {
+			return &pb.DeleteSRPolicyResponse{
+				IsSuccess: false,
+			}, errors.New("invalid source address")
+		}
 	}
 
-	dstAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
+	dstAddr, ok := netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
 	if !ok {
 		return &pb.DeleteSRPolicyResponse{
 			IsSuccess: false,
@@ -623,8 +626,7 @@ func (s *APIServer) GetSessionList(ctx context.Context, _ *pb.GetSessionListRequ
 		}
 		seenCapabilities := make(map[string]struct{})
 		for _, cap := range pcepSession.AdvertisedCapabilities() {
-			capStrs := cap.CapStrings()
-			capabilityKey := fmt.Sprintf("%d:%s", cap.Type(), strings.Join(capStrs, ","))
+			capabilityKey := fmt.Sprintf("%d:%s", cap.Type(), cap.Serialize())
 			if _, ok := seenCapabilities[capabilityKey]; ok {
 				continue
 			}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -108,7 +108,7 @@ func enrichSRv6Segment(srv6Seg table.SegmentSRv6, segment *pb.Segment, usidMode 
 	if structure, err := parseSidStructure(segment.GetSidStructure()); err != nil {
 		return srv6Seg, err
 	} else if structure != nil {
-		srv6Seg.Structure = structure
+		srv6Seg.Structure = table.SIDStructureBytes(structure)
 	}
 	if s := segment.GetLocalAddr(); s != "" {
 		la, err := netip.ParseAddr(s)
@@ -276,21 +276,15 @@ func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, segmentL
 		Metric:      metricType,
 	}
 
-	// PCEP does not report candidate path type/metric after LSP establishment,
-	// so remember them when creating or updating the policy (RFC 9256 §2.4.2).
-	pcepSession.RememberSRPolicyIntent(srPolicy.Color, dstAddr, policyType, metricType)
-
 	if id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), dstAddr); exists {
 		s.logger.Debug("Request to update SR Policy", zap.Uint32("plspID", id))
 		srPolicy.PlspID = id
 		if err := pcepSession.SendPCUpdate(srPolicy); err != nil {
-			pcepSession.forgetSRPolicyIntent(srPolicy.Color, dstAddr)
 			return fmt.Errorf("failed to send PC update: %w", err)
 		}
 	} else {
 		s.logger.Debug("Request to create SR Policy")
 		if err := pcepSession.RequestSRPolicyCreated(srPolicy); err != nil {
-			pcepSession.forgetSRPolicyIntent(srPolicy.Color, dstAddr)
 			return fmt.Errorf("failed to request SR policy creation: %w", err)
 		}
 	}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"net"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -77,47 +78,56 @@ func validateCreateSRPolicy(req *pb.CreateSRPolicyRequest, disablePathCompute bo
 
 // parseSidStructure parses a comma-separated SID structure string (e.g. "32,16,0,80")
 // into a []uint8 slice suitable for table.SegmentSRv6.Structure.
-// Returns nil if the input is empty or malformed.
-func parseSidStructure(s string) []uint8 {
+// Returns nil for empty input.
+func parseSidStructure(s string) ([]uint8, error) {
 	if s == "" {
-		return nil
+		return nil, nil
 	}
+
 	parts := strings.Split(s, ",")
 	if len(parts) != 4 {
-		return nil
+		return nil, fmt.Errorf("invalid SID structure %q", s)
 	}
+
 	result := make([]uint8, 4)
 	for i, p := range parts {
 		v, err := strconv.ParseUint(strings.TrimSpace(p), 10, 8)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("invalid SID structure %q: %w", s, err)
 		}
 		result[i] = uint8(v)
 	}
-	return result
+	return result, nil
 }
 
-// enrichSRv6Segment applies SRv6-specific overrides (uSID flag, SID structure,
-// LocalAddr, RemoteAddr) coming from the gRPC Segment message onto the
-// SRv6 segment that was just created.
-func enrichSRv6Segment(srv6Seg table.SegmentSRv6, segment *pb.Segment, usidMode bool) table.SegmentSRv6 {
+// enrichSRv6Segment applies gRPC overrides to an SRv6 segment.
+func enrichSRv6Segment(srv6Seg table.SegmentSRv6, segment *pb.Segment, usidMode bool) (table.SegmentSRv6, error) {
 	if usidMode {
 		srv6Seg.USid = true
 	}
-	if structure := parseSidStructure(segment.GetSidStructure()); structure != nil {
+	if structure, err := parseSidStructure(segment.GetSidStructure()); err != nil {
+		return srv6Seg, err
+	} else if structure != nil {
 		srv6Seg.Structure = structure
 	}
-	if la, err := netip.ParseAddr(segment.GetLocalAddr()); err == nil {
+	if s := segment.GetLocalAddr(); s != "" {
+		la, err := netip.ParseAddr(s)
+		if err != nil {
+			return srv6Seg, fmt.Errorf("invalid localAddr %q for SID %s: %w", s, segment.GetSid(), err)
+		}
 		srv6Seg.LocalAddr = la
 	}
-	if ra, err := netip.ParseAddr(segment.GetRemoteAddr()); err == nil {
+	if s := segment.GetRemoteAddr(); s != "" {
+		ra, err := netip.ParseAddr(s)
+		if err != nil {
+			return srv6Seg, fmt.Errorf("invalid remoteAddr %q for SID %s: %w", s, segment.GetSid(), err)
+		}
 		srv6Seg.RemoteAddr = ra
 	}
-	return srv6Seg
+	return srv6Seg, nil
 }
 
-// enrichSRMPLSSegment applies NAI information from a gRPC Segment message
-// to an SR-MPLS segment.
+// enrichSRMPLSSegment applies gRPC NAI information to an SR-MPLS segment.
 func enrichSRMPLSSegment(mplsSeg table.SegmentSRMPLS, segment *pb.Segment) (table.SegmentSRMPLS, error) {
 	if s := segment.GetLocalAddr(); s != "" {
 		la, err := netip.ParseAddr(s)
@@ -136,8 +146,7 @@ func enrichSRMPLSSegment(mplsSeg table.SegmentSRMPLS, segment *pb.Segment) (tabl
 	return mplsSeg, nil
 }
 
-// newEnrichedSegment turns a gRPC Segment message into a table.Segment, applying
-// the extras carried alongside the SID (NAI, SID structure, uSID).
+// newEnrichedSegment converts a gRPC Segment to a table.Segment.
 func newEnrichedSegment(segment *pb.Segment, usidMode bool) (table.Segment, error) {
 	seg, err := table.NewSegment(segment.GetSid())
 	if err != nil {
@@ -145,7 +154,7 @@ func newEnrichedSegment(segment *pb.Segment, usidMode bool) (table.Segment, erro
 	}
 	switch v := seg.(type) {
 	case table.SegmentSRv6:
-		return enrichSRv6Segment(v, segment, usidMode), nil
+		return enrichSRv6Segment(v, segment, usidMode)
 	case table.SegmentSRMPLS:
 		return enrichSRMPLSSegment(v, segment)
 	}
@@ -160,40 +169,54 @@ func buildSegmentList(s *APIServer, input *pb.CreateSRPolicyRequest, disablePath
 	inputSRPolicy := input.GetSrPolicy()
 
 	if !disablePathCompute {
-		if s.pce.ted == nil {
+		ted := s.pce.TED()
+		if ted == nil {
 			return nil, netip.Addr{}, netip.Addr{}, errors.New("ted is disabled")
 		}
 
-		if len(s.pce.ted.Nodes) == 0 {
+		if len(ted.Nodes) == 0 {
 			return nil, netip.Addr{}, netip.Addr{}, errors.New("no node in TED")
 		}
 
 		// Request ASN check
-		// TODO: Add ASN to LsTED and compare against it directly.
-		for _, node := range s.pce.ted.Nodes {
+		for _, node := range ted.Nodes {
 			if node.ASN != input.GetAsn() {
 				return nil, netip.Addr{}, netip.Addr{}, fmt.Errorf("request ASN %d does not match ted ASN %d", input.GetAsn(), node.ASN)
 			}
 			break // All nodes are expected to share the same ASN; check only the first
 		}
 
-		srcAddr, err = getLoopbackAddr(s.pce, inputSRPolicy.GetSrcRouterId())
+		srcAddr, err = getLoopbackAddr(ted, inputSRPolicy.GetSrcRouterId())
 		if err != nil {
 			return nil, netip.Addr{}, netip.Addr{}, err
 		}
 
-		dstAddr, err = getLoopbackAddr(s.pce, inputSRPolicy.GetDstRouterId())
+		dstAddr, err = getLoopbackAddr(ted, inputSRPolicy.GetDstRouterId())
 		if err != nil {
 			return nil, netip.Addr{}, netip.Addr{}, err
 		}
 
-		segmentList, err = getSegmentList(inputSRPolicy, s.pce.ted, s.usidMode)
+		segmentList, err = getSegmentList(inputSRPolicy, ted, s.usidMode)
 		if err != nil {
 			return nil, netip.Addr{}, netip.Addr{}, err
 		}
 	} else {
-		srcAddr, _ = netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
-		dstAddr, _ = netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
+		var ok bool
+		srcAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
+		if !ok {
+			return nil, netip.Addr{}, netip.Addr{}, fmt.Errorf(
+				"invalid source address %v",
+				inputSRPolicy.GetSrcAddr(),
+			)
+		}
+
+		dstAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
+		if !ok {
+			return nil, netip.Addr{}, netip.Addr{}, fmt.Errorf(
+				"invalid destination address %v",
+				inputSRPolicy.GetDstAddr(),
+			)
+		}
 
 		for _, segment := range inputSRPolicy.GetSegmentList() {
 			seg, err := newEnrichedSegment(segment, s.usidMode)
@@ -207,12 +230,39 @@ func buildSegmentList(s *APIServer, input *pb.CreateSRPolicyRequest, disablePath
 	return segmentList, srcAddr, dstAddr, nil
 }
 
-func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, segmentList []table.Segment, srcAddr, dstAddr netip.Addr) error {
+// resolveSRPolicyIntent resolves the candidate-path type and metric per RFC 9256 §2.4.2.
+func resolveSRPolicyIntent(inputSRPolicy *pb.SRPolicy, disablePathCompute bool) (table.PolicyType, table.MetricType, error) {
+	if disablePathCompute {
+		// disable_path_compute uses the given SegmentList as an explicit candidate path,
+		// regardless of the requested policy type.
+		return table.PolicyTypeExplicit, table.UnspecifiedMetric, nil
+	}
+
+	switch inputSRPolicy.GetType() {
+	case pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT:
+		return table.PolicyTypeExplicit, table.UnspecifiedMetric, nil
+	case pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC:
+		metricType, err := getMetricType(inputSRPolicy.GetMetric())
+		if err != nil {
+			return "", table.UnspecifiedMetric, err
+		}
+		return table.PolicyTypeDynamic, metricType, nil
+	default:
+		return "", table.UnspecifiedMetric, errors.New("undefined SR Policy type")
+	}
+}
+
+func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, segmentList []table.Segment, srcAddr, dstAddr netip.Addr, disablePathCompute bool) error {
 	inputSRPolicy := input.GetSrPolicy()
 
 	pcepSession, err := getSyncedPCEPSession(s.pce, inputSRPolicy.GetPcepSessionAddr())
 	if err != nil {
 		return fmt.Errorf("failed to get synchronized PCEP session: %w", err)
+	}
+
+	policyType, metricType, err := resolveSRPolicyIntent(inputSRPolicy, disablePathCompute)
+	if err != nil {
+		return fmt.Errorf("failed to resolve SR policy type: %w", err)
 	}
 
 	srPolicy := table.SRPolicy{
@@ -222,18 +272,25 @@ func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, segmentL
 		DstAddr:     dstAddr,
 		Color:       inputSRPolicy.GetColor(),
 		Preference:  100,
+		Type:        policyType,
+		Metric:      metricType,
 	}
+
+	// PCEP does not report candidate path type/metric after LSP establishment,
+	// so remember them when creating or updating the policy (RFC 9256 §2.4.2).
+	pcepSession.RememberSRPolicyIntent(srPolicy.Color, dstAddr, policyType, metricType)
 
 	if id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), dstAddr); exists {
 		s.logger.Debug("Request to update SR Policy", zap.Uint32("plspID", id))
 		srPolicy.PlspID = id
-
 		if err := pcepSession.SendPCUpdate(srPolicy); err != nil {
+			pcepSession.forgetSRPolicyIntent(srPolicy.Color, dstAddr)
 			return fmt.Errorf("failed to send PC update: %w", err)
 		}
 	} else {
 		s.logger.Debug("Request to create SR Policy")
 		if err := pcepSession.RequestSRPolicyCreated(srPolicy); err != nil {
+			pcepSession.forgetSRPolicyIntent(srPolicy.Color, dstAddr)
 			return fmt.Errorf("failed to request SR policy creation: %w", err)
 		}
 	}
@@ -256,7 +313,7 @@ func (s *APIServer) CreateSRPolicy(ctx context.Context, req *pb.CreateSRPolicyRe
 		return nil, err
 	}
 
-	if err := sendSRPolicyRequest(s, req, segmentList, srcAddr, dstAddr); err != nil {
+	if err := sendSRPolicyRequest(s, req, segmentList, srcAddr, dstAddr, disablePathCompute); err != nil {
 		return nil, fmt.Errorf("failed to send SR policy request: %w", err)
 	}
 
@@ -298,7 +355,7 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []ta
 		return nil
 	}
 
-	ted := s.pce.ted
+	ted := s.pce.TED()
 	if ted == nil {
 		return status.Errorf(codes.FailedPrecondition,
 			"TED is not enabled, SID validation cannot be performed")
@@ -331,8 +388,20 @@ func (s *APIServer) DeleteSRPolicy(ctx context.Context, input *pb.DeleteSRPolicy
 	var srcAddr, dstAddr netip.Addr
 	var segmentList []table.Segment
 
-	srcAddr, _ = netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
-	dstAddr, _ = netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
+	srcAddr, ok := netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
+	if !ok {
+		return &pb.DeleteSRPolicyResponse{
+			IsSuccess: false,
+		}, errors.New("invalid source address")
+	}
+
+	dstAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
+	if !ok {
+		return &pb.DeleteSRPolicyResponse{
+			IsSuccess: false,
+		}, errors.New("invalid destination address")
+	}
+
 	for _, segment := range inputSRPolicy.GetSegmentList() {
 		seg, err := newEnrichedSegment(segment, s.usidMode)
 		if err != nil {
@@ -381,7 +450,7 @@ func validate(inputSRPolicy *pb.SRPolicy, asn uint32, validationKind ValidationK
 	if inputSRPolicy == nil {
 		return errors.New("validate error, input is nil")
 	}
-	if validationKind != ValidationAddDisablePathCompute && validationKind != ValidationDelete && asn == 0 {
+	if validationKind == ValidationAdd && asn == 0 {
 		return errors.New("validate error, ASN must not be zero")
 	}
 	if validateFunc, ok := validator[validationKind]; ok {
@@ -457,7 +526,11 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 }
 
 func getSyncedPCEPSession(pce *Server, addr []byte) (*Session, error) {
-	pcepSessionAddr, _ := netip.AddrFromSlice(addr)
+	pcepSessionAddr, ok := netip.AddrFromSlice(addr)
+	if !ok {
+		return nil, fmt.Errorf("invalid PCEP session address: %v", addr)
+	}
+
 	pcepSession := pce.SearchSession(pcepSessionAddr, true)
 	if pcepSession == nil {
 		return nil, fmt.Errorf("no synced session with %s", pcepSessionAddr)
@@ -465,8 +538,8 @@ func getSyncedPCEPSession(pce *Server, addr []byte) (*Session, error) {
 	return pcepSession, nil
 }
 
-func getLoopbackAddr(pce *Server, routerID string) (netip.Addr, error) {
-	node, ok := pce.ted.Nodes[routerID]
+func getLoopbackAddr(ted *table.LsTED, routerID string) (netip.Addr, error) {
+	node, ok := ted.Nodes[routerID]
 	if !ok {
 		return netip.Addr{}, fmt.Errorf("no node with router ID %s", routerID)
 	}
@@ -544,23 +617,25 @@ func getMetricType(metricType pb.MetricType) (table.MetricType, error) {
 func (s *APIServer) GetSessionList(ctx context.Context, _ *pb.GetSessionListRequest) (*pb.GetSessionListResponse, error) {
 	s.logger.Info("Received GetSessionList API request")
 
+	pcepSessions := s.pce.Sessions()
+	slices.SortFunc(pcepSessions, func(a, b *Session) int { return a.peerAddr.Compare(b.peerAddr) })
+
 	var sessions []*pb.Session
-	for _, pcepSession := range s.pce.sessionList {
+	for _, pcepSession := range pcepSessions {
 		ss := &pb.Session{
 			Addr:     pcepSession.peerAddr.AsSlice(),
 			State:    pb.SessionState_SESSION_STATE_UP, // Only the UP state in the current specification
-			Caps:     []string{},
-			IsSynced: pcepSession.isSynced,
+			IsSynced: pcepSession.IsSynced(),
 		}
-		seenCaps := make(map[string]struct{})
-		for _, cap := range pcepSession.advertisedCapabilities {
-			for _, capStr := range cap.CapStrings() {
-				if _, ok := seenCaps[capStr]; ok {
-					continue
-				}
-				seenCaps[capStr] = struct{}{}
-				ss.Caps = append(ss.Caps, capStr)
+		seenCapabilities := make(map[string]struct{})
+		for _, cap := range pcepSession.AdvertisedCapabilities() {
+			capStrs := cap.CapStrings()
+			capabilityKey := fmt.Sprintf("%d:%s", cap.Type(), strings.Join(capStrs, ","))
+			if _, ok := seenCapabilities[capabilityKey]; ok {
+				continue
 			}
+			seenCapabilities[capabilityKey] = struct{}{}
+			ss.Capabilities = append(ss.Capabilities, buildCapability(cap))
 		}
 		sessions = append(sessions, ss)
 	}
@@ -571,36 +646,260 @@ func (s *APIServer) GetSessionList(ctx context.Context, _ *pb.GetSessionListRequ
 	}, nil
 }
 
-func (s *APIServer) GetSRPolicyList(ctx context.Context, _ *pb.GetSRPolicyListRequest) (*pb.GetSRPolicyListResponse, error) {
+func buildCapability(cap pcep.CapabilityInterface) *pb.Capability {
+	c := &pb.Capability{Type: capabilityType(cap.Type())}
+	switch tlv := cap.(type) {
+	case *pcep.StatefulPCECapability:
+		c.Detail = &pb.Capability_Stateful{Stateful: &pb.StatefulCapability{
+			LspUpdate:            tlv.LSPUpdateCapability,
+			IncludeDbVersion:     tlv.IncludeDBVersion,
+			LspInstantiation:     tlv.LSPInstantiationCapability,
+			TriggeredResync:      tlv.TriggeredResync,
+			DeltaLspSync:         tlv.DeltaLSPSyncCapability,
+			TriggeredInitialSync: tlv.TriggeredInitialSync,
+			Color:                tlv.ColorCapability,
+		}}
+	case *pcep.SRPCECapability:
+		c.Detail = &pb.Capability_Sr{Sr: &pb.SrCapability{
+			UnlimitedMsd: tlv.HasUnlimitedMaxSIDDepth,
+			NaiSupported: tlv.IsNAISupported,
+			Msd:          uint32(tlv.MaximumSidDepth),
+		}}
+	case *pcep.SRv6PCECapability:
+		c.Detail = &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
+			NaiSupported: tlv.IsNAISupported,
+		}}
+	case *pcep.PathSetupTypeCapability:
+		psts := make([]uint32, len(tlv.PathSetupTypes))
+		for i, pst := range tlv.PathSetupTypes {
+			psts[i] = uint32(pst)
+		}
+		c.Detail = &pb.Capability_PathSetupType{PathSetupType: &pb.PathSetupTypeCapability{
+			PathSetupTypes: psts,
+		}}
+	case *pcep.AssocTypeList:
+		assocTypes := make([]uint32, len(tlv.AssocTypes))
+		for i, at := range tlv.AssocTypes {
+			assocTypes[i] = uint32(at)
+		}
+		c.Detail = &pb.Capability_AssocTypeList{AssocTypeList: &pb.AssocTypeListCapability{
+			AssocTypes: assocTypes,
+		}}
+	case *pcep.LSPDBVersion:
+		c.Detail = &pb.Capability_LspDbVersion{LspDbVersion: &pb.LspDbVersionCapability{
+			VersionNumber: tlv.VersionNumber,
+		}}
+	case *pcep.MultipathCapability:
+		c.Detail = &pb.Capability_Multipath{Multipath: &pb.MultipathCapability{
+			MaxMultipaths: uint32(tlv.MaxMultipaths),
+			Weighted:      tlv.IsWeightedSupported,
+			OppositeDir:   tlv.IsOppositeDirSupported,
+			ForwardClass:  tlv.IsForwardClassSupported,
+			CompositePath: tlv.IsCompositePathSupported,
+		}}
+	case *pcep.VendorInformation:
+		c.Detail = &pb.Capability_VendorInformation{VendorInformation: &pb.VendorInformationCapability{
+			EnterpriseNumber: uint32(tlv.EnterpriseNumber),
+		}}
+	case *pcep.UnknownTLV:
+		c.Detail = &pb.Capability_Unknown{Unknown: &pb.UnknownCapability{
+			TlvType: uint32(tlv.Typ),
+		}}
+	}
+	return c
+}
+
+func capabilityType(t pcep.TLVType) pb.CapabilityType {
+	switch t {
+	case pcep.TLVStatefulPCECapability:
+		return pb.CapabilityType_CAPABILITY_TYPE_STATEFUL
+	case pcep.TLVSRPCECapability:
+		return pb.CapabilityType_CAPABILITY_TYPE_SR
+	case pcep.TLVSRv6PCECapability:
+		return pb.CapabilityType_CAPABILITY_TYPE_SRV6
+	case pcep.TLVPathSetupTypeCapability:
+		return pb.CapabilityType_CAPABILITY_TYPE_PATH_SETUP_TYPE
+	case pcep.TLVAssocTypeList:
+		return pb.CapabilityType_CAPABILITY_TYPE_ASSOC_TYPE_LIST
+	case pcep.TLVLSPDBVersion:
+		return pb.CapabilityType_CAPABILITY_TYPE_LSP_DB_VERSION
+	case pcep.TLVMultipathCap:
+		return pb.CapabilityType_CAPABILITY_TYPE_MULTIPATH
+	case pcep.TLVVendorInformation:
+		return pb.CapabilityType_CAPABILITY_TYPE_VENDOR_INFORMATION
+	default:
+		return pb.CapabilityType_CAPABILITY_TYPE_UNKNOWN
+	}
+}
+
+func (s *APIServer) GetSRPolicyList(ctx context.Context, req *pb.GetSRPolicyListRequest) (*pb.GetSRPolicyListResponse, error) {
 	s.logger.Info("Received GetSRPolicyList API request")
 
-	var srPolicies []*pb.SRPolicy
-	for ssAddr, policies := range s.pce.SRPolicies() {
-		for _, policy := range policies {
-			srPolicy := &pb.SRPolicy{
-				PcepSessionAddr: ssAddr.AsSlice(),
-				SegmentList:     make([]*pb.Segment, 0),
-				Color:           policy.Color,
-				Preference:      policy.Preference,
-				PolicyName:      policy.Name,
-				SrcAddr:         policy.SrcAddr.AsSlice(),
-				DstAddr:         policy.DstAddr.AsSlice(),
-			}
-
-			for _, segment := range policy.SegmentList {
-				srPolicy.SegmentList = append(srPolicy.SegmentList, &pb.Segment{
-					Sid: segment.SidString(),
-				})
-			}
-
-			srPolicies = append(srPolicies, srPolicy)
+	var filterAddr netip.Addr
+	if raw := req.GetSessionAddr(); len(raw) > 0 {
+		var ok bool
+		filterAddr, ok = netip.AddrFromSlice(raw)
+		if !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid session filter address %v", raw)
 		}
+	}
+
+	policiesByPeer := s.pce.SRPolicies()
+	peerAddrs := make([]netip.Addr, 0, len(policiesByPeer))
+	for peerAddr := range policiesByPeer {
+		if filterAddr.IsValid() && peerAddr != filterAddr {
+			continue
+		}
+		peerAddrs = append(peerAddrs, peerAddr)
+	}
+	slices.SortFunc(peerAddrs, func(a, b netip.Addr) int { return a.Compare(b) })
+
+	routerIDIndex := buildRouterIDIndex(s.pce.TED())
+	sessions := make([]*pb.Session, 0, len(peerAddrs))
+	for _, peerAddr := range peerAddrs {
+		pbPolicies := make([]*pb.SRPolicy, 0, len(policiesByPeer[peerAddr]))
+		for _, policy := range policiesByPeer[peerAddr] {
+			pbPolicies = append(pbPolicies, s.buildPBSRPolicy(peerAddr, policy, routerIDIndex))
+		}
+		slices.SortFunc(pbPolicies, func(a, b *pb.SRPolicy) int {
+			if a.GetColor() < b.GetColor() {
+				return -1
+			}
+			if a.GetColor() > b.GetColor() {
+				return 1
+			}
+			if a.GetPlspId() < b.GetPlspId() {
+				return -1
+			}
+			if a.GetPlspId() > b.GetPlspId() {
+				return 1
+			}
+			return strings.Compare(a.GetPolicyName(), b.GetPolicyName())
+		})
+
+		sessions = append(sessions, &pb.Session{
+			Addr:       peerAddr.AsSlice(),
+			SrPolicies: pbPolicies,
+		})
 	}
 
 	s.logger.Debug("Send SRPolicyList API reply")
 	return &pb.GetSRPolicyListResponse{
-		SrPolicies: srPolicies,
+		Sessions: sessions,
 	}, nil
+}
+
+func (s *APIServer) buildPBSRPolicy(peerAddr netip.Addr, policy *table.SRPolicy, routerIDIndex map[netip.Addr]string) *pb.SRPolicy {
+	srPolicy := &pb.SRPolicy{
+		PcepSessionAddr: peerAddr.AsSlice(),
+		SegmentList:     make([]*pb.Segment, 0, len(policy.SegmentList)),
+		Color:           policy.Color,
+		Preference:      policy.Preference,
+		PolicyName:      policy.Name,
+		SrcAddr:         policy.SrcAddr.AsSlice(),
+		DstAddr:         policy.DstAddr.AsSlice(),
+		PlspId:          policy.PlspID,
+		LspId:           uint32(policy.LSPID),
+		State:           toPBPolicyState(policy.State),
+		Type:            toPBPolicyType(policy.Type),
+		Metric:          toPBMetricType(policy.Metric),
+	}
+
+	if routerIDIndex != nil {
+		srPolicy.SrcRouterId = routerIDIndex[policy.SrcAddr]
+		srPolicy.DstRouterId = routerIDIndex[policy.DstAddr]
+	}
+
+	for _, segment := range policy.SegmentList {
+		srPolicy.SegmentList = append(srPolicy.SegmentList, convertSegment(segment))
+	}
+
+	return srPolicy
+}
+
+func toPBPolicyType(polType table.PolicyType) pb.SRPolicyType {
+	switch polType {
+	case table.PolicyTypeExplicit:
+		return pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT
+	case table.PolicyTypeDynamic:
+		return pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC
+	default:
+		return pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED
+	}
+}
+
+func toPBMetricType(metricType table.MetricType) pb.MetricType {
+	switch metricType {
+	case table.IGPMetric:
+		return pb.MetricType_METRIC_TYPE_IGP
+	case table.TEMetric:
+		return pb.MetricType_METRIC_TYPE_TE
+	case table.DelayMetric:
+		return pb.MetricType_METRIC_TYPE_DELAY
+	case table.HopcountMetric:
+		return pb.MetricType_METRIC_TYPE_HOPCOUNT
+	default:
+		return pb.MetricType_METRIC_TYPE_UNSPECIFIED
+	}
+}
+
+func toPBPolicyState(state table.PolicyState) pb.SRPolicyState {
+	switch state {
+	case table.PolicyDown:
+		return pb.SRPolicyState_SR_POLICY_STATE_DOWN
+	case table.PolicyUp:
+		return pb.SRPolicyState_SR_POLICY_STATE_UP
+	case table.PolicyActive:
+		return pb.SRPolicyState_SR_POLICY_STATE_ACTIVE
+	case table.PolicyUnknown:
+		return pb.SRPolicyState_SR_POLICY_STATE_UNKNOWN
+	default:
+		return pb.SRPolicyState_SR_POLICY_STATE_UNSPECIFIED
+	}
+}
+
+// buildRouterIDIndex builds a loopback-address-to-router-ID index from the TED.
+func buildRouterIDIndex(ted *table.LsTED) map[netip.Addr]string {
+	if ted == nil {
+		return nil
+	}
+
+	index := make(map[netip.Addr]string, len(ted.Nodes))
+	for _, node := range ted.Nodes {
+		if node == nil {
+			continue
+		}
+		for _, prefix := range node.Prefixes {
+			if prefix.Prefix.Bits() == prefix.Prefix.Addr().BitLen() {
+				index[prefix.Prefix.Addr()] = node.RouterID
+			}
+		}
+	}
+	return index
+}
+
+func convertSegment(seg table.Segment) *pb.Segment {
+	pbSeg := &pb.Segment{Sid: seg.SidString()}
+	switch v := seg.(type) {
+	case table.SegmentSRv6:
+		if v.LocalAddr.IsValid() {
+			pbSeg.LocalAddr = v.LocalAddr.String()
+		}
+		if v.RemoteAddr.IsValid() {
+			pbSeg.RemoteAddr = v.RemoteAddr.String()
+		}
+		if len(v.Structure) == 4 {
+			pbSeg.SidStructure = fmt.Sprintf("%d,%d,%d,%d", v.Structure[0], v.Structure[1], v.Structure[2], v.Structure[3])
+		}
+	case table.SegmentSRMPLS:
+		if v.LocalAddr.IsValid() {
+			pbSeg.LocalAddr = v.LocalAddr.String()
+		}
+		if v.RemoteAddr.IsValid() {
+			pbSeg.RemoteAddr = v.RemoteAddr.String()
+		}
+	}
+	return pbSeg
 }
 
 // GetTED returns the TED information in a structured way.
@@ -608,12 +907,17 @@ func (s *APIServer) GetTED(ctx context.Context, req *pb.GetTEDRequest) (*pb.GetT
 	s.logger.Info("Received GetTED API request")
 
 	ret := &pb.GetTEDResponse{Enable: true}
-	if s.pce == nil || s.pce.ted == nil {
+	if s.pce == nil {
+		ret.Enable = false
+		return ret, nil
+	}
+	ted := s.pce.TED()
+	if ted == nil {
 		ret.Enable = false
 		return ret, nil
 	}
 
-	for _, node := range s.pce.ted.Nodes {
+	for _, node := range ted.Nodes {
 		if n := convertLsNode(node, s.logger); n != nil {
 			ret.LsNodes = append(ret.LsNodes, n)
 		}

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -25,7 +25,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// localAddr / remoteAddr from the gRPC message must land on the SR-MPLS segment.
+// TestNewEnrichedSegmentSRMPLS verifies that localAddr and remoteAddr are
+// propagated to SR-MPLS segments.
 func TestNewEnrichedSegmentSRMPLS(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -78,8 +79,7 @@ func TestNewEnrichedSegmentSRMPLS(t *testing.T) {
 	}
 }
 
-// newEnrichedSegment is shared by the SR-MPLS and the SRv6 call paths, so the
-// SRv6 extras must keep being applied.
+// TestNewEnrichedSegmentSRv6 verifies that SRv6 segment attributes are preserved.
 func TestNewEnrichedSegmentSRv6(t *testing.T) {
 	segment := &pb.Segment{
 		Sid:          "2001:db8:1005::",
@@ -97,7 +97,7 @@ func TestNewEnrichedSegmentSRv6(t *testing.T) {
 		assert.Equal(t, "2001:db8:1005::", srv6Seg.Sid.String(), "Sid")
 		assert.Equal(t, "2001:db8::5", addrString(srv6Seg.LocalAddr), "LocalAddr")
 		assert.Equal(t, "2001:db8::6", addrString(srv6Seg.RemoteAddr), "RemoteAddr")
-		assert.Equal(t, []uint8{32, 16, 0, 80}, srv6Seg.Structure, "Structure")
+		assert.Equal(t, table.SIDStructureBytes{32, 16, 0, 80}, srv6Seg.Structure, "Structure")
 		assert.Equalf(t, usidMode, srv6Seg.USid, "USid with usidMode=%v", usidMode)
 	}
 }
@@ -114,8 +114,8 @@ func addrString(addr netip.Addr) string {
 	return addr.String()
 }
 
-// An SR-MPLS segment carrying a localAddr must be serialized into an SR-ERO
-// subobject whose body ends with that address (RFC8664 4.3.1 node NAI).
+// TestCreateEroFromSegmentListWithNAI verifies that a localAddr is encoded as
+// the SR-ERO node NAI.
 func TestCreateEroFromSegmentListWithNAI(t *testing.T) {
 	seg := table.NewSegmentSRMPLS(16002)
 	seg.LocalAddr = netip.MustParseAddr("10.255.0.2")
@@ -398,7 +398,7 @@ func TestConvertLsPrefixes_SidIndexPresence(t *testing.T) {
 	}
 }
 
-func TestGetSessionList_DeduplicatesNonAdjacentCaps(t *testing.T) {
+func TestGetSessionList_DeduplicatesNonAdjacentCapabilities(t *testing.T) {
 	session := &Session{
 		peerAddr: netip.MustParseAddr("10.0.0.1"),
 		isSynced: true,
@@ -416,9 +416,413 @@ func TestGetSessionList_DeduplicatesNonAdjacentCaps(t *testing.T) {
 	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 1)
+	require.Len(t, resp.Sessions[0].Capabilities, 2)
 
-	assert.Equal(t, []string{
-		"SR", "MSD=0", "SR-NAI-Supported",
-		"SRv6", "SRv6-NAI-Supported",
-	}, resp.Sessions[0].Caps)
+	sr := resp.Sessions[0].Capabilities[0]
+	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_SR, sr.GetType())
+	assert.True(t, sr.GetSr().GetNaiSupported())
+
+	srv6 := resp.Sessions[0].Capabilities[1]
+	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_SRV6, srv6.GetType())
+	assert.True(t, srv6.GetSrv6().GetNaiSupported())
+}
+
+func TestGetSessionList_BuildsStructuredCapabilities(t *testing.T) {
+	session := &Session{
+		peerAddr: netip.MustParseAddr("10.0.0.1"),
+		isSynced: true,
+		advertisedCapabilities: []pcep.CapabilityInterface{
+			&pcep.SRPCECapability{IsNAISupported: true, MaximumSidDepth: 10},
+			&pcep.LSPDBVersion{VersionNumber: 42},
+		},
+	}
+	s := &APIServer{
+		pce:    &Server{sessionList: []*Session{session}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	require.Len(t, resp.Sessions[0].Capabilities, 2)
+
+	sr := resp.Sessions[0].Capabilities[0]
+	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_SR, sr.GetType())
+	assert.Equal(t, uint32(10), sr.GetSr().GetMsd())
+	assert.True(t, sr.GetSr().GetNaiSupported())
+
+	dbVersion := resp.Sessions[0].Capabilities[1]
+	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_LSP_DB_VERSION, dbVersion.GetType())
+	assert.Equal(t, uint64(42), dbVersion.GetLspDbVersion().GetVersionNumber())
+}
+
+func TestGetSessionList_MultipathCapabilityDoesNotSetMsd(t *testing.T) {
+	session := &Session{
+		peerAddr: netip.MustParseAddr("10.0.0.1"),
+		isSynced: true,
+		advertisedCapabilities: []pcep.CapabilityInterface{
+			pcep.NewMultipathCapability(8, true, true, true, true),
+		},
+	}
+	s := &APIServer{
+		pce:    &Server{sessionList: []*Session{session}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	require.Len(t, resp.Sessions[0].Capabilities, 1)
+
+	multipath := resp.Sessions[0].Capabilities[0]
+	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_MULTIPATH, multipath.GetType())
+	assert.Nil(t, multipath.GetSr(), "MaxMultipaths must not be reported via the SR capability's Msd (Maximum SID Depth)")
+	assert.Equal(t, uint32(8), multipath.GetMultipath().GetMaxMultipaths())
+}
+
+func TestGetSessionList_SortsSessionsByAddr(t *testing.T) {
+	s := &APIServer{
+		pce: &Server{sessionList: []*Session{
+			{peerAddr: netip.MustParseAddr("10.0.0.2")},
+			{peerAddr: netip.MustParseAddr("10.0.0.1")},
+		}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 2)
+
+	addr0, _ := netip.AddrFromSlice(resp.Sessions[0].GetAddr())
+	addr1, _ := netip.AddrFromSlice(resp.Sessions[1].GetAddr())
+	assert.Equal(t, "10.0.0.1", addr0.String())
+	assert.Equal(t, "10.0.0.2", addr1.String())
+}
+
+func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing.T) {
+	seg, err := table.NewSegment("16003")
+	require.NoError(t, err)
+
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+	srcNode := table.NewLsNode(65000, "0000.0aff.0001")
+	srcPrefix := table.NewLsPrefix(srcNode)
+	srcPrefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
+	srcNode.Prefixes = append(srcNode.Prefixes, srcPrefix)
+	ted.Nodes[srcNode.RouterID] = srcNode
+
+	session2 := &Session{
+		peerAddr: netip.MustParseAddr("10.0.0.2"),
+		isSynced: true,
+		srPolicies: []*table.SRPolicy{
+			table.NewSRPolicy(1, "policy-b", []table.Segment{seg},
+				netip.MustParseAddr("192.0.2.10"), netip.MustParseAddr("192.0.2.20"),
+				200, 100, 5, table.PolicyUp),
+		},
+	}
+	session1 := &Session{
+		peerAddr: netip.MustParseAddr("10.0.0.1"),
+		isSynced: true,
+		srPolicies: []*table.SRPolicy{
+			table.NewSRPolicy(2, "policy-a", []table.Segment{seg},
+				netip.MustParseAddr("192.0.2.10"), netip.MustParseAddr("192.0.2.20"),
+				100, 100, 7, table.PolicyActive),
+		},
+	}
+
+	s := &APIServer{
+		pce:    &Server{sessionList: []*Session{session2, session1}, ted: ted},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 2)
+
+	// Sessions are ordered by peer address, not insertion order.
+	addr0, _ := netip.AddrFromSlice(resp.Sessions[0].GetAddr())
+	assert.Equal(t, "10.0.0.1", addr0.String())
+	require.Len(t, resp.Sessions[0].GetSrPolicies(), 1)
+
+	policy := resp.Sessions[0].GetSrPolicies()[0]
+	assert.Equal(t, uint32(2), policy.GetPlspId())
+	assert.Equal(t, uint32(7), policy.GetLspId())
+	assert.Equal(t, pb.SRPolicyState_SR_POLICY_STATE_ACTIVE, policy.GetState())
+	assert.Equal(t, "0000.0aff.0001", policy.GetSrcRouterId())
+	assert.Empty(t, policy.GetDstRouterId(), "no TED node owns the destination address")
+}
+
+func TestBuildRouterIDIndex(t *testing.T) {
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+
+	v4Node := table.NewLsNode(65000, "router-v4")
+	v4Prefix := table.NewLsPrefix(v4Node)
+	v4Prefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
+	v4Node.Prefixes = append(v4Node.Prefixes, v4Prefix)
+	ted.Nodes[v4Node.RouterID] = v4Node
+
+	v6Node := table.NewLsNode(65000, "router-v6")
+	v6Prefix := table.NewLsPrefix(v6Node)
+	v6Prefix.Prefix = netip.MustParsePrefix("2001:db8::1/128")
+	v6Node.Prefixes = append(v6Node.Prefixes, v6Prefix)
+	ted.Nodes[v6Node.RouterID] = v6Node
+
+	// A node without a loopback (host) prefix must not appear in the index.
+	noLoopbackNode := table.NewLsNode(65000, "router-no-loopback")
+	nonHostPrefix := table.NewLsPrefix(noLoopbackNode)
+	nonHostPrefix.Prefix = netip.MustParsePrefix("192.0.2.0/24")
+	noLoopbackNode.Prefixes = append(noLoopbackNode.Prefixes, nonHostPrefix)
+	ted.Nodes[noLoopbackNode.RouterID] = noLoopbackNode
+
+	index := buildRouterIDIndex(ted)
+	assert.Equal(t, "router-v4", index[netip.MustParseAddr("192.0.2.10")])
+	assert.Equal(t, "router-v6", index[netip.MustParseAddr("2001:db8::1")])
+	assert.Empty(t, index[netip.MustParseAddr("192.0.2.0")])
+
+	assert.Nil(t, buildRouterIDIndex(nil))
+}
+
+func TestGetSRPolicyList_FiltersBySessionAddr(t *testing.T) {
+	seg, err := table.NewSegment("16003")
+	require.NoError(t, err)
+
+	s := &APIServer{
+		pce: &Server{sessionList: []*Session{
+			{
+				peerAddr: netip.MustParseAddr("10.0.0.1"),
+				isSynced: true,
+				srPolicies: []*table.SRPolicy{
+					table.NewSRPolicy(1, "policy-a", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 100, 100, 0, table.PolicyUp),
+				},
+			},
+			{
+				peerAddr: netip.MustParseAddr("10.0.0.2"),
+				isSynced: true,
+				srPolicies: []*table.SRPolicy{
+					table.NewSRPolicy(2, "policy-b", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 200, 100, 0, table.PolicyUp),
+				},
+			},
+		}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{SessionAddr: netip.MustParseAddr("10.0.0.2").AsSlice()})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	addr, _ := netip.AddrFromSlice(resp.Sessions[0].GetAddr())
+	assert.Equal(t, "10.0.0.2", addr.String())
+}
+
+func TestGetSRPolicyList_RejectsInvalidSessionFilter(t *testing.T) {
+	s := &APIServer{
+		pce:    &Server{},
+		logger: zap.NewNop(),
+	}
+
+	_, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{SessionAddr: []byte{1, 2, 3}})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestResolveSRPolicyIntent(t *testing.T) {
+	tests := []struct {
+		name               string
+		policy             *pb.SRPolicy
+		disablePathCompute bool
+		wantType           table.PolicyType
+		wantMetric         table.MetricType
+		wantErr            bool
+	}{
+		{
+			name:               "disable_path_compute is always explicit regardless of Type",
+			policy:             &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC},
+			disablePathCompute: true,
+			wantType:           table.PolicyTypeExplicit,
+			wantMetric:         table.UnspecifiedMetric,
+		},
+		{
+			name:       "explicit path has no metric",
+			policy:     &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT},
+			wantType:   table.PolicyTypeExplicit,
+			wantMetric: table.UnspecifiedMetric,
+		},
+		{
+			name:       "dynamic path resolves its metric",
+			policy:     &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, Metric: pb.MetricType_METRIC_TYPE_TE},
+			wantType:   table.PolicyTypeDynamic,
+			wantMetric: table.TEMetric,
+		},
+		{
+			name:    "dynamic path with unresolvable metric is an error",
+			policy:  &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, Metric: pb.MetricType_METRIC_TYPE_UNSPECIFIED},
+			wantErr: true,
+		},
+		{
+			name:    "unspecified type is an error",
+			policy:  &pb.SRPolicy{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotMetric, err := resolveSRPolicyIntent(tt.policy, tt.disablePathCompute)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantType, gotType)
+			assert.Equal(t, tt.wantMetric, gotMetric)
+		})
+	}
+}
+
+func TestGetSRPolicyList_RoundTripsTypeAndMetric(t *testing.T) {
+	seg, err := table.NewSegment("16003")
+	require.NoError(t, err)
+
+	knownPolicy := table.NewSRPolicy(1, "policy-known", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 100, 100, 0, table.PolicyUp)
+	knownPolicy.Type = table.PolicyTypeDynamic
+	knownPolicy.Metric = table.DelayMetric
+
+	unknownPolicy := table.NewSRPolicy(2, "policy-unknown", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 200, 100, 0, table.PolicyUp)
+
+	s := &APIServer{
+		pce: &Server{sessionList: []*Session{
+			{
+				peerAddr:   netip.MustParseAddr("10.0.0.1"),
+				isSynced:   true,
+				srPolicies: []*table.SRPolicy{knownPolicy, unknownPolicy},
+			},
+		}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	require.Len(t, resp.Sessions[0].GetSrPolicies(), 2)
+
+	byColor := map[uint32]*pb.SRPolicy{}
+	for _, p := range resp.Sessions[0].GetSrPolicies() {
+		byColor[p.GetColor()] = p
+	}
+
+	known := byColor[100]
+	require.NotNil(t, known)
+	assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, known.GetType())
+	assert.Equal(t, pb.MetricType_METRIC_TYPE_DELAY, known.GetMetric())
+
+	unknown := byColor[200]
+	require.NotNil(t, unknown)
+	assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED, unknown.GetType())
+	assert.Equal(t, pb.MetricType_METRIC_TYPE_UNSPECIFIED, unknown.GetMetric())
+}
+
+func TestConvertSegment_CarriesSRv6NAIAndStructure(t *testing.T) {
+	sid := netip.MustParseAddr("2001:db8:1005::")
+	seg := table.SegmentSRv6{
+		Sid:        sid,
+		LocalAddr:  netip.MustParseAddr("2001:db8::5"),
+		RemoteAddr: netip.MustParseAddr("2001:db8::6"),
+		Structure:  table.SIDStructureBytes{32, 16, 0, 80},
+	}
+
+	pbSeg := convertSegment(seg)
+	assert.Equal(t, sid.String(), pbSeg.GetSid())
+	assert.Equal(t, "2001:db8::5", pbSeg.GetLocalAddr())
+	assert.Equal(t, "2001:db8::6", pbSeg.GetRemoteAddr())
+	assert.Equal(t, "32,16,0,80", pbSeg.GetSidStructure())
+}
+
+func TestConvertSegment_SRMPLS(t *testing.T) {
+	tests := []struct {
+		name       string
+		localAddr  netip.Addr
+		remoteAddr netip.Addr
+	}{
+		{name: "localAddr only", localAddr: netip.MustParseAddr("192.0.2.1")},
+		{name: "remoteAddr only", remoteAddr: netip.MustParseAddr("192.0.2.2")},
+		{
+			name:       "localAddr and remoteAddr",
+			localAddr:  netip.MustParseAddr("192.0.2.1"),
+			remoteAddr: netip.MustParseAddr("192.0.2.2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seg := table.SegmentSRMPLS{Sid: 16003, LocalAddr: tt.localAddr, RemoteAddr: tt.remoteAddr}
+
+			pbSeg := convertSegment(seg)
+			assert.Equal(t, "16003", pbSeg.GetSid())
+			if tt.localAddr.IsValid() {
+				assert.Equal(t, tt.localAddr.String(), pbSeg.GetLocalAddr())
+			} else {
+				assert.Empty(t, pbSeg.GetLocalAddr())
+			}
+			if tt.remoteAddr.IsValid() {
+				assert.Equal(t, tt.remoteAddr.String(), pbSeg.GetRemoteAddr())
+			} else {
+				assert.Empty(t, pbSeg.GetRemoteAddr())
+			}
+		})
+	}
+}
+
+// TestTED_ConcurrentUpdate verifies that TED reads and updates are synchronized.
+func TestTED_ConcurrentUpdate(t *testing.T) {
+	s := &Server{ted: &table.LsTED{Nodes: map[string]*table.LsNode{}}}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			node := table.NewLsNode(1, "router")
+			prefix := table.NewLsPrefix(node)
+			prefix.Prefix = netip.MustParsePrefix("192.0.2.1/32")
+			node.Prefixes = append(node.Prefixes, prefix)
+			s.setTED(&table.LsTED{Nodes: map[string]*table.LsNode{"router": node}})
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		_ = s.TED()
+	}
+	<-done
+}
+
+// TestSessionList_ConcurrentAccess verifies that session list reads and updates are synchronized.
+func TestSessionList_ConcurrentAccess(t *testing.T) {
+	s := &Server{}
+	addr := netip.MustParseAddr("192.0.2.1")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			ss := &Session{sessionID: uint8(i), peerAddr: addr, isSynced: true}
+
+			s.sessionMu.Lock()
+			s.sessionList = append(s.sessionList, ss)
+			s.sessionMu.Unlock()
+
+			s.sessionMu.Lock()
+			for j, v := range s.sessionList {
+				if v.sessionID == ss.sessionID {
+					s.sessionList[j] = s.sessionList[len(s.sessionList)-1]
+					s.sessionList = s.sessionList[:len(s.sessionList)-1]
+					break
+				}
+			}
+			s.sessionMu.Unlock()
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		s.SearchSession(addr, false)
+		s.SRPolicies()
+		s.Sessions()
+	}
+	<-done
 }

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -826,3 +826,43 @@ func TestSessionList_ConcurrentAccess(t *testing.T) {
 	}
 	<-done
 }
+
+func TestDeleteSRPolicy_SrcAddrOmitted(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close client connection: %v", err)
+		}
+	})
+
+	peerAddr := netip.MustParseAddr("10.0.255.1")
+	dstAddr := netip.MustParseAddr("10.255.0.2")
+
+	ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+	ss.isSynced = true
+	ss.srPolicies = []*table.SRPolicy{
+		{
+			PlspID:     1,
+			Name:       "test-policy",
+			DstAddr:    dstAddr,
+			Color:      100,
+			Preference: 100,
+		},
+	}
+
+	pce := &Server{sessionList: []*Session{ss}}
+	apiServer := &APIServer{pce: pce, logger: zap.NewNop()}
+
+	req := &pb.DeleteSRPolicyRequest{
+		SrPolicy: &pb.SRPolicy{
+			PcepSessionAddr: peerAddr.AsSlice(),
+			DstAddr:         dstAddr.AsSlice(),
+			Color:           100,
+			PolicyName:      "test-policy",
+		},
+	}
+
+	resp, err := apiServer.DeleteSRPolicy(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, resp.GetIsSuccess())
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,7 +11,9 @@ import (
 	"math"
 	"net"
 	"net/netip"
+	"slices"
 	"strconv"
+	"sync"
 
 	"go.uber.org/zap"
 	grpc "google.golang.org/grpc"
@@ -20,10 +22,25 @@ import (
 )
 
 type Server struct {
+	sessionMu   sync.RWMutex // guards sessionList; written from the PCEP accept/close goroutines, read from gRPC handler goroutines.
 	sessionList []*Session
+	tedMu       sync.RWMutex // guards ted; written from the TED-update goroutine, read from gRPC handler goroutines.
 	ted         *table.LsTED
 	logger      *zap.Logger
 	asn         uint32
+}
+
+// TED returns the current TED snapshot. Safe for concurrent use with setTED.
+func (s *Server) TED() *table.LsTED {
+	s.tedMu.RLock()
+	defer s.tedMu.RUnlock()
+	return s.ted
+}
+
+func (s *Server) setTED(ted *table.LsTED) {
+	s.tedMu.Lock()
+	defer s.tedMu.Unlock()
+	s.ted = ted
 }
 
 type PCEOptions struct {
@@ -42,9 +59,9 @@ func NewPCE(o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem
 		asn:    o.ASN,
 	}
 	if o.TEDEnable {
-		s.ted = &table.LsTED{
+		s.setTED(&table.LsTED{
 			Nodes: map[string]*table.LsNode{},
-		}
+		})
 
 		// Update TED
 		go func() {
@@ -54,7 +71,7 @@ func NewPCE(o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem
 					Nodes: map[string]*table.LsNode{},
 				}
 				ted.Update(tedElems, o.ASN)
-				s.ted = ted
+				s.setTED(ted)
 				logger.Debug("Update TED")
 			}
 		}()
@@ -121,10 +138,12 @@ func (s *Server) Serve(address string, port string, usidMode bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse remote address %s: %w", tcpConn.RemoteAddr().String(), err)
 		}
-		ss := NewSession(sessionID, peerAddrPort.Addr(), tcpConn, s.logger, s.ted, s.asn)
+		ss := NewSession(sessionID, peerAddrPort.Addr(), tcpConn, s.logger, s.TED(), s.asn)
 		ss.logger.Info("start PCEP session")
 
+		s.sessionMu.Lock()
 		s.sessionList = append(s.sessionList, ss)
+		s.sessionMu.Unlock()
 		go func() {
 			ss.Established()
 			s.closeSession(ss)
@@ -138,8 +157,10 @@ func (s *Server) closeSession(session *Session) {
 	if err := session.tcpConn.Close(); err != nil {
 		s.logger.Warn("failed to close TCP connection", zap.Error(err))
 	}
+	session.clearSRPolicyIntents()
 
 	// Remove Session List
+	s.sessionMu.Lock()
 	for i, v := range s.sessionList {
 		if v.sessionID == session.sessionID {
 			s.sessionList[i] = s.sessionList[len(s.sessionList)-1]
@@ -147,14 +168,17 @@ func (s *Server) closeSession(session *Session) {
 			break
 		}
 	}
+	s.sessionMu.Unlock()
 }
 
 // SearchSession returns a struct pointer of (Synced) session.
 // If not exist, return nil
 func (s *Server) SearchSession(peerAddr netip.Addr, onlySynced bool) *Session {
+	s.sessionMu.RLock()
+	defer s.sessionMu.RUnlock()
 	for _, pcepSession := range s.sessionList {
 		if pcepSession.peerAddr == peerAddr {
-			if !onlySynced || pcepSession.isSynced {
+			if !onlySynced || pcepSession.IsSynced() {
 				return pcepSession
 			}
 		}
@@ -162,12 +186,23 @@ func (s *Server) SearchSession(peerAddr netip.Addr, onlySynced bool) *Session {
 	return nil
 }
 
+// Sessions returns a snapshot copy of the current session list, safe for concurrent use.
+func (s *Server) Sessions() []*Session {
+	s.sessionMu.RLock()
+	defer s.sessionMu.RUnlock()
+	return slices.Clone(s.sessionList)
+}
+
 // SRPolicies returns a map of registered SR Policy with key sessionAddr
 func (s *Server) SRPolicies() map[netip.Addr][]*table.SRPolicy {
+	s.sessionMu.RLock()
+	sessions := slices.Clone(s.sessionList)
+	s.sessionMu.RUnlock()
+
 	srPolicies := make(map[netip.Addr][]*table.SRPolicy)
-	for _, ss := range s.sessionList {
-		if ss.isSynced {
-			srPolicies[ss.peerAddr] = ss.srPolicies
+	for _, ss := range sessions {
+		if ss.IsSynced() {
+			srPolicies[ss.peerAddr] = ss.SRPolicies()
 		}
 	}
 	return srPolicies

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -22,18 +22,31 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// defaultSRPolicyIntentTTL is the lifetime of an SR Policy intent.
+	defaultSRPolicyIntentTTL = 60 * time.Second
+	// defaultSRPolicyIntentSweepInterval is the sweep interval for expired intents.
+	defaultSRPolicyIntentSweepInterval = 10 * time.Second
+)
+
 type Session struct {
 	sessionID               uint8
 	peerAddr                netip.Addr
 	tcpConn                 *net.TCPConn
+	sendMu                  sync.Mutex
 	stateMu                 sync.RWMutex // guards isSynced and advertisedCapabilities.
 	isSynced                bool
 	srpIDMu                 sync.Mutex   // guards SRP-ID allocation and intent registration.
 	srpIDHead               uint32       // 0x00000000 and 0xFFFFFFFF are reserved.
 	srPoliciesMu            sync.RWMutex // guards srPolicies.
 	srPolicies              []*table.SRPolicy
-	srPolicyIntentsMu       sync.Mutex // guards srPolicyIntents.
+	srPolicyIntentsMu       sync.Mutex
 	srPolicyIntents         map[uint32]srPolicyIntent
+	srPolicyIntentTTL       time.Duration
+	sweepInterval           time.Duration
+	sweepMu                 sync.Mutex
+	sweepStop               chan struct{}
+	sweepDone               chan struct{}
 	logger                  *zap.Logger
 	keepAlive               uint8
 	pccType                 pcep.PccType
@@ -43,11 +56,11 @@ type Session struct {
 	asn                     uint32
 }
 
-// srPolicyIntent stores the candidate-path type and metric because PCEP does
-// not report them after the policy is established.
+// srPolicyIntent stores policy information not reported by PCEP.
 type srPolicyIntent struct {
-	polType table.PolicyType
-	metric  table.MetricType
+	polType   table.PolicyType
+	metric    table.MetricType
+	expiresAt time.Time
 }
 
 // rememberSRPolicyIntent records the intent for an SRP-ID.
@@ -61,7 +74,71 @@ func (ss *Session) rememberSRPolicyIntent(srpID uint32, polType table.PolicyType
 	if ss.srPolicyIntents == nil {
 		ss.srPolicyIntents = make(map[uint32]srPolicyIntent)
 	}
-	ss.srPolicyIntents[srpID] = srPolicyIntent{polType: polType, metric: metric}
+	ss.srPolicyIntents[srpID] = srPolicyIntent{polType: polType, metric: metric, expiresAt: time.Now().Add(ss.srPolicyIntentTTL)}
+}
+
+func (ss *Session) srPolicyIntentExists(srpID uint32) bool {
+	ss.srPolicyIntentsMu.Lock()
+	defer ss.srPolicyIntentsMu.Unlock()
+	_, ok := ss.srPolicyIntents[srpID]
+	return ok
+}
+
+// sweepExpiredSRPolicyIntents removes expired intents.
+func (ss *Session) sweepExpiredSRPolicyIntents() {
+	now := time.Now()
+	ss.srPolicyIntentsMu.Lock()
+	defer ss.srPolicyIntentsMu.Unlock()
+	for srpID, intent := range ss.srPolicyIntents {
+		if now.After(intent.expiresAt) {
+			delete(ss.srPolicyIntents, srpID)
+		}
+	}
+}
+
+// startIntentSweep starts the intent sweeper. It is idempotent.
+func (ss *Session) startIntentSweep() {
+	ss.sweepMu.Lock()
+	defer ss.sweepMu.Unlock()
+
+	if ss.sweepStop != nil {
+		return
+	}
+
+	ss.sweepStop = make(chan struct{})
+	ss.sweepDone = make(chan struct{})
+	go ss.runIntentSweep(ss.sweepStop, ss.sweepDone)
+}
+
+func (ss *Session) runIntentSweep(stop, done chan struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(ss.sweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			ss.sweepExpiredSRPolicyIntents()
+		}
+	}
+}
+
+func (ss *Session) stopIntentSweep() {
+	ss.sweepMu.Lock()
+	if ss.sweepStop == nil {
+		ss.sweepMu.Unlock()
+		return
+	}
+
+	stop := ss.sweepStop
+	done := ss.sweepDone
+	ss.sweepStop = nil
+	ss.sweepDone = nil
+	ss.sweepMu.Unlock()
+
+	close(stop)
+	<-done
 }
 
 // takeSRPolicyIntent returns and removes the intent for srpID.
@@ -96,15 +173,17 @@ func (ss *Session) clearSRPolicyIntents() {
 
 func NewSession(sessionID uint8, peerAddr netip.Addr, tcpConn *net.TCPConn, logger *zap.Logger, ted *table.LsTED, asn uint32) *Session {
 	return &Session{
-		sessionID: sessionID,
-		isSynced:  false,
-		srpIDHead: uint32(1),
-		logger:    logger.With(zap.String("server", "pcep"), zap.String("session", peerAddr.String())),
-		pccType:   pcep.RFCCompliant,
-		peerAddr:  peerAddr,
-		tcpConn:   tcpConn,
-		ted:       ted,
-		asn:       asn,
+		sessionID:         sessionID,
+		isSynced:          false,
+		srpIDHead:         uint32(1),
+		srPolicyIntentTTL: defaultSRPolicyIntentTTL,
+		sweepInterval:     defaultSRPolicyIntentSweepInterval,
+		logger:            logger.With(zap.String("server", "pcep"), zap.String("session", peerAddr.String())),
+		pccType:           pcep.RFCCompliant,
+		peerAddr:          peerAddr,
+		tcpConn:           tcpConn,
+		ted:               ted,
+		asn:               asn,
 	}
 }
 
@@ -120,6 +199,9 @@ func (ss *Session) Established() {
 		ss.logger.Debug("ERROR! Send Keepalive Message", zap.Error(err))
 		return
 	}
+
+	ss.startIntentSweep()
+	defer ss.stopIntentSweep()
 
 	done := make(chan struct{}, 1)
 
@@ -147,15 +229,18 @@ func (ss *Session) Established() {
 	}
 }
 
+// sendPCEPMessage serializes and writes a PCEP message.
 func (ss *Session) sendPCEPMessage(message pcep.Message) error {
 	byteMessage, err := message.Serialize()
 	if err != nil {
 		return err
 	}
-	if _, err = ss.tcpConn.Write(byteMessage); err != nil {
-		return err
-	}
-	return nil
+
+	ss.sendMu.Lock()
+	defer ss.sendMu.Unlock()
+
+	_, err = ss.tcpConn.Write(byteMessage)
+	return err
 }
 
 func (ss *Session) Open() error {
@@ -230,18 +315,11 @@ func (ss *Session) SendClose(reason pcep.CloseReason) error {
 	if err != nil {
 		return err
 	}
-	byteCloseMessage, err := closeMessage.Serialize()
-	if err != nil {
-		return err
-	}
 
 	ss.logger.Debug("Send Close Message",
 		zap.Uint8("reason", uint8(closeMessage.CloseObject.Reason)),
 		zap.String("detail", "See https://www.iana.org/assignments/pcep/pcep.xhtml#close-object-reason-field"))
-	if _, err := ss.tcpConn.Write(byteCloseMessage); err != nil {
-		return err
-	}
-	return nil
+	return ss.sendPCEPMessage(closeMessage)
 }
 
 func (ss *Session) ReceivePCEPMessage() error {
@@ -598,21 +676,43 @@ func (ss *Session) SendOpen() error {
 	return ss.sendPCEPMessage(openMessage)
 }
 
-// allocateSRPID allocates a non-reserved SRP-ID and records its intent.
-func (ss *Session) allocateSRPID(polType table.PolicyType, metric table.MetricType) uint32 {
+// nextUnusedSRPID returns an unused SRP-ID, wrapping at max.
+// It returns an error if all non-reserved IDs are in use.
+func nextUnusedSRPID(head, max uint32, used func(uint32) bool) (srpID uint32, nextHead uint32, err error) {
+	capacity := max - 1 // valid range is [1, max-1]; 0 and max are reserved.
+	for attempts := uint32(0); attempts < capacity; attempts++ {
+		if head == 0 || head >= max {
+			head = 1
+		}
+		candidate := head
+		head++
+		if !used(candidate) {
+			return candidate, head, nil
+		}
+	}
+	return 0, head, errors.New("no SRP-ID available: all SRP-IDs are in use")
+}
+
+// allocateSRPID allocates an unused SRP-ID and records its intent.
+// In-use IDs are skipped on wraparound.
+func (ss *Session) allocateSRPID(polType table.PolicyType, metric table.MetricType) (uint32, error) {
 	ss.srpIDMu.Lock()
 	defer ss.srpIDMu.Unlock()
-	if ss.srpIDHead == 0 || ss.srpIDHead == math.MaxUint32 {
-		ss.srpIDHead = 1
+
+	srpID, nextHead, err := nextUnusedSRPID(ss.srpIDHead, math.MaxUint32, ss.srPolicyIntentExists)
+	if err != nil {
+		return 0, err
 	}
-	srpID := ss.srpIDHead
-	ss.srpIDHead++
+	ss.srpIDHead = nextHead
 	ss.rememberSRPolicyIntent(srpID, polType, metric)
-	return srpID
+	return srpID, nil
 }
 
 func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error {
-	srpID := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
+	srpID, err := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
+	if err != nil {
+		return err
+	}
 
 	pcinitiateMessage, err := pcep.NewPCInitiateMessage(srpID, srPolicy.Name, lspDelete, srPolicy.PlspID, srPolicy.SegmentList, srPolicy.Color, srPolicy.Preference, srPolicy.SrcAddr, srPolicy.DstAddr, pcep.VendorSpecific(ss.pccType), pcep.OriginatorASN(ss.asn))
 	if err != nil {
@@ -628,7 +728,10 @@ func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error
 }
 
 func (ss *Session) SendPCUpdate(srPolicy table.SRPolicy) error {
-	srpID := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
+	srpID, err := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
+	if err != nil {
+		return err
+	}
 
 	pcupdateMessage, err := pcep.NewPCUpdMessage(srpID, srPolicy.Name, srPolicy.PlspID, srPolicy.SegmentList)
 	if err != nil {
@@ -821,6 +924,7 @@ func (ss *Session) SRPolicies() []*table.SRPolicy {
 	policies := make([]*table.SRPolicy, len(ss.srPolicies))
 	for i, p := range ss.srPolicies {
 		clone := *p
+		clone.SegmentList = slices.Clone(p.SegmentList)
 		policies[i] = &clone
 	}
 	return policies

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -8,6 +8,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/netip"
 	"slices"
@@ -27,11 +28,12 @@ type Session struct {
 	tcpConn                 *net.TCPConn
 	stateMu                 sync.RWMutex // guards isSynced and advertisedCapabilities.
 	isSynced                bool
+	srpIDMu                 sync.Mutex   // guards SRP-ID allocation and intent registration.
 	srpIDHead               uint32       // 0x00000000 and 0xFFFFFFFF are reserved.
 	srPoliciesMu            sync.RWMutex // guards srPolicies.
 	srPolicies              []*table.SRPolicy
 	srPolicyIntentsMu       sync.Mutex // guards srPolicyIntents.
-	srPolicyIntents         map[srPolicyIntentKey]srPolicyIntent
+	srPolicyIntents         map[uint32]srPolicyIntent
 	logger                  *zap.Logger
 	keepAlive               uint8
 	pccType                 pcep.PccType
@@ -41,13 +43,6 @@ type Session struct {
 	asn                     uint32
 }
 
-// srPolicyIntentKey identifies an SR Policy the same way SearchPlspID does,
-// since a PCRpt for a newly requested policy does not provide a known PLSP-ID.
-type srPolicyIntentKey struct {
-	color uint32
-	dst   netip.Addr
-}
-
 // srPolicyIntent stores the candidate-path type and metric because PCEP does
 // not report them after the policy is established.
 type srPolicyIntent struct {
@@ -55,31 +50,41 @@ type srPolicyIntent struct {
 	metric  table.MetricType
 }
 
-// RememberSRPolicyIntent records the candidate-path type and metric for an SR Policy.
-func (ss *Session) RememberSRPolicyIntent(color uint32, dst netip.Addr, polType table.PolicyType, metric table.MetricType) {
+// rememberSRPolicyIntent records the intent for an SRP-ID.
+// SRP-ID 0 is reserved for unsolicited PCRpt messages and is ignored.
+func (ss *Session) rememberSRPolicyIntent(srpID uint32, polType table.PolicyType, metric table.MetricType) {
+	if srpID == 0 {
+		return
+	}
 	ss.srPolicyIntentsMu.Lock()
 	defer ss.srPolicyIntentsMu.Unlock()
 	if ss.srPolicyIntents == nil {
-		ss.srPolicyIntents = make(map[srPolicyIntentKey]srPolicyIntent)
+		ss.srPolicyIntents = make(map[uint32]srPolicyIntent)
 	}
-	ss.srPolicyIntents[srPolicyIntentKey{color: color, dst: dst}] = srPolicyIntent{polType: polType, metric: metric}
+	ss.srPolicyIntents[srpID] = srPolicyIntent{polType: polType, metric: metric}
 }
 
-// takeSRPolicyIntent returns and removes the intent for (color, dst).
-func (ss *Session) takeSRPolicyIntent(color uint32, dst netip.Addr) (srPolicyIntent, bool) {
+// takeSRPolicyIntent returns and removes the intent for srpID.
+// SRP-ID 0 never consumes an intent.
+func (ss *Session) takeSRPolicyIntent(srpID uint32) (srPolicyIntent, bool) {
+	if srpID == 0 {
+		return srPolicyIntent{}, false
+	}
 	ss.srPolicyIntentsMu.Lock()
 	defer ss.srPolicyIntentsMu.Unlock()
-	key := srPolicyIntentKey{color: color, dst: dst}
-	intent, ok := ss.srPolicyIntents[key]
-	delete(ss.srPolicyIntents, key)
+	intent, ok := ss.srPolicyIntents[srpID]
+	delete(ss.srPolicyIntents, srpID)
 	return intent, ok
 }
 
 // forgetSRPolicyIntent discards an intent that will no longer be consumed.
-func (ss *Session) forgetSRPolicyIntent(color uint32, dst netip.Addr) {
+func (ss *Session) forgetSRPolicyIntent(srpID uint32) {
+	if srpID == 0 {
+		return
+	}
 	ss.srPolicyIntentsMu.Lock()
 	defer ss.srPolicyIntentsMu.Unlock()
-	delete(ss.srPolicyIntents, srPolicyIntentKey{color: color, dst: dst})
+	delete(ss.srPolicyIntents, srpID)
 }
 
 // clearSRPolicyIntents discards all remembered intents when the session ends.
@@ -265,15 +270,7 @@ func (ss *Session) ReceivePCEPMessage() error {
 			if err := pcerrMessage.DecodeFromBytes(bytePCErrMessageBody); err != nil {
 				return err
 			}
-
-			srpIDs := pcerrMessage.SRPIDs()
-			for _, errObj := range pcerrMessage.Errors {
-				ss.logger.Debug("Received PCErr",
-					zap.Uint8("error-Type", errObj.ErrorType),
-					zap.Uint8("error-value", errObj.ErrorValue),
-					zap.Uint32s("srp-ids", srpIDs),
-					zap.String("detail", "See https://www.iana.org/assignments/pcep/pcep.xhtml#pcep-error-object"))
-			}
+			ss.handlePCErr(pcerrMessage)
 		case pcep.MessageTypeClose:
 			byteCloseMessageBody := make([]uint8, commonHeader.MessageLength-pcep.CommonHeaderLength)
 			if _, err := ss.tcpConn.Read(byteCloseMessageBody); err != nil {
@@ -307,6 +304,21 @@ func (ss *Session) readCommonHeader() (*pcep.CommonHeader, error) {
 	}
 
 	return commonHeader, nil
+}
+
+// handlePCErr logs the error and forgets intents for the reported SRP-IDs.
+func (ss *Session) handlePCErr(pcerrMessage *pcep.PCErrMessage) {
+	srpIDs := pcerrMessage.SRPIDs()
+	for _, errObj := range pcerrMessage.Errors {
+		ss.logger.Debug("Received PCErr",
+			zap.Uint8("error-Type", errObj.ErrorType),
+			zap.Uint8("error-value", errObj.ErrorValue),
+			zap.Uint32s("srp-ids", srpIDs),
+			zap.String("detail", "See https://www.iana.org/assignments/pcep/pcep.xhtml#pcep-error-object"))
+	}
+	for _, srpID := range srpIDs {
+		ss.forgetSRPolicyIntent(srpID)
+	}
 }
 
 func (ss *Session) handlePCRpt(length uint16) error {
@@ -586,30 +598,49 @@ func (ss *Session) SendOpen() error {
 	return ss.sendPCEPMessage(openMessage)
 }
 
+// allocateSRPID allocates a non-reserved SRP-ID and records its intent.
+func (ss *Session) allocateSRPID(polType table.PolicyType, metric table.MetricType) uint32 {
+	ss.srpIDMu.Lock()
+	defer ss.srpIDMu.Unlock()
+	if ss.srpIDHead == 0 || ss.srpIDHead == math.MaxUint32 {
+		ss.srpIDHead = 1
+	}
+	srpID := ss.srpIDHead
+	ss.srpIDHead++
+	ss.rememberSRPolicyIntent(srpID, polType, metric)
+	return srpID
+}
+
 func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error {
-	pcinitiateMessage, err := pcep.NewPCInitiateMessage(ss.srpIDHead, srPolicy.Name, lspDelete, srPolicy.PlspID, srPolicy.SegmentList, srPolicy.Color, srPolicy.Preference, srPolicy.SrcAddr, srPolicy.DstAddr, pcep.VendorSpecific(ss.pccType), pcep.OriginatorASN(ss.asn))
+	srpID := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
+
+	pcinitiateMessage, err := pcep.NewPCInitiateMessage(srpID, srPolicy.Name, lspDelete, srPolicy.PlspID, srPolicy.SegmentList, srPolicy.Color, srPolicy.Preference, srPolicy.SrcAddr, srPolicy.DstAddr, pcep.VendorSpecific(ss.pccType), pcep.OriginatorASN(ss.asn))
 	if err != nil {
+		ss.forgetSRPolicyIntent(srpID)
 		return err
 	}
 	ss.logger.Debug("Send PCInitiate Message")
-	err = ss.sendPCEPMessage(pcinitiateMessage)
-	if err == nil {
-		ss.srpIDHead++
+	if err := ss.sendPCEPMessage(pcinitiateMessage); err != nil {
+		ss.forgetSRPolicyIntent(srpID)
+		return err
 	}
-	return err
+	return nil
 }
 
 func (ss *Session) SendPCUpdate(srPolicy table.SRPolicy) error {
-	pcupdateMessage, err := pcep.NewPCUpdMessage(ss.srpIDHead, srPolicy.Name, srPolicy.PlspID, srPolicy.SegmentList)
+	srpID := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
+
+	pcupdateMessage, err := pcep.NewPCUpdMessage(srpID, srPolicy.Name, srPolicy.PlspID, srPolicy.SegmentList)
 	if err != nil {
+		ss.forgetSRPolicyIntent(srpID)
 		return err
 	}
 	ss.logger.Debug("Send Update Message")
-	err = ss.sendPCEPMessage(pcupdateMessage)
-	if err == nil {
-		ss.srpIDHead++
+	if err := ss.sendPCEPMessage(pcupdateMessage); err != nil {
+		ss.forgetSRPolicyIntent(srpID)
+		return err
 	}
-	return err
+	return nil
 }
 
 func (ss *Session) RegisterSRPolicy(sr pcep.StateReport) error {
@@ -704,7 +735,7 @@ func (ss *Session) updateOrCreatePolicy(sr pcep.StateReport, segmentList []table
 				LSPID:       lspID,
 				State:       state,
 			})
-			if intent, ok := ss.takeSRPolicyIntent(color, p.DstAddr); ok {
+			if intent, ok := ss.takeSRPolicyIntent(sr.SrpObject.SrpID); ok {
 				p.Type = intent.polType
 				p.Metric = intent.metric
 			}
@@ -730,7 +761,7 @@ func (ss *Session) updateOrCreatePolicy(sr pcep.StateReport, segmentList []table
 	}
 
 	p := table.NewSRPolicy(sr.LSPObject.PlspID, sr.LSPObject.Name, segmentList, src, dst, color, preference, lspID, state)
-	if intent, ok := ss.takeSRPolicyIntent(color, dst); ok {
+	if intent, ok := ss.takeSRPolicyIntent(sr.SrpObject.SrpID); ok {
 		p.Type = intent.polType
 		p.Metric = intent.metric
 	}
@@ -747,7 +778,7 @@ func (ss *Session) DeleteSRPolicy(sr pcep.StateReport) {
 	for i, v := range ss.srPolicies {
 		// If the LSP ID is old, it is not the latest data update.
 		if v.PlspID == sr.LSPObject.PlspID && v.LSPID <= lspID {
-			ss.forgetSRPolicyIntent(v.Color, v.DstAddr)
+			ss.forgetSRPolicyIntent(sr.SrpObject.SrpID)
 			ss.srPolicies[i] = ss.srPolicies[len(ss.srPolicies)-1]
 			ss.srPolicies = ss.srPolicies[:len(ss.srPolicies)-1]
 			break

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -925,6 +925,12 @@ func (ss *Session) SRPolicies() []*table.SRPolicy {
 	for i, p := range ss.srPolicies {
 		clone := *p
 		clone.SegmentList = slices.Clone(p.SegmentList)
+		for j, seg := range clone.SegmentList {
+			if srv6, ok := seg.(table.SegmentSRv6); ok {
+				srv6.Structure = slices.Clone(srv6.Structure)
+				clone.SegmentList[j] = srv6
+			}
+		}
 		policies[i] = &clone
 	}
 	return policies

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/netip"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/nttcom/pola/pkg/cspf"
@@ -24,9 +25,13 @@ type Session struct {
 	sessionID               uint8
 	peerAddr                netip.Addr
 	tcpConn                 *net.TCPConn
+	stateMu                 sync.RWMutex // guards isSynced and advertisedCapabilities.
 	isSynced                bool
-	srpIDHead               uint32 // 0x00000000 and 0xFFFFFFFF are reserved.
+	srpIDHead               uint32       // 0x00000000 and 0xFFFFFFFF are reserved.
+	srPoliciesMu            sync.RWMutex // guards srPolicies.
 	srPolicies              []*table.SRPolicy
+	srPolicyIntentsMu       sync.Mutex // guards srPolicyIntents.
+	srPolicyIntents         map[srPolicyIntentKey]srPolicyIntent
 	logger                  *zap.Logger
 	keepAlive               uint8
 	pccType                 pcep.PccType
@@ -34,6 +39,54 @@ type Session struct {
 	receivedPccCapabilities []pcep.CapabilityInterface // Capabilities received from the PCC.
 	ted                     *table.LsTED
 	asn                     uint32
+}
+
+// srPolicyIntentKey identifies an SR Policy the same way SearchPlspID does,
+// since a PCRpt for a newly requested policy does not provide a known PLSP-ID.
+type srPolicyIntentKey struct {
+	color uint32
+	dst   netip.Addr
+}
+
+// srPolicyIntent stores the candidate-path type and metric because PCEP does
+// not report them after the policy is established.
+type srPolicyIntent struct {
+	polType table.PolicyType
+	metric  table.MetricType
+}
+
+// RememberSRPolicyIntent records the candidate-path type and metric for an SR Policy.
+func (ss *Session) RememberSRPolicyIntent(color uint32, dst netip.Addr, polType table.PolicyType, metric table.MetricType) {
+	ss.srPolicyIntentsMu.Lock()
+	defer ss.srPolicyIntentsMu.Unlock()
+	if ss.srPolicyIntents == nil {
+		ss.srPolicyIntents = make(map[srPolicyIntentKey]srPolicyIntent)
+	}
+	ss.srPolicyIntents[srPolicyIntentKey{color: color, dst: dst}] = srPolicyIntent{polType: polType, metric: metric}
+}
+
+// takeSRPolicyIntent returns and removes the intent for (color, dst).
+func (ss *Session) takeSRPolicyIntent(color uint32, dst netip.Addr) (srPolicyIntent, bool) {
+	ss.srPolicyIntentsMu.Lock()
+	defer ss.srPolicyIntentsMu.Unlock()
+	key := srPolicyIntentKey{color: color, dst: dst}
+	intent, ok := ss.srPolicyIntents[key]
+	delete(ss.srPolicyIntents, key)
+	return intent, ok
+}
+
+// forgetSRPolicyIntent discards an intent that will no longer be consumed.
+func (ss *Session) forgetSRPolicyIntent(color uint32, dst netip.Addr) {
+	ss.srPolicyIntentsMu.Lock()
+	defer ss.srPolicyIntentsMu.Unlock()
+	delete(ss.srPolicyIntents, srPolicyIntentKey{color: color, dst: dst})
+}
+
+// clearSRPolicyIntents discards all remembered intents when the session ends.
+func (ss *Session) clearSRPolicyIntents() {
+	ss.srPolicyIntentsMu.Lock()
+	defer ss.srPolicyIntentsMu.Unlock()
+	ss.srPolicyIntents = nil
 }
 
 func NewSession(sessionID uint8, peerAddr netip.Addr, tcpConn *net.TCPConn, logger *zap.Logger, ted *table.LsTED, asn uint32) *Session {
@@ -147,7 +200,7 @@ func (ss *Session) ReceiveOpen() error {
 	}
 
 	ss.receivedPccCapabilities = slices.Clone(openMessage.OpenObject.Caps)
-	ss.advertisedCapabilities = pcep.PolaCapability(openMessage.OpenObject.Caps)
+	ss.setAdvertisedCapabilities(pcep.PolaCapability(openMessage.OpenObject.Caps))
 
 	// pccType detection
 	// * FRRouting cannot be detected from the open message, so it is treated as an RFC compliant
@@ -308,7 +361,33 @@ func (ss *Session) handleSynchronization(sr *pcep.StateReport, message *pcep.PCR
 // Finish synchronization (PlspID == 0)
 func (ss *Session) handleFinishSynchronization() {
 	ss.logger.Debug("Finish PCRpt state synchronization")
+	ss.setSynced()
+}
+
+// IsSynced reports whether the session has finished PCRpt state synchronization.
+func (ss *Session) IsSynced() bool {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return ss.isSynced
+}
+
+func (ss *Session) setSynced() {
+	ss.stateMu.Lock()
+	defer ss.stateMu.Unlock()
 	ss.isSynced = true
+}
+
+// AdvertisedCapabilities returns a snapshot of the capabilities Pola advertises to the PCC.
+func (ss *Session) AdvertisedCapabilities() []pcep.CapabilityInterface {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return slices.Clone(ss.advertisedCapabilities)
+}
+
+func (ss *Session) setAdvertisedCapabilities(caps []pcep.CapabilityInterface) {
+	ss.stateMu.Lock()
+	defer ss.stateMu.Unlock()
+	ss.advertisedCapabilities = caps
 }
 
 // Response to request from PCE (SrpID != 0)
@@ -499,7 +578,7 @@ func (ss *Session) RequestSRPolicyCreated(srPolicy table.SRPolicy) error {
 }
 
 func (ss *Session) SendOpen() error {
-	openMessage, err := pcep.NewOpenMessage(ss.sessionID, ss.keepAlive, ss.advertisedCapabilities)
+	openMessage, err := pcep.NewOpenMessage(ss.sessionID, ss.keepAlive, ss.AdvertisedCapabilities())
 	if err != nil {
 		return err
 	}
@@ -611,7 +690,10 @@ func validateSegmentList(sr pcep.StateReport) ([]table.Segment, error) {
 func (ss *Session) updateOrCreatePolicy(sr pcep.StateReport, segmentList []table.Segment, color, preference uint32, state table.PolicyState) error {
 	lspID := sr.LSPObject.LSPID
 
-	if p, ok := ss.SearchSRPolicy(sr.LSPObject.PlspID); ok {
+	ss.srPoliciesMu.Lock()
+	defer ss.srPoliciesMu.Unlock()
+
+	if p, ok := ss.searchSRPolicyLocked(sr.LSPObject.PlspID); ok {
 		// Update existing policy if LSPID is new or equal
 		if p.LSPID <= lspID {
 			p.Update(table.PolicyDiff{
@@ -622,6 +704,10 @@ func (ss *Session) updateOrCreatePolicy(sr pcep.StateReport, segmentList []table
 				LSPID:       lspID,
 				State:       state,
 			})
+			if intent, ok := ss.takeSRPolicyIntent(color, p.DstAddr); ok {
+				p.Type = intent.polType
+				p.Metric = intent.metric
+			}
 		}
 		return nil
 	}
@@ -644,15 +730,24 @@ func (ss *Session) updateOrCreatePolicy(sr pcep.StateReport, segmentList []table
 	}
 
 	p := table.NewSRPolicy(sr.LSPObject.PlspID, sr.LSPObject.Name, segmentList, src, dst, color, preference, lspID, state)
+	if intent, ok := ss.takeSRPolicyIntent(color, dst); ok {
+		p.Type = intent.polType
+		p.Metric = intent.metric
+	}
 	ss.srPolicies = append(ss.srPolicies, p)
 	return nil
 }
 
 func (ss *Session) DeleteSRPolicy(sr pcep.StateReport) {
 	lspID := sr.LSPObject.LSPID
+
+	ss.srPoliciesMu.Lock()
+	defer ss.srPoliciesMu.Unlock()
+
 	for i, v := range ss.srPolicies {
 		// If the LSP ID is old, it is not the latest data update.
 		if v.PlspID == sr.LSPObject.PlspID && v.LSPID <= lspID {
+			ss.forgetSRPolicyIntent(v.Color, v.DstAddr)
 			ss.srPolicies[i] = ss.srPolicies[len(ss.srPolicies)-1]
 			ss.srPolicies = ss.srPolicies[:len(ss.srPolicies)-1]
 			break
@@ -660,7 +755,8 @@ func (ss *Session) DeleteSRPolicy(sr pcep.StateReport) {
 	}
 }
 
-func (ss *Session) SearchSRPolicy(plspID uint32) (*table.SRPolicy, bool) {
+// searchSRPolicyLocked searches srPolicies without locking.
+func (ss *Session) searchSRPolicyLocked(plspID uint32) (*table.SRPolicy, bool) {
 	for _, v := range ss.srPolicies {
 		if v.PlspID == plspID {
 			return v, true
@@ -669,12 +765,32 @@ func (ss *Session) SearchSRPolicy(plspID uint32) (*table.SRPolicy, bool) {
 	return nil, false
 }
 
+func (ss *Session) SearchSRPolicy(plspID uint32) (*table.SRPolicy, bool) {
+	ss.srPoliciesMu.RLock()
+	defer ss.srPoliciesMu.RUnlock()
+	return ss.searchSRPolicyLocked(plspID)
+}
+
 // SearchPlspID returns the PLSP-ID of a registered SR Policy, along with a boolean value indicating if it was found.
 func (ss *Session) SearchPlspID(color uint32, endpoint netip.Addr) (uint32, bool) {
+	ss.srPoliciesMu.RLock()
+	defer ss.srPoliciesMu.RUnlock()
 	for _, v := range ss.srPolicies {
 		if v.Color == color && v.DstAddr == endpoint {
 			return v.PlspID, true
 		}
 	}
 	return 0, false
+}
+
+// SRPolicies returns a snapshot of the registered SR Policies.
+func (ss *Session) SRPolicies() []*table.SRPolicy {
+	ss.srPoliciesMu.RLock()
+	defer ss.srPoliciesMu.RUnlock()
+	policies := make([]*table.SRPolicy, len(ss.srPolicies))
+	for i, p := range ss.srPolicies {
+		clone := *p
+		policies[i] = &clone
+	}
+	return policies
 }

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -13,6 +13,7 @@ import (
 
 	"go.uber.org/zap"
 
+	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/nttcom/pola/pkg/table"
 )
@@ -84,9 +85,7 @@ func newTestStateReport(t *testing.T, plspID uint32, srpID uint32) *pcep.StateRe
 	return sr
 }
 
-// A PCC may report an SR Policy on its own (SRP-ID 0), which asks the PCE to compute a path.
-// With the TED disabled the PCE cannot compute anything, but that must not fail the state report:
-// doing so used to tear down the PCEP session and made the PCC reconnect in a loop.
+// A PCC may report an SR Policy with SRP-ID 0 even when TED is unavailable.
 func TestHandleStateReportWithoutTED(t *testing.T) {
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
@@ -104,6 +103,177 @@ func TestHandleStateReportWithoutTED(t *testing.T) {
 	}
 	if len(policy.SegmentList) != 2 {
 		t.Errorf("segment list length: got %d, want 2", len(policy.SegmentList))
+	}
+}
+
+// A CreateSRPolicy request's type/metric has no PCEP wire representation (RFC 9256
+// §2.4.2), so RememberSRPolicyIntent is the only way it reaches the eventual PCRpt-created record.
+func TestRememberSRPolicyIntent_AttachedOnCreation(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	sr := newTestStateReport(t, 1, 0)
+
+	ss.RememberSRPolicyIntent(0, sr.LSPObject.DstAddr, table.PolicyTypeDynamic, table.TEMetric)
+
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if policy.Type != table.PolicyTypeDynamic {
+		t.Errorf("policy type: got %q, want %q", policy.Type, table.PolicyTypeDynamic)
+	}
+	if policy.Metric != table.TEMetric {
+		t.Errorf("policy metric: got %v, want %v", policy.Metric, table.TEMetric)
+	}
+}
+
+// A policy update must also replace the recorded type and metric.
+func TestRememberSRPolicyIntent_AttachedOnUpdate(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	sr := newTestStateReport(t, 1, 0)
+
+	ss.RememberSRPolicyIntent(0, sr.LSPObject.DstAddr, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if policy.Type != table.PolicyTypeExplicit || policy.Metric != table.UnspecifiedMetric {
+		t.Fatalf("initial policy intent: got (%q, %v), want (%q, %v)", policy.Type, policy.Metric, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	}
+
+	ss.RememberSRPolicyIntent(0, sr.LSPObject.DstAddr, table.PolicyTypeDynamic, table.TEMetric)
+
+	sr2 := newTestStateReport(t, 1, 0)
+	if err := ss.handleStateReport(sr2, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	policy, found = ss.SearchSRPolicy(sr2.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if policy.Type != table.PolicyTypeDynamic {
+		t.Errorf("policy type after update: got %q, want %q", policy.Type, table.PolicyTypeDynamic)
+	}
+	if policy.Metric != table.TEMetric {
+		t.Errorf("policy metric after update: got %v, want %v", policy.Metric, table.TEMetric)
+	}
+}
+
+// A policy with no remembered intent must keep its type and metric unset.
+func TestSRPolicyIntent_UnknownWhenNeverRemembered(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	sr := newTestStateReport(t, 1, 0)
+
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if policy.Type != "" {
+		t.Errorf("policy type: got %q, want unset", policy.Type)
+	}
+	if policy.Metric != table.UnspecifiedMetric {
+		t.Errorf("policy metric: got %v, want UnspecifiedMetric", policy.Metric)
+	}
+}
+
+// Removing a policy must also remove its remembered intent to prevent stale reuse.
+func TestSRPolicyIntent_ClearedOnDelete(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	sr := newTestStateReport(t, 1, 0)
+
+	ss.RememberSRPolicyIntent(0, sr.LSPObject.DstAddr, table.PolicyTypeDynamic, table.TEMetric)
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	sr.LSPObject.RFlag = true
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	sr2 := newTestStateReport(t, 2, 0)
+	if err := ss.handleStateReport(sr2, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+	policy, found := ss.SearchSRPolicy(sr2.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if policy.Type != "" {
+		t.Errorf("policy type: got %q, want unset (stale intent must not be reused)", policy.Type)
+	}
+}
+
+// A failed PCEP send must not leave an intent waiting for a PCRpt that will never arrive.
+func TestSendSRPolicyRequest_ForgetsIntentOnSendFailure(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close client connection: %v", err)
+		}
+	})
+
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.isSynced = true
+
+	// Close the PCEP-side connection so the send inside sendSRPolicyRequest fails.
+	if err := server.Close(); err != nil {
+		t.Fatalf("failed to close server connection: %v", err)
+	}
+
+	pce := &Server{sessionList: []*Session{ss}}
+	apiServer := &APIServer{pce: pce, logger: zap.NewNop()}
+
+	dstAddr := netip.MustParseAddr("10.255.0.2")
+	req := &pb.CreateSRPolicyRequest{
+		SrPolicy: &pb.SRPolicy{
+			PcepSessionAddr: ss.peerAddr.AsSlice(),
+			DstAddr:         dstAddr.AsSlice(),
+			Color:           100,
+			PolicyName:      "test-policy",
+			Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+		},
+		DisablePathCompute: true,
+	}
+
+	if err := sendSRPolicyRequest(apiServer, req, nil, netip.MustParseAddr("10.255.0.1"), dstAddr, true); err == nil {
+		t.Fatal("expected sendSRPolicyRequest to fail once the connection is closed")
+	}
+
+	if _, ok := ss.takeSRPolicyIntent(100, dstAddr); ok {
+		t.Error("srPolicyIntents entry was not removed after a failed send")
+	}
+}
+
+// Closing a session must clear its remembered SR Policy intents.
+func TestCloseSession_ClearsSRPolicyIntents(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close client connection: %v", err)
+		}
+	})
+
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.RememberSRPolicyIntent(100, netip.MustParseAddr("10.255.0.2"), table.PolicyTypeDynamic, table.TEMetric)
+
+	s := &Server{sessionList: []*Session{ss}, logger: zap.NewNop()}
+	s.closeSession(ss)
+
+	if len(ss.srPolicyIntents) != 0 {
+		t.Errorf("srPolicyIntents was not cleared on session close: %+v", ss.srPolicyIntents)
 	}
 }
 

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -136,6 +136,37 @@ func TestSRPolicies_SnapshotSegmentListIsIndependent(t *testing.T) {
 	}
 }
 
+func TestSRPolicies_SnapshotSRv6StructureIsIndependent(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+
+	srv6Seg := table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1005::"))
+	srv6Seg.Structure = table.SIDStructureBytes{32, 16, 0, 80}
+	ss.srPolicies = append(ss.srPolicies, table.NewSRPolicy(1, "pe01-policy1", []table.Segment{srv6Seg}, netip.MustParseAddr("10.255.0.1"), netip.MustParseAddr("10.255.0.2"), 0, 0, 0, table.PolicyUp))
+
+	policies := ss.SRPolicies()
+	if len(policies) != 1 || len(policies[0].SegmentList) == 0 {
+		t.Fatalf("expected one SR Policy with a non-empty segment list, got %+v", policies)
+	}
+
+	snapshotSeg, ok := policies[0].SegmentList[0].(table.SegmentSRv6)
+	if !ok {
+		t.Fatalf("segment type: got %T, want table.SegmentSRv6", policies[0].SegmentList[0])
+	}
+	snapshotSeg.Structure[0] = 99
+
+	got, found := ss.SearchSRPolicy(1)
+	if !found {
+		t.Fatal("SR Policy was not registered")
+	}
+	gotSeg, ok := got.SegmentList[0].(table.SegmentSRv6)
+	if !ok {
+		t.Fatalf("segment type: got %T, want table.SegmentSRv6", got.SegmentList[0])
+	}
+	if !reflect.DeepEqual(gotSeg.Structure, table.SIDStructureBytes{32, 16, 0, 80}) {
+		t.Errorf("mutating the snapshot's SegmentSRv6.Structure changed the session's SR Policy: got %v", gotSeg.Structure)
+	}
+}
+
 func TestSRPolicyIntent_AttachedOnCreationBySRPID(t *testing.T) {
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 7)
@@ -665,6 +696,116 @@ func TestAllocateSRPID_SkipsInUseIDsOnWraparound(t *testing.T) {
 	}
 }
 
+// concurrentSendCase defines a PCEP message send used by the concurrent-send test.
+type concurrentSendCase struct {
+	name string
+	send func(ss *Session, i int) error
+}
+
+var concurrentSendCases = []concurrentSendCase{
+	{
+		name: "SendKeepalive",
+		send: func(ss *Session, i int) error { return ss.SendKeepalive() },
+	},
+	{
+		name: "SendOpen",
+		send: func(ss *Session, i int) error { return ss.SendOpen() },
+	},
+	{
+		name: "SendClose",
+		send: func(ss *Session, i int) error {
+			return ss.SendClose(pcep.CloseReasonNoExplanationProvided)
+		},
+	},
+	{
+		name: "SendPCUpdate",
+		send: func(ss *Session, i int) error {
+			return ss.SendPCUpdate(table.SRPolicy{
+				Name:    "concurrent-send-test",
+				SrcAddr: netip.MustParseAddr("10.255.0.1"),
+				DstAddr: netip.MustParseAddr("10.255.0.2"),
+				Type:    table.PolicyTypeDynamic,
+				Metric:  table.TEMetric,
+			})
+		},
+	},
+	{
+		name: "RequestSRPolicyCreated",
+		send: func(ss *Session, i int) error {
+			return ss.RequestSRPolicyCreated(table.SRPolicy{
+				Name:    "concurrent-send-test",
+				SrcAddr: netip.MustParseAddr("10.255.0.1"),
+				DstAddr: netip.MustParseAddr("10.255.0.2"),
+				Color:   uint32(i),
+				Type:    table.PolicyTypeDynamic,
+				Metric:  table.TEMetric,
+			})
+		},
+	},
+}
+
+func sendConcurrentPCEPMessages(t *testing.T, ss *Session, goroutines int) {
+	t.Helper()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c := concurrentSendCases[i%len(concurrentSendCases)]
+			errCh <- c.send(ss, i)
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Errorf("send returned an error: %v", err)
+		}
+	}
+}
+
+// readPCEPMessage reads and validates one PCEP message.
+func readPCEPMessage(r io.Reader) error {
+	headerBytes := make([]byte, pcep.CommonHeaderLength)
+	if _, err := io.ReadFull(r, headerBytes); err != nil {
+		return err
+	}
+
+	var header pcep.CommonHeader
+	if err := header.DecodeFromBytes(headerBytes); err != nil {
+		return fmt.Errorf("failed to decode a PCEP common header; sends may have interleaved: %w", err)
+	}
+
+	bodyLen := int(header.MessageLength) - int(pcep.CommonHeaderLength)
+	if bodyLen == 0 {
+		return nil
+	}
+	_, err := io.ReadFull(r, make([]byte, bodyLen))
+	return err
+}
+
+// startPCEPFramingValidator validates PCEP message framing in the background.
+func startPCEPFramingValidator(r io.Reader, wantCount int) <-chan error {
+	result := make(chan error, 1)
+
+	go func() {
+		for i := 0; i < wantCount; i++ {
+			if err := readPCEPMessage(r); err != nil {
+				result <- err
+				return
+			}
+		}
+		result <- nil
+	}()
+
+	return result
+}
+
 func TestSendPCEPMessage_ConcurrentSendsDoNotInterleave(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() {
@@ -677,84 +818,9 @@ func TestSendPCEPMessage_ConcurrentSendsDoNotInterleave(t *testing.T) {
 
 	const goroutines = 40
 
-	readerErr := make(chan error, 1)
+	readerErr := startPCEPFramingValidator(client, goroutines)
 
-	go func() {
-		receivedCount := 0
-		for receivedCount < goroutines {
-			headerBytes := make([]byte, pcep.CommonHeaderLength)
-			if _, err := io.ReadFull(client, headerBytes); err != nil {
-				readerErr <- err
-				return
-			}
-
-			var header pcep.CommonHeader
-			if err := header.DecodeFromBytes(headerBytes); err != nil {
-				readerErr <- fmt.Errorf(
-					"failed to decode a PCEP common header; sends may have interleaved: %w",
-					err,
-				)
-				return
-			}
-
-			bodyLen := int(header.MessageLength) - int(pcep.CommonHeaderLength)
-			if bodyLen > 0 {
-				if _, err := io.ReadFull(client, make([]byte, bodyLen)); err != nil {
-					readerErr <- err
-					return
-				}
-			}
-
-			receivedCount++
-		}
-
-		readerErr <- nil
-	}()
-
-	var wg sync.WaitGroup
-	errCh := make(chan error, goroutines)
-
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-
-			switch i % 5 {
-			case 0:
-				errCh <- ss.SendKeepalive()
-			case 1:
-				errCh <- ss.SendOpen()
-			case 2:
-				errCh <- ss.SendClose(pcep.CloseReasonNoExplanationProvided)
-			case 3:
-				errCh <- ss.SendPCUpdate(table.SRPolicy{
-					Name:    "concurrent-send-test",
-					SrcAddr: netip.MustParseAddr("10.255.0.1"),
-					DstAddr: netip.MustParseAddr("10.255.0.2"),
-					Type:    table.PolicyTypeDynamic,
-					Metric:  table.TEMetric,
-				})
-			default:
-				errCh <- ss.RequestSRPolicyCreated(table.SRPolicy{
-					Name:    "concurrent-send-test",
-					SrcAddr: netip.MustParseAddr("10.255.0.1"),
-					DstAddr: netip.MustParseAddr("10.255.0.2"),
-					Color:   uint32(i),
-					Type:    table.PolicyTypeDynamic,
-					Metric:  table.TEMetric,
-				})
-			}
-		}(i)
-	}
-
-	wg.Wait()
-	close(errCh)
-
-	for err := range errCh {
-		if err != nil {
-			t.Errorf("send returned an error: %v", err)
-		}
-	}
+	sendConcurrentPCEPMessages(t, ss, goroutines)
 
 	select {
 	case err := <-readerErr:

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -6,12 +6,15 @@
 package server
 
 import (
+	"fmt"
+	"io"
 	"math"
 	"net"
 	"net/netip"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -108,9 +111,31 @@ func TestHandleStateReportWithoutTED(t *testing.T) {
 	}
 }
 
-// A CreateSRPolicy request's type/metric has no PCEP wire representation (RFC 9256
-// §2.4.2), so rememberSRPolicyIntent, keyed by the SRP-ID assigned to the request, is
-// the only way it reaches the eventual PCRpt-created record.
+func TestSRPolicies_SnapshotSegmentListIsIndependent(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	sr := newTestStateReport(t, 1, 0)
+
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	policies := ss.SRPolicies()
+	if len(policies) != 1 || len(policies[0].SegmentList) == 0 {
+		t.Fatalf("expected one SR Policy with a non-empty segment list, got %+v", policies)
+	}
+
+	want := policies[0].SegmentList[0]
+	policies[0].SegmentList[0] = table.NewSegmentSRMPLS(99999)
+
+	got, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if !reflect.DeepEqual(got.SegmentList[0], want) {
+		t.Errorf("mutating the snapshot's SegmentList changed the session's SR Policy: got %v, want %v", got.SegmentList[0], want)
+	}
+}
+
 func TestSRPolicyIntent_AttachedOnCreationBySRPID(t *testing.T) {
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 7)
@@ -401,7 +426,10 @@ func TestAllocateSRPID_SkipsReservedValues(t *testing.T) {
 	ss.srpIDHead = math.MaxUint32 - 1
 
 	for i, want := range []uint32{math.MaxUint32 - 1, 1, 2} {
-		got := ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+		got, err := ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+		if err != nil {
+			t.Fatalf("allocation %d: unexpected error: %v", i, err)
+		}
 		if got == 0 || got == math.MaxUint32 {
 			t.Fatalf("allocation %d: got reserved SRP-ID %d", i, got)
 		}
@@ -490,5 +518,283 @@ func TestReceiveOpenSeparatesPccAndPolaCapabilities(t *testing.T) {
 	}
 	if receivedCap.LSPUpdateCapability == polaCap.LSPUpdateCapability {
 		t.Error("expected received and advertised StatefulPCECapability to diverge, got identical LSPUpdateCapability")
+	}
+}
+
+func TestSweepExpiredSRPolicyIntents_RemovesExpired(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.srPolicyIntentsMu.Lock()
+	ss.srPolicyIntents = map[uint32]srPolicyIntent{
+		1: {polType: table.PolicyTypeDynamic, metric: table.TEMetric, expiresAt: time.Now().Add(-time.Second)},
+	}
+	ss.srPolicyIntentsMu.Unlock()
+
+	ss.sweepExpiredSRPolicyIntents()
+
+	if _, ok := ss.takeSRPolicyIntent(1); ok {
+		t.Error("expired intent was not removed by the sweeper")
+	}
+}
+
+func TestSweepExpiredSRPolicyIntents_KeepsUnexpired(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.srPolicyIntentsMu.Lock()
+	ss.srPolicyIntents = map[uint32]srPolicyIntent{
+		1: {polType: table.PolicyTypeDynamic, metric: table.TEMetric, expiresAt: time.Now().Add(time.Hour)},
+	}
+	ss.srPolicyIntentsMu.Unlock()
+
+	ss.sweepExpiredSRPolicyIntents()
+
+	if _, ok := ss.takeSRPolicyIntent(1); !ok {
+		t.Error("unexpired intent was removed by the sweeper")
+	}
+}
+
+func TestSweepExpiredSRPolicyIntents_KeepsUnrelatedIntent(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(2, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+
+	if _, ok := ss.takeSRPolicyIntent(1); !ok {
+		t.Fatal("expected intent 1 to be present before consuming it")
+	}
+
+	ss.sweepExpiredSRPolicyIntents()
+
+	if _, ok := ss.takeSRPolicyIntent(2); !ok {
+		t.Error("sweep must not remove an unrelated intent still within its TTL")
+	}
+}
+
+func TestIntentSweep_RunsInBackgroundAndStopsCleanly(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.srPolicyIntentTTL = 10 * time.Millisecond
+	ss.sweepInterval = 5 * time.Millisecond
+
+	ss.startIntentSweep()
+	defer ss.stopIntentSweep()
+
+	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for ss.srPolicyIntentExists(1) {
+		if time.Now().After(deadline) {
+			t.Fatal("intent was not swept in the background within the deadline")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestIntentSweep_StopsCleanly(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.startIntentSweep()
+
+	done := make(chan struct{})
+	go func() {
+		ss.stopIntentSweep()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopIntentSweep did not return; the sweep goroutine may have leaked")
+	}
+}
+
+func TestIntentSweep_ConcurrentWithIntentConsumption(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.srPolicyIntentTTL = 5 * time.Millisecond
+	ss.sweepInterval = 2 * time.Millisecond
+	ss.startIntentSweep()
+	defer ss.stopIntentSweep()
+
+	var wg sync.WaitGroup
+	for i := uint32(1); i <= 20; i++ {
+		wg.Add(1)
+		go func(srpID uint32) {
+			defer wg.Done()
+			ss.rememberSRPolicyIntent(srpID, table.PolicyTypeDynamic, table.TEMetric)
+			time.Sleep(time.Millisecond)
+			ss.takeSRPolicyIntent(srpID)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestNextUnusedSRPID_SkipsUsedAcrossWraparound(t *testing.T) {
+	used := map[uint32]bool{1: true, 2: true, 4: true}
+	got, _, err := nextUnusedSRPID(4, 5, func(id uint32) bool { return used[id] })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("got %d, want 3 (SRP-IDs 4, 1 and 2 are in use and must be skipped)", got)
+	}
+}
+
+func TestNextUnusedSRPID_ErrorsWhenExhausted(t *testing.T) {
+	used := map[uint32]bool{1: true, 2: true, 3: true, 4: true}
+	if _, _, err := nextUnusedSRPID(1, 5, func(id uint32) bool { return used[id] }); err == nil {
+		t.Fatal("expected an error when every non-reserved SRP-ID is in use")
+	}
+}
+
+func TestAllocateSRPID_SkipsInUseIDsOnWraparound(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.srpIDHead = math.MaxUint32 - 1
+
+	// Pre-occupy SRP-ID 1 so the wraparound scan must skip over it.
+	ss.rememberSRPolicyIntent(1, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+
+	got, err := ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+	if err != nil || got != math.MaxUint32-1 {
+		t.Fatalf("allocation 1: got (%d, %v), want (%d, nil)", got, err, uint32(math.MaxUint32-1))
+	}
+
+	got, err = ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+	if err != nil {
+		t.Fatalf("allocation 2: unexpected error: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("allocation 2: got %d, want 2 (SRP-ID 1 is still in use and must be skipped)", got)
+	}
+	if _, ok := ss.takeSRPolicyIntent(2); !ok {
+		t.Error("allocateSRPID must register an intent for the SRP-ID it returns")
+	}
+}
+
+func TestSendPCEPMessage_ConcurrentSendsDoNotInterleave(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close client connection: %v", err)
+		}
+	})
+
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	const goroutines = 40
+
+	readerErr := make(chan error, 1)
+
+	go func() {
+		receivedCount := 0
+		for receivedCount < goroutines {
+			headerBytes := make([]byte, pcep.CommonHeaderLength)
+			if _, err := io.ReadFull(client, headerBytes); err != nil {
+				readerErr <- err
+				return
+			}
+
+			var header pcep.CommonHeader
+			if err := header.DecodeFromBytes(headerBytes); err != nil {
+				readerErr <- fmt.Errorf(
+					"failed to decode a PCEP common header; sends may have interleaved: %w",
+					err,
+				)
+				return
+			}
+
+			bodyLen := int(header.MessageLength) - int(pcep.CommonHeaderLength)
+			if bodyLen > 0 {
+				if _, err := io.ReadFull(client, make([]byte, bodyLen)); err != nil {
+					readerErr <- err
+					return
+				}
+			}
+
+			receivedCount++
+		}
+
+		readerErr <- nil
+	}()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			switch i % 5 {
+			case 0:
+				errCh <- ss.SendKeepalive()
+			case 1:
+				errCh <- ss.SendOpen()
+			case 2:
+				errCh <- ss.SendClose(pcep.CloseReasonNoExplanationProvided)
+			case 3:
+				errCh <- ss.SendPCUpdate(table.SRPolicy{
+					Name:    "concurrent-send-test",
+					SrcAddr: netip.MustParseAddr("10.255.0.1"),
+					DstAddr: netip.MustParseAddr("10.255.0.2"),
+					Type:    table.PolicyTypeDynamic,
+					Metric:  table.TEMetric,
+				})
+			default:
+				errCh <- ss.RequestSRPolicyCreated(table.SRPolicy{
+					Name:    "concurrent-send-test",
+					SrcAddr: netip.MustParseAddr("10.255.0.1"),
+					DstAddr: netip.MustParseAddr("10.255.0.2"),
+					Color:   uint32(i),
+					Type:    table.PolicyTypeDynamic,
+					Metric:  table.TEMetric,
+				})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Errorf("send returned an error: %v", err)
+		}
+	}
+
+	select {
+	case err := <-readerErr:
+		if err != nil {
+			t.Fatalf("reader failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("did not observe all messages on the wire; sends may have interleaved and corrupted framing")
+	}
+}
+
+func TestSendPCEPMessage_UnlocksAfterSendFailure(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close client connection: %v", err)
+		}
+	})
+
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	if err := server.Close(); err != nil {
+		t.Fatalf("failed to close server connection: %v", err)
+	}
+
+	if err := ss.SendKeepalive(); err == nil {
+		t.Fatal("expected SendKeepalive to fail once the connection is closed")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ss.SendKeepalive()
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected second SendKeepalive to fail")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second SendKeepalive blocked; send mutex may not have been released")
 	}
 }

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -6,9 +6,11 @@
 package server
 
 import (
+	"math"
 	"net"
 	"net/netip"
 	"reflect"
+	"sync"
 	"testing"
 
 	"go.uber.org/zap"
@@ -107,12 +109,13 @@ func TestHandleStateReportWithoutTED(t *testing.T) {
 }
 
 // A CreateSRPolicy request's type/metric has no PCEP wire representation (RFC 9256
-// §2.4.2), so RememberSRPolicyIntent is the only way it reaches the eventual PCRpt-created record.
-func TestRememberSRPolicyIntent_AttachedOnCreation(t *testing.T) {
+// §2.4.2), so rememberSRPolicyIntent, keyed by the SRP-ID assigned to the request, is
+// the only way it reaches the eventual PCRpt-created record.
+func TestSRPolicyIntent_AttachedOnCreationBySRPID(t *testing.T) {
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
-	sr := newTestStateReport(t, 1, 0)
+	sr := newTestStateReport(t, 1, 7)
 
-	ss.RememberSRPolicyIntent(0, sr.LSPObject.DstAddr, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(7, table.PolicyTypeDynamic, table.TEMetric)
 
 	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
 		t.Fatalf("handleStateReport returned an error: %v", err)
@@ -130,44 +133,6 @@ func TestRememberSRPolicyIntent_AttachedOnCreation(t *testing.T) {
 	}
 }
 
-// A policy update must also replace the recorded type and metric.
-func TestRememberSRPolicyIntent_AttachedOnUpdate(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
-	sr := newTestStateReport(t, 1, 0)
-
-	ss.RememberSRPolicyIntent(0, sr.LSPObject.DstAddr, table.PolicyTypeExplicit, table.UnspecifiedMetric)
-	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
-		t.Fatalf("handleStateReport returned an error: %v", err)
-	}
-
-	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
-	if !found {
-		t.Fatal("SR Policy reported by the PCC was not registered")
-	}
-	if policy.Type != table.PolicyTypeExplicit || policy.Metric != table.UnspecifiedMetric {
-		t.Fatalf("initial policy intent: got (%q, %v), want (%q, %v)", policy.Type, policy.Metric, table.PolicyTypeExplicit, table.UnspecifiedMetric)
-	}
-
-	ss.RememberSRPolicyIntent(0, sr.LSPObject.DstAddr, table.PolicyTypeDynamic, table.TEMetric)
-
-	sr2 := newTestStateReport(t, 1, 0)
-	if err := ss.handleStateReport(sr2, pcep.NewPCRptMessage()); err != nil {
-		t.Fatalf("handleStateReport returned an error: %v", err)
-	}
-
-	policy, found = ss.SearchSRPolicy(sr2.LSPObject.PlspID)
-	if !found {
-		t.Fatal("SR Policy reported by the PCC was not registered")
-	}
-	if policy.Type != table.PolicyTypeDynamic {
-		t.Errorf("policy type after update: got %q, want %q", policy.Type, table.PolicyTypeDynamic)
-	}
-	if policy.Metric != table.TEMetric {
-		t.Errorf("policy metric after update: got %v, want %v", policy.Metric, table.TEMetric)
-	}
-}
-
-// A policy with no remembered intent must keep its type and metric unset.
 func TestSRPolicyIntent_UnknownWhenNeverRemembered(t *testing.T) {
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
@@ -188,31 +153,110 @@ func TestSRPolicyIntent_UnknownWhenNeverRemembered(t *testing.T) {
 	}
 }
 
-// Removing a policy must also remove its remembered intent to prevent stale reuse.
-func TestSRPolicyIntent_ClearedOnDelete(t *testing.T) {
+func TestSRPolicyIntent_IndependentPerSRPID(t *testing.T) {
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+
+	ss.rememberSRPolicyIntent(1, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
+
+	// SRP-ID 2's PCRpt arrives first and must only consume intent 2.
+	srB := newTestStateReport(t, 20, 2)
+	if err := ss.handleStateReport(srB, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+	policyB, found := ss.SearchSRPolicy(srB.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy for SRP-ID 2 was not registered")
+	}
+	if policyB.Type != table.PolicyTypeDynamic || policyB.Metric != table.TEMetric {
+		t.Errorf("policy for SRP-ID 2: got (%q, %v), want (%q, %v)", policyB.Type, policyB.Metric, table.PolicyTypeDynamic, table.TEMetric)
+	}
+	ss.srPolicyIntentsMu.Lock()
+	_, ok := ss.srPolicyIntents[1]
+	ss.srPolicyIntentsMu.Unlock()
+	if !ok {
+		t.Error("intent for SRP-ID 1 must survive consuming SRP-ID 2's intent")
+	}
+
+	// SRP-ID 1's PCRpt arrives second and must consume only intent 1.
+	srA := newTestStateReport(t, 10, 1)
+	if err := ss.handleStateReport(srA, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+	policyA, found := ss.SearchSRPolicy(srA.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy for SRP-ID 1 was not registered")
+	}
+	if policyA.Type != table.PolicyTypeExplicit || policyA.Metric != table.UnspecifiedMetric {
+		t.Errorf("policy for SRP-ID 1: got (%q, %v), want (%q, %v)", policyA.Type, policyA.Metric, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	}
+}
+
+func TestSRPolicyIntent_UnsolicitedPCRptDoesNotConsume(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
+
 	sr := newTestStateReport(t, 1, 0)
-
-	ss.RememberSRPolicyIntent(0, sr.LSPObject.DstAddr, table.PolicyTypeDynamic, table.TEMetric)
 	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
 		t.Fatalf("handleStateReport returned an error: %v", err)
 	}
 
-	sr.LSPObject.RFlag = true
-	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
-		t.Fatalf("handleStateReport returned an error: %v", err)
-	}
-
-	sr2 := newTestStateReport(t, 2, 0)
-	if err := ss.handleStateReport(sr2, pcep.NewPCRptMessage()); err != nil {
-		t.Fatalf("handleStateReport returned an error: %v", err)
-	}
-	policy, found := ss.SearchSRPolicy(sr2.LSPObject.PlspID)
+	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
 	if !found {
 		t.Fatal("SR Policy reported by the PCC was not registered")
 	}
 	if policy.Type != "" {
-		t.Errorf("policy type: got %q, want unset (stale intent must not be reused)", policy.Type)
+		t.Errorf("policy type: got %q, want unset (unsolicited PCRpt must not consume an intent)", policy.Type)
+	}
+
+	if _, ok := ss.takeSRPolicyIntent(1); !ok {
+		t.Error("intent for SRP-ID 1 must remain after an unrelated unsolicited PCRpt")
+	}
+}
+
+func TestSRPolicyIntent_ClearedOnRFlagDelete(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+
+	// Create the policy unsolicited so its creation does not consume the intent below.
+	sr := newTestStateReport(t, 1, 0)
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	ss.rememberSRPolicyIntent(5, table.PolicyTypeDynamic, table.TEMetric)
+
+	del := newTestStateReport(t, 1, 5)
+	del.LSPObject.RFlag = true
+	if err := ss.handleStateReport(del, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	if _, found := ss.SearchSRPolicy(del.LSPObject.PlspID); found {
+		t.Error("SR Policy is still registered after being reported as removed")
+	}
+	if _, ok := ss.takeSRPolicyIntent(5); ok {
+		t.Error("intent for SRP-ID 5 was not removed after an R-Flag PCRpt")
+	}
+}
+
+func TestHandlePCErr_ForgetsReportedSRPIDIntents(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(2, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+
+	pcerrMessage, err := pcep.NewPCErrMessage(1, 1, nil)
+	if err != nil {
+		t.Fatalf("failed to create PCErr message: %v", err)
+	}
+	pcerrMessage.SRPs = []*pcep.SrpObject{{SrpID: 1}}
+
+	ss.handlePCErr(pcerrMessage)
+
+	if _, ok := ss.takeSRPolicyIntent(1); ok {
+		t.Error("intent for SRP-ID 1 was not removed after a PCErr reporting it")
+	}
+	if _, ok := ss.takeSRPolicyIntent(2); !ok {
+		t.Error("intent for SRP-ID 2 must survive a PCErr that does not report it")
 	}
 }
 
@@ -227,6 +271,7 @@ func TestSendSRPolicyRequest_ForgetsIntentOnSendFailure(t *testing.T) {
 
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 	ss.isSynced = true
+	wantSRPID := ss.srpIDHead
 
 	// Close the PCEP-side connection so the send inside sendSRPolicyRequest fails.
 	if err := server.Close(); err != nil {
@@ -252,7 +297,7 @@ func TestSendSRPolicyRequest_ForgetsIntentOnSendFailure(t *testing.T) {
 		t.Fatal("expected sendSRPolicyRequest to fail once the connection is closed")
 	}
 
-	if _, ok := ss.takeSRPolicyIntent(100, dstAddr); ok {
+	if _, ok := ss.takeSRPolicyIntent(wantSRPID); ok {
 		t.Error("srPolicyIntents entry was not removed after a failed send")
 	}
 }
@@ -267,13 +312,102 @@ func TestCloseSession_ClearsSRPolicyIntents(t *testing.T) {
 	})
 
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
-	ss.RememberSRPolicyIntent(100, netip.MustParseAddr("10.255.0.2"), table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
 
 	s := &Server{sessionList: []*Session{ss}, logger: zap.NewNop()}
 	s.closeSession(ss)
 
 	if len(ss.srPolicyIntents) != 0 {
 		t.Errorf("srPolicyIntents was not cleared on session close: %+v", ss.srPolicyIntents)
+	}
+}
+
+// Concurrent SendPCUpdate/SendPCInitiate calls must never allocate the same SRP-ID,
+// and every allocated SRP-ID must have exactly one intent registered for it.
+func TestConcurrentSRPolicyRequestsAllocateUniqueSRPIDs(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("failed to close server connection: %v", err)
+		}
+	})
+
+	// Drain everything the server writes so sends never block on a full socket buffer.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			if _, err := client.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close client connection: %v", err)
+		}
+		<-done
+	})
+
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			srPolicy := table.SRPolicy{
+				Name:    "concurrent-test",
+				SrcAddr: netip.MustParseAddr("10.255.0.1"),
+				DstAddr: netip.MustParseAddr("10.255.0.2"),
+				Color:   uint32(i),
+				Type:    table.PolicyTypeDynamic,
+				Metric:  table.TEMetric,
+			}
+			var err error
+			if i%2 == 0 {
+				err = ss.SendPCUpdate(srPolicy)
+			} else {
+				err = ss.RequestSRPolicyCreated(srPolicy)
+			}
+			errCh <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Errorf("send returned an error: %v", err)
+		}
+	}
+
+	ss.srPolicyIntentsMu.Lock()
+	gotIntents := len(ss.srPolicyIntents)
+	ss.srPolicyIntentsMu.Unlock()
+	if gotIntents != goroutines {
+		t.Errorf("srPolicyIntents count: got %d, want %d (SRP-IDs must not collide)", gotIntents, goroutines)
+	}
+	if ss.srpIDHead != uint32(1+goroutines) {
+		t.Errorf("srpIDHead: got %d, want %d", ss.srpIDHead, uint32(1+goroutines))
+	}
+}
+
+func TestAllocateSRPID_SkipsReservedValues(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.srpIDHead = math.MaxUint32 - 1
+
+	for i, want := range []uint32{math.MaxUint32 - 1, 1, 2} {
+		got := ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+		if got == 0 || got == math.MaxUint32 {
+			t.Fatalf("allocation %d: got reserved SRP-ID %d", i, got)
+		}
+		if got != want {
+			t.Errorf("allocation %d: got %d, want %d", i, got, want)
+		}
 	}
 }
 

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -25,9 +25,7 @@ const (
 
 // PolicyType is the RFC 9256 §2.4.2 SR Policy candidate path type: a candidate path
 // is either explicit (a fixed SID list) or dynamic (computed against an optimization
-// metric, and subject to recomputation). The zero value means "not known": PCEP
-// carries no TLV for this on PCRpt, so it can only be known for policies Pola itself
-// created (see Session.RememberSRPolicyIntent).
+// metric and subject to recomputation). The zero value means "not known".
 type PolicyType string
 
 const (
@@ -226,7 +224,7 @@ func NewSegmentSRv6WithNodeInfo(sid netip.Addr, n *LsNode) (SegmentSRv6, error) 
 				return seg, err
 			}
 			seg.LocalAddr = addr
-			seg.Structure = []uint8{
+			seg.Structure = SIDStructureBytes{
 				srv6SID.SIDStructure.LocalBlock,
 				srv6SID.SIDStructure.LocalNode,
 				srv6SID.SIDStructure.LocalFunc,

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -6,9 +6,11 @@
 package table
 
 import (
+	"encoding/json"
 	"errors"
 	"net/netip"
 	"strconv"
+	"strings"
 )
 
 // sr-policy state
@@ -21,16 +23,34 @@ const (
 	PolicyUnknown = PolicyState("unknown")
 )
 
+// PolicyType is the RFC 9256 §2.4.2 SR Policy candidate path type: a candidate path
+// is either explicit (a fixed SID list) or dynamic (computed against an optimization
+// metric, and subject to recomputation). The zero value means "not known": PCEP
+// carries no TLV for this on PCRpt, so it can only be known for policies Pola itself
+// created (see Session.RememberSRPolicyIntent).
+type PolicyType string
+
+const (
+	PolicyTypeExplicit = PolicyType("explicit")
+	PolicyTypeDynamic  = PolicyType("dynamic")
+)
+
 type SRPolicy struct {
-	PlspID      uint32
-	Name        string
-	SegmentList []Segment
-	SrcAddr     netip.Addr
-	DstAddr     netip.Addr
-	Color       uint32
-	Preference  uint32
-	LSPID       uint16
-	State       PolicyState
+	PlspID      uint32      `json:"plspId,omitempty"`
+	Name        string      `json:"policyName"`
+	SegmentList []Segment   `json:"segmentList"`
+	SrcAddr     netip.Addr  `json:"srcAddr"`
+	DstAddr     netip.Addr  `json:"dstAddr"`
+	SrcRouterID string      `json:"srcRouterId,omitempty"`
+	DstRouterID string      `json:"dstRouterId,omitempty"`
+	Color       uint32      `json:"color"`
+	Preference  uint32      `json:"preference"`
+	LSPID       uint16      `json:"lspId,omitempty"`
+	State       PolicyState `json:"state,omitempty"`
+	// Type and Metric are only known for policies Pola itself created; both are
+	// left at their zero value ("" / UnspecifiedMetric) otherwise. See PolicyType.
+	Type   PolicyType `json:"type,omitempty"`
+	Metric MetricType `json:"metric,omitempty"`
 }
 
 func NewSRPolicy(
@@ -144,12 +164,27 @@ func BehaviorToString(behavior uint16) string {
 
 const FirstSIDIndex = 0 // Index for first SID in Sids array
 
+// SIDStructureBytes is the [LocalBlock, LocalNode, LocalFunc, LocalArg] length split of an SRv6 SID.
+// It marshals as a comma-separated string (e.g. "32,16,0,80").
+type SIDStructureBytes []uint8
+
+func (s SIDStructureBytes) MarshalJSON() ([]byte, error) {
+	if len(s) == 0 {
+		return json.Marshal(nil)
+	}
+	parts := make([]string, len(s))
+	for i, v := range s {
+		parts[i] = strconv.Itoa(int(v))
+	}
+	return json.Marshal(strings.Join(parts, ","))
+}
+
 type SegmentSRv6 struct {
-	Sid        netip.Addr
-	LocalAddr  netip.Addr
-	RemoteAddr netip.Addr
-	Structure  []uint8
-	USid       bool
+	Sid        netip.Addr        `json:"sid"`
+	LocalAddr  netip.Addr        `json:"localAddr,omitzero"`
+	RemoteAddr netip.Addr        `json:"remoteAddr,omitzero"`
+	Structure  SIDStructureBytes `json:"sidStructure,omitempty"`
+	USid       bool              `json:"uSid,omitempty"`
 }
 
 func (seg SegmentSRv6) SidString() string {
@@ -214,13 +249,13 @@ func NewSegmentSRv6WithNodeInfo(sid netip.Addr, n *LsNode) (SegmentSRv6, error) 
 }
 
 type SegmentSRMPLS struct {
-	Sid uint32
-	TTL uint8
-	TC  uint8
-	S   bool
+	Sid uint32 `json:"sid"`
+	TTL uint8  `json:"ttl,omitempty"`
+	TC  uint8  `json:"tc,omitempty"`
+	S   bool   `json:"s,omitempty"`
 	// Optional NAI for SR-ERO encoding (RFC8664 4.3.1).
-	LocalAddr  netip.Addr
-	RemoteAddr netip.Addr
+	LocalAddr  netip.Addr `json:"localAddr,omitzero"`
+	RemoteAddr netip.Addr `json:"remoteAddr,omitzero"`
 }
 
 func (seg SegmentSRMPLS) SidString() string {

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -6,6 +6,7 @@
 package table
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/netip"
@@ -112,7 +113,7 @@ func printLink(link *LsLink) {
 			if metric == nil {
 				continue
 			}
-			fmt.Printf("        %s: %d\n", metric.Type.String(), metric.Value)
+			fmt.Printf("        %s: %d\n", metric.Type.DisplayString(), metric.Value)
 		}
 	}
 
@@ -393,7 +394,10 @@ func NewMetric(metricType MetricType, value uint32) *Metric {
 type MetricType int
 
 const (
-	IGPMetric MetricType = iota
+	// UnspecifiedMetric is the zero value: no optimization metric applies (e.g. an
+	// explicit SR Policy candidate path, which by definition has no objective function).
+	UnspecifiedMetric MetricType = iota
+	IGPMetric
 	TEMetric
 	DelayMetric
 	HopcountMetric
@@ -412,6 +416,29 @@ func (m MetricType) String() string {
 	default:
 		return "METRIC_TYPE_UNSPECIFIED"
 	}
+}
+
+// DisplayString renders the metric as a short lowercase token (e.g. "igp"), used
+// for human-facing CLI output (unlike String()'s "METRIC_TYPE_..." form).
+func (m MetricType) DisplayString() string {
+	switch m {
+	case IGPMetric:
+		return "igp"
+	case TEMetric:
+		return "te"
+	case DelayMetric:
+		return "delay"
+	case HopcountMetric:
+		return "hopcount"
+	default:
+		return ""
+	}
+}
+
+// MarshalJSON renders the metric as a short lowercase token (e.g. "igp"), consistent
+// with the other lowercase enum-like fields on SRPolicy (e.g. State).
+func (m MetricType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.DisplayString())
 }
 
 type Srv6EndXSID struct {


### PR DESCRIPTION
## Description

Redesign the per-session views for capabilities and SR policies.

- Structure capability TLVs and group SR policies by session.
- Add missing SR policy information, deterministic ordering, and `--session` filtering.
- Update CLI documentation and tests.
- **This is a breaking change to the gRPC API.**

## Type of change

* [x] New feature
* [x] Bug fix
* [x] Refactoring
* [x] Documentation
* [ ] Build / CI

## How was this tested?

* `gofmt -l .`
* `go build ./...`
* `go test ./...`

## Checklist

* [x] `make ci` passes locally
* [x] Tests added or updated if needed
* [x] Documentation updated if needed
