### PR TITLE
refactor: move gRPC converters to separate file

### DIFF
--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -618,7 +618,7 @@ func NewPCInitiateMessage(srpID uint32, srPolicy table.SRPolicy, opt ...Opt) (*P
 		return nil, err
 	}
 	if m.EroObject, err = NewEroObject(srPolicy.SegmentList); err != nil {
-		return m, err
+		return nil, err
 	}
 
 	switch opts.pccType {

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -985,10 +985,11 @@ func TestNewPCInitiateMessage_Errors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := NewPCInitiateMessage(1, table.SRPolicy{
+			m, err := NewPCInitiateMessage(1, table.SRPolicy{
 				Name: "policy1", SegmentList: tt.segmentList, Color: 100, Preference: 200, SrcAddr: tt.srcAddr, DstAddr: tt.dstAddr,
 			}, tt.opts...)
-			assert.Error(t, err)
+			require.Error(t, err)
+			assert.Nil(t, m)
 		})
 	}
 }

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package server
+
+import (
+	"fmt"
+	"net/netip"
+
+	pb "github.com/nttcom/pola/api/pola/v1"
+	"github.com/nttcom/pola/pkg/packet/pcep"
+	"github.com/nttcom/pola/pkg/table"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+func buildCapability(cap pcep.CapabilityInterface) *pb.Capability {
+	c := &pb.Capability{Type: capabilityType(cap.Type())}
+	switch tlv := cap.(type) {
+	case *pcep.StatefulPCECapability:
+		c.Detail = &pb.Capability_Stateful{Stateful: &pb.StatefulCapability{
+			LspUpdate:            tlv.LSPUpdateCapability,
+			IncludeDbVersion:     tlv.IncludeDBVersion,
+			LspInstantiation:     tlv.LSPInstantiationCapability,
+			TriggeredResync:      tlv.TriggeredResync,
+			DeltaLspSync:         tlv.DeltaLSPSyncCapability,
+			TriggeredInitialSync: tlv.TriggeredInitialSync,
+			Color:                tlv.ColorCapability,
+		}}
+	case *pcep.SRPCECapability:
+		c.Detail = &pb.Capability_Sr{Sr: &pb.SrCapability{
+			UnlimitedMsd: tlv.HasUnlimitedMaxSIDDepth,
+			NaiSupported: tlv.IsNAISupported,
+			Msd:          uint32(tlv.MaximumSidDepth),
+		}}
+	case *pcep.SRv6PCECapability:
+		c.Detail = &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
+			NaiSupported: tlv.IsNAISupported,
+		}}
+	case *pcep.PathSetupTypeCapability:
+		psts := make([]uint32, len(tlv.PathSetupTypes))
+		for i, pst := range tlv.PathSetupTypes {
+			psts[i] = uint32(pst)
+		}
+		c.Detail = &pb.Capability_PathSetupType{PathSetupType: &pb.PathSetupTypeCapability{
+			PathSetupTypes: psts,
+		}}
+	case *pcep.AssocTypeList:
+		assocTypes := make([]uint32, len(tlv.AssocTypes))
+		for i, at := range tlv.AssocTypes {
+			assocTypes[i] = uint32(at)
+		}
+		c.Detail = &pb.Capability_AssocTypeList{AssocTypeList: &pb.AssocTypeListCapability{
+			AssocTypes: assocTypes,
+		}}
+	case *pcep.LSPDBVersion:
+		c.Detail = &pb.Capability_LspDbVersion{LspDbVersion: &pb.LspDbVersionCapability{
+			VersionNumber: tlv.VersionNumber,
+		}}
+	case *pcep.MultipathCapability:
+		c.Detail = &pb.Capability_Multipath{Multipath: &pb.MultipathCapability{
+			MaxMultipaths: uint32(tlv.MaxMultipaths),
+			Weighted:      tlv.IsWeightedSupported,
+			OppositeDir:   tlv.IsOppositeDirSupported,
+			ForwardClass:  tlv.IsForwardClassSupported,
+			CompositePath: tlv.IsCompositePathSupported,
+		}}
+	case *pcep.VendorInformation:
+		c.Detail = &pb.Capability_VendorInformation{VendorInformation: &pb.VendorInformationCapability{
+			EnterpriseNumber: uint32(tlv.EnterpriseNumber),
+		}}
+	case *pcep.UnknownTLV:
+		c.Detail = &pb.Capability_Unknown{Unknown: &pb.UnknownCapability{
+			TlvType: uint32(tlv.Typ),
+		}}
+	}
+	return c
+}
+
+func capabilityType(t pcep.TLVType) pb.CapabilityType {
+	switch t {
+	case pcep.TLVStatefulPCECapability:
+		return pb.CapabilityType_CAPABILITY_TYPE_STATEFUL
+	case pcep.TLVSRPCECapability:
+		return pb.CapabilityType_CAPABILITY_TYPE_SR
+	case pcep.TLVSRv6PCECapability:
+		return pb.CapabilityType_CAPABILITY_TYPE_SRV6
+	case pcep.TLVPathSetupTypeCapability:
+		return pb.CapabilityType_CAPABILITY_TYPE_PATH_SETUP_TYPE
+	case pcep.TLVAssocTypeList:
+		return pb.CapabilityType_CAPABILITY_TYPE_ASSOC_TYPE_LIST
+	case pcep.TLVLSPDBVersion:
+		return pb.CapabilityType_CAPABILITY_TYPE_LSP_DB_VERSION
+	case pcep.TLVMultipathCap:
+		return pb.CapabilityType_CAPABILITY_TYPE_MULTIPATH
+	case pcep.TLVVendorInformation:
+		return pb.CapabilityType_CAPABILITY_TYPE_VENDOR_INFORMATION
+	default:
+		return pb.CapabilityType_CAPABILITY_TYPE_UNKNOWN
+	}
+}
+
+func (s *APIServer) buildPBSRPolicy(peerAddr netip.Addr, policy *table.SRPolicy, routerIDIndex map[netip.Addr]string) *pb.SRPolicy {
+	srPolicy := &pb.SRPolicy{
+		PcepSessionAddr: peerAddr.AsSlice(),
+		SegmentList:     make([]*pb.Segment, 0, len(policy.SegmentList)),
+		Color:           policy.Color,
+		Preference:      policy.Preference,
+		PolicyName:      policy.Name,
+		SrcAddr:         policy.SrcAddr.AsSlice(),
+		DstAddr:         policy.DstAddr.AsSlice(),
+		PlspId:          policy.PlspID,
+		LspId:           uint32(policy.LSPID),
+		State:           toPBPolicyState(policy.State),
+		Type:            toPBPolicyType(policy.Type),
+		Metric:          toPBMetricType(policy.Metric),
+	}
+
+	srPolicy.SrcRouterId = routerIDIndex[policy.SrcAddr]
+	srPolicy.DstRouterId = routerIDIndex[policy.DstAddr]
+
+	for _, segment := range policy.SegmentList {
+		srPolicy.SegmentList = append(srPolicy.SegmentList, convertSegment(segment))
+	}
+
+	return srPolicy
+}
+
+func toPBPolicyType(polType table.PolicyType) pb.SRPolicyType {
+	switch polType {
+	case table.PolicyTypeExplicit:
+		return pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT
+	case table.PolicyTypeDynamic:
+		return pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC
+	default:
+		return pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED
+	}
+}
+
+func toPBMetricType(metricType table.MetricType) pb.MetricType {
+	switch metricType {
+	case table.IGPMetric:
+		return pb.MetricType_METRIC_TYPE_IGP
+	case table.TEMetric:
+		return pb.MetricType_METRIC_TYPE_TE
+	case table.DelayMetric:
+		return pb.MetricType_METRIC_TYPE_DELAY
+	case table.HopcountMetric:
+		return pb.MetricType_METRIC_TYPE_HOPCOUNT
+	default:
+		return pb.MetricType_METRIC_TYPE_UNSPECIFIED
+	}
+}
+
+func toPBPolicyState(state table.PolicyState) pb.SRPolicyState {
+	switch state {
+	case table.PolicyDown:
+		return pb.SRPolicyState_SR_POLICY_STATE_DOWN
+	case table.PolicyUp:
+		return pb.SRPolicyState_SR_POLICY_STATE_UP
+	case table.PolicyActive:
+		return pb.SRPolicyState_SR_POLICY_STATE_ACTIVE
+	case table.PolicyUnknown:
+		return pb.SRPolicyState_SR_POLICY_STATE_UNKNOWN
+	default:
+		return pb.SRPolicyState_SR_POLICY_STATE_UNSPECIFIED
+	}
+}
+
+func convertSegment(seg table.Segment) *pb.Segment {
+	pbSeg := &pb.Segment{Sid: seg.SidString()}
+	switch v := seg.(type) {
+	case table.SegmentSRv6:
+		if v.LocalAddr.IsValid() {
+			pbSeg.LocalAddr = v.LocalAddr.String()
+		}
+		if v.RemoteAddr.IsValid() {
+			pbSeg.RemoteAddr = v.RemoteAddr.String()
+		}
+		if len(v.Structure) == 4 {
+			pbSeg.SidStructure = fmt.Sprintf("%d,%d,%d,%d", v.Structure[0], v.Structure[1], v.Structure[2], v.Structure[3])
+		}
+	case table.SegmentSRMPLS:
+		if v.LocalAddr.IsValid() {
+			pbSeg.LocalAddr = v.LocalAddr.String()
+		}
+		if v.RemoteAddr.IsValid() {
+			pbSeg.RemoteAddr = v.RemoteAddr.String()
+		}
+	}
+	return pbSeg
+}
+
+// convertLsNode converts a table.LsNode to a protobuf LsNode.
+func convertLsNode(lsNode *table.LsNode, logger *zap.Logger) *pb.LsNode {
+	if lsNode == nil {
+		return nil
+	}
+
+	return &pb.LsNode{
+		Asn:        lsNode.ASN,
+		RouterId:   lsNode.RouterID,
+		IsisAreaId: lsNode.IsisAreaID,
+		Hostname:   lsNode.Hostname,
+		SrgbBegin:  lsNode.SrgbBegin,
+		SrgbEnd:    lsNode.SrgbEnd,
+		LsLinks:    convertLsLinks(lsNode.Links, logger),
+		LsPrefixes: convertLsPrefixes(lsNode.Prefixes),
+		LsSrv6Sids: convertLsSrv6SIDs(lsNode.SRv6SIDs),
+	}
+}
+
+// convertLsLinks converts a slice of table.LsLink to protobuf LsLink.
+func convertLsLinks(links []*table.LsLink, logger *zap.Logger) []*pb.LsLink {
+	if links == nil {
+		return nil
+	}
+	result := make([]*pb.LsLink, 0, len(links))
+	for _, link := range links {
+		if link == nil || link.LocalNode == nil || link.RemoteNode == nil {
+			logger.Debug("skip link with nil node", zap.Any("link", link))
+			continue
+		}
+		result = append(result, buildLsLink(link))
+	}
+	return result
+}
+
+// buildLsLink converts a single table.LsLink to protobuf LsLink.
+func buildLsLink(link *table.LsLink) *pb.LsLink {
+	localIP, _ := link.LocalIP.MarshalText()
+	remoteIP, _ := link.RemoteIP.MarshalText()
+
+	pbLink := &pb.LsLink{
+		LocalRouterId:  link.LocalNode.RouterID,
+		LocalAsn:       link.LocalNode.ASN,
+		LocalIp:        string(localIP),
+		RemoteRouterId: link.RemoteNode.RouterID,
+		RemoteAsn:      link.RemoteNode.ASN,
+		RemoteIp:       string(remoteIP),
+		Metrics:        convertMetrics(link.Metrics),
+		AdjSid:         link.AdjSid,
+	}
+
+	if link.Srv6EndXSID != nil {
+		pbLink.Srv6EndXSid = convertSrv6EndXSID(link.Srv6EndXSID)
+	}
+	return pbLink
+}
+
+// convertMetrics converts a slice of table.Metric to protobuf Metric.
+func convertMetrics(metrics []*table.Metric) []*pb.Metric {
+	if metrics == nil {
+		return nil
+	}
+	result := make([]*pb.Metric, 0, len(metrics))
+	for _, m := range metrics {
+		if m != nil {
+			if mt, ok := pb.MetricType_value[m.Type.String()]; ok {
+				result = append(result, &pb.Metric{Type: pb.MetricType(mt), Value: m.Value})
+			}
+		}
+	}
+	return result
+}
+
+// convertLsPrefixes converts a slice of table.LsPrefix to protobuf LsPrefix.
+func convertLsPrefixes(prefixes []*table.LsPrefix) []*pb.LsPrefix {
+	if prefixes == nil {
+		return nil
+	}
+	result := make([]*pb.LsPrefix, 0, len(prefixes))
+	for _, p := range prefixes {
+		if p != nil {
+			pbPrefix := &pb.LsPrefix{Prefix: p.Prefix.String()}
+			// Preserve Prefix-SID presence, including index 0.
+			if p.HasPrefixSID() {
+				pbPrefix.SidIndex = proto.Uint32(p.SidIndex)
+			}
+			result = append(result, pbPrefix)
+		}
+	}
+	return result
+}
+
+// convertLsSrv6SIDs converts a slice of table.LsSrv6SID to protobuf LsSrv6SID.
+func convertLsSrv6SIDs(sids []*table.LsSrv6SID) []*pb.LsSrv6SID {
+	if sids == nil {
+		return nil
+	}
+	result := make([]*pb.LsSrv6SID, 0, len(sids))
+	for _, s := range sids {
+		if s != nil {
+			result = append(result, buildLsSrv6SID(s))
+		}
+	}
+	return result
+}
+
+// buildLsSrv6SID converts a single table.LsSrv6SID to protobuf LsSrv6SID.
+func buildLsSrv6SID(s *table.LsSrv6SID) *pb.LsSrv6SID {
+	pbSID := &pb.LsSrv6SID{
+		Sids:         make([]*pb.SID, 0, len(s.Sids)),
+		MultiTopoIds: make([]*pb.MultiTopoID, 0, len(s.MultiTopoIDs)),
+		SidStructure: &pb.SidStructure{
+			LocalBlock: uint32(s.SIDStructure.LocalBlock),
+			LocalNode:  uint32(s.SIDStructure.LocalNode),
+			LocalFunc:  uint32(s.SIDStructure.LocalFunc),
+			LocalArg:   uint32(s.SIDStructure.LocalArg),
+		},
+	}
+
+	for _, sid := range s.Sids {
+		if sid != "" {
+			pbSID.Sids = append(pbSID.Sids, &pb.SID{Sid: sid})
+		}
+	}
+
+	for _, topoID := range s.MultiTopoIDs {
+		pbSID.MultiTopoIds = append(pbSID.MultiTopoIds, &pb.MultiTopoID{MultiTopoId: topoID})
+	}
+
+	if s.EndpointBehavior != (table.EndpointBehavior{}) {
+		pbSID.EndpointBehavior = &pb.EndpointBehavior{
+			Behavior:  uint32(s.EndpointBehavior.Behavior),
+			Flags:     uint32(s.EndpointBehavior.Flags),
+			Algorithm: uint32(s.EndpointBehavior.Algorithm),
+		}
+	}
+
+	return pbSID
+}
+
+// convertSrv6EndXSID converts table.Srv6EndXSID to protobuf Srv6EndXSID.
+func convertSrv6EndXSID(sid *table.Srv6EndXSID) *pb.Srv6EndXSID {
+	pbSID := &pb.Srv6EndXSID{
+		EndpointBehavior: uint32(sid.EndpointBehavior),
+		Sids:             make([]*pb.SID, 0, len(sid.Sids)),
+		SidStructure: &pb.SidStructure{
+			LocalBlock: uint32(sid.Srv6SIDStructure.LocalBlock),
+			LocalNode:  uint32(sid.Srv6SIDStructure.LocalNode),
+			LocalFunc:  uint32(sid.Srv6SIDStructure.LocalFunc),
+			LocalArg:   uint32(sid.Srv6SIDStructure.LocalArg),
+		},
+	}
+
+	for _, s := range sid.Sids {
+		if s != "" {
+			pbSID.Sids = append(pbSID.Sids, &pb.SID{Sid: s})
+		}
+	}
+
+	return pbSID
+}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -522,6 +522,65 @@ func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRe
 	return &pb.DeleteSRPolicyResponse{IsSuccess: true}, nil
 }
 
+// GetSRPolicyList returns a list of SR Policies registered with PCEP sessions.
+func (s *APIServer) GetSRPolicyList(_ context.Context, req *pb.GetSRPolicyListRequest) (*pb.GetSRPolicyListResponse, error) {
+	s.logger.Info("Received GetSRPolicyList API request")
+
+	var filterAddr netip.Addr
+	if raw := req.GetSessionAddr(); len(raw) > 0 {
+		var ok bool
+		filterAddr, ok = netip.AddrFromSlice(raw)
+		if !ok {
+			return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid session filter address %v", raw)
+		}
+	}
+
+	policiesByPeer := s.pce.SRPolicies()
+	peerAddrs := make([]netip.Addr, 0, len(policiesByPeer))
+	for peerAddr := range policiesByPeer {
+		if filterAddr.IsValid() && peerAddr != filterAddr {
+			continue
+		}
+		peerAddrs = append(peerAddrs, peerAddr)
+	}
+	slices.SortFunc(peerAddrs, func(a, b netip.Addr) int { return a.Compare(b) })
+
+	routerIDIndex := s.pce.TED().RouterIDIndex()
+
+	sessions := make([]*pb.Session, 0, len(peerAddrs))
+	for _, peerAddr := range peerAddrs {
+		pbPolicies := make([]*pb.SRPolicy, 0, len(policiesByPeer[peerAddr]))
+		for _, policy := range policiesByPeer[peerAddr] {
+			pbPolicies = append(pbPolicies, s.buildPBSRPolicy(peerAddr, policy, routerIDIndex))
+		}
+		slices.SortFunc(pbPolicies, func(a, b *pb.SRPolicy) int {
+			if a.GetColor() < b.GetColor() {
+				return -1
+			}
+			if a.GetColor() > b.GetColor() {
+				return 1
+			}
+			if a.GetPlspId() < b.GetPlspId() {
+				return -1
+			}
+			if a.GetPlspId() > b.GetPlspId() {
+				return 1
+			}
+			return strings.Compare(a.GetPolicyName(), b.GetPolicyName())
+		})
+
+		sessions = append(sessions, &pb.Session{
+			Addr:       peerAddr.AsSlice(),
+			SrPolicies: pbPolicies,
+		})
+	}
+
+	s.logger.Debug("Send SRPolicyList API reply")
+	return &pb.GetSRPolicyListResponse{
+		Sessions: sessions,
+	}, nil
+}
+
 func validate(inputSRPolicy *pb.SRPolicy, asn uint32, validationKind ValidationKind) error {
 	if inputSRPolicy == nil {
 		return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "validate error, input is nil")
@@ -756,277 +815,28 @@ func (s *APIServer) GetSessionList(_ context.Context, _ *pb.GetSessionListReques
 	}, nil
 }
 
