### PR TITLE
Simplify SR policy path and PCEP message construction

### DIFF
--- a/cmd/pola/ted.go
+++ b/cmd/pola/ted.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
+	"github.com/nttcom/pola/pkg/table"
 	"github.com/spf13/cobra"
 )
 
@@ -37,95 +38,94 @@ func printTED(jsonFlag bool) error {
 	}
 
 	if jsonFlag {
-		// Output JSON format
-		nodes := []map[string]any{}
-		for _, node := range ted.Nodes {
-			nodeMap := map[string]any{ // TODO: Fix format according to readme
-				"asn":        node.ASN,
-				"routerID":   node.RouterID,
-				"isisAreaID": node.IsisAreaID,
-				"hostname":   node.Hostname,
-				"srgbBegin":  node.SrgbBegin,
-				"srgbEnd":    node.SrgbEnd,
-				"prefixes":   []map[string]any{},
-				"links":      []map[string]any{},
-			}
-
-			links := []map[string]any{}
-			for _, link := range node.Links {
-				metrics := []map[string]any{}
-				for _, metric := range link.Metrics {
-					metricMap := map[string]any{
-						"type":  metric.Type.String(),
-						"value": metric.Value,
-					}
-					metrics = append(metrics, metricMap)
-				}
-
-				var localIP string
-				var remoteIP string
-				if link.LocalIP.IsValid() {
-					localIP = link.LocalIP.String()
-				} else {
-					localIP = "None"
-				}
-				if link.RemoteIP.IsValid() {
-					remoteIP = link.RemoteIP.String()
-				} else {
-					remoteIP = "None"
-				}
-
-				linkMap := map[string]any{
-					"localIP":    localIP,
-					"remoteIP":   remoteIP,
-					"remoteNode": link.RemoteNode.RouterID,
-					"metrics":    metrics,
-					"adjSid":     link.AdjSid,
-				}
-				links = append(links, linkMap)
-			}
-			nodeMap["links"] = links
-
-			prefixes := []map[string]any{}
-			for _, prefix := range node.Prefixes {
-				prefixMap := map[string]any{
-					"prefix": prefix.Prefix.String(),
-				}
-				if prefix.HasPrefixSID() {
-					prefixMap["sidIndex"] = prefix.SidIndex
-				}
-				prefixes = append(prefixes, prefixMap)
-			}
-			nodeMap["prefixes"] = prefixes
-
-			srv6SIDs := []map[string]any{}
-			for _, srv6SID := range node.SRv6SIDs {
-				srv6SIDMap := map[string]any{
-					"sids":             srv6SID.Sids,
-					"endpointBehavior": srv6SID.EndpointBehavior,
-					"multiTopoIDs":     srv6SID.MultiTopoIDs,
-				}
-				srv6SIDs = append(srv6SIDs, srv6SIDMap)
-			}
-			nodeMap["srv6SIDs"] = srv6SIDs
-
-			nodes = append(nodes, nodeMap)
-		}
-
-		outputMap := map[string]any{
-			"ted": nodes,
-		}
-
-		outputJSON, err := json.Marshal(outputMap)
+		outputJSON, err := json.Marshal(tedToJSONMap(ted))
 		if err != nil {
 			return err
 		}
 		fmt.Println(string(outputJSON))
-
 	} else {
-		// Output user-friendly format
 		ted.Print()
 	}
 
 	return nil
+}
+
+// tedToJSONMap converts ted into the map shape marshalled by printTED.
+func tedToJSONMap(ted *table.LsTED) map[string]any {
+	nodes := []map[string]any{}
+	for _, node := range ted.Nodes {
+		nodes = append(nodes, tedNodeToJSONMap(node))
+	}
+
+	return map[string]any{
+		"ted": nodes,
+	}
+}
+
+func tedNodeToJSONMap(node *table.LsNode) map[string]any {
+	links := []map[string]any{}
+	for _, link := range node.Links {
+		links = append(links, tedLinkToJSONMap(link))
+	}
+
+	prefixes := []map[string]any{}
+	for _, prefix := range node.Prefixes {
+		prefixMap := map[string]any{
+			"prefix": prefix.Prefix.String(),
+		}
+		if prefix.HasPrefixSID() {
+			prefixMap["sidIndex"] = prefix.SidIndex
+		}
+		prefixes = append(prefixes, prefixMap)
+	}
+
+	srv6SIDs := []map[string]any{}
+	for _, srv6SID := range node.SRv6SIDs {
+		srv6SIDs = append(srv6SIDs, map[string]any{
+			"sids":             srv6SID.Sids,
+			"endpointBehavior": srv6SID.EndpointBehavior,
+			"multiTopoIDs":     srv6SID.MultiTopoIDs,
+		})
+	}
+
+	return map[string]any{ // TODO: Fix format according to readme
+		"asn":        node.ASN,
+		"routerID":   node.RouterID,
+		"isisAreaID": node.IsisAreaID,
+		"hostname":   node.Hostname,
+		"srgbBegin":  node.SrgbBegin,
+		"srgbEnd":    node.SrgbEnd,
+		"prefixes":   prefixes,
+		"links":      links,
+		"srv6SIDs":   srv6SIDs,
+	}
+}
+
+func tedLinkToJSONMap(link *table.LsLink) map[string]any {
+	metrics := []map[string]any{}
+	for _, metric := range link.Metrics {
+		metrics = append(metrics, map[string]any{
+			"type":  metric.Type.String(),
+			"value": metric.Value,
+		})
+	}
+
+	// Links whose BGP-LS descriptor carried no interface address report "None",
+	// matching table.LsTED.Print.
+	localIP := "None"
+	if link.LocalIP.IsValid() {
+		localIP = link.LocalIP.String()
+	}
+	remoteIP := "None"
+	if link.RemoteIP.IsValid() {
+		remoteIP = link.RemoteIP.String()
+	}
+
+	return map[string]any{
+		"localIP":    localIP,
+		"remoteIP":   remoteIP,
+		"remoteNode": link.RemoteNode.RouterID,
+		"metrics":    metrics,
+		"adjSid":     link.AdjSid,
+	}
 }

--- a/cmd/polad/main.go
+++ b/cmd/polad/main.go
@@ -92,6 +92,8 @@ func run(args []string, deps runDeps) error {
 		}
 	}()
 
+	// Cancelling ctx on SIGINT/SIGTERM is what drives graceful shutdown: it stops
+	// the PCE servers and the BGP-LS monitor goroutine.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -129,6 +131,8 @@ func loadConfig(configFile string) (config.Config, error) {
 }
 
 func openLogFile(c *config.Config) (*os.File, error) {
+	// Create the log directory if it does not exist. Logs can carry topology
+	// and peer details, so access is limited to the owner and group.
 	if err := os.MkdirAll(c.Global.Log.Path, 0750); err != nil {
 		return nil, fmt.Errorf("failed to create log directory: %w", err)
 	}

--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net/netip"
 
 	"github.com/nttcom/pola/pkg/table"
 )
@@ -595,8 +594,9 @@ func (m *PCInitiateMessage) Serialize() ([]uint8, error) {
 	return bytePCInitiateMessage, nil
 }
 
-// NewPCInitiateMessage creates a new PCInitiateMessage.
-func NewPCInitiateMessage(srpID uint32, lspName string, lspDelete bool, plspID uint32, segmentList []table.Segment, color uint32, preference uint32, srcAddr netip.Addr, dstAddr netip.Addr, opt ...Opt) (*PCInitiateMessage, error) {
+// NewPCInitiateMessage creates a PCInitiateMessage that instantiates srPolicy
+// as a new LSP. Use NewPCInitiateDeleteMessage to remove one.
+func NewPCInitiateMessage(srpID uint32, srPolicy table.SRPolicy, opt ...Opt) (*PCInitiateMessage, error) {
 	opts := optParams{
 		pccType: RFCCompliant,
 	}
@@ -608,37 +608,33 @@ func NewPCInitiateMessage(srpID uint32, lspName string, lspDelete bool, plspID u
 	m := &PCInitiateMessage{}
 	var err error
 
-	if m.SrpObject, err = NewSrpObject(segmentList, srpID, lspDelete); err != nil {
+	if m.SrpObject, err = NewSrpObject(srPolicy.SegmentList, srpID, false); err != nil {
 		return nil, err
 	}
 
-	if lspDelete {
-		m.LSPObject = NewLSPObject(lspName, &color, plspID)
-		return m, nil
-	}
-
-	m.LSPObject = NewLSPObject(lspName, &color, 0)
-	if m.EndpointsObject, err = NewEndpointsObject(dstAddr, srcAddr); err != nil {
+	// PLSP-ID is 0 on instantiation; the PCC assigns it (RFC 8281 §5.3.1).
+	m.LSPObject = NewLSPObject(srPolicy.Name, &srPolicy.Color, 0)
+	if m.EndpointsObject, err = NewEndpointsObject(srPolicy.DstAddr, srPolicy.SrcAddr); err != nil {
 		return nil, err
 	}
-	if m.EroObject, err = NewEroObject(segmentList); err != nil {
+	if m.EroObject, err = NewEroObject(srPolicy.SegmentList); err != nil {
 		return m, err
 	}
 
 	switch opts.pccType {
 	case JuniperLegacy:
-		if m.AssociationObject, err = NewAssociationObject(srcAddr, dstAddr, color, preference, VendorSpecific(opts.pccType), OriginatorASN(opts.originatorASN)); err != nil {
+		if m.AssociationObject, err = NewAssociationObject(srPolicy.SrcAddr, srPolicy.DstAddr, srPolicy.Color, srPolicy.Preference, VendorSpecific(opts.pccType), OriginatorASN(opts.originatorASN)); err != nil {
 			return nil, err
 		}
 	case CiscoLegacy:
-		if m.VendorInformationObject, err = NewVendorInformationObject(CiscoLegacy, color, preference); err != nil {
+		if m.VendorInformationObject, err = NewVendorInformationObject(CiscoLegacy, srPolicy.Color, srPolicy.Preference); err != nil {
 			return nil, err
 		}
 	case RFCCompliant:
-		if m.AssociationObject, err = NewAssociationObject(srcAddr, dstAddr, color, preference, OriginatorASN(opts.originatorASN)); err != nil {
+		if m.AssociationObject, err = NewAssociationObject(srPolicy.SrcAddr, srPolicy.DstAddr, srPolicy.Color, srPolicy.Preference, OriginatorASN(opts.originatorASN)); err != nil {
 			return nil, err
 		}
-		if m.VendorInformationObject, err = NewVendorInformationObject(CiscoLegacy, color, preference); err != nil {
+		if m.VendorInformationObject, err = NewVendorInformationObject(CiscoLegacy, srPolicy.Color, srPolicy.Preference); err != nil {
 			return nil, err
 		}
 	default:
@@ -646,6 +642,23 @@ func NewPCInitiateMessage(srpID uint32, lspName string, lspDelete bool, plspID u
 	}
 
 	return m, nil
+}
+
+// NewPCInitiateDeleteMessage creates a PCInitiateMessage that removes the LSP
+// identified by srPolicy.PlspID, flagged by the SRP R flag (RFC 8281 §5.2).
+// Deletion carries only the SRP and LSP objects, so srPolicy's endpoints and
+// vendor-specific attributes are not encoded; its segment list is still read to
+// derive the PATH-SETUP-TYPE TLV.
+func NewPCInitiateDeleteMessage(srpID uint32, srPolicy table.SRPolicy) (*PCInitiateMessage, error) {
+	srpObject, err := NewSrpObject(srPolicy.SegmentList, srpID, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PCInitiateMessage{
+		SrpObject: srpObject,
+		LSPObject: NewLSPObject(srPolicy.Name, &srPolicy.Color, srPolicy.PlspID),
+	}, nil
 }
 
 // PCUpdMessage is a PCEP Update message.
@@ -680,16 +693,18 @@ func (m *PCUpdMessage) Serialize() ([]uint8, error) {
 	return bytePCUpdMessage, nil
 }
 
-// NewPCUpdMessage creates a new PCUpdMessage.
-func NewPCUpdMessage(srpID uint32, lspName string, plspID uint32, segmentList []table.Segment) (*PCUpdMessage, error) {
+// NewPCUpdMessage creates a PCUpdMessage that re-signals the LSP identified by
+// srPolicy.PlspID with srPolicy's segment list.
+func NewPCUpdMessage(srpID uint32, srPolicy table.SRPolicy) (*PCUpdMessage, error) {
 	m := &PCUpdMessage{}
 	var err error
 
-	if m.SrpObject, err = NewSrpObject(segmentList, srpID, false); err != nil {
+	if m.SrpObject, err = NewSrpObject(srPolicy.SegmentList, srpID, false); err != nil {
 		return nil, err
 	}
-	m.LSPObject = NewLSPObject(lspName, nil, plspID)
-	if m.EroObject, err = NewEroObject(segmentList); err != nil {
+	// A nil color omits the COLOR TLV, leaving the value set at instantiation.
+	m.LSPObject = NewLSPObject(srPolicy.Name, nil, srPolicy.PlspID)
+	if m.EroObject, err = NewEroObject(srPolicy.SegmentList); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -121,7 +121,9 @@ func TestNewPCInitiateMessage_OriginatorASNReachesWire(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			m, err := NewPCInitiateMessage(1, "policy1", false, 0, segmentList, 100, 200, srcAddr, dstAddr, tt.opts...)
+			m, err := NewPCInitiateMessage(1, table.SRPolicy{
+				Name: "policy1", SegmentList: segmentList, Color: 100, Preference: 200, SrcAddr: srcAddr, DstAddr: dstAddr,
+			}, tt.opts...)
 			require.NoError(t, err, "NewPCInitiateMessage failed")
 			require.NotNil(t, m.AssociationObject, "RFC compliant PCInitiate must carry an ASSOCIATION object")
 
@@ -185,7 +187,9 @@ func TestNewPCInitiateMessage_VendorObjectSelection(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			m, err := NewPCInitiateMessage(1, "policy1", false, 0, segmentList, 100, 200, srcAddr, dstAddr, VendorSpecific(tt.pccType))
+			m, err := NewPCInitiateMessage(1, table.SRPolicy{
+				Name: "policy1", SegmentList: segmentList, Color: 100, Preference: 200, SrcAddr: srcAddr, DstAddr: dstAddr,
+			}, VendorSpecific(tt.pccType))
 			require.NoError(t, err, "NewPCInitiateMessage failed")
 
 			if tt.wantAssociation {
@@ -675,7 +679,7 @@ func TestNewPCUpdMessage(t *testing.T) {
 
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16001), table.NewSegmentSRMPLS(16002)}
 
-	m, err := NewPCUpdMessage(1, "policy1", 5, segmentList)
+	m, err := NewPCUpdMessage(1, table.SRPolicy{Name: "policy1", PlspID: 5, SegmentList: segmentList})
 	require.NoError(t, err)
 
 	raw, err := m.Serialize()
@@ -721,7 +725,7 @@ func TestNewPCUpdMessage_Errors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := NewPCUpdMessage(1, "policy1", 5, segs)
+			_, err := NewPCUpdMessage(1, table.SRPolicy{Name: "policy1", PlspID: 5, SegmentList: segs})
 			assert.Error(t, err)
 		})
 	}
@@ -921,17 +925,30 @@ func TestPCInitiateMessage_Serialize_MessageLengthBoundary(t *testing.T) {
 	assert.ErrorContains(t, err, "exceeds")
 }
 
-func TestNewPCInitiateMessage_LSPDelete(t *testing.T) {
+func TestNewPCInitiateDeleteMessage(t *testing.T) {
 	t.Parallel()
 
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16001)}
-	m, err := NewPCInitiateMessage(1, "policy1", true, 5, segmentList, 100, 200, netip.Addr{}, netip.Addr{})
+	m, err := NewPCInitiateDeleteMessage(1, table.SRPolicy{
+		Name: "policy1", PlspID: 5, SegmentList: segmentList, Color: 100, Preference: 200,
+	})
 	require.NoError(t, err)
 
+	assert.True(t, m.SrpObject.RFlag, "deletion must set the SRP R flag")
 	assert.Equal(t, uint32(5), m.LSPObject.PlspID)
 	assert.Nil(t, m.EndpointsObject)
 	assert.Nil(t, m.EroObject)
 	assert.Nil(t, m.AssociationObject)
+	assert.Nil(t, m.VendorInformationObject)
+}
+
+func TestNewPCInitiateDeleteMessage_InvalidSegmentType(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewPCInitiateDeleteMessage(1, table.SRPolicy{
+		Name: "policy1", PlspID: 5, SegmentList: []table.Segment{fakeSegment{}},
+	})
+	assert.Error(t, err)
 }
 
 func TestNewPCInitiateMessage_Errors(t *testing.T) {
@@ -968,7 +985,9 @@ func TestNewPCInitiateMessage_Errors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := NewPCInitiateMessage(1, "policy1", false, 0, tt.segmentList, 100, 200, tt.srcAddr, tt.dstAddr, tt.opts...)
+			_, err := NewPCInitiateMessage(1, table.SRPolicy{
+				Name: "policy1", SegmentList: tt.segmentList, Color: 100, Preference: 200, SrcAddr: tt.srcAddr, DstAddr: tt.dstAddr,
+			}, tt.opts...)
 			assert.Error(t, err)
 		})
 	}

--- a/pkg/packet/pcep/tlv_common.go
+++ b/pkg/packet/pcep/tlv_common.go
@@ -19,7 +19,6 @@ func decodeTLVLength(data []byte, allowPadding bool) (int, error) {
 	length := int(binary.BigEndian.Uint16(data[TLVLengthOffset:TLVValueOffset]))
 	expected := TLVValueOffset + length
 
-	// Validate length and optional padding strictly.
 	if len(data) < expected {
 		return 0, fmt.Errorf("tlv: invalid length (expected at least %d bytes, got %d)", expected, len(data))
 	}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -231,9 +231,19 @@ func newEnrichedSegment(segment *pb.Segment, usidMode bool) (table.Segment, erro
 	}
 }
 
-// buildSegmentList returns the segment list and the metric type used for path computation.
-// It returns table.UnspecifiedMetric when path computation is disabled.
-func buildSegmentList(s *APIServer, input *pb.CreateSRPolicyRequest, disablePathCompute bool) ([]table.Segment, netip.Addr, netip.Addr, table.MetricType, error) {
+// resolvedPath is the path of the requested SR Policy: its endpoints, its
+// segment list, and the metric it was optimized for.
+type resolvedPath struct {
+	SegmentList []table.Segment
+	SrcAddr     netip.Addr
+	DstAddr     netip.Addr
+	Metric      table.MetricType
+}
+
+// resolvePath resolves the SR Policy path either by computing it over the TED,
+// or, when path computation is disabled, by taking the request values verbatim.
+// Metric is table.UnspecifiedMetric in the latter case, since nothing was optimized.
+func resolvePath(s *APIServer, input *pb.CreateSRPolicyRequest, disablePathCompute bool) (resolvedPath, error) {
 	var srcAddr, dstAddr netip.Addr
 	var segmentList []table.Segment
 	metricType := table.UnspecifiedMetric
@@ -244,11 +254,11 @@ func buildSegmentList(s *APIServer, input *pb.CreateSRPolicyRequest, disablePath
 	if !disablePathCompute {
 		ted := s.pce.TED()
 		if ted == nil {
-			return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, newStatus(codes.FailedPrecondition, ReasonTEDDisabled, "ted is disabled")
+			return resolvedPath{}, newStatus(codes.FailedPrecondition, ReasonTEDDisabled, "ted is disabled")
 		}
 
 		if len(ted.Nodes) == 0 {
-			return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, newStatus(codes.FailedPrecondition, ReasonTEDNotSynced, "no node in TED")
+			return resolvedPath{}, newStatus(codes.FailedPrecondition, ReasonTEDNotSynced, "no node in TED")
 		}
 
 		// Check the ASN against the first TED node; all nodes are expected to share the same ASN.
@@ -257,30 +267,30 @@ func buildSegmentList(s *APIServer, input *pb.CreateSRPolicyRequest, disablePath
 				continue
 			}
 			if node.ASN != input.GetAsn() {
-				return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "request ASN %d does not match ted ASN %d", input.GetAsn(), node.ASN)
+				return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "request ASN %d does not match ted ASN %d", input.GetAsn(), node.ASN)
 			}
 			break
 		}
 
 		srcAddr, err = getLoopbackAddr(ted, inputSRPolicy.GetSrcRouterId())
 		if err != nil {
-			return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, err
+			return resolvedPath{}, err
 		}
 
 		dstAddr, err = getLoopbackAddr(ted, inputSRPolicy.GetDstRouterId())
 		if err != nil {
-			return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, err
+			return resolvedPath{}, err
 		}
 
 		segmentList, metricType, err = getSegmentList(inputSRPolicy, ted, s.usidMode)
 		if err != nil {
-			return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, err
+			return resolvedPath{}, err
 		}
 	} else {
 		var ok bool
 		srcAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
 		if !ok {
-			return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
+			return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
 				"invalid source address %v",
 				inputSRPolicy.GetSrcAddr(),
 			)
@@ -288,7 +298,7 @@ func buildSegmentList(s *APIServer, input *pb.CreateSRPolicyRequest, disablePath
 
 		dstAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
 		if !ok {
-			return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
+			return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
 				"invalid destination address %v",
 				inputSRPolicy.GetDstAddr(),
 			)
@@ -297,13 +307,13 @@ func buildSegmentList(s *APIServer, input *pb.CreateSRPolicyRequest, disablePath
 		for _, segment := range inputSRPolicy.GetSegmentList() {
 			seg, err := newEnrichedSegment(segment, s.usidMode)
 			if err != nil {
-				return nil, netip.Addr{}, netip.Addr{}, table.UnspecifiedMetric, err
+				return resolvedPath{}, err
 			}
 			segmentList = append(segmentList, seg)
 		}
 	}
 
-	return segmentList, srcAddr, dstAddr, metricType, nil
+	return resolvedPath{SegmentList: segmentList, SrcAddr: srcAddr, DstAddr: dstAddr, Metric: metricType}, nil
 }
 
 // resolveSRPolicyIntent resolves the candidate-path type and metric per RFC 9256 §2.4.2.
@@ -324,7 +334,7 @@ func resolveSRPolicyIntent(inputSRPolicy *pb.SRPolicy, disablePathCompute bool, 
 	}
 }
 
-func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, segmentList []table.Segment, srcAddr, dstAddr netip.Addr, disablePathCompute bool, metricType table.MetricType) error {
+func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, path resolvedPath, disablePathCompute bool) error {
 	inputSRPolicy := input.GetSrPolicy()
 
 	pcepSession, err := getSyncedPCEPSession(s.pce, inputSRPolicy.GetPcepSessionAddr())
@@ -332,23 +342,23 @@ func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, segmentL
 		return wrapStatusError(err, "failed to get synchronized PCEP session")
 	}
 
-	policyType, metricType, err := resolveSRPolicyIntent(inputSRPolicy, disablePathCompute, metricType)
+	policyType, metricType, err := resolveSRPolicyIntent(inputSRPolicy, disablePathCompute, path.Metric)
 	if err != nil {
 		return wrapStatusError(err, "failed to resolve SR policy type")
 	}
 
 	srPolicy := table.SRPolicy{
 		Name:        inputSRPolicy.GetPolicyName(),
-		SegmentList: segmentList,
-		SrcAddr:     srcAddr,
-		DstAddr:     dstAddr,
+		SegmentList: path.SegmentList,
+		SrcAddr:     path.SrcAddr,
+		DstAddr:     path.DstAddr,
 		Color:       inputSRPolicy.GetColor(),
 		Preference:  100,
 		Type:        policyType,
 		Metric:      metricType,
 	}
 
-	if id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), dstAddr); exists {
+	if id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), path.DstAddr); exists {
 		s.logger.Debug("Request to update SR Policy", zap.Uint32("plspID", id))
 		srPolicy.PlspID = id
 		if err := pcepSession.SendPCUpdate(srPolicy); err != nil {
@@ -371,16 +381,16 @@ func (s *APIServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyRequ
 		return nil, wrapStatusError(err, "failed to validate SR policy creation")
 	}
 
-	segmentList, srcAddr, dstAddr, metricType, err := buildSegmentList(s, req, disablePathCompute)
+	path, err := resolvePath(s, req, disablePathCompute)
 	if err != nil {
-		return nil, wrapStatusError(err, "failed to build segment list")
+		return nil, wrapStatusError(err, "failed to resolve SR policy path")
 	}
 
-	if err := s.validateSIDs(req, segmentList); err != nil {
+	if err := s.validateSIDs(req, path.SegmentList); err != nil {
 		return nil, err
 	}
 
-	if err := sendSRPolicyRequest(s, req, segmentList, srcAddr, dstAddr, disablePathCompute, metricType); err != nil {
+	if err := sendSRPolicyRequest(s, req, path, disablePathCompute); err != nil {
 		return nil, wrapStatusError(err, "failed to send SR policy request")
 	}
 
@@ -1223,7 +1233,8 @@ func (s *APIServer) DeleteSession(_ context.Context, req *pb.DeleteSessionReques
 		return &pb.DeleteSessionResponse{IsSuccess: false}, newStatus(codes.Internal, ReasonPCEPRequestFailed, "failed to send close message: %v", err)
 	}
 
-	// Remove session info from PCE server
+	// A PCEP Close only notifies the peer; the TCP connection and the server-side
+	// session state have to be torn down here as well.
 	pce.closeSession(ss)
 
 	return &pb.DeleteSessionResponse{IsSuccess: true}, nil

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -1460,7 +1460,7 @@ func TestNewEnrichedSegmentSRMPLS_SubobjectValidationErrors(t *testing.T) {
 	}
 }
 
-func TestBuildSegmentList_PathCompute(t *testing.T) {
+func TestResolvePath_PathCompute(t *testing.T) {
 	srcNode := &table.LsNode{ASN: 65000, RouterID: "r1", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}}}
 	dstNode := &table.LsNode{ASN: 65000, RouterID: "r2", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.2/32")}}}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{srcNode.RouterID: srcNode, dstNode.RouterID: dstNode}}
@@ -1479,22 +1479,22 @@ func TestBuildSegmentList_PathCompute(t *testing.T) {
 
 	t.Run("success resolves loopbacks and segments", func(t *testing.T) {
 		s := newTestAPIServer(ted)
-		segmentList, srcAddr, dstAddr, _, err := buildSegmentList(s, explicitReq(), false)
+		path, err := resolvePath(s, explicitReq(), false)
 		require.NoError(t, err)
-		assert.Equal(t, "10.0.0.1", srcAddr.String())
-		assert.Equal(t, "10.0.0.2", dstAddr.String())
-		assert.Len(t, segmentList, 1)
+		assert.Equal(t, "10.0.0.1", path.SrcAddr.String())
+		assert.Equal(t, "10.0.0.2", path.DstAddr.String())
+		assert.Len(t, path.SegmentList, 1)
 	})
 
 	t.Run("TED disabled", func(t *testing.T) {
 		s := newTestAPIServer(nil)
-		_, _, _, _, err := buildSegmentList(s, explicitReq(), false)
+		_, err := resolvePath(s, explicitReq(), false)
 		assert.ErrorContains(t, err, "ted is disabled")
 	})
 
 	t.Run("TED not yet synchronized", func(t *testing.T) {
 		s := newTestAPIServer(&table.LsTED{Nodes: map[string]*table.LsNode{}})
-		_, _, _, _, err := buildSegmentList(s, explicitReq(), false)
+		_, err := resolvePath(s, explicitReq(), false)
 		assert.ErrorContains(t, err, "no node in TED")
 	})
 
@@ -1502,20 +1502,20 @@ func TestBuildSegmentList_PathCompute(t *testing.T) {
 		s := newTestAPIServer(ted)
 		req := explicitReq()
 		req.Asn = 1
-		_, _, _, _, err := buildSegmentList(s, req, false)
+		_, err := resolvePath(s, req, false)
 		assert.ErrorContains(t, err, "does not match ted ASN")
 	})
 
 	t.Run("nil TED entry is skipped by the ASN check", func(t *testing.T) {
 		nodes := map[string]*table.LsNode{srcNode.RouterID: srcNode, dstNode.RouterID: dstNode, "r0": nil}
 		s := newTestAPIServer(&table.LsTED{Nodes: nodes})
-		_, _, _, _, err := buildSegmentList(s, explicitReq(), false)
+		_, err := resolvePath(s, explicitReq(), false)
 		require.NoError(t, err)
 	})
 
 	t.Run("TED holding only nil entries", func(t *testing.T) {
 		s := newTestAPIServer(&table.LsTED{Nodes: map[string]*table.LsNode{"r0": nil}})
-		_, _, _, _, err := buildSegmentList(s, explicitReq(), false)
+		_, err := resolvePath(s, explicitReq(), false)
 		assert.ErrorContains(t, err, "no node with router ID r1")
 	})
 
@@ -1523,7 +1523,7 @@ func TestBuildSegmentList_PathCompute(t *testing.T) {
 		s := newTestAPIServer(ted)
 		req := explicitReq()
 		req.SrPolicy.SrcRouterId = "missing"
-		_, _, _, _, err := buildSegmentList(s, req, false)
+		_, err := resolvePath(s, req, false)
 		assert.ErrorContains(t, err, "no node with router ID missing")
 	})
 
@@ -1531,7 +1531,7 @@ func TestBuildSegmentList_PathCompute(t *testing.T) {
 		s := newTestAPIServer(ted)
 		req := explicitReq()
 		req.SrPolicy.DstRouterId = "missing"
-		_, _, _, _, err := buildSegmentList(s, req, false)
+		_, err := resolvePath(s, req, false)
 		assert.ErrorContains(t, err, "no node with router ID missing")
 	})
 
@@ -1539,12 +1539,12 @@ func TestBuildSegmentList_PathCompute(t *testing.T) {
 		s := newTestAPIServer(ted)
 		req := explicitReq()
 		req.SrPolicy.SegmentList = nil
-		_, _, _, _, err := buildSegmentList(s, req, false)
+		_, err := resolvePath(s, req, false)
 		assert.ErrorContains(t, err, "no segments in SRPolicy input")
 	})
 }
 
-func TestBuildSegmentList_DisablePathCompute(t *testing.T) {
+func TestResolvePath_DisablePathCompute(t *testing.T) {
 	disabledReq := func() *pb.CreateSRPolicyRequest {
 		return &pb.CreateSRPolicyRequest{
 			DisablePathCompute: true,
@@ -1558,18 +1558,18 @@ func TestBuildSegmentList_DisablePathCompute(t *testing.T) {
 
 	t.Run("success uses the request addresses and segments verbatim", func(t *testing.T) {
 		s := newTestAPIServer(nil)
-		segmentList, srcAddr, dstAddr, _, err := buildSegmentList(s, disabledReq(), true)
+		path, err := resolvePath(s, disabledReq(), true)
 		require.NoError(t, err)
-		assert.Equal(t, "10.0.0.1", srcAddr.String())
-		assert.Equal(t, "10.0.0.2", dstAddr.String())
-		assert.Len(t, segmentList, 1)
+		assert.Equal(t, "10.0.0.1", path.SrcAddr.String())
+		assert.Equal(t, "10.0.0.2", path.DstAddr.String())
+		assert.Len(t, path.SegmentList, 1)
 	})
 
 	t.Run("malformed source address", func(t *testing.T) {
 		s := newTestAPIServer(nil)
 		req := disabledReq()
 		req.SrPolicy.SrcAddr = []byte{1, 2, 3}
-		_, _, _, _, err := buildSegmentList(s, req, true)
+		_, err := resolvePath(s, req, true)
 		assert.ErrorContains(t, err, "invalid source address")
 	})
 
@@ -1577,7 +1577,7 @@ func TestBuildSegmentList_DisablePathCompute(t *testing.T) {
 		s := newTestAPIServer(nil)
 		req := disabledReq()
 		req.SrPolicy.DstAddr = []byte{1, 2, 3}
-		_, _, _, _, err := buildSegmentList(s, req, true)
+		_, err := resolvePath(s, req, true)
 		assert.ErrorContains(t, err, "invalid destination address")
 	})
 
@@ -1585,7 +1585,7 @@ func TestBuildSegmentList_DisablePathCompute(t *testing.T) {
 		s := newTestAPIServer(nil)
 		req := disabledReq()
 		req.SrPolicy.SegmentList = []*pb.Segment{{Sid: "not-a-sid"}}
-		_, _, _, _, err := buildSegmentList(s, req, true)
+		_, err := resolvePath(s, req, true)
 		assert.Error(t, err)
 	})
 }
@@ -1622,10 +1622,10 @@ func TestCreateSRPolicy(t *testing.T) {
 		assert.ErrorContains(t, err, "failed to validate SR policy creation")
 	})
 
-	t.Run("build segment list error", func(t *testing.T) {
+	t.Run("resolve path error", func(t *testing.T) {
 		s := newTestAPIServer(nil)
 		_, err := s.CreateSRPolicy(context.Background(), baseReq())
-		assert.ErrorContains(t, err, "failed to build segment list")
+		assert.ErrorContains(t, err, "failed to resolve SR policy path")
 	})
 
 	t.Run("SID validation error", func(t *testing.T) {
@@ -2101,7 +2101,7 @@ func TestSendSRPolicyRequest_GetSyncedPCEPSessionError(t *testing.T) {
 	s := &APIServer{pce: &Server{}, logger: zap.NewNop()}
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: netip.MustParseAddr("10.0.255.1").AsSlice()}}
 
-	err := sendSRPolicyRequest(s, req, nil, netip.Addr{}, netip.Addr{}, false, table.UnspecifiedMetric)
+	err := sendSRPolicyRequest(s, req, resolvedPath{}, false)
 	assert.ErrorContains(t, err, "failed to get synchronized PCEP session")
 }
 
@@ -2111,7 +2111,7 @@ func TestSendSRPolicyRequest_ResolveIntentError(t *testing.T) {
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Type: pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED}}
 
-	err := sendSRPolicyRequest(s, req, nil, netip.Addr{}, netip.Addr{}, false, table.UnspecifiedMetric)
+	err := sendSRPolicyRequest(s, req, resolvedPath{}, false)
 	assert.ErrorContains(t, err, "failed to resolve SR policy type")
 }
 
@@ -2130,7 +2130,7 @@ func TestSendSRPolicyRequest_CreatesNewPolicy(t *testing.T) {
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	require.NoError(t, sendSRPolicyRequest(s, req, segmentList, netip.MustParseAddr("10.255.0.1"), dstAddr, false, table.UnspecifiedMetric))
+	require.NoError(t, sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false))
 	assert.NoError(t, readPCEPMessage(client), "expected a well-framed PCInitiate message on the wire")
 }
 
@@ -2150,7 +2150,7 @@ func TestSendSRPolicyRequest_UpdatesExistingPolicy(t *testing.T) {
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	require.NoError(t, sendSRPolicyRequest(s, req, segmentList, netip.MustParseAddr("10.255.0.1"), dstAddr, false, table.UnspecifiedMetric))
+	require.NoError(t, sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false))
 	assert.NoError(t, readPCEPMessage(client), "expected a well-framed PCUpdate message on the wire")
 }
 
@@ -2171,7 +2171,7 @@ func TestSendSRPolicyRequest_UpdateSendFailure(t *testing.T) {
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := sendSRPolicyRequest(s, req, segmentList, netip.MustParseAddr("10.255.0.1"), dstAddr, false, table.UnspecifiedMetric)
+	err := sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false)
 	require.ErrorContains(t, err, "failed to send PC update")
 	assert.Equal(t, ReasonPCEPRequestFailed, errInfoReason(t, err))
 }
@@ -2192,7 +2192,7 @@ func TestSendSRPolicyRequest_CreateSendFailure(t *testing.T) {
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := sendSRPolicyRequest(s, req, segmentList, netip.MustParseAddr("10.255.0.1"), dstAddr, false, table.UnspecifiedMetric)
+	err := sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false)
 	require.ErrorContains(t, err, "failed to request SR policy creation")
 	assert.Equal(t, ReasonPCEPRequestFailed, errInfoReason(t, err))
 }

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -840,7 +840,12 @@ func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error
 		return err
 	}
 
-	pcinitiateMessage, err := pcep.NewPCInitiateMessage(srpID, srPolicy.Name, lspDelete, srPolicy.PlspID, srPolicy.SegmentList, srPolicy.Color, srPolicy.Preference, srPolicy.SrcAddr, srPolicy.DstAddr, pcep.VendorSpecific(ss.pccType), pcep.OriginatorASN(ss.asn))
+	var pcinitiateMessage *pcep.PCInitiateMessage
+	if lspDelete {
+		pcinitiateMessage, err = pcep.NewPCInitiateDeleteMessage(srpID, srPolicy)
+	} else {
+		pcinitiateMessage, err = pcep.NewPCInitiateMessage(srpID, srPolicy, pcep.VendorSpecific(ss.pccType), pcep.OriginatorASN(ss.asn))
+	}
 	if err != nil {
 		ss.forgetSRPolicyIntent(srpID)
 		return err
@@ -860,7 +865,7 @@ func (ss *Session) SendPCUpdate(srPolicy table.SRPolicy) error {
 		return err
 	}
 
-	pcupdateMessage, err := pcep.NewPCUpdMessage(srpID, srPolicy.Name, srPolicy.PlspID, srPolicy.SegmentList)
+	pcupdateMessage, err := pcep.NewPCUpdMessage(srpID, srPolicy)
 	if err != nil {
 		ss.forgetSRPolicyIntent(srpID)
 		return err
@@ -875,19 +880,14 @@ func (ss *Session) SendPCUpdate(srPolicy table.SRPolicy) error {
 
 // RegisterSRPolicy registers an SR Policy from a PCEP state report.
 func (ss *Session) RegisterSRPolicy(sr pcep.StateReport) error {
-	// Resolve color and preference for this SR Policy
 	color, preference := ss.resolveColorPreference(&sr)
-
-	// Determine the policy state based on O-Flag
 	state := resolvePolicyState(sr.LSPObject.OFlag)
 
-	// Validate Segment List
 	segmentList, err := validateSegmentList(sr)
 	if err != nil {
 		return err
 	}
 
-	// Update existing policy or create a new one
 	return ss.updateOrCreatePolicy(sr, segmentList, color, preference, state)
 }
 
@@ -974,7 +974,6 @@ func (ss *Session) updateOrCreatePolicy(sr pcep.StateReport, segmentList []table
 		return nil
 	}
 
-	// Create a new SR Policy
 	src := sr.LSPObject.SrcAddr
 	if !src.IsValid() {
 		src = sr.AssociationObject.AssocSrc

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -327,7 +327,7 @@ func TestSendSRPolicyRequest_ForgetsIntentOnSendFailure(t *testing.T) {
 		DisablePathCompute: true,
 	}
 
-	err := sendSRPolicyRequest(apiServer, req, nil, netip.MustParseAddr("10.255.0.1"), dstAddr, true, table.UnspecifiedMetric)
+	err := sendSRPolicyRequest(apiServer, req, resolvedPath{SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, true)
 	require.Error(t, err, "expected sendSRPolicyRequest to fail once the connection is closed")
 
 	_, ok := ss.takeSRPolicyIntent(wantSRPID)


### PR DESCRIPTION
## Description

Refactor SR Policy path resolution and PCEP message construction to simplify internal APIs and clarify responsibilities.

- Introduce `resolvedPath` for path resolution results.
- Simplify PCEP message constructors and separate PCInitiate creation/deletion.
- Update related session handling, TED JSON helpers, and tests.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

- `make ci`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed
