### PR TITLE
Preserve SR policy segment identity

### DIFF
--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -305,11 +305,13 @@ func (MetricType) EnumDescriptor() ([]byte, []int) {
 }
 
 type Segment struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Sid           string                 `protobuf:"bytes,1,opt,name=sid,proto3" json:"sid,omitempty"`
-	SidStructure  string                 `protobuf:"bytes,2,opt,name=sid_structure,json=sidStructure,proto3" json:"sid_structure,omitempty"`
-	LocalAddr     string                 `protobuf:"bytes,3,opt,name=local_addr,json=localAddr,proto3" json:"local_addr,omitempty"`
-	RemoteAddr    string                 `protobuf:"bytes,4,opt,name=remote_addr,json=remoteAddr,proto3" json:"remote_addr,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Sid          string                 `protobuf:"bytes,1,opt,name=sid,proto3" json:"sid,omitempty"`
+	SidStructure string                 `protobuf:"bytes,2,opt,name=sid_structure,json=sidStructure,proto3" json:"sid_structure,omitempty"`
+	LocalAddr    string                 `protobuf:"bytes,3,opt,name=local_addr,json=localAddr,proto3" json:"local_addr,omitempty"`
+	RemoteAddr   string                 `protobuf:"bytes,4,opt,name=remote_addr,json=remoteAddr,proto3" json:"remote_addr,omitempty"`
+	// sid_absent indicates that the SID is omitted and the NAI identifies the segment.
+	SidAbsent     bool `protobuf:"varint,5,opt,name=sid_absent,json=sidAbsent,proto3" json:"sid_absent,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -370,6 +372,13 @@ func (x *Segment) GetRemoteAddr() string {
 		return x.RemoteAddr
 	}
 	return ""
+}
+
+func (x *Segment) GetSidAbsent() bool {
+	if x != nil {
+		return x.SidAbsent
+	}
+	return false
 }
 
 type Waypoint struct {
@@ -2628,14 +2637,16 @@ var File_api_pola_v1_pola_proto protoreflect.FileDescriptor
 
 const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\n" +
-	"\x16api/pola/v1/pola.proto\x12\vapi.pola.v1\"\x80\x01\n" +
+	"\x16api/pola/v1/pola.proto\x12\vapi.pola.v1\"\x9f\x01\n" +
 	"\aSegment\x12\x10\n" +
 	"\x03sid\x18\x01 \x01(\tR\x03sid\x12#\n" +
 	"\rsid_structure\x18\x02 \x01(\tR\fsidStructure\x12\x1d\n" +
 	"\n" +
 	"local_addr\x18\x03 \x01(\tR\tlocalAddr\x12\x1f\n" +
 	"\vremote_addr\x18\x04 \x01(\tR\n" +
-	"remoteAddr\"9\n" +
+	"remoteAddr\x12\x1d\n" +
+	"\n" +
+	"sid_absent\x18\x05 \x01(\bR\tsidAbsent\"9\n" +
 	"\bWaypoint\x12\x1b\n" +
 	"\trouter_id\x18\x01 \x01(\tR\brouterId\x12\x10\n" +
 	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xbb\x04\n" +

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -23,6 +23,8 @@ message Segment {
   string sid_structure = 2;
   string local_addr = 3;
   string remote_addr = 4;
+  // sid_absent indicates that the SID is omitted and the NAI identifies the segment.
+  bool sid_absent = 5;
 }
 
 enum SRPolicyType {

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -464,6 +464,7 @@ func segmentFromPB(s *pb.Segment) (table.Segment, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid SR-MPLS remote address %q: %w", s.GetRemoteAddr(), err)
 		}
+		v.SidAbsent = s.GetSidAbsent()
 		return v, nil
 	default:
 		return nil, fmt.Errorf("unsupported segment type for SID %q", s.GetSid())

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -151,6 +151,20 @@ func TestSegmentFromPB_SRMPLS(t *testing.T) {
 	}
 }
 
+func TestSegmentFromPB_SRMPLS_SidAbsent(t *testing.T) {
+	seg, err := segmentFromPB(&pb.Segment{
+		Sid:       "0",
+		LocalAddr: "192.0.2.1",
+		SidAbsent: true,
+	})
+	require.NoError(t, err)
+
+	mplsSeg, ok := seg.(table.SegmentSRMPLS)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", seg)
+	assert.True(t, mplsSeg.SidAbsent)
+	assert.Equal(t, "192.0.2.1", mplsSeg.LocalAddr.String())
+}
+
 func TestSegmentFromPB_SRv6(t *testing.T) {
 	seg, err := segmentFromPB(&pb.Segment{
 		Sid:          "2001:db8:1005::",

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1108,14 +1108,18 @@ func (o *SREroSubobject) DecodeFromBytes(subobject []uint8) error {
 	o.CFlag = (subobject[3] & 0x02) != 0
 	o.MFlag = (subobject[3] & 0x01) != 0
 
-	if o.SFlag && o.FFlag {
-		return errors.New("SREroSubobject: both SID and NAI are absent")
-	}
 	// Bound reads to the declared length to prevent consuming the next subobject.
 	if int(o.Length) < 4 || len(subobject) < int(o.Length) {
 		return errors.New("SREroSubobject: invalid subobject length")
 	}
 	subobject = subobject[:o.Length]
+
+	if o.SFlag && o.FFlag {
+		return errors.New("SREroSubobject: both SID and NAI are absent")
+	}
+	if o.SFlag && o.NAIType == NAITypeSRAbsent {
+		return errors.New("SREroSubobject: SID absent requires a non-absent NAI")
+	}
 
 	off, err := o.decodeSID(subobject)
 	if err != nil {
@@ -1135,7 +1139,7 @@ func (o *SREroSubobject) DecodeFromBytes(subobject []uint8) error {
 
 func (o *SREroSubobject) decodeSID(subobject []uint8) (int, error) {
 	if o.SFlag {
-		o.Segment = table.SegmentSRMPLS{}
+		o.Segment = table.SegmentSRMPLS{SidAbsent: true}
 		return 4, nil
 	}
 	if len(subobject) < 8 {
@@ -1321,13 +1325,21 @@ func NewSREroSubobject(seg table.SegmentSRMPLS) (*SREroSubobject, error) {
 	if err != nil {
 		return nil, err
 	}
+	if seg.SidAbsent {
+		if naiType == NAITypeSRAbsent {
+			return nil, errors.New("SREroSubobject: both SID and NAI are absent")
+		}
+		if seg.HasMPLSStackEntryAttrs() {
+			return nil, errors.New("SREroSubobject: MPLS stack entry attributes require a SID")
+		}
+	}
 
 	subo := &SREroSubobject{
 		LFlag:         false,
 		SubobjectType: SubobjectTypeEROSR,
 		NAIType:       naiType,
 		FFlag:         naiType == NAITypeSRAbsent, // F=1: NAI is absent
-		SFlag:         false,
+		SFlag:         seg.SidAbsent,
 		CFlag:         seg.HasMPLSStackEntryAttrs(),
 		MFlag:         true, // TODO: Determine either MPLS label or index
 		Segment:       seg,

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -93,12 +93,6 @@ func TestSREroSubobject_RoundTrip(t *testing.T) {
 				return seg
 			}(),
 		},
-		"AbsentNAIType_FFlagFalse_SFlagTrue": {
-			SubobjectType: SubobjectTypeEROSR,
-			NAIType:       NAITypeSRAbsent,
-			SFlag:         true, MFlag: true,
-			Segment: table.SegmentSRMPLS{},
-		},
 	}
 
 	for name, want := range cases {
@@ -221,7 +215,17 @@ func TestSREroSubobject_DecodeErrors(t *testing.T) {
 func TestSREroSubobject_DecodeFromBytes_BothSIDAndNAIAbsent(t *testing.T) {
 	t.Parallel()
 
-	raw := []uint8{0x24, 0x08, 0x00, 0x0c} // S=1, F=1
+	raw := []uint8{0x24, 0x04, 0x00, 0x0c} // Length=4, S=1, F=1
+
+	var subo SREroSubobject
+	assert.EqualError(t, subo.DecodeFromBytes(raw), "SREroSubobject: both SID and NAI are absent")
+}
+
+// RFC 8664 §4.3.1 requires a non-absent NAI when S=1.
+func TestSREroSubobject_DecodeFromBytes_SIDAbsentWithoutNAI(t *testing.T) {
+	t.Parallel()
+
+	raw := []uint8{0x24, 0x04, 0x00, 0x04} // S=1, F=0, NAIType=Absent
 
 	var subo SREroSubobject
 	assert.Error(t, subo.DecodeFromBytes(raw))
@@ -375,6 +379,60 @@ func TestSREroSubobject_DecodeFromBytes_SIDAbsent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSREroSubobject_TableRoundTrip_SIDAbsent(t *testing.T) {
+	t.Parallel()
+
+	seg := table.SegmentSRMPLS{SidAbsent: true, LocalAddr: netip.MustParseAddr("10.0.0.1")}
+	subo := &SREroSubobject{
+		SubobjectType: SubobjectTypeEROSR,
+		NAIType:       NAITypeSRIPv4Node,
+		SFlag:         true,
+		MFlag:         true,
+		Segment:       seg,
+	}
+	l, err := subo.Len()
+	require.NoError(t, err)
+	subo.Length = uint8(l)
+	raw, err := subo.Serialize()
+	require.NoError(t, err)
+
+	var decoded SREroSubobject
+	require.NoError(t, decoded.DecodeFromBytes(raw))
+	assert.True(t, decoded.SFlag)
+
+	tableSeg, ok := decoded.ToSegment().(table.SegmentSRMPLS)
+	require.True(t, ok)
+	assert.True(t, tableSeg.SidAbsent, "SID-absent must survive conversion to the table layer")
+	assert.Zero(t, tableSeg.Sid, "SID-absent must not be mistaken for label 0")
+
+	rebuilt, err := NewSREroSubobject(tableSeg)
+	require.NoError(t, err)
+	assert.True(t, rebuilt.SFlag, "NewSREroSubobject must restore S=1 from SidAbsent")
+
+	raw2, err := rebuilt.Serialize()
+	require.NoError(t, err)
+	assert.Equal(t, raw, raw2, "re-serialized bytes must match the original SID-absent encoding")
+}
+
+func TestNewSREroSubobject_SidAbsentWithoutNAI(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSREroSubobject(table.SegmentSRMPLS{SidAbsent: true})
+	assert.Error(t, err)
+}
+
+func TestNewSREroSubobject_SidAbsentWithMPLSStackEntryAttrs(t *testing.T) {
+	t.Parallel()
+
+	seg := table.SegmentSRMPLS{
+		SidAbsent: true,
+		LocalAddr: netip.MustParseAddr("10.0.0.1"),
+		TTL:       1,
+	}
+	_, err := NewSREroSubobject(seg)
+	assert.Error(t, err, "MPLS stack entry attributes are unrepresentable without a SID")
 }
 
 func TestSREroSubobject_DecodeFromBytes_TruncatedAfterHeader(t *testing.T) {

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -189,6 +189,7 @@ func convertSegment(seg table.Segment) *pb.Segment {
 		if v.RemoteAddr.IsValid() {
 			pbSeg.RemoteAddr = v.RemoteAddr.String()
 		}
+		pbSeg.SidAbsent = v.SidAbsent
 	}
 	return pbSeg
 }

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -198,6 +198,7 @@ func enrichSRMPLSSegment(mplsSeg table.SegmentSRMPLS, segment *pb.Segment) (tabl
 		}
 		mplsSeg.RemoteAddr = ra
 	}
+	mplsSeg.SidAbsent = segment.GetSidAbsent()
 	return mplsSeg, nil
 }
 

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -863,6 +863,20 @@ func TestConvertSegment_SRMPLS(t *testing.T) {
 	}
 }
 
+func TestConvertSegment_SRMPLS_SidAbsent(t *testing.T) {
+	seg := table.SegmentSRMPLS{SidAbsent: true, LocalAddr: netip.MustParseAddr("192.0.2.1")}
+
+	pbSeg := convertSegment(seg)
+	assert.True(t, pbSeg.GetSidAbsent())
+
+	enriched, err := newEnrichedSegment(pbSeg, false)
+	require.NoError(t, err)
+	mplsSeg, ok := enriched.(table.SegmentSRMPLS)
+	require.True(t, ok)
+	assert.True(t, mplsSeg.SidAbsent)
+	assert.Equal(t, "192.0.2.1", mplsSeg.LocalAddr.String())
+}
+
 func TestTED_ConcurrentUpdate(_ *testing.T) {
 	s := &Server{ted: &table.LsTED{Nodes: map[string]*table.LsNode{}}}
 

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -304,6 +305,8 @@ type SegmentSRMPLS struct {
 	TTL uint8  `json:"ttl,omitempty"`
 	TC  uint8  `json:"tc,omitempty"`
 	S   bool   `json:"s,omitempty"`
+	// SidAbsent indicates that the SID is omitted and the NAI identifies the segment.
+	SidAbsent bool `json:"sidAbsent,omitempty"`
 	// Optional NAI for SR-ERO encoding (RFC 8664 §4.3.1).
 	LocalAddr  netip.Addr `json:"localAddr,omitzero"`
 	RemoteAddr netip.Addr `json:"remoteAddr,omitzero"`
@@ -330,13 +333,21 @@ func NewSegmentSRMPLS(sid uint32) SegmentSRMPLS {
 func (seg SegmentSRv6) Equal(other SegmentSRv6) bool {
 	return seg.Sid == other.Sid &&
 		seg.LocalAddr == other.LocalAddr &&
-		seg.RemoteAddr == other.RemoteAddr
+		seg.RemoteAddr == other.RemoteAddr &&
+		seg.USid == other.USid &&
+		slices.Equal(seg.Structure, other.Structure)
 }
 
 // Equal reports whether this SR-MPLS segment is equal to another.
 func (seg SegmentSRMPLS) Equal(other SegmentSRMPLS) bool {
-	// Compare only the MPLS SID; the NAI does not change the hop.
-	return seg.Sid == other.Sid
+	if seg.SidAbsent != other.SidAbsent {
+		return false
+	}
+	if !seg.SidAbsent && seg.Sid != other.Sid {
+		return false
+	}
+	return seg.TTL == other.TTL && seg.TC == other.TC && seg.S == other.S &&
+		seg.LocalAddr == other.LocalAddr && seg.RemoteAddr == other.RemoteAddr
 }
 
 // SegmentsEqual reports whether two segments are equal.

--- a/pkg/table/sr_policy_test.go
+++ b/pkg/table/sr_policy_test.go
@@ -49,16 +49,45 @@ func TestSegmentsEqual(t *testing.T) {
 			want: true,
 		},
 		{
-			// Same label with a different NAI is still the same hop.
 			name: "SR-MPLS same label with different NAI",
 			a:    newTestSegmentSRMPLS(16001, "10.0.0.1", ""),
 			b:    newTestSegmentSRMPLS(16001, "10.0.0.2", "10.0.0.3"),
-			want: true,
+			want: false,
 		},
 		{
 			name: "SR-MPLS different label",
 			a:    newTestSegmentSRMPLS(16001, "10.0.0.1", ""),
 			b:    newTestSegmentSRMPLS(16002, "10.0.0.1", ""),
+			want: false,
+		},
+		{
+			name: "SR-MPLS SID-absent vs label 0",
+			a:    SegmentSRMPLS{SidAbsent: true, LocalAddr: netip.MustParseAddr("10.0.0.1")},
+			b:    newTestSegmentSRMPLS(0, "10.0.0.1", ""),
+			want: false,
+		},
+		{
+			name: "SR-MPLS both SID-absent with same NAI",
+			a:    SegmentSRMPLS{SidAbsent: true, LocalAddr: netip.MustParseAddr("10.0.0.1")},
+			b:    SegmentSRMPLS{SidAbsent: true, LocalAddr: netip.MustParseAddr("10.0.0.1")},
+			want: true,
+		},
+		{
+			name: "SR-MPLS same label with different TTL",
+			a:    func() SegmentSRMPLS { s := newTestSegmentSRMPLS(16001, "", ""); s.TTL = 1; return s }(),
+			b:    func() SegmentSRMPLS { s := newTestSegmentSRMPLS(16001, "", ""); s.TTL = 2; return s }(),
+			want: false,
+		},
+		{
+			name: "SR-MPLS same label with different TC",
+			a:    func() SegmentSRMPLS { s := newTestSegmentSRMPLS(16001, "", ""); s.TC = 1; return s }(),
+			b:    func() SegmentSRMPLS { s := newTestSegmentSRMPLS(16001, "", ""); s.TC = 2; return s }(),
+			want: false,
+		},
+		{
+			name: "SR-MPLS same label with different S",
+			a:    func() SegmentSRMPLS { s := newTestSegmentSRMPLS(16001, "", ""); s.S = false; return s }(),
+			b:    func() SegmentSRMPLS { s := newTestSegmentSRMPLS(16001, "", ""); s.S = true; return s }(),
 			want: false,
 		},
 		{
@@ -71,6 +100,26 @@ func TestSegmentsEqual(t *testing.T) {
 			name: "SRv6 same SID with different NAI",
 			a:    newTestSegmentSRv6("fc00:0:1::", "2001:db8::1", ""),
 			b:    newTestSegmentSRv6("fc00:0:1::", "2001:db8::2", ""),
+			want: false,
+		},
+		{
+			name: "SRv6 same SID with different USid",
+			a:    func() SegmentSRv6 { s := newTestSegmentSRv6("fc00:0:1::", "", ""); s.USid = false; return s }(),
+			b:    func() SegmentSRv6 { s := newTestSegmentSRv6("fc00:0:1::", "", ""); s.USid = true; return s }(),
+			want: false,
+		},
+		{
+			name: "SRv6 same SID with different Structure",
+			a: func() SegmentSRv6 {
+				s := newTestSegmentSRv6("fc00:0:1::", "", "")
+				s.Structure = SIDStructureBytes{1, 2, 3, 4}
+				return s
+			}(),
+			b: func() SegmentSRv6 {
+				s := newTestSegmentSRv6("fc00:0:1::", "", "")
+				s.Structure = SIDStructureBytes{5, 6, 7, 8}
+				return s
+			}(),
 			want: false,
 		},
 		{


### PR DESCRIPTION
## Description
<!-- What does this PR change, and why is it needed? -->

Preserve SR-MPLS SID-absent state across SR-ERO/table conversion and compare all relevant segment attributes in Equal().

## Type of change
<!-- Check all that apply. -->
- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?
<!-- Commands run (e.g. `make test`, `make test-scenario`), and/or
example topologies verified.
-->

make ci

## Checklist

- [x] `make ci` passes locally
- [ ] Tests added or updated if needed
- [ ] Documentation updated if needed
