### PR TITLE
Add version and build metadata

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     main: ./cmd/pola/
     binary: pola
     ldflags:
-      - -s -w -X main.build={{.Version}}
+      - -s -w -X github.com/nttcom/pola/internal/version.version={{.Version}}
     goos:
       - linux
     goarch:
@@ -21,7 +21,7 @@ builds:
     main: ./cmd/polad/
     binary: polad
     ldflags:
-      - -s -w -X main.build={{.Version}}
+      - -s -w -X github.com/nttcom/pola/internal/version.version={{.Version}}
     goos:
       - linux
     goarch:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,14 +3,55 @@
 // This software is released under the MIT License.
 // see https://github.com/nttcom/pola/blob/main/LICENSE
 
+// Package version reports the running binary's version and build metadata.
 package version
 
-import "fmt"
+import (
+	"runtime"
+	"runtime/debug"
+)
 
-const Major uint = 1
-const Minor uint = 4
-const Patch uint = 0
+const devVersion = "dev"
 
+// version is embedded at build time via ldflags.
+var version = devVersion
+
+// Version returns the release version, or "dev" for local builds.
 func Version() string {
-	return fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
+	return version
+}
+
+// Info holds version and build metadata for the running binary.
+type Info struct {
+	Version   string
+	GoVersion string
+	Revision  string
+	Time      string
+	Modified  bool
+}
+
+// Get returns the current build Info.
+func Get() Info {
+	info := Info{
+		Version:   Version(),
+		GoVersion: runtime.Version(),
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		info.Revision, info.Time, info.Modified = vcsSettings(bi.Settings)
+	}
+	return info
+}
+
+func vcsSettings(settings []debug.BuildSetting) (revision, t string, modified bool) {
+	for _, s := range settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.time":
+			t = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	return revision, t, modified
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -6,13 +6,85 @@
 package version
 
 import (
-	"fmt"
+	"runtime"
+	"runtime/debug"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVersion(t *testing.T) {
-	want := fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
-	assert.Equal(t, want, Version())
+func TestVersion_Default(t *testing.T) {
+	assert.Equal(t, devVersion, Version())
+}
+
+func TestVersion_Ldflags(t *testing.T) {
+	old := version
+	defer func() { version = old }()
+
+	version = "1.2.3"
+	assert.Equal(t, "1.2.3", Version())
+}
+
+func TestGet(t *testing.T) {
+	old := version
+	defer func() { version = old }()
+
+	version = "1.2.3"
+	info := Get()
+	assert.Equal(t, "1.2.3", info.Version)
+	assert.Equal(t, runtime.Version(), info.GoVersion)
+}
+
+func TestVcsSettings(t *testing.T) {
+	tests := []struct {
+		name         string
+		settings     []debug.BuildSetting
+		wantRevision string
+		wantTime     string
+		wantModified bool
+	}{
+		{
+			name: "vcs info present and clean",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abc123"},
+				{Key: "vcs.time", Value: "2026-08-14T00:00:00Z"},
+				{Key: "vcs.modified", Value: "false"},
+			},
+			wantRevision: "abc123",
+			wantTime:     "2026-08-14T00:00:00Z",
+			wantModified: false,
+		},
+		{
+			name: "vcs info present and modified",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abc123"},
+				{Key: "vcs.modified", Value: "true"},
+			},
+			wantRevision: "abc123",
+			wantModified: true,
+		},
+		{
+			name:         "no vcs info",
+			settings:     []debug.BuildSetting{{Key: "GOARCH", Value: "amd64"}},
+			wantRevision: "",
+			wantTime:     "",
+			wantModified: false,
+		},
+		{
+			name:         "no settings",
+			settings:     nil,
+			wantRevision: "",
+			wantTime:     "",
+			wantModified: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			revision, ts, modified := vcsSettings(tt.settings)
+			assert.Equal(t, tt.wantRevision, revision)
+			assert.Equal(t, tt.wantTime, ts)
+			assert.Equal(t, tt.wantModified, modified)
+		})
+	}
 }


### PR DESCRIPTION
## Description
Add release version and Go/VCS build metadata to the version package.
Embed the release version via GoReleaser ldflags.

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [x] Build / CI

## How was this tested?
- `go test ./internal/version/...`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed