### PR TITLE
Feat/server graceful shutdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Then use `make test-coverage-html` to see those lines in context.
 
 Notes:
 
-* Comparison starts at the merge base of your branch and `DIFF_BASE` (default `origin/main`) — the same changes a PR shows under "Files changed".
+* Comparison starts at the merge base of your branch and `DIFF_BASE` (default `origin/develop`) — the same changes a PR shows under "Files changed".
 * Coverage is measured against your working tree, not `HEAD`, so uncommitted changes to tracked files are included. Untracked files must be staged with `git add` to be included.
 * Only instrumented lines count (Go skips declarations, comments, blanks, closing braces).
 * Threshold is `DIFF_COVER_MIN` (default `90`). Override with `make test-coverage-diff DIFF_BASE=origin/develop DIFF_COVER_MIN=85`.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ COVER_PKGS    := ./cmd/... ./internal/... ./pkg/...
 COVER_PROFILE := coverage.out
 # Branch that test-coverage-diff compares against; its merge base with HEAD is
 # used, so the comparison covers only what this branch introduced.
-DIFF_BASE      ?= origin/main
+DIFF_BASE      ?= origin/develop
 DIFF_COVER_MIN ?= 90
 
 # External dependencies

--- a/cmd/polad/main.go
+++ b/cmd/polad/main.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"go.uber.org/zap"
 
@@ -77,12 +79,16 @@ func main() {
 		logger.Panic("TED is enabled but Global.TED.ASN is missing or invalid")
 	}
 
+	// Handle SIGINT/SIGTERM for graceful shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	// Prepare TED update tools
 	var tedElemsChan chan []table.TEDElem
 	if c.Global.TED.Enable {
 		switch c.Global.TED.Source {
 		case "gobgp":
-			tedElemsChan = startGoBGPUpdate(context.Background(), &c, logger)
+			tedElemsChan = startGoBGPUpdate(ctx, &c, logger)
 			if tedElemsChan == nil {
 				logger.Panic("GoBGP update channel is nil")
 			}
@@ -101,7 +107,7 @@ func main() {
 		USidMode:  c.Global.USidMode,
 		ASN:       c.Global.TED.ASN,
 	}
-	if serverErr := server.NewPCE(o, logger, tedElemsChan); serverErr.Error != nil {
+	if serverErr := server.NewPCE(ctx, o, logger, tedElemsChan); serverErr.Error != nil {
 		logger.Panic("Failed to start new server", zap.String("server", serverErr.Server), zap.Error(serverErr.Error))
 	}
 }

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -110,7 +110,10 @@ func (s *APIServer) Serve(address string, port string) error {
 		return fmt.Errorf("failed to listen on gRPC port %s: %w", localAddr.String(), err)
 	}
 	s.logger.Info("Start listening on gRPC port", zap.String("listenInfo", grpcListener.Addr().String()))
-	return s.grpcServer.Serve(grpcListener)
+	if err := s.grpcServer.Serve(grpcListener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+		return err
+	}
+	return nil
 }
 
 func validateCreateSRPolicy(req *pb.CreateSRPolicyRequest, disablePathCompute bool) error {

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -422,6 +422,14 @@ func TestServe_ListenFailure(t *testing.T) {
 	require.ErrorContains(t, s.Serve(addr, port), "failed to listen on gRPC port", "expected the already-bound port to be rejected")
 }
 
+func TestServe_ReturnsNilWhenAlreadyStoppedBeforeServing(t *testing.T) {
+	grpcServer := grpc.NewServer()
+	grpcServer.GracefulStop() // simulate ctx cancellation winning the startup race against Serve
+
+	s := &APIServer{grpcServer: grpcServer, logger: zap.NewNop()}
+	assert.NoError(t, s.Serve("127.0.0.1", "0"), "grpc.ErrServerStopped from the startup race should not be reported as a failure")
+}
+
 func TestServe_ListensAndLogsActualAddr(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	s := &APIServer{grpcServer: grpc.NewServer(), logger: zap.New(core)}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -18,6 +19,7 @@ import (
 	"go.uber.org/zap"
 	grpc "google.golang.org/grpc"
 
+	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/nttcom/pola/pkg/table"
 )
 
@@ -28,6 +30,10 @@ type Server struct {
 	ted         *table.LsTED
 	logger      *zap.Logger
 	asn         uint32
+
+	listenerMu sync.Mutex // guards listener and closed.
+	listener   *net.TCPListener
+	closed     bool // set by Shutdown; makes Serve and AcceptTCP errors resolve without error.
 }
 
 // TED returns the current TED snapshot. Safe for concurrent use with setTED.
@@ -53,7 +59,9 @@ type PCEOptions struct {
 	ASN       uint32
 }
 
-func NewPCE(o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem) Error {
+// NewPCE starts the PCEP and gRPC servers and blocks until they stop.
+// It returns an error if either server exits with a failure.
+func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem) Error {
 	s := &Server{
 		logger: logger,
 		asn:    o.ASN,
@@ -77,30 +85,40 @@ func NewPCE(o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem
 		}()
 	}
 
-	errChan := make(chan Error)
+	grpcServer := grpc.NewServer()
+	apiServer := NewAPIServer(s, grpcServer, o.USidMode, logger)
+
+	type result struct {
+		server string
+		err    error
+	}
+	resultChan := make(chan result, 2)
+
 	go func() {
-		if err := s.Serve(o.PCEPAddr, o.PCEPPort); err != nil {
-			errChan <- Error{
-				Server: "pcep",
-				Error:  err,
-			}
-		}
+		resultChan <- result{server: "pcep", err: s.Serve(o.PCEPAddr, o.PCEPPort)}
 	}()
 
 	go func() {
-		grpcServer := grpc.NewServer()
-		apiServer := NewAPIServer(s, grpcServer, o.USidMode, logger)
-		if err := apiServer.Serve(o.GRPCAddr, o.GRPCPort); err != nil {
-			errChan <- Error{
-				Server: "grpc",
-				Error:  err,
-			}
-		}
+		resultChan <- result{server: "grpc", err: apiServer.Serve(o.GRPCAddr, o.GRPCPort)}
 	}()
 
-	serverError := <-errChan
-	logger.Error("Server encountered an error", zap.String("server", serverError.Server), zap.Error(serverError.Error))
-	return serverError
+	go func() {
+		<-ctx.Done()
+		logger.Info("shutdown requested, stopping PCE server")
+		if err := s.Shutdown(); err != nil {
+			logger.Warn("failed to shut down PCEP server", zap.Error(err))
+		}
+		grpcServer.GracefulStop()
+	}()
+
+	for range 2 {
+		r := <-resultChan
+		if r.err != nil {
+			logger.Error("Server encountered an error", zap.String("server", r.server), zap.Error(r.err))
+			return Error{Server: r.server, Error: r.err}
+		}
+	}
+	return Error{}
 }
 
 func (s *Server) Serve(address string, port string) error {
@@ -122,8 +140,21 @@ func (s *Server) Serve(address string, port string) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen on PCEP port %s: %w", localAddr.String(), err)
 	}
+
+	s.listenerMu.Lock()
+	if s.closed {
+		// Shutdown ran before Serve started listening; don't accept anything.
+		s.listenerMu.Unlock()
+		return l.Close()
+	}
+	s.listener = l
+	s.listenerMu.Unlock()
+
 	defer func() {
-		if err := l.Close(); err != nil {
+		s.listenerMu.Lock()
+		s.listener = nil
+		s.listenerMu.Unlock()
+		if err := l.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 			s.logger.Warn("failed to close PCEP listener", zap.Error(err))
 		}
 	}()
@@ -132,6 +163,9 @@ func (s *Server) Serve(address string, port string) error {
 	for {
 		tcpConn, err := l.AcceptTCP()
 		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
 			return fmt.Errorf("failed to accept TCP connection: %w", err)
 		}
 		peerAddrPort, err := netip.ParseAddrPort(tcpConn.RemoteAddr().String())
@@ -151,6 +185,28 @@ func (s *Server) Serve(address string, port string) error {
 		}()
 		sessionID++
 	}
+}
+
+// Shutdown stops accepting connections and gracefully closes established sessions.
+func (s *Server) Shutdown() error {
+	s.listenerMu.Lock()
+	s.closed = true
+	l := s.listener
+	s.listenerMu.Unlock()
+
+	var err error
+	if l != nil {
+		err = l.Close()
+	}
+
+	for _, ss := range s.Sessions() {
+		if sendErr := ss.SendClose(pcep.CloseReasonNoExplanationProvided); sendErr != nil {
+			s.logger.Warn("failed to send PCEP close message during shutdown", zap.Error(sendErr))
+		}
+		s.closeSession(ss)
+	}
+
+	return err
 }
 
 func (s *Server) closeSession(session *Session) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,8 +32,13 @@ type Server struct {
 	asn         uint32
 
 	listenerMu sync.Mutex // guards listener and closed.
-	listener   *net.TCPListener
+	listener   tcpListener
 	closed     bool // set by Shutdown; makes Serve and AcceptTCP errors resolve without error.
+}
+
+type tcpListener interface {
+	AcceptTCP() (*net.TCPConn, error)
+	Close() error
 }
 
 // TED returns the current TED snapshot. Safe for concurrent use with setTED.
@@ -62,6 +67,9 @@ type PCEOptions struct {
 // NewPCE starts the PCEP and gRPC servers and blocks until they stop.
 // It returns an error if either server exits with a failure.
 func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem) Error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	s := &Server{
 		logger: logger,
 		asn:    o.ASN,
@@ -70,19 +78,7 @@ func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan
 		s.setTED(&table.LsTED{
 			Nodes: map[string]*table.LsNode{},
 		})
-
-		// Update TED
-		go func() {
-			for {
-				tedElems := <-tedElemsChan
-				ted := &table.LsTED{
-					Nodes: map[string]*table.LsNode{},
-				}
-				ted.Update(tedElems, o.ASN)
-				s.setTED(ted)
-				logger.Debug("Update TED")
-			}
-		}()
+		go s.syncTEDLoop(ctx, tedElemsChan, o.ASN, logger)
 	}
 
 	grpcServer := grpc.NewServer()
@@ -102,14 +98,7 @@ func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan
 		resultChan <- result{server: "grpc", err: apiServer.Serve(o.GRPCAddr, o.GRPCPort)}
 	}()
 
-	go func() {
-		<-ctx.Done()
-		logger.Info("shutdown requested, stopping PCE server")
-		if err := s.Shutdown(); err != nil {
-			logger.Warn("failed to shut down PCEP server", zap.Error(err))
-		}
-		grpcServer.GracefulStop()
-	}()
+	go s.awaitShutdown(ctx, logger, grpcServer.GracefulStop)
 
 	for range 2 {
 		r := <-resultChan
@@ -119,6 +108,25 @@ func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan
 		}
 	}
 	return Error{}
+}
+
+func (s *Server) syncTEDLoop(ctx context.Context, tedElemsChan <-chan []table.TEDElem, asn uint32, logger *zap.Logger) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case tedElems, ok := <-tedElemsChan:
+			if !ok {
+				return
+			}
+			ted := &table.LsTED{
+				Nodes: map[string]*table.LsNode{},
+			}
+			ted.Update(tedElems, asn)
+			s.setTED(ted)
+			logger.Debug("Update TED")
+		}
+	}
 }
 
 func (s *Server) Serve(address string, port string) error {
@@ -187,6 +195,15 @@ func (s *Server) Serve(address string, port string) error {
 	}
 }
 
+func (s *Server) awaitShutdown(ctx context.Context, logger *zap.Logger, stopGRPC func()) {
+	<-ctx.Done()
+	logger.Info("shutdown requested, stopping PCE server")
+	if err := s.Shutdown(); err != nil {
+		logger.Warn("failed to shut down PCEP server", zap.Error(err))
+	}
+	stopGRPC()
+}
+
 // Shutdown stops accepting connections and gracefully closes established sessions.
 func (s *Server) Shutdown() error {
 	s.listenerMu.Lock()
@@ -196,7 +213,9 @@ func (s *Server) Shutdown() error {
 
 	var err error
 	if l != nil {
-		err = l.Close()
+		if err = l.Close(); errors.Is(err, net.ErrClosed) {
+			err = nil
+		}
 	}
 
 	for _, ss := range s.Sessions() {
@@ -210,12 +229,11 @@ func (s *Server) Shutdown() error {
 }
 
 func (s *Server) closeSession(session *Session) {
-	if err := session.tcpConn.Close(); err != nil {
+	if err := session.tcpConn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 		s.logger.Warn("failed to close TCP connection", zap.Error(err))
 	}
 	session.clearSRPolicyIntents()
 
-	// Remove Session List
 	s.sessionMu.Lock()
 	for i, v := range s.sessionList {
 		if v.sessionID == session.sessionID {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	grpc "google.golang.org/grpc"
@@ -23,17 +24,22 @@ import (
 	"github.com/nttcom/pola/pkg/table"
 )
 
+// Maximum time to wait for the PCEP Close message during shutdown.
+const defaultShutdownSendCloseTimeout = 2 * time.Second
+
 type Server struct {
-	sessionMu   sync.RWMutex // guards sessionList; written from the PCEP accept/close goroutines, read from gRPC handler goroutines.
+	sessionMu   sync.RWMutex // guards sessionList
 	sessionList []*Session
-	tedMu       sync.RWMutex // guards ted; written from the TED-update goroutine, read from gRPC handler goroutines.
+	tedMu       sync.RWMutex // guards ted
 	ted         *table.LsTED
 	logger      *zap.Logger
 	asn         uint32
 
-	listenerMu sync.Mutex // guards listener and closed.
+	listenerMu sync.Mutex // guards listener and closed
 	listener   tcpListener
-	closed     bool // set by Shutdown; makes Serve and AcceptTCP errors resolve without error.
+	closed     bool // set by Shutdown; suppresses Serve/AcceptTCP errors
+
+	shutdownSendCloseTimeout time.Duration // zero uses the default
 }
 
 type tcpListener interface {
@@ -100,14 +106,20 @@ func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan
 
 	go s.awaitShutdown(ctx, logger, grpcServer.GracefulStop)
 
+	// Wait for both servers to stop before returning the first error.
+	var firstErr Error
 	for range 2 {
 		r := <-resultChan
-		if r.err != nil {
-			logger.Error("Server encountered an error", zap.String("server", r.server), zap.Error(r.err))
-			return Error{Server: r.server, Error: r.err}
+		if r.err == nil {
+			continue
+		}
+		logger.Error("Server encountered an error", zap.String("server", r.server), zap.Error(r.err))
+		if firstErr.Error == nil {
+			firstErr = Error{Server: r.server, Error: r.err}
+			cancel()
 		}
 	}
-	return Error{}
+	return firstErr
 }
 
 func (s *Server) syncTEDLoop(ctx context.Context, tedElemsChan <-chan []table.TEDElem, asn uint32, logger *zap.Logger) {
@@ -180,19 +192,37 @@ func (s *Server) Serve(address string, port string) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse remote address %s: %w", tcpConn.RemoteAddr().String(), err)
 		}
-		ss := NewSession(sessionID, peerAddrPort.Addr(), tcpConn, s.logger, s.TED(), s.asn)
-		ss.logger.Info("start PCEP session")
 
-		s.sessionMu.Lock()
-		s.sessionList = append(s.sessionList, ss)
-		s.sessionMu.Unlock()
+		ss := s.registerSession(tcpConn, sessionID, peerAddrPort.Addr())
+		sessionID++
+		if ss == nil {
+			continue
+		}
+		ss.logger.Info("start PCEP session")
 		go func() {
 			ss.Established()
 			s.closeSession(ss)
 			ss.logger.Info("close PCEP session")
 		}()
-		sessionID++
 	}
+}
+
+func (s *Server) registerSession(tcpConn *net.TCPConn, sessionID uint8, peerAddr netip.Addr) *Session {
+	s.listenerMu.Lock()
+	defer s.listenerMu.Unlock()
+
+	if s.closed {
+		if err := tcpConn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			s.logger.Warn("failed to close TCP connection accepted after shutdown", zap.Error(err))
+		}
+		return nil
+	}
+
+	ss := NewSession(sessionID, peerAddr, tcpConn, s.logger, s.TED(), s.asn)
+	s.sessionMu.Lock()
+	s.sessionList = append(s.sessionList, ss)
+	s.sessionMu.Unlock()
+	return ss
 }
 
 func (s *Server) awaitShutdown(ctx context.Context, logger *zap.Logger, stopGRPC func()) {
@@ -209,6 +239,9 @@ func (s *Server) Shutdown() error {
 	s.listenerMu.Lock()
 	s.closed = true
 	l := s.listener
+	s.sessionMu.RLock()
+	sessions := slices.Clone(s.sessionList)
+	s.sessionMu.RUnlock()
 	s.listenerMu.Unlock()
 
 	var err error
@@ -218,14 +251,40 @@ func (s *Server) Shutdown() error {
 		}
 	}
 
-	for _, ss := range s.Sessions() {
+	var wg sync.WaitGroup
+	for _, ss := range sessions {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.gracefulCloseSession(ss)
+		}()
+	}
+	wg.Wait()
+
+	return err
+}
+
+// Sends a PCEP Close message with a bounded wait before force-closing the session.
+func (s *Server) gracefulCloseSession(ss *Session) {
+	sendDone := make(chan struct{})
+	go func() {
+		defer close(sendDone)
 		if sendErr := ss.SendClose(pcep.CloseReasonNoExplanationProvided); sendErr != nil {
 			s.logger.Warn("failed to send PCEP close message during shutdown", zap.Error(sendErr))
 		}
-		s.closeSession(ss)
+	}()
+
+	timeout := s.shutdownSendCloseTimeout
+	if timeout <= 0 {
+		timeout = defaultShutdownSendCloseTimeout
+	}
+	select {
+	case <-sendDone:
+	case <-time.After(timeout):
+		s.logger.Warn("timed out sending PCEP close message during shutdown", zap.String("session", ss.peerAddr.String()))
 	}
 
-	return err
+	s.closeSession(ss)
 }
 
 func (s *Server) closeSession(session *Session) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -9,8 +9,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/netip"
+	"sync"
 	"testing"
 	"time"
 
@@ -102,8 +104,12 @@ func TestServer_Shutdown_ClosesListenerAndStopsServe(t *testing.T) {
 	go func() { serveErrCh <- s.Serve(addr, port) }()
 
 	require.Eventually(t, func() bool {
-		_, dialErr := net.DialTimeout("tcp", net.JoinHostPort(addr, port), 100*time.Millisecond)
-		return dialErr == nil
+		conn, dialErr := net.DialTimeout("tcp", net.JoinHostPort(addr, port), 100*time.Millisecond)
+		if dialErr != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
 	}, 2*time.Second, 10*time.Millisecond, "expected the PCEP listener to accept connections before shutdown")
 
 	require.NoError(t, s.Shutdown(), "Shutdown should close the listener without error")
@@ -254,15 +260,17 @@ func TestNewPCE_TEDEnabledUpdatesTEDOnElemsReceived(t *testing.T) {
 	core, logs := observer.New(zap.DebugLevel)
 	tedElemsChan := make(chan []table.TEDElem, 1)
 	o := &PCEOptions{
-		PCEPAddr:  "not-an-ip", // fail before listening
+		PCEPAddr:  "127.0.0.1",
 		PCEPPort:  "0",
 		GRPCAddr:  "127.0.0.1",
 		GRPCPort:  "0",
 		TEDEnable: true,
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	errCh := make(chan Error, 1)
-	go func() { errCh <- NewPCE(context.Background(), o, zap.New(core), tedElemsChan) }()
+	go func() { errCh <- NewPCE(ctx, o, zap.New(core), tedElemsChan) }()
 
 	tedElemsChan <- []table.TEDElem{}
 
@@ -270,11 +278,45 @@ func TestNewPCE_TEDEnabledUpdatesTEDOnElemsReceived(t *testing.T) {
 		return len(logs.FilterMessage("Update TED").All()) > 0
 	}, 2*time.Second, 10*time.Millisecond, "expected the TED update goroutine to run")
 
+	cancel()
+
+	select {
+	case err := <-errCh:
+		assert.Empty(t, err.Server)
+		assert.NoError(t, err.Error)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for NewPCE to shut down after context cancellation")
+	}
+}
+
+// TestNewPCE_WaitsForBothServersBeforeReturning ensures NewPCE waits for both servers to stop before returning.
+func TestNewPCE_WaitsForBothServersBeforeReturning(t *testing.T) {
+	grpcLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to reserve a port")
+	grpcAddr, grpcPort, err := net.SplitHostPort(grpcLn.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, grpcLn.Close(), "failed to release the reserved port")
+
+	o := &PCEOptions{
+		PCEPAddr: "not-an-ip", // fails before listening, well before gRPC would stop on its own
+		PCEPPort: "0",
+		GRPCAddr: grpcAddr,
+		GRPCPort: grpcPort,
+	}
+
+	errCh := make(chan Error, 1)
+	go func() { errCh <- NewPCE(context.Background(), o, zap.NewNop(), make(chan []table.TEDElem)) }()
+
 	select {
 	case err := <-errCh:
 		assert.Equal(t, "pcep", err.Server)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for NewPCE to report an error")
+	}
+
+	ln, err := net.Listen("tcp", net.JoinHostPort(grpcAddr, grpcPort))
+	if assert.NoError(t, err, "expected the gRPC listener to be released by the time NewPCE returns") {
+		assert.NoError(t, ln.Close())
 	}
 }
 
@@ -393,4 +435,79 @@ func TestServer_SyncTEDLoop_ExitsWhenChannelClosed(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for syncTEDLoop to return after the channel closed")
 	}
+}
+
+func TestServer_RegisterSession_ClosesConnWhenAlreadyShutdown(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { _ = client.Close() })
+
+	s := &Server{logger: zap.NewNop(), closed: true}
+	ss := s.registerSession(server, 1, netip.MustParseAddr("10.0.255.1"))
+
+	assert.Nil(t, ss, "expected registerSession to reject a connection accepted after Shutdown")
+	assert.Empty(t, s.Sessions())
+
+	require.NoError(t, client.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, err := client.Read(make([]byte, 1))
+	assert.ErrorIs(t, err, io.EOF, "expected the connection accepted after shutdown to be closed immediately")
+}
+
+func TestServer_RegisterSession_AppendsWhenNotShutdown(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	s := &Server{logger: zap.NewNop()}
+	ss := s.registerSession(server, 1, netip.MustParseAddr("10.0.255.1"))
+
+	require.NotNil(t, ss)
+	assert.Equal(t, []*Session{ss}, s.Sessions())
+
+	s.closeSession(ss)
+}
+
+// blockingWriteConn simulates a peer that stopped reading.
+type blockingWriteConn struct {
+	r       io.Reader
+	unblock chan struct{}
+	once    sync.Once
+}
+
+func (c *blockingWriteConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+func (c *blockingWriteConn) Write(p []byte) (int, error) {
+	<-c.unblock
+	return 0, net.ErrClosed
+}
+
+func (c *blockingWriteConn) Close() error {
+	c.once.Do(func() { close(c.unblock) })
+	return nil
+}
+
+func (c *blockingWriteConn) SetReadDeadline(time.Time) error { return nil }
+
+func TestServer_Shutdown_BoundsBlockedSendClose(t *testing.T) {
+	conn := &blockingWriteConn{r: bytes.NewReader(nil), unblock: make(chan struct{})}
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	core, logs := observer.New(zap.WarnLevel)
+	s := &Server{
+		sessionList:              []*Session{ss},
+		logger:                   zap.New(core),
+		shutdownSendCloseTimeout: 50 * time.Millisecond,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.NoError(t, s.Shutdown())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown did not return after the SendClose timeout elapsed, despite the blocked write")
+	}
+
+	assert.Len(t, logs.FilterMessage("timed out sending PCEP close message during shutdown").All(), 1)
+	assert.Empty(t, s.Sessions(), "expected the session to be force-closed and untracked despite the blocked write")
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6,6 +6,7 @@
 package server
 
 import (
+	"context"
 	"net"
 	"net/netip"
 	"testing"
@@ -61,6 +62,7 @@ func TestServer_Serve_AcceptsConnectionAndUntracksOnClose(t *testing.T) {
 
 	s := &Server{logger: zap.NewNop()}
 	go func() { _ = s.Serve(addr, port) }()
+	t.Cleanup(func() { assert.NoError(t, s.Shutdown()) })
 
 	var client net.Conn
 	require.Eventually(t, func() bool {
@@ -84,6 +86,81 @@ func TestServer_Serve_AcceptsConnectionAndUntracksOnClose(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(s.Sessions()) == 0
 	}, 2*time.Second, 10*time.Millisecond, "expected the session to be untracked once the PCEP session ended")
+}
+
+func TestServer_Shutdown_ClosesListenerAndStopsServe(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to reserve a port")
+	addr, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, ln.Close(), "failed to release the reserved port")
+
+	s := &Server{logger: zap.NewNop()}
+	serveErrCh := make(chan error, 1)
+	go func() { serveErrCh <- s.Serve(addr, port) }()
+
+	require.Eventually(t, func() bool {
+		_, dialErr := net.DialTimeout("tcp", net.JoinHostPort(addr, port), 100*time.Millisecond)
+		return dialErr == nil
+	}, 2*time.Second, 10*time.Millisecond, "expected the PCEP listener to accept connections before shutdown")
+
+	require.NoError(t, s.Shutdown(), "Shutdown should close the listener without error")
+
+	select {
+	case err := <-serveErrCh:
+		assert.NoError(t, err, "Serve should return cleanly once the listener is closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Serve to return after Shutdown closed the listener")
+	}
+
+	_, dialErr := net.DialTimeout("tcp", net.JoinHostPort(addr, port), 100*time.Millisecond)
+	assert.Error(t, dialErr, "expected the listener to no longer accept connections after Shutdown")
+}
+
+func TestServer_Shutdown_BeforeServeStillReturnsCleanly(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to reserve a port")
+	addr, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, ln.Close(), "failed to release the reserved port")
+
+	s := &Server{logger: zap.NewNop()}
+	require.NoError(t, s.Shutdown(), "Shutdown before Serve starts should be a no-op that succeeds")
+
+	require.NoError(t, s.Serve(addr, port), "Serve should return cleanly if Shutdown already ran")
+
+	_, dialErr := net.DialTimeout("tcp", net.JoinHostPort(addr, port), 100*time.Millisecond)
+	assert.Error(t, dialErr, "expected Serve not to accept connections after an earlier Shutdown")
+}
+
+func TestServer_Shutdown_ClosesActiveSessions(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to reserve a port")
+	addr, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, ln.Close(), "failed to release the reserved port")
+
+	s := &Server{logger: zap.NewNop()}
+	go func() { _ = s.Serve(addr, port) }()
+
+	var client net.Conn
+	require.Eventually(t, func() bool {
+		c, dialErr := net.DialTimeout("tcp", net.JoinHostPort(addr, port), 100*time.Millisecond)
+		if dialErr != nil {
+			return false
+		}
+		client = c
+		return true
+	}, 2*time.Second, 10*time.Millisecond, "expected to dial the PCEP listener once it starts")
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Eventually(t, func() bool {
+		return len(s.Sessions()) == 1
+	}, 2*time.Second, 10*time.Millisecond, "expected the accepted connection to be tracked as a session")
+
+	require.NoError(t, s.Shutdown())
+
+	assert.Empty(t, s.Sessions(), "expected Shutdown to close and untrack the active session")
 }
 
 func TestServer_CloseSession_LogsWarnOnCloseFailure(t *testing.T) {
@@ -133,7 +210,7 @@ func TestNewPCE_ReturnsTaggedError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			errCh := make(chan Error, 1)
-			go func() { errCh <- NewPCE(tt.o, zap.NewNop(), make(chan []table.TEDElem)) }()
+			go func() { errCh <- NewPCE(context.Background(), tt.o, zap.NewNop(), make(chan []table.TEDElem)) }()
 
 			select {
 			case err := <-errCh:
@@ -158,7 +235,7 @@ func TestNewPCE_TEDEnabledUpdatesTEDOnElemsReceived(t *testing.T) {
 	}
 
 	errCh := make(chan Error, 1)
-	go func() { errCh <- NewPCE(o, zap.New(core), tedElemsChan) }()
+	go func() { errCh <- NewPCE(context.Background(), o, zap.New(core), tedElemsChan) }()
 
 	tedElemsChan <- []table.TEDElem{}
 
@@ -171,5 +248,31 @@ func TestNewPCE_TEDEnabledUpdatesTEDOnElemsReceived(t *testing.T) {
 		assert.Equal(t, "pcep", err.Server)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for NewPCE to report an error")
+	}
+}
+
+func TestNewPCE_ContextCancelShutsDownCleanly(t *testing.T) {
+	o := &PCEOptions{
+		PCEPAddr: "127.0.0.1",
+		PCEPPort: "0",
+		GRPCAddr: "127.0.0.1",
+		GRPCPort: "0",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan Error, 1)
+	go func() { errCh <- NewPCE(ctx, o, zap.NewNop(), make(chan []table.TEDElem)) }()
+
+	// Give both servers a moment to start listening before requesting shutdown.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		assert.Empty(t, err.Server)
+		assert.NoError(t, err.Error)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for NewPCE to shut down after context cancellation")
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6,7 +6,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"net"
 	"net/netip"
 	"testing"
@@ -133,6 +135,18 @@ func TestServer_Shutdown_BeforeServeStillReturnsCleanly(t *testing.T) {
 	assert.Error(t, dialErr, "expected Serve not to accept connections after an earlier Shutdown")
 }
 
+func TestServer_Shutdown_LogsWarnOnSendCloseFailure(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	core, logs := observer.New(zap.WarnLevel)
+	s := &Server{sessionList: []*Session{ss}, logger: zap.New(core)}
+
+	require.NoError(t, s.Shutdown())
+
+	assert.Len(t, logs.FilterMessage("failed to send PCEP close message during shutdown").All(), 1)
+	assert.Empty(t, s.Sessions())
+}
+
 func TestServer_Shutdown_ClosesActiveSessions(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "failed to reserve a port")
@@ -163,7 +177,7 @@ func TestServer_Shutdown_ClosesActiveSessions(t *testing.T) {
 	assert.Empty(t, s.Sessions(), "expected Shutdown to close and untrack the active session")
 }
 
-func TestServer_CloseSession_LogsWarnOnCloseFailure(t *testing.T) {
+func TestServer_CloseSession_SuppressesWarnOnAlreadyClosedConnection(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() {
 		assert.NoError(t, client.Close(), "failed to close client connection")
@@ -171,6 +185,19 @@ func TestServer_CloseSession_LogsWarnOnCloseFailure(t *testing.T) {
 	require.NoError(t, server.Close(), "failed to pre-close server connection")
 
 	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	core, logs := observer.New(zap.WarnLevel)
+	s := &Server{sessionList: []*Session{ss}, logger: zap.New(core)}
+
+	s.closeSession(ss)
+
+	assert.Empty(t, logs.FilterMessage("failed to close TCP connection").All(),
+		"a double close (Shutdown racing the session's own close) should not be logged as a failure")
+	assert.Empty(t, s.Sessions())
+}
+
+func TestServer_CloseSession_LogsWarnOnOtherCloseFailure(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil), closeErr: errors.New("boom")}
+	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 	core, logs := observer.New(zap.WarnLevel)
 	s := &Server{sessionList: []*Session{ss}, logger: zap.New(core)}
 
@@ -274,5 +301,96 @@ func TestNewPCE_ContextCancelShutsDownCleanly(t *testing.T) {
 		assert.NoError(t, err.Error)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for NewPCE to shut down after context cancellation")
+	}
+}
+
+type fakeListener struct {
+	closeErr error
+}
+
+func (l *fakeListener) AcceptTCP() (*net.TCPConn, error) { <-make(chan struct{}); return nil, nil }
+func (l *fakeListener) Close() error                     { return l.closeErr }
+
+func TestServer_Shutdown_TreatsRepeatCloseAsNoError(t *testing.T) {
+	s := &Server{logger: zap.NewNop(), listener: &fakeListener{closeErr: net.ErrClosed}}
+
+	assert.NoError(t, s.Shutdown(), "a listener already closed elsewhere should not fail Shutdown")
+}
+
+func TestServer_Shutdown_PropagatesOtherListenerCloseError(t *testing.T) {
+	wantErr := errors.New("boom")
+	s := &Server{logger: zap.NewNop(), listener: &fakeListener{closeErr: wantErr}}
+
+	assert.ErrorIs(t, s.Shutdown(), wantErr)
+}
+
+func TestServer_AwaitShutdown_LogsWarnOnShutdownError(t *testing.T) {
+	wantErr := errors.New("boom")
+	core, logs := observer.New(zap.WarnLevel)
+	s := &Server{logger: zap.NewNop(), listener: &fakeListener{closeErr: wantErr}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stopped := false
+	done := make(chan struct{})
+	go func() {
+		s.awaitShutdown(ctx, zap.New(core), func() { stopped = true })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for awaitShutdown to return")
+	}
+
+	assert.Len(t, logs.FilterMessage("failed to shut down PCEP server").All(), 1)
+	assert.True(t, stopped, "expected the gRPC server to be stopped even when Shutdown fails")
+}
+
+func TestServer_SyncTEDLoop_AppliesReceivedElems(t *testing.T) {
+	s := &Server{}
+	core, logs := observer.New(zap.DebugLevel)
+	tedElemsChan := make(chan []table.TEDElem, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		s.syncTEDLoop(ctx, tedElemsChan, 65000, zap.New(core))
+		close(done)
+	}()
+
+	tedElemsChan <- []table.TEDElem{}
+
+	require.Eventually(t, func() bool {
+		return len(logs.FilterMessage("Update TED").All()) > 0
+	}, 2*time.Second, 10*time.Millisecond, "expected the received TED elements to be applied")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for syncTEDLoop to return after context cancellation")
+	}
+}
+
+func TestServer_SyncTEDLoop_ExitsWhenChannelClosed(t *testing.T) {
+	s := &Server{}
+	tedElemsChan := make(chan []table.TEDElem)
+
+	done := make(chan struct{})
+	go func() {
+		s.syncTEDLoop(context.Background(), tedElemsChan, 65000, zap.NewNop())
+		close(done)
+	}()
+
+	close(tedElemsChan)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for syncTEDLoop to return after the channel closed")
 	}
 }

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -69,6 +69,7 @@ type fakeConn struct {
 	failAfter          int // number of successful writes before writeErr is returned; ignored if writeErr is nil.
 	writeErr           error
 	setReadDeadlineErr error
+	closeErr           error
 }
 
 func (c *fakeConn) Read(p []byte) (int, error) { return c.r.Read(p) }
@@ -83,7 +84,7 @@ func (c *fakeConn) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (c *fakeConn) Close() error { return nil }
+func (c *fakeConn) Close() error { return c.closeErr }
 
 func (c *fakeConn) SetReadDeadline(t time.Time) error { return c.setReadDeadlineErr }
 


### PR DESCRIPTION
## Description

Add graceful shutdown support for the PCEP server and handle SIGINT/SIGTERM.

## Type of change

* [x] New feature
* [ ] Bug fix
* [x] Refactoring
* [ ] Documentation
* [ ] Build / CI

## How was this tested?

* Added a test for graceful shutdown on context cancellation.

## Checklist

* [x] `make ci` passes locally
* [x] Tests added or updated if needed
* [ ] Documentation updated if needed