-func buildCapability(cap pcep.CapabilityInterface) *pb.Capability {
-	c := &pb.Capability{Type: capabilityType(cap.Type())}
-	switch tlv := cap.(type) {
-	case *pcep.StatefulPCECapability:
-		c.Detail = &pb.Capability_Stateful{Stateful: &pb.StatefulCapability{
-			LspUpdate:            tlv.LSPUpdateCapability,
-			IncludeDbVersion:     tlv.IncludeDBVersion,
-			LspInstantiation:     tlv.LSPInstantiationCapability,
-			TriggeredResync:      tlv.TriggeredResync,
-			DeltaLspSync:         tlv.DeltaLSPSyncCapability,
-			TriggeredInitialSync: tlv.TriggeredInitialSync,
-			Color:                tlv.ColorCapability,
-		}}
-	case *pcep.SRPCECapability:
-		c.Detail = &pb.Capability_Sr{Sr: &pb.SrCapability{
-			UnlimitedMsd: tlv.HasUnlimitedMaxSIDDepth,
-			NaiSupported: tlv.IsNAISupported,
-			Msd:          uint32(tlv.MaximumSidDepth),
-		}}
-	case *pcep.SRv6PCECapability:
-		c.Detail = &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
-			NaiSupported: tlv.IsNAISupported,
-		}}
-	case *pcep.PathSetupTypeCapability:
-		psts := make([]uint32, len(tlv.PathSetupTypes))
-		for i, pst := range tlv.PathSetupTypes {
-			psts[i] = uint32(pst)
-		}
-		c.Detail = &pb.Capability_PathSetupType{PathSetupType: &pb.PathSetupTypeCapability{
-			PathSetupTypes: psts,
-		}}
-	case *pcep.AssocTypeList:
-		assocTypes := make([]uint32, len(tlv.AssocTypes))
-		for i, at := range tlv.AssocTypes {
-			assocTypes[i] = uint32(at)
-		}
-		c.Detail = &pb.Capability_AssocTypeList{AssocTypeList: &pb.AssocTypeListCapability{
-			AssocTypes: assocTypes,
-		}}
-	case *pcep.LSPDBVersion:
-		c.Detail = &pb.Capability_LspDbVersion{LspDbVersion: &pb.LspDbVersionCapability{
-			VersionNumber: tlv.VersionNumber,
-		}}
-	case *pcep.MultipathCapability:
-		c.Detail = &pb.Capability_Multipath{Multipath: &pb.MultipathCapability{
-			MaxMultipaths: uint32(tlv.MaxMultipaths),
-			Weighted:      tlv.IsWeightedSupported,
-			OppositeDir:   tlv.IsOppositeDirSupported,
-			ForwardClass:  tlv.IsForwardClassSupported,
-			CompositePath: tlv.IsCompositePathSupported,
-		}}
-	case *pcep.VendorInformation:
-		c.Detail = &pb.Capability_VendorInformation{VendorInformation: &pb.VendorInformationCapability{
-			EnterpriseNumber: uint32(tlv.EnterpriseNumber),
-		}}
-	case *pcep.UnknownTLV:
-		c.Detail = &pb.Capability_Unknown{Unknown: &pb.UnknownCapability{
-			TlvType: uint32(tlv.Typ),
-		}}
-	}
-	return c
-}
-
-func capabilityType(t pcep.TLVType) pb.CapabilityType {
-	switch t {
-	case pcep.TLVStatefulPCECapability:
-		return pb.CapabilityType_CAPABILITY_TYPE_STATEFUL
-	case pcep.TLVSRPCECapability:
-		return pb.CapabilityType_CAPABILITY_TYPE_SR
-	case pcep.TLVSRv6PCECapability:
-		return pb.CapabilityType_CAPABILITY_TYPE_SRV6
-	case pcep.TLVPathSetupTypeCapability:
-		return pb.CapabilityType_CAPABILITY_TYPE_PATH_SETUP_TYPE
-	case pcep.TLVAssocTypeList:
-		return pb.CapabilityType_CAPABILITY_TYPE_ASSOC_TYPE_LIST
-	case pcep.TLVLSPDBVersion:
-		return pb.CapabilityType_CAPABILITY_TYPE_LSP_DB_VERSION
-	case pcep.TLVMultipathCap:
-		return pb.CapabilityType_CAPABILITY_TYPE_MULTIPATH
-	case pcep.TLVVendorInformation:
-		return pb.CapabilityType_CAPABILITY_TYPE_VENDOR_INFORMATION
-	default:
-		return pb.CapabilityType_CAPABILITY_TYPE_UNKNOWN
-	}
-}
-
-// GetSRPolicyList returns a list of SR Policies registered with PCEP sessions.
-func (s *APIServer) GetSRPolicyList(_ context.Context, req *pb.GetSRPolicyListRequest) (*pb.GetSRPolicyListResponse, error) {
-	s.logger.Info("Received GetSRPolicyList API request")
-
-	var filterAddr netip.Addr
-	if raw := req.GetSessionAddr(); len(raw) > 0 {
-		var ok bool
-		filterAddr, ok = netip.AddrFromSlice(raw)
-		if !ok {
-			return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid session filter address %v", raw)
-		}
+// DeleteSession deletes a PCEP session.
+func (s *APIServer) DeleteSession(_ context.Context, req *pb.DeleteSessionRequest) (*pb.DeleteSessionResponse, error) {
+	ssAddr, ok := netip.AddrFromSlice(req.GetAddr())
+	if !ok {
+		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid address: %v", req.GetAddr())
 	}
 
-	policiesByPeer := s.pce.SRPolicies()
-	peerAddrs := make([]netip.Addr, 0, len(policiesByPeer))
-	for peerAddr := range policiesByPeer {
-		if filterAddr.IsValid() && peerAddr != filterAddr {
-			continue
-		}
-		peerAddrs = append(peerAddrs, peerAddr)
-	}
-	slices.SortFunc(peerAddrs, func(a, b netip.Addr) int { return a.Compare(b) })
-
-	routerIDIndex := buildRouterIDIndex(s.pce.TED())
-
-	sessions := make([]*pb.Session, 0, len(peerAddrs))
-	for _, peerAddr := range peerAddrs {
-		pbPolicies := make([]*pb.SRPolicy, 0, len(policiesByPeer[peerAddr]))
-		for _, policy := range policiesByPeer[peerAddr] {
-			pbPolicies = append(pbPolicies, s.buildPBSRPolicy(peerAddr, policy, routerIDIndex))
-		}
-		slices.SortFunc(pbPolicies, func(a, b *pb.SRPolicy) int {
-			if a.GetColor() < b.GetColor() {
-				return -1
-			}
-			if a.GetColor() > b.GetColor() {
-				return 1
-			}
-			if a.GetPlspId() < b.GetPlspId() {
-				return -1
-			}
-			if a.GetPlspId() > b.GetPlspId() {
-				return 1
-			}
-			return strings.Compare(a.GetPolicyName(), b.GetPolicyName())
-		})
-
-		sessions = append(sessions, &pb.Session{
-			Addr:       peerAddr.AsSlice(),
-			SrPolicies: pbPolicies,
-		})
+	pce := s.pce
+	ss := pce.SearchSession(ssAddr, false)
+	if ss == nil {
+		return nil, newStatus(codes.NotFound, ReasonPCEPSessionNotFound, "no session with address %s found", ssAddr)
 	}
 
-	s.logger.Debug("Send SRPolicyList API reply")
-	return &pb.GetSRPolicyListResponse{
-		Sessions: sessions,
-	}, nil
-}
-
-func (s *APIServer) buildPBSRPolicy(peerAddr netip.Addr, policy *table.SRPolicy, routerIDIndex map[netip.Addr]string) *pb.SRPolicy {
-	srPolicy := &pb.SRPolicy{
-		PcepSessionAddr: peerAddr.AsSlice(),
-		SegmentList:     make([]*pb.Segment, 0, len(policy.SegmentList)),
-		Color:           policy.Color,
-		Preference:      policy.Preference,
-		PolicyName:      policy.Name,
-		SrcAddr:         policy.SrcAddr.AsSlice(),
-		DstAddr:         policy.DstAddr.AsSlice(),
-		PlspId:          policy.PlspID,
-		LspId:           uint32(policy.LSPID),
-		State:           toPBPolicyState(policy.State),
-		Type:            toPBPolicyType(policy.Type),
-		Metric:          toPBMetricType(policy.Metric),
+	if err := ss.SendClose(pcep.CloseReasonNoExplanationProvided); err != nil {
+		return &pb.DeleteSessionResponse{IsSuccess: false}, newStatus(codes.Internal, ReasonPCEPRequestFailed, "failed to send close message: %v", err)
 	}
 
-	srPolicy.SrcRouterId = routerIDIndex[policy.SrcAddr]
-	srPolicy.DstRouterId = routerIDIndex[policy.DstAddr]
+	// A PCEP Close only notifies the peer; the TCP connection and the server-side
+	// session state have to be torn down here as well.
+	pce.closeSession(ss)
 
-	for _, segment := range policy.SegmentList {
-		srPolicy.SegmentList = append(srPolicy.SegmentList, convertSegment(segment))
-	}
-
-	return srPolicy
-}
-
-func toPBPolicyType(polType table.PolicyType) pb.SRPolicyType {
-	switch polType {
-	case table.PolicyTypeExplicit:
-		return pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT
-	case table.PolicyTypeDynamic:
-		return pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC
-	default:
-		return pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED
-	}
-}
-
-func toPBMetricType(metricType table.MetricType) pb.MetricType {
-	switch metricType {
-	case table.IGPMetric:
-		return pb.MetricType_METRIC_TYPE_IGP
-	case table.TEMetric:
-		return pb.MetricType_METRIC_TYPE_TE
-	case table.DelayMetric:
-		return pb.MetricType_METRIC_TYPE_DELAY
-	case table.HopcountMetric:
-		return pb.MetricType_METRIC_TYPE_HOPCOUNT
-	default:
-		return pb.MetricType_METRIC_TYPE_UNSPECIFIED
-	}
-}
-
-func toPBPolicyState(state table.PolicyState) pb.SRPolicyState {
-	switch state {
-	case table.PolicyDown:
-		return pb.SRPolicyState_SR_POLICY_STATE_DOWN
-	case table.PolicyUp:
-		return pb.SRPolicyState_SR_POLICY_STATE_UP
-	case table.PolicyActive:
-		return pb.SRPolicyState_SR_POLICY_STATE_ACTIVE
-	case table.PolicyUnknown:
-		return pb.SRPolicyState_SR_POLICY_STATE_UNKNOWN
-	default:
-		return pb.SRPolicyState_SR_POLICY_STATE_UNSPECIFIED
-	}
-}
-
-// buildRouterIDIndex builds a loopback-address-to-router-ID index from the TED.
-func buildRouterIDIndex(ted *table.LsTED) map[netip.Addr]string {
-	if ted == nil {
-		return nil
-	}
-
-	index := make(map[netip.Addr]string, len(ted.Nodes))
-	for _, node := range ted.Nodes {
-		if node == nil {
-			continue
-		}
-		for _, prefix := range node.Prefixes {
-			if prefix.Prefix.Bits() == prefix.Prefix.Addr().BitLen() {
-				index[prefix.Prefix.Addr()] = node.RouterID
-			}
-		}
-	}
-	return index
-}
-
-// buildAddressRouterIDIndex builds an index from prefix addresses to router IDs.
-func buildAddressRouterIDIndex(ted *table.LsTED) map[netip.Addr]string {
-	if ted == nil {
-		return nil
-	}
-	index := make(map[netip.Addr]string)
-	for routerID, node := range ted.Nodes {
-		if node == nil {
-			continue
-		}
-		for _, prefix := range node.Prefixes {
-			index[prefix.Prefix.Addr()] = routerID
-		}
-	}
-	return index
-}
-
-func convertSegment(seg table.Segment) *pb.Segment {
-	pbSeg := &pb.Segment{Sid: seg.SidString()}
-	switch v := seg.(type) {
-	case table.SegmentSRv6:
-		if v.LocalAddr.IsValid() {
-			pbSeg.LocalAddr = v.LocalAddr.String()
-		}
-		if v.RemoteAddr.IsValid() {
-			pbSeg.RemoteAddr = v.RemoteAddr.String()
-		}
-		if len(v.Structure) == 4 {
-			pbSeg.SidStructure = fmt.Sprintf("%d,%d,%d,%d", v.Structure[0], v.Structure[1], v.Structure[2], v.Structure[3])
-		}
-	case table.SegmentSRMPLS:
-		if v.LocalAddr.IsValid() {
-			pbSeg.LocalAddr = v.LocalAddr.String()
-		}
-		if v.RemoteAddr.IsValid() {
-			pbSeg.RemoteAddr = v.RemoteAddr.String()
-		}
-	}
-	return pbSeg
+	return &pb.DeleteSessionResponse{IsSuccess: true}, nil
 }
 
 // GetTED returns the TED information in a structured way.
@@ -1052,190 +862,4 @@ func (s *APIServer) GetTED(_ context.Context, _ *pb.GetTEDRequest) (*pb.GetTEDRe
 
 	s.logger.Debug("Send GetTED API reply")
 	return ret, nil
-}
-
-// convertLsNode converts a table.LsNode to a protobuf LsNode.
-func convertLsNode(lsNode *table.LsNode, logger *zap.Logger) *pb.LsNode {
-	if lsNode == nil {
-		return nil
-	}
-
-	return &pb.LsNode{
-		Asn:        lsNode.ASN,
-		RouterId:   lsNode.RouterID,
-		IsisAreaId: lsNode.IsisAreaID,
-		Hostname:   lsNode.Hostname,
-		SrgbBegin:  lsNode.SrgbBegin,
-		SrgbEnd:    lsNode.SrgbEnd,
-		LsLinks:    convertLsLinks(lsNode.Links, logger),
-		LsPrefixes: convertLsPrefixes(lsNode.Prefixes),
-		LsSrv6Sids: convertLsSrv6SIDs(lsNode.SRv6SIDs),
-	}
-}
-
-// convertLsLinks converts a slice of table.LsLink to protobuf LsLink.
-func convertLsLinks(links []*table.LsLink, logger *zap.Logger) []*pb.LsLink {
-	if links == nil {
-		return nil
-	}
-	result := make([]*pb.LsLink, 0, len(links))
-	for _, link := range links {
-		if link == nil || link.LocalNode == nil || link.RemoteNode == nil {
-			logger.Debug("skip link with nil node", zap.Any("link", link))
-			continue
-		}
-		result = append(result, buildLsLink(link))
-	}
-	return result
-}
-
-// buildLsLink converts a single table.LsLink to protobuf LsLink.
-func buildLsLink(link *table.LsLink) *pb.LsLink {
-	localIP, _ := link.LocalIP.MarshalText()
-	remoteIP, _ := link.RemoteIP.MarshalText()
-
-	pbLink := &pb.LsLink{
-		LocalRouterId:  link.LocalNode.RouterID,
-		LocalAsn:       link.LocalNode.ASN,
-		LocalIp:        string(localIP),
-		RemoteRouterId: link.RemoteNode.RouterID,
-		RemoteAsn:      link.RemoteNode.ASN,
-		RemoteIp:       string(remoteIP),
-		Metrics:        convertMetrics(link.Metrics),
-		AdjSid:         link.AdjSid,
-	}
-
-	if link.Srv6EndXSID != nil {
-		pbLink.Srv6EndXSid = convertSrv6EndXSID(link.Srv6EndXSID)
-	}
-	return pbLink
-}
-
-// convertMetrics converts a slice of table.Metric to protobuf Metric.
-func convertMetrics(metrics []*table.Metric) []*pb.Metric {
-	if metrics == nil {
-		return nil
-	}
-	result := make([]*pb.Metric, 0, len(metrics))
-	for _, m := range metrics {
-		if m != nil {
-			if mt, ok := pb.MetricType_value[m.Type.String()]; ok {
-				result = append(result, &pb.Metric{Type: pb.MetricType(mt), Value: m.Value})
-			}
-		}
-	}
-	return result
-}
-
-// convertLsPrefixes converts a slice of table.LsPrefix to protobuf LsPrefix.
-func convertLsPrefixes(prefixes []*table.LsPrefix) []*pb.LsPrefix {
-	if prefixes == nil {
-		return nil
-	}
-	result := make([]*pb.LsPrefix, 0, len(prefixes))
-	for _, p := range prefixes {
-		if p != nil {
-			pbPrefix := &pb.LsPrefix{Prefix: p.Prefix.String()}
-			// Preserve Prefix-SID presence, including index 0.
-			if p.HasPrefixSID() {
-				pbPrefix.SidIndex = proto.Uint32(p.SidIndex)
-			}
-			result = append(result, pbPrefix)
-		}
-	}
-	return result
-}
-
-// convertLsSrv6SIDs converts a slice of table.LsSrv6SID to protobuf LsSrv6SID.
-func convertLsSrv6SIDs(sids []*table.LsSrv6SID) []*pb.LsSrv6SID {
-	if sids == nil {
-		return nil
-	}
-	result := make([]*pb.LsSrv6SID, 0, len(sids))
-	for _, s := range sids {
-		if s != nil {
-			result = append(result, buildLsSrv6SID(s))
-		}
-	}
-	return result
-}
-
-// buildLsSrv6SID converts a single table.LsSrv6SID to protobuf LsSrv6SID.
-func buildLsSrv6SID(s *table.LsSrv6SID) *pb.LsSrv6SID {
-	pbSID := &pb.LsSrv6SID{
-		Sids:         make([]*pb.SID, 0, len(s.Sids)),
-		MultiTopoIds: make([]*pb.MultiTopoID, 0, len(s.MultiTopoIDs)),
-		SidStructure: &pb.SidStructure{
-			LocalBlock: uint32(s.SIDStructure.LocalBlock),
-			LocalNode:  uint32(s.SIDStructure.LocalNode),
-			LocalFunc:  uint32(s.SIDStructure.LocalFunc),
-			LocalArg:   uint32(s.SIDStructure.LocalArg),
-		},
-	}
-
-	for _, sid := range s.Sids {
-		if sid != "" {
-			pbSID.Sids = append(pbSID.Sids, &pb.SID{Sid: sid})
-		}
-	}
-
-	for _, topoID := range s.MultiTopoIDs {
-		pbSID.MultiTopoIds = append(pbSID.MultiTopoIds, &pb.MultiTopoID{MultiTopoId: topoID})
-	}
-
-	if s.EndpointBehavior != (table.EndpointBehavior{}) {
-		pbSID.EndpointBehavior = &pb.EndpointBehavior{
-			Behavior:  uint32(s.EndpointBehavior.Behavior),
-			Flags:     uint32(s.EndpointBehavior.Flags),
-			Algorithm: uint32(s.EndpointBehavior.Algorithm),
-		}
-	}
-
-	return pbSID
-}
-
-// convertSrv6EndXSID converts table.Srv6EndXSID to protobuf Srv6EndXSID.
-func convertSrv6EndXSID(sid *table.Srv6EndXSID) *pb.Srv6EndXSID {
-	pbSID := &pb.Srv6EndXSID{
-		EndpointBehavior: uint32(sid.EndpointBehavior),
-		Sids:             make([]*pb.SID, 0, len(sid.Sids)),
-		SidStructure: &pb.SidStructure{
-			LocalBlock: uint32(sid.Srv6SIDStructure.LocalBlock),
-			LocalNode:  uint32(sid.Srv6SIDStructure.LocalNode),
-			LocalFunc:  uint32(sid.Srv6SIDStructure.LocalFunc),
-			LocalArg:   uint32(sid.Srv6SIDStructure.LocalArg),
-		},
-	}
-
-	for _, s := range sid.Sids {
-		if s != "" {
-			pbSID.Sids = append(pbSID.Sids, &pb.SID{Sid: s})
-		}
-	}
-
-	return pbSID
-}
-
-// DeleteSession deletes a PCEP session.
-func (s *APIServer) DeleteSession(_ context.Context, req *pb.DeleteSessionRequest) (*pb.DeleteSessionResponse, error) {
-	ssAddr, ok := netip.AddrFromSlice(req.GetAddr())
-	if !ok {
-		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid address: %v", req.GetAddr())
-	}
-
-	pce := s.pce
-	ss := pce.SearchSession(ssAddr, false)
-	if ss == nil {
-		return nil, newStatus(codes.NotFound, ReasonPCEPSessionNotFound, "no session with address %s found", ssAddr)
-	}
-
-	if err := ss.SendClose(pcep.CloseReasonNoExplanationProvided); err != nil {
-		return &pb.DeleteSessionResponse{IsSuccess: false}, newStatus(codes.Internal, ReasonPCEPRequestFailed, "failed to send close message: %v", err)
-	}
-
-	// A PCEP Close only notifies the peer; the TCP connection and the server-side
-	// session state have to be torn down here as well.
-	pce.closeSession(ss)
-
-	return &pb.DeleteSessionResponse{IsSuccess: true}, nil
 }

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -547,6 +547,39 @@ func TestGetSessionList_BuildsStructuredCapabilities(t *testing.T) {
 	assert.Equal(t, uint64(42), dbVersion.GetLspDbVersion().GetVersionNumber())
 }
 
+type failingCapability struct {
+	pcep.SRPCECapability
+}
+
+func (c *failingCapability) Serialize() ([]byte, error) {
+	return nil, errors.New("serialize failure")
+}
+
+func TestGetSessionList_SkipsCapabilityOnSerializeError(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	session := &Session{
+		peerAddr: netip.MustParseAddr("10.0.0.1"),
+		isSynced: true,
+		advertisedCapabilities: []pcep.CapabilityInterface{
+			&failingCapability{},
+			&pcep.SRv6PCECapability{IsNAISupported: true},
+		},
+	}
+	s := &APIServer{
+		pce:    &Server{sessionList: []*Session{session}},
+		logger: zap.New(core),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	require.Len(t, resp.Sessions[0].Capabilities, 1, "the failing capability must be skipped")
+
+	srv6 := resp.Sessions[0].Capabilities[0]
+	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_SRV6, srv6.GetType())
+	assert.Len(t, logs.FilterMessage("failed to serialize advertised capability").All(), 1)
+}
+
 func TestGetSessionList_MultipathCapabilityDoesNotSetMsd(t *testing.T) {
 	session := &Session{
 		peerAddr: netip.MustParseAddr("10.0.0.1"),
@@ -640,68 +673,6 @@ func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing
 	assert.Equal(t, pb.SRPolicyState_SR_POLICY_STATE_ACTIVE, policy.GetState())
 	assert.Equal(t, "0000.0aff.0001", policy.GetSrcRouterId())
 	assert.Empty(t, policy.GetDstRouterId(), "no TED node owns the destination address")
-}
-
-func TestBuildRouterIDIndex(t *testing.T) {
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
-
-	v4Node := table.NewLsNode(65000, "router-v4")
-	v4Prefix := table.NewLsPrefix(v4Node)
-	v4Prefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
-	v4Node.Prefixes = append(v4Node.Prefixes, v4Prefix)
-	ted.Nodes[v4Node.RouterID] = v4Node
-
-	v6Node := table.NewLsNode(65000, "router-v6")
-	v6Prefix := table.NewLsPrefix(v6Node)
-	v6Prefix.Prefix = netip.MustParsePrefix("2001:db8::1/128")
-	v6Node.Prefixes = append(v6Node.Prefixes, v6Prefix)
-	ted.Nodes[v6Node.RouterID] = v6Node
-
-	// A node without a loopback (host) prefix must not appear in the index.
-	noLoopbackNode := table.NewLsNode(65000, "router-no-loopback")
-	nonHostPrefix := table.NewLsPrefix(noLoopbackNode)
-	nonHostPrefix.Prefix = netip.MustParsePrefix("192.0.2.0/24")
-	noLoopbackNode.Prefixes = append(noLoopbackNode.Prefixes, nonHostPrefix)
-	ted.Nodes[noLoopbackNode.RouterID] = noLoopbackNode
-	ted.Nodes["router-nil"] = nil
-
-	index := buildRouterIDIndex(ted)
-	assert.Equal(t, "router-v4", index[netip.MustParseAddr("192.0.2.10")])
-	assert.Equal(t, "router-v6", index[netip.MustParseAddr("2001:db8::1")])
-	assert.Empty(t, index[netip.MustParseAddr("192.0.2.0")])
-
-	assert.Nil(t, buildRouterIDIndex(nil))
-}
-
-func TestBuildAddressRouterIDIndex(t *testing.T) {
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
-
-	v4Node := table.NewLsNode(65000, "router-v4")
-	v4Prefix := table.NewLsPrefix(v4Node)
-	v4Prefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
-	v4Node.Prefixes = append(v4Node.Prefixes, v4Prefix)
-	ted.Nodes[v4Node.RouterID] = v4Node
-
-	v6Node := table.NewLsNode(65000, "router-v6")
-	v6Prefix := table.NewLsPrefix(v6Node)
-	v6Prefix.Prefix = netip.MustParsePrefix("2001:db8::1/128")
-	v6Node.Prefixes = append(v6Node.Prefixes, v6Prefix)
-	ted.Nodes[v6Node.RouterID] = v6Node
-
-	// Non-host prefixes are indexed too, by their network address.
-	subnetNode := table.NewLsNode(65000, "router-subnet")
-	subnetPrefix := table.NewLsPrefix(subnetNode)
-	subnetPrefix.Prefix = netip.MustParsePrefix("192.0.2.0/24")
-	subnetNode.Prefixes = append(subnetNode.Prefixes, subnetPrefix)
-	ted.Nodes[subnetNode.RouterID] = subnetNode
-	ted.Nodes["router-nil"] = nil
-
-	index := buildAddressRouterIDIndex(ted)
-	assert.Equal(t, "router-v4", index[netip.MustParseAddr("192.0.2.10")])
-	assert.Equal(t, "router-v6", index[netip.MustParseAddr("2001:db8::1")])
-	assert.Equal(t, "router-subnet", index[netip.MustParseAddr("192.0.2.0")])
-
-	assert.Nil(t, buildAddressRouterIDIndex(nil))
 }
 
 func TestGetSRPolicyList_FiltersBySessionAddr(t *testing.T) {
@@ -908,7 +879,7 @@ func TestTED_ConcurrentUpdate(_ *testing.T) {
 	}()
 
 	for range 100 {
-		_ = buildRouterIDIndex(s.TED())
+		_ = s.TED().RouterIDIndex()
 	}
 	<-done
 }

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -700,7 +700,7 @@ func (ss *Session) extractSrcDstRouterIDs(sr pcep.StateReport) (string, string, 
 		return "", "", errors.New("could not extract valid source and destination addresses")
 	}
 
-	addrIndex := buildAddressRouterIDIndex(ss.ted)
+	addrIndex := ss.ted.AddressRouterIDIndex()
 
 	srcRouterID, err := ss.findRouterIDFromAddress(addrIndex, srcAddr)
 	if err != nil {

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -880,7 +880,7 @@ func TestFindRouterIDFromAddress(t *testing.T) {
 	ted.Nodes["198.51.100.2"] = nil
 
 	ss := &Session{ted: ted}
-	addrIndex := buildAddressRouterIDIndex(ted)
+	addrIndex := ted.AddressRouterIDIndex()
 
 	cases := []struct {
 		name    string

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -24,6 +24,43 @@ func (ted *LsTED) Update(tedElems []TEDElem, asn uint32) {
 	}
 }
 
+// RouterIDIndex builds a loopback-address-to-router-ID index from the TED.
+func (ted *LsTED) RouterIDIndex() map[netip.Addr]string {
+	if ted == nil {
+		return nil
+	}
+
+	index := make(map[netip.Addr]string, len(ted.Nodes))
+	for _, node := range ted.Nodes {
+		if node == nil {
+			continue
+		}
+		for _, prefix := range node.Prefixes {
+			if prefix.Prefix.Bits() == prefix.Prefix.Addr().BitLen() {
+				index[prefix.Prefix.Addr()] = node.RouterID
+			}
+		}
+	}
+	return index
+}
+
+// AddressRouterIDIndex builds an index from prefix addresses to router IDs.
+func (ted *LsTED) AddressRouterIDIndex() map[netip.Addr]string {
+	if ted == nil {
+		return nil
+	}
+	index := make(map[netip.Addr]string)
+	for routerID, node := range ted.Nodes {
+		if node == nil {
+			continue
+		}
+		for _, prefix := range node.Prefixes {
+			index[prefix.Prefix.Addr()] = routerID
+		}
+	}
+	return index
+}
+
 // Print prints the TED, listing each node with its prefixes, links and SRv6 SIDs.
 func (ted *LsTED) Print() {
 	if ted == nil || ted.Nodes == nil {

--- a/pkg/table/ted_test.go
+++ b/pkg/table/ted_test.go
@@ -602,3 +602,67 @@ func TestLsTEDPrint_Populated(t *testing.T) {
 	assert.Contains(t, out, "EndpointBehavior: UN, Flags: 1, Algorithm: 0")
 	assert.Contains(t, out, "MultiTopoIDs: [1]")
 }
+
+func TestLsTEDRouterIDIndex(t *testing.T) {
+	ted := &LsTED{Nodes: map[string]*LsNode{}}
+
+	v4Node := NewLsNode(65000, "router-v4")
+	v4Prefix := NewLsPrefix(v4Node)
+	v4Prefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
+	v4Node.Prefixes = append(v4Node.Prefixes, v4Prefix)
+	ted.Nodes[v4Node.RouterID] = v4Node
+
+	v6Node := NewLsNode(65000, "router-v6")
+	v6Prefix := NewLsPrefix(v6Node)
+	v6Prefix.Prefix = netip.MustParsePrefix("2001:db8::1/128")
+	v6Node.Prefixes = append(v6Node.Prefixes, v6Prefix)
+	ted.Nodes[v6Node.RouterID] = v6Node
+
+	// A node without a loopback (host) prefix must not appear in the index.
+	noLoopbackNode := NewLsNode(65000, "router-no-loopback")
+	nonHostPrefix := NewLsPrefix(noLoopbackNode)
+	nonHostPrefix.Prefix = netip.MustParsePrefix("192.0.2.0/24")
+	noLoopbackNode.Prefixes = append(noLoopbackNode.Prefixes, nonHostPrefix)
+	ted.Nodes[noLoopbackNode.RouterID] = noLoopbackNode
+	ted.Nodes["router-nil"] = nil
+
+	index := ted.RouterIDIndex()
+	assert.Equal(t, "router-v4", index[netip.MustParseAddr("192.0.2.10")])
+	assert.Equal(t, "router-v6", index[netip.MustParseAddr("2001:db8::1")])
+	assert.Empty(t, index[netip.MustParseAddr("192.0.2.0")])
+
+	var nilTED *LsTED
+	assert.Nil(t, nilTED.RouterIDIndex())
+}
+
+func TestLsTEDAddressRouterIDIndex(t *testing.T) {
+	ted := &LsTED{Nodes: map[string]*LsNode{}}
+
+	v4Node := NewLsNode(65000, "router-v4")
+	v4Prefix := NewLsPrefix(v4Node)
+	v4Prefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
+	v4Node.Prefixes = append(v4Node.Prefixes, v4Prefix)
+	ted.Nodes[v4Node.RouterID] = v4Node
+
+	v6Node := NewLsNode(65000, "router-v6")
+	v6Prefix := NewLsPrefix(v6Node)
+	v6Prefix.Prefix = netip.MustParsePrefix("2001:db8::1/128")
+	v6Node.Prefixes = append(v6Node.Prefixes, v6Prefix)
+	ted.Nodes[v6Node.RouterID] = v6Node
+
+	// Non-host prefixes are indexed too, by their network address.
+	subnetNode := NewLsNode(65000, "router-subnet")
+	subnetPrefix := NewLsPrefix(subnetNode)
+	subnetPrefix.Prefix = netip.MustParsePrefix("192.0.2.0/24")
+	subnetNode.Prefixes = append(subnetNode.Prefixes, subnetPrefix)
+	ted.Nodes[subnetNode.RouterID] = subnetNode
+	ted.Nodes["router-nil"] = nil
+
+	index := ted.AddressRouterIDIndex()
+	assert.Equal(t, "router-v4", index[netip.MustParseAddr("192.0.2.10")])
+	assert.Equal(t, "router-v6", index[netip.MustParseAddr("2001:db8::1")])
+	assert.Equal(t, "router-subnet", index[netip.MustParseAddr("192.0.2.0")])
+
+	var nilTED *LsTED
+	assert.Nil(t, nilTED.AddressRouterIDIndex())
+}


### PR DESCRIPTION
## Description

Move gRPC converters to a separate file and move TED index helpers to `LsTED`.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

- `make ci`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed