### PR TITLE
Optimize router ID lookup

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -750,7 +750,11 @@ func (s *APIServer) GetSRPolicyList(ctx context.Context, req *pb.GetSRPolicyList
 	}
 	slices.SortFunc(peerAddrs, func(a, b netip.Addr) int { return a.Compare(b) })
 
-	routerIDIndex := buildRouterIDIndex(s.pce.TED())
+	var routerIDIndex map[netip.Addr]string
+	if s.pce != nil {
+		routerIDIndex = buildRouterIDIndex(s.pce.TED())
+	}
+
 	sessions := make([]*pb.Session, 0, len(peerAddrs))
 	for _, peerAddr := range peerAddrs {
 		pbPolicies := make([]*pb.SRPolicy, 0, len(policiesByPeer[peerAddr]))
@@ -801,10 +805,8 @@ func (s *APIServer) buildPBSRPolicy(peerAddr netip.Addr, policy *table.SRPolicy,
 		Metric:          toPBMetricType(policy.Metric),
 	}
 
-	if routerIDIndex != nil {
-		srPolicy.SrcRouterId = routerIDIndex[policy.SrcAddr]
-		srPolicy.DstRouterId = routerIDIndex[policy.DstAddr]
-	}
+	srPolicy.SrcRouterId = routerIDIndex[policy.SrcAddr]
+	srPolicy.DstRouterId = routerIDIndex[policy.DstAddr]
 
 	for _, segment := range policy.SegmentList {
 		srPolicy.SegmentList = append(srPolicy.SegmentList, convertSegment(segment))

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -750,10 +750,7 @@ func (s *APIServer) GetSRPolicyList(ctx context.Context, req *pb.GetSRPolicyList
 	}
 	slices.SortFunc(peerAddrs, func(a, b netip.Addr) int { return a.Compare(b) })
 
-	var routerIDIndex map[netip.Addr]string
-	if s.pce != nil {
-		routerIDIndex = buildRouterIDIndex(s.pce.TED())
-	}
+	routerIDIndex := buildRouterIDIndex(s.pce.TED())
 
 	sessions := make([]*pb.Session, 0, len(peerAddrs))
 	for _, peerAddr := range peerAddrs {
@@ -871,6 +868,23 @@ func buildRouterIDIndex(ted *table.LsTED) map[netip.Addr]string {
 			if prefix.Prefix.Bits() == prefix.Prefix.Addr().BitLen() {
 				index[prefix.Prefix.Addr()] = node.RouterID
 			}
+		}
+	}
+	return index
+}
+
+// buildAddressRouterIDIndex builds an index from prefix addresses to router IDs.
+func buildAddressRouterIDIndex(ted *table.LsTED) map[netip.Addr]string {
+	if ted == nil {
+		return nil
+	}
+	index := make(map[netip.Addr]string)
+	for routerID, node := range ted.Nodes {
+		if node == nil {
+			continue
+		}
+		for _, prefix := range node.Prefixes {
+			index[prefix.Prefix.Addr()] = routerID
 		}
 	}
 	return index

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -787,7 +787,7 @@ func TestTED_ConcurrentUpdate(t *testing.T) {
 	}()
 
 	for i := 0; i < 100; i++ {
-		_ = s.TED()
+		_ = buildRouterIDIndex(s.TED())
 	}
 	<-done
 }

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -581,6 +581,36 @@ func TestBuildRouterIDIndex(t *testing.T) {
 	assert.Nil(t, buildRouterIDIndex(nil))
 }
 
+func TestBuildAddressRouterIDIndex(t *testing.T) {
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+
+	v4Node := table.NewLsNode(65000, "router-v4")
+	v4Prefix := table.NewLsPrefix(v4Node)
+	v4Prefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
+	v4Node.Prefixes = append(v4Node.Prefixes, v4Prefix)
+	ted.Nodes[v4Node.RouterID] = v4Node
+
+	v6Node := table.NewLsNode(65000, "router-v6")
+	v6Prefix := table.NewLsPrefix(v6Node)
+	v6Prefix.Prefix = netip.MustParsePrefix("2001:db8::1/128")
+	v6Node.Prefixes = append(v6Node.Prefixes, v6Prefix)
+	ted.Nodes[v6Node.RouterID] = v6Node
+
+	// Non-host prefixes are indexed too, by their network address.
+	subnetNode := table.NewLsNode(65000, "router-subnet")
+	subnetPrefix := table.NewLsPrefix(subnetNode)
+	subnetPrefix.Prefix = netip.MustParsePrefix("192.0.2.0/24")
+	subnetNode.Prefixes = append(subnetNode.Prefixes, subnetPrefix)
+	ted.Nodes[subnetNode.RouterID] = subnetNode
+
+	index := buildAddressRouterIDIndex(ted)
+	assert.Equal(t, "router-v4", index[netip.MustParseAddr("192.0.2.10")])
+	assert.Equal(t, "router-v6", index[netip.MustParseAddr("2001:db8::1")])
+	assert.Equal(t, "router-subnet", index[netip.MustParseAddr("192.0.2.0")])
+
+	assert.Nil(t, buildAddressRouterIDIndex(nil))
+}
+
 func TestGetSRPolicyList_FiltersBySessionAddr(t *testing.T) {
 	seg, err := table.NewSegment("16003")
 	require.NoError(t, err)

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -576,12 +576,14 @@ func (ss *Session) extractSrcDstRouterIDs(sr pcep.StateReport) (string, string, 
 		return "", "", errors.New("could not extract valid source and destination addresses")
 	}
 
-	srcRouterID, err := ss.findRouterIDFromAddress(srcAddr)
+	addrIndex := buildAddressRouterIDIndex(ss.ted)
+
+	srcRouterID, err := ss.findRouterIDFromAddress(addrIndex, srcAddr)
 	if err != nil {
 		return "", "", fmt.Errorf("cannot find source router ID for %s: %w", srcAddr, err)
 	}
 
-	dstRouterID, err := ss.findRouterIDFromAddress(dstAddr)
+	dstRouterID, err := ss.findRouterIDFromAddress(addrIndex, dstAddr)
 	if err != nil {
 		return "", "", fmt.Errorf("cannot find destination router ID for %s: %w", dstAddr, err)
 	}
@@ -589,17 +591,12 @@ func (ss *Session) extractSrcDstRouterIDs(sr pcep.StateReport) (string, string, 
 	return srcRouterID, dstRouterID, nil
 }
 
-func (ss *Session) findRouterIDFromAddress(addr netip.Addr) (string, error) {
-	for routerID, node := range ss.ted.Nodes {
-		if node.RouterID == addr.String() {
-			return routerID, nil
-		}
-
-		for _, prefix := range node.Prefixes {
-			if prefix.Prefix.Addr() == addr {
-				return routerID, nil
-			}
-		}
+func (ss *Session) findRouterIDFromAddress(addrIndex map[netip.Addr]string, addr netip.Addr) (string, error) {
+	if node, ok := ss.ted.Nodes[addr.String()]; ok {
+		return node.RouterID, nil
+	}
+	if routerID, ok := addrIndex[addr]; ok {
+		return routerID, nil
 	}
 	return "", fmt.Errorf("address %s not found in TED", addr)
 }

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -189,8 +189,6 @@ func TestSRPolicyIntent_AttachedOnCreationBySRPID(t *testing.T) {
 	}
 }
 
-// A policy update must also replace the recorded type and metric, using the intent
-// keyed by the SRP-ID of the update request.
 func TestSRPolicyIntent_AttachedOnUpdateBySRPID(t *testing.T) {
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 
@@ -900,6 +898,102 @@ func TestSendPCEPMessage_UnlocksAfterSendFailure(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("second SendKeepalive blocked; send mutex may not have been released")
+	}
+}
+
+func TestFindRouterIDFromAddress(t *testing.T) {
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+
+	v4Node := table.NewLsNode(0, "router-v4")
+	v4Prefix := table.NewLsPrefix(v4Node)
+	v4Prefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
+	v4Node.Prefixes = append(v4Node.Prefixes, v4Prefix)
+	ted.Nodes[v4Node.RouterID] = v4Node
+
+	v6Node := table.NewLsNode(0, "router-v6")
+	v6Prefix := table.NewLsPrefix(v6Node)
+	v6Prefix.Prefix = netip.MustParsePrefix("2001:db8::1/128")
+	v6Node.Prefixes = append(v6Node.Prefixes, v6Prefix)
+	ted.Nodes[v6Node.RouterID] = v6Node
+
+	subnetNode := table.NewLsNode(0, "router-subnet")
+	subnetPrefix := table.NewLsPrefix(subnetNode)
+	subnetPrefix.Prefix = netip.MustParsePrefix("192.0.2.0/24")
+	subnetNode.Prefixes = append(subnetNode.Prefixes, subnetPrefix)
+	ted.Nodes[subnetNode.RouterID] = subnetNode
+
+	// No prefixes: only matchable by Router ID.
+	idNode := table.NewLsNode(0, "198.51.100.1")
+	ted.Nodes[idNode.RouterID] = idNode
+
+	ss := &Session{ted: ted}
+	addrIndex := buildAddressRouterIDIndex(ted)
+
+	cases := []struct {
+		name    string
+		addr    netip.Addr
+		want    string
+		wantErr bool
+	}{
+		{"ipv4 prefix", netip.MustParseAddr("192.0.2.10"), "router-v4", false},
+		{"ipv6 prefix", netip.MustParseAddr("2001:db8::1"), "router-v6", false},
+		{"non-host prefix network address", netip.MustParseAddr("192.0.2.0"), "router-subnet", false},
+		{"router id match", netip.MustParseAddr("198.51.100.1"), "198.51.100.1", false},
+		{"not found", netip.MustParseAddr("203.0.113.5"), "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ss.findRouterIDFromAddress(addrIndex, tc.addr)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got routerID %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractSrcDstRouterIDs(t *testing.T) {
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+
+	srcNode := table.NewLsNode(0, "src-router")
+	srcPrefix := table.NewLsPrefix(srcNode)
+	srcPrefix.Prefix = netip.MustParsePrefix("10.255.0.1/32")
+	srcNode.Prefixes = append(srcNode.Prefixes, srcPrefix)
+	ted.Nodes[srcNode.RouterID] = srcNode
+
+	dstNode := table.NewLsNode(0, "10.255.0.2")
+	ted.Nodes[dstNode.RouterID] = dstNode
+
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+
+	sr := newTestStateReport(t, 1, 0)
+	srcRouterID, dstRouterID, err := ss.extractSrcDstRouterIDs(*sr)
+	if err != nil {
+		t.Fatalf("extractSrcDstRouterIDs failed: %v", err)
+	}
+	if srcRouterID != "src-router" {
+		t.Errorf("srcRouterID: got %q, want %q", srcRouterID, "src-router")
+	}
+	if dstRouterID != "10.255.0.2" {
+		t.Errorf("dstRouterID: got %q, want %q", dstRouterID, "10.255.0.2")
+	}
+}
+
+func TestExtractSrcDstRouterIDs_AddressNotFound(t *testing.T) {
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+
+	sr := newTestStateReport(t, 1, 0)
+	if _, _, err := ss.extractSrcDstRouterIDs(*sr); err == nil {
+		t.Error("expected an error when neither address is present in the TED")
 	}
 }
 

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -902,3 +902,21 @@ func TestSendPCEPMessage_UnlocksAfterSendFailure(t *testing.T) {
 		t.Fatal("second SendKeepalive blocked; send mutex may not have been released")
 	}
 }
+
+// TestIsSynced_ConcurrentAccess verifies that setSynced and IsSynced are synchronized.
+func TestIsSynced_ConcurrentAccess(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			ss.setSynced()
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		ss.IsSynced()
+	}
+	<-done
+}

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -189,6 +189,44 @@ func TestSRPolicyIntent_AttachedOnCreationBySRPID(t *testing.T) {
 	}
 }
 
+// A policy update must also replace the recorded type and metric, using the intent
+// keyed by the SRP-ID of the update request.
+func TestSRPolicyIntent_AttachedOnUpdateBySRPID(t *testing.T) {
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+
+	ss.rememberSRPolicyIntent(1, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	sr := newTestStateReport(t, 1, 1)
+	if err := ss.handleStateReport(sr, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if policy.Type != table.PolicyTypeExplicit || policy.Metric != table.UnspecifiedMetric {
+		t.Fatalf("initial policy intent: got (%q, %v), want (%q, %v)", policy.Type, policy.Metric, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	}
+
+	// A PCRpt for the same PLSP-ID takes the update path and must pick up the new intent.
+	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
+	sr2 := newTestStateReport(t, 1, 2)
+	if err := ss.handleStateReport(sr2, pcep.NewPCRptMessage()); err != nil {
+		t.Fatalf("handleStateReport returned an error: %v", err)
+	}
+
+	policy, found = ss.SearchSRPolicy(sr2.LSPObject.PlspID)
+	if !found {
+		t.Fatal("SR Policy reported by the PCC was not registered")
+	}
+	if policy.Type != table.PolicyTypeDynamic {
+		t.Errorf("policy type after update: got %q, want %q", policy.Type, table.PolicyTypeDynamic)
+	}
+	if policy.Metric != table.TEMetric {
+		t.Errorf("policy metric after update: got %v, want %v", policy.Metric, table.TEMetric)
+	}
+}
+
 func TestSRPolicyIntent_UnknownWhenNeverRemembered(t *testing.T) {
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-// sr-policy state
+// PolicyState represents the state of an SR Policy.
 type PolicyState string
 
 const (
@@ -23,11 +23,8 @@ const (
 	PolicyUnknown = PolicyState("unknown")
 )
 
-// PolicyType is the RFC 9256 §2.4.2 SR Policy candidate path type: a candidate path
-// is either explicit (a fixed SID list) or dynamic (computed against an optimization
-// metric and subject to recomputation). The zero value means "not known": PCEP
-// carries no TLV for this on PCRpt, so it can only be known for policies Pola itself
-// created (see Session.RememberSRPolicyIntent).
+// PolicyType is the SR Policy candidate path type defined in RFC 9256 §2.4.2.
+// The zero value means the type is unknown.
 type PolicyType string
 
 const (
@@ -47,8 +44,7 @@ type SRPolicy struct {
 	Preference  uint32      `json:"preference"`
 	LSPID       uint16      `json:"lspId,omitempty"`
 	State       PolicyState `json:"state,omitempty"`
-	// Type and Metric are only known for policies Pola itself created; both are
-	// left at their zero value ("" / UnspecifiedMetric) otherwise. See PolicyType.
+	// Type and Metric are only known for policies created by Pola.
 	Type   PolicyType `json:"type,omitempty"`
 	Metric MetricType `json:"metric,omitempty"`
 }
@@ -79,7 +75,7 @@ func NewSRPolicy(
 	return p
 }
 
-// SR Policy parameter that can be changed
+// PolicyDiff contains SR Policy parameters that can be changed.
 type PolicyDiff struct {
 	Name        *string
 	Color       *uint32
@@ -253,7 +249,7 @@ type SegmentSRMPLS struct {
 	TTL uint8  `json:"ttl,omitempty"`
 	TC  uint8  `json:"tc,omitempty"`
 	S   bool   `json:"s,omitempty"`
-	// Optional NAI for SR-ERO encoding (RFC8664 4.3.1).
+	// Optional NAI for SR-ERO encoding (RFC 8664 §4.3.1).
 	LocalAddr  netip.Addr `json:"localAddr,omitzero"`
 	RemoteAddr netip.Addr `json:"remoteAddr,omitzero"`
 }
@@ -272,21 +268,18 @@ func NewSegmentSRMPLS(sid uint32) SegmentSRMPLS {
 	}
 }
 
-// Equal for SegmentSRv6
 func (seg SegmentSRv6) Equal(other SegmentSRv6) bool {
-	// Compare SID, LocalAddr, and RemoteAddr
 	return seg.Sid == other.Sid &&
 		seg.LocalAddr == other.LocalAddr &&
 		seg.RemoteAddr == other.RemoteAddr
 }
 
-// Equal for SegmentSRMPLS
 func (seg SegmentSRMPLS) Equal(other SegmentSRMPLS) bool {
-	// Compare MPLS SID only: the NAI does not change which hop the label is.
+	// Compare only the MPLS SID; the NAI does not change the hop.
 	return seg.Sid == other.Sid
 }
 
-// Helper function for Segment interface equality check
+// SegmentsEqual reports whether two segments are equal.
 func SegmentsEqual(a, b Segment) bool {
 	switch sa := a.(type) {
 	case SegmentSRv6:

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -25,7 +25,9 @@ const (
 
 // PolicyType is the RFC 9256 §2.4.2 SR Policy candidate path type: a candidate path
 // is either explicit (a fixed SID list) or dynamic (computed against an optimization
-// metric and subject to recomputation). The zero value means "not known".
+// metric and subject to recomputation). The zero value means "not known": PCEP
+// carries no TLV for this on PCRpt, so it can only be known for policies Pola itself
+// created (see Session.RememberSRPolicyIntent).
 type PolicyType string
 
 const (


### PR DESCRIPTION
## Description

Optimize SR Policy router ID lookup by indexing TED addresses, avoiding repeated traversal of TED nodes.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

- Added unit tests for address-based router ID lookup and SR Policy endpoint extraction.
- `make ci`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed