### PR TITLE
Implement RFC 5440 PCEP session management and enrich API/CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,5 @@ release: ## Cut a release: make release VERSION=X.Y.Z
 
 clean: ## Remove generated files
 	$(RM) -r bin
-	# Preserve the tracked .gitignore in TEST_BIN_DIR.
 	@find $(TEST_BIN_DIR) -type f ! -name .gitignore -delete 2>/dev/null || true
 	$(RM) $(COVER_PROFILE)

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -307,6 +307,109 @@ func (CapabilityType) EnumDescriptor() ([]byte, []int) {
 	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
 }
 
+// RFC 9826 ietf-pcep: /pcep/entity/peers/peer/sessions/session/initiator
+type SessionInitiator int32
+
+const (
+	SessionInitiator_SESSION_INITIATOR_UNSPECIFIED SessionInitiator = 0
+	SessionInitiator_SESSION_INITIATOR_LOCAL       SessionInitiator = 1
+	SessionInitiator_SESSION_INITIATOR_REMOTE      SessionInitiator = 2
+)
+
+// Enum value maps for SessionInitiator.
+var (
+	SessionInitiator_name = map[int32]string{
+		0: "SESSION_INITIATOR_UNSPECIFIED",
+		1: "SESSION_INITIATOR_LOCAL",
+		2: "SESSION_INITIATOR_REMOTE",
+	}
+	SessionInitiator_value = map[string]int32{
+		"SESSION_INITIATOR_UNSPECIFIED": 0,
+		"SESSION_INITIATOR_LOCAL":       1,
+		"SESSION_INITIATOR_REMOTE":      2,
+	}
+)
+
+func (x SessionInitiator) Enum() *SessionInitiator {
+	p := new(SessionInitiator)
+	*p = x
+	return p
+}
+
+func (x SessionInitiator) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SessionInitiator) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_pola_v1_pola_proto_enumTypes[5].Descriptor()
+}
+
+func (SessionInitiator) Type() protoreflect.EnumType {
+	return &file_api_pola_v1_pola_proto_enumTypes[5]
+}
+
+func (x SessionInitiator) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SessionInitiator.Descriptor instead.
+func (SessionInitiator) EnumDescriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
+}
+
+// LSP-DB synchronization state defined by RFC 8231 and exposed by RFC 9826.
+type LspDbSyncState int32
+
+const (
+	LspDbSyncState_LSP_DB_SYNC_STATE_UNSPECIFIED LspDbSyncState = 0
+	LspDbSyncState_LSP_DB_SYNC_STATE_PENDING     LspDbSyncState = 1
+	LspDbSyncState_LSP_DB_SYNC_STATE_ONGOING     LspDbSyncState = 2
+	LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED    LspDbSyncState = 3
+)
+
+// Enum value maps for LspDbSyncState.
+var (
+	LspDbSyncState_name = map[int32]string{
+		0: "LSP_DB_SYNC_STATE_UNSPECIFIED",
+		1: "LSP_DB_SYNC_STATE_PENDING",
+		2: "LSP_DB_SYNC_STATE_ONGOING",
+		3: "LSP_DB_SYNC_STATE_FINISHED",
+	}
+	LspDbSyncState_value = map[string]int32{
+		"LSP_DB_SYNC_STATE_UNSPECIFIED": 0,
+		"LSP_DB_SYNC_STATE_PENDING":     1,
+		"LSP_DB_SYNC_STATE_ONGOING":     2,
+		"LSP_DB_SYNC_STATE_FINISHED":    3,
+	}
+)
+
+func (x LspDbSyncState) Enum() *LspDbSyncState {
+	p := new(LspDbSyncState)
+	*p = x
+	return p
+}
+
+func (x LspDbSyncState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (LspDbSyncState) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_pola_v1_pola_proto_enumTypes[6].Descriptor()
+}
+
+func (LspDbSyncState) Type() protoreflect.EnumType {
+	return &file_api_pola_v1_pola_proto_enumTypes[6]
+}
+
+func (x LspDbSyncState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use LspDbSyncState.Descriptor instead.
+func (LspDbSyncState) EnumDescriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{6}
+}
+
 type MetricType int32
 
 const (
@@ -346,11 +449,11 @@ func (x MetricType) String() string {
 }
 
 func (MetricType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[5].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[7].Descriptor()
 }
 
 func (MetricType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[5]
+	return &file_api_pola_v1_pola_proto_enumTypes[7]
 }
 
 func (x MetricType) Number() protoreflect.EnumNumber {
@@ -359,7 +462,7 @@ func (x MetricType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use MetricType.Descriptor instead.
 func (MetricType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
 }
 
 type Segment struct {
@@ -441,7 +544,7 @@ func (x *Segment) GetSidAbsent() bool {
 type Waypoint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RouterId      string                 `protobuf:"bytes,1,opt,name=router_id,json=routerId,proto3" json:"router_id,omitempty"`
-	Sid           string                 `protobuf:"bytes,2,opt,name=sid,proto3" json:"sid,omitempty"` // optional: explicit SID override
+	Sid           string                 `protobuf:"bytes,2,opt,name=sid,proto3" json:"sid,omitempty"` // Optional: explicit SID override
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -491,24 +594,24 @@ func (x *Waypoint) GetSid() string {
 }
 
 type SRPolicy struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	PcepSessionAddr []byte                 `protobuf:"bytes,1,opt,name=pcep_session_addr,json=pcepSessionAddr,proto3" json:"pcep_session_addr,omitempty"`
-	SrcAddr         []byte                 `protobuf:"bytes,2,opt,name=src_addr,json=srcAddr,proto3" json:"src_addr,omitempty"`
-	DstAddr         []byte                 `protobuf:"bytes,3,opt,name=dst_addr,json=dstAddr,proto3" json:"dst_addr,omitempty"`
-	SrcRouterId     string                 `protobuf:"bytes,4,opt,name=src_router_id,json=srcRouterId,proto3" json:"src_router_id,omitempty"`
-	DstRouterId     string                 `protobuf:"bytes,5,opt,name=dst_router_id,json=dstRouterId,proto3" json:"dst_router_id,omitempty"`
-	Color           uint32                 `protobuf:"varint,6,opt,name=color,proto3" json:"color,omitempty"`
-	Preference      uint32                 `protobuf:"varint,7,opt,name=preference,proto3" json:"preference,omitempty"`
-	PolicyName      string                 `protobuf:"bytes,8,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
-	Type            SRPolicyType           `protobuf:"varint,9,opt,name=type,proto3,enum=api.pola.v1.SRPolicyType" json:"type,omitempty"`
-	SegmentList     []*Segment             `protobuf:"bytes,10,rep,name=segment_list,json=segmentList,proto3" json:"segment_list,omitempty"`
-	Metric          MetricType             `protobuf:"varint,11,opt,name=metric,proto3,enum=api.pola.v1.MetricType" json:"metric,omitempty"`
-	Waypoints       []*Waypoint            `protobuf:"bytes,12,rep,name=waypoints,proto3" json:"waypoints,omitempty"`
-	PlspId          uint32                 `protobuf:"varint,13,opt,name=plsp_id,json=plspId,proto3" json:"plsp_id,omitempty"`
-	LspId           uint32                 `protobuf:"varint,14,opt,name=lsp_id,json=lspId,proto3" json:"lsp_id,omitempty"`
-	State           SRPolicyState          `protobuf:"varint,15,opt,name=state,proto3,enum=api.pola.v1.SRPolicyState" json:"state,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PeerAddr      []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
+	SrcAddr       []byte                 `protobuf:"bytes,2,opt,name=src_addr,json=srcAddr,proto3" json:"src_addr,omitempty"`
+	DstAddr       []byte                 `protobuf:"bytes,3,opt,name=dst_addr,json=dstAddr,proto3" json:"dst_addr,omitempty"`
+	SrcRouterId   string                 `protobuf:"bytes,4,opt,name=src_router_id,json=srcRouterId,proto3" json:"src_router_id,omitempty"`
+	DstRouterId   string                 `protobuf:"bytes,5,opt,name=dst_router_id,json=dstRouterId,proto3" json:"dst_router_id,omitempty"`
+	Color         uint32                 `protobuf:"varint,6,opt,name=color,proto3" json:"color,omitempty"`
+	Preference    uint32                 `protobuf:"varint,7,opt,name=preference,proto3" json:"preference,omitempty"`
+	PolicyName    string                 `protobuf:"bytes,8,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
+	Type          SRPolicyType           `protobuf:"varint,9,opt,name=type,proto3,enum=api.pola.v1.SRPolicyType" json:"type,omitempty"`
+	SegmentList   []*Segment             `protobuf:"bytes,10,rep,name=segment_list,json=segmentList,proto3" json:"segment_list,omitempty"`
+	Metric        MetricType             `protobuf:"varint,11,opt,name=metric,proto3,enum=api.pola.v1.MetricType" json:"metric,omitempty"`
+	Waypoints     []*Waypoint            `protobuf:"bytes,12,rep,name=waypoints,proto3" json:"waypoints,omitempty"`
+	PlspId        uint32                 `protobuf:"varint,13,opt,name=plsp_id,json=plspId,proto3" json:"plsp_id,omitempty"`
+	LspId         uint32                 `protobuf:"varint,14,opt,name=lsp_id,json=lspId,proto3" json:"lsp_id,omitempty"`
+	State         SRPolicyState          `protobuf:"varint,15,opt,name=state,proto3,enum=api.pola.v1.SRPolicyState" json:"state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SRPolicy) Reset() {
@@ -541,9 +644,9 @@ func (*SRPolicy) Descriptor() ([]byte, []int) {
 	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *SRPolicy) GetPcepSessionAddr() []byte {
+func (x *SRPolicy) GetPeerAddr() []byte {
 	if x != nil {
-		return x.PcepSessionAddr
+		return x.PeerAddr
 	}
 	return nil
 }
@@ -716,7 +819,6 @@ func (x *CreateSRPolicyRequest) GetNoSidValidate() bool {
 
 type CreateSRPolicyResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	IsSuccess     bool                   `protobuf:"varint,1,opt,name=is_success,json=isSuccess,proto3" json:"is_success,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -749,13 +851,6 @@ func (x *CreateSRPolicyResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use CreateSRPolicyResponse.ProtoReflect.Descriptor instead.
 func (*CreateSRPolicyResponse) Descriptor() ([]byte, []int) {
 	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *CreateSRPolicyResponse) GetIsSuccess() bool {
-	if x != nil {
-		return x.IsSuccess
-	}
-	return false
 }
 
 type DeleteSRPolicyRequest struct {
@@ -812,7 +907,6 @@ func (x *DeleteSRPolicyRequest) GetAsn() uint32 {
 
 type DeleteSRPolicyResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	IsSuccess     bool                   `protobuf:"varint,1,opt,name=is_success,json=isSuccess,proto3" json:"is_success,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -845,13 +939,6 @@ func (x *DeleteSRPolicyResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteSRPolicyResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSRPolicyResponse) Descriptor() ([]byte, []int) {
 	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{6}
-}
-
-func (x *DeleteSRPolicyResponse) GetIsSuccess() bool {
-	if x != nil {
-		return x.IsSuccess
-	}
-	return false
 }
 
 type StatefulCapability struct {
@@ -1652,27 +1739,200 @@ func (x *EffectiveTimers) GetDeadTimer() uint32 {
 	return 0
 }
 
+// MessageCounter contains the sent and received message counters from RFC 9826 ietf-pcep-stats.
+type MessageCounter struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sent          uint64                 `protobuf:"varint,1,opt,name=sent,proto3" json:"sent,omitempty"`
+	Rcvd          uint64                 `protobuf:"varint,2,opt,name=rcvd,proto3" json:"rcvd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MessageCounter) Reset() {
+	*x = MessageCounter{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MessageCounter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MessageCounter) ProtoMessage() {}
+
+func (x *MessageCounter) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MessageCounter.ProtoReflect.Descriptor instead.
+func (*MessageCounter) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *MessageCounter) GetSent() uint64 {
+	if x != nil {
+		return x.Sent
+	}
+	return 0
+}
+
+func (x *MessageCounter) GetRcvd() uint64 {
+	if x != nil {
+		return x.Rcvd
+	}
+	return 0
+}
+
+// SessionStats contains the message counters defined by RFC 9826 ietf-pcep-stats.
+type SessionStats struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Keepalive        *MessageCounter        `protobuf:"bytes,1,opt,name=keepalive,proto3" json:"keepalive,omitempty"`                                        // keepalive-sent / keepalive-rcvd
+	Pcerr            *MessageCounter        `protobuf:"bytes,2,opt,name=pcerr,proto3" json:"pcerr,omitempty"`                                                // pcerr-sent / pcerr-rcvd
+	Pcntf            *MessageCounter        `protobuf:"bytes,3,opt,name=pcntf,proto3" json:"pcntf,omitempty"`                                                // pcntf-sent / pcntf-rcvd
+	Report           *MessageCounter        `protobuf:"bytes,4,opt,name=report,proto3" json:"report,omitempty"`                                              // rpt-sent / rpt-rcvd (stateful)
+	Update           *MessageCounter        `protobuf:"bytes,5,opt,name=update,proto3" json:"update,omitempty"`                                              // upd-sent / upd-rcvd (stateful)
+	Initiate         *MessageCounter        `protobuf:"bytes,6,opt,name=initiate,proto3" json:"initiate,omitempty"`                                          // pcinitiate-sent / pcinitiate-rcvd (initiation)
+	UnrecognizedRcvd uint64                 `protobuf:"varint,7,opt,name=unrecognized_rcvd,json=unrecognizedRcvd,proto3" json:"unrecognized_rcvd,omitempty"` // unknown-rcvd
+	CorruptRcvd      uint64                 `protobuf:"varint,8,opt,name=corrupt_rcvd,json=corruptRcvd,proto3" json:"corrupt_rcvd,omitempty"`                // corrupt-rcvd
+	SessSetupOk      uint64                 `protobuf:"varint,9,opt,name=sess_setup_ok,json=sessSetupOk,proto3" json:"sess_setup_ok,omitempty"`              // sess-setup-ok (per peer, survives session teardown)
+	SessSetupFail    uint64                 `protobuf:"varint,10,opt,name=sess_setup_fail,json=sessSetupFail,proto3" json:"sess_setup_fail,omitempty"`       // sess-setup-fail (per peer, survives session teardown)
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *SessionStats) Reset() {
+	*x = SessionStats{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionStats) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionStats) ProtoMessage() {}
+
+func (x *SessionStats) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionStats.ProtoReflect.Descriptor instead.
+func (*SessionStats) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *SessionStats) GetKeepalive() *MessageCounter {
+	if x != nil {
+		return x.Keepalive
+	}
+	return nil
+}
+
+func (x *SessionStats) GetPcerr() *MessageCounter {
+	if x != nil {
+		return x.Pcerr
+	}
+	return nil
+}
+
+func (x *SessionStats) GetPcntf() *MessageCounter {
+	if x != nil {
+		return x.Pcntf
+	}
+	return nil
+}
+
+func (x *SessionStats) GetReport() *MessageCounter {
+	if x != nil {
+		return x.Report
+	}
+	return nil
+}
+
+func (x *SessionStats) GetUpdate() *MessageCounter {
+	if x != nil {
+		return x.Update
+	}
+	return nil
+}
+
+func (x *SessionStats) GetInitiate() *MessageCounter {
+	if x != nil {
+		return x.Initiate
+	}
+	return nil
+}
+
+func (x *SessionStats) GetUnrecognizedRcvd() uint64 {
+	if x != nil {
+		return x.UnrecognizedRcvd
+	}
+	return 0
+}
+
+func (x *SessionStats) GetCorruptRcvd() uint64 {
+	if x != nil {
+		return x.CorruptRcvd
+	}
+	return 0
+}
+
+func (x *SessionStats) GetSessSetupOk() uint64 {
+	if x != nil {
+		return x.SessSetupOk
+	}
+	return 0
+}
+
+func (x *SessionStats) GetSessSetupFail() uint64 {
+	if x != nil {
+		return x.SessSetupFail
+	}
+	return 0
+}
+
 type Session struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	Addr            []byte                 `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	State           SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
-	IsSynced        bool                   `protobuf:"varint,4,opt,name=is_synced,json=isSynced,proto3" json:"is_synced,omitempty"`
-	Capabilities    []*Capability          `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
-	SrPolicies      []*SRPolicy            `protobuf:"bytes,6,rep,name=sr_policies,json=srPolicies,proto3" json:"sr_policies,omitempty"`
-	PccType         PccType                `protobuf:"varint,7,opt,name=pcc_type,json=pccType,proto3,enum=api.pola.v1.PccType" json:"pcc_type,omitempty"`
-	PccCapabilities []*Capability          `protobuf:"bytes,8,rep,name=pcc_capabilities,json=pccCapabilities,proto3" json:"pcc_capabilities,omitempty"`
-	LocalTimers     *SessionTimers         `protobuf:"bytes,9,opt,name=local_timers,json=localTimers,proto3" json:"local_timers,omitempty"`
-	PccTimers       *SessionTimers         `protobuf:"bytes,10,opt,name=pcc_timers,json=pccTimers,proto3" json:"pcc_timers,omitempty"`
-	LocalSessionId  *uint32                `protobuf:"varint,11,opt,name=local_session_id,json=localSessionId,proto3,oneof" json:"local_session_id,omitempty"`
-	PccSessionId    *uint32                `protobuf:"varint,12,opt,name=pcc_session_id,json=pccSessionId,proto3,oneof" json:"pcc_session_id,omitempty"`
-	EffectiveTimers *EffectiveTimers       `protobuf:"bytes,13,opt,name=effective_timers,json=effectiveTimers,proto3" json:"effective_timers,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	PeerAddr              []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
+	State                 SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
+	LocalCapabilities     []*Capability          `protobuf:"bytes,5,rep,name=local_capabilities,json=localCapabilities,proto3" json:"local_capabilities,omitempty"`
+	PccType               PccType                `protobuf:"varint,7,opt,name=pcc_type,json=pccType,proto3,enum=api.pola.v1.PccType" json:"pcc_type,omitempty"`
+	PeerCapabilities      []*Capability          `protobuf:"bytes,8,rep,name=peer_capabilities,json=peerCapabilities,proto3" json:"peer_capabilities,omitempty"`
+	LocalTimers           *SessionTimers         `protobuf:"bytes,9,opt,name=local_timers,json=localTimers,proto3" json:"local_timers,omitempty"`
+	PeerTimers            *SessionTimers         `protobuf:"bytes,10,opt,name=peer_timers,json=peerTimers,proto3" json:"peer_timers,omitempty"`
+	LocalSessionId        *uint32                `protobuf:"varint,11,opt,name=local_session_id,json=localSessionId,proto3,oneof" json:"local_session_id,omitempty"`
+	PeerSessionId         *uint32                `protobuf:"varint,12,opt,name=peer_session_id,json=peerSessionId,proto3,oneof" json:"peer_session_id,omitempty"`
+	EffectiveTimers       *EffectiveTimers       `protobuf:"bytes,13,opt,name=effective_timers,json=effectiveTimers,proto3" json:"effective_timers,omitempty"`
+	Initiator             SessionInitiator       `protobuf:"varint,14,opt,name=initiator,proto3,enum=api.pola.v1.SessionInitiator" json:"initiator,omitempty"`
+	SyncState             LspDbSyncState         `protobuf:"varint,15,opt,name=sync_state,json=syncState,proto3,enum=api.pola.v1.LspDbSyncState" json:"sync_state,omitempty"`
+	CreatedAtUnixNano     int64                  `protobuf:"varint,16,opt,name=created_at_unix_nano,json=createdAtUnixNano,proto3" json:"created_at_unix_nano,omitempty"`             // Unix time in nanoseconds; 0 = unset.
+	EstablishedAtUnixNano int64                  `protobuf:"varint,17,opt,name=established_at_unix_nano,json=establishedAtUnixNano,proto3" json:"established_at_unix_nano,omitempty"` // Unix time in nanoseconds; 0 = not established.
+	Stats                 *SessionStats          `protobuf:"bytes,18,opt,name=stats,proto3" json:"stats,omitempty"`                                                                   // Populated only when include_stats is true.
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *Session) Reset() {
 	*x = Session{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1684,7 +1944,7 @@ func (x *Session) String() string {
 func (*Session) ProtoMessage() {}
 
 func (x *Session) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1697,12 +1957,12 @@ func (x *Session) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Session.ProtoReflect.Descriptor instead.
 func (*Session) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
 }
 
-func (x *Session) GetAddr() []byte {
+func (x *Session) GetPeerAddr() []byte {
 	if x != nil {
-		return x.Addr
+		return x.PeerAddr
 	}
 	return nil
 }
@@ -1714,23 +1974,9 @@ func (x *Session) GetState() SessionState {
 	return SessionState_SESSION_STATE_UNSPECIFIED
 }
 
-func (x *Session) GetIsSynced() bool {
+func (x *Session) GetLocalCapabilities() []*Capability {
 	if x != nil {
-		return x.IsSynced
-	}
-	return false
-}
-
-func (x *Session) GetCapabilities() []*Capability {
-	if x != nil {
-		return x.Capabilities
-	}
-	return nil
-}
-
-func (x *Session) GetSrPolicies() []*SRPolicy {
-	if x != nil {
-		return x.SrPolicies
+		return x.LocalCapabilities
 	}
 	return nil
 }
@@ -1742,9 +1988,9 @@ func (x *Session) GetPccType() PccType {
 	return PccType_PCC_TYPE_UNSPECIFIED
 }
 
-func (x *Session) GetPccCapabilities() []*Capability {
+func (x *Session) GetPeerCapabilities() []*Capability {
 	if x != nil {
-		return x.PccCapabilities
+		return x.PeerCapabilities
 	}
 	return nil
 }
@@ -1756,9 +2002,9 @@ func (x *Session) GetLocalTimers() *SessionTimers {
 	return nil
 }
 
-func (x *Session) GetPccTimers() *SessionTimers {
+func (x *Session) GetPeerTimers() *SessionTimers {
 	if x != nil {
-		return x.PccTimers
+		return x.PeerTimers
 	}
 	return nil
 }
@@ -1770,9 +2016,9 @@ func (x *Session) GetLocalSessionId() uint32 {
 	return 0
 }
 
-func (x *Session) GetPccSessionId() uint32 {
-	if x != nil && x.PccSessionId != nil {
-		return *x.PccSessionId
+func (x *Session) GetPeerSessionId() uint32 {
+	if x != nil && x.PeerSessionId != nil {
+		return *x.PeerSessionId
 	}
 	return 0
 }
@@ -1780,6 +2026,109 @@ func (x *Session) GetPccSessionId() uint32 {
 func (x *Session) GetEffectiveTimers() *EffectiveTimers {
 	if x != nil {
 		return x.EffectiveTimers
+	}
+	return nil
+}
+
+func (x *Session) GetInitiator() SessionInitiator {
+	if x != nil {
+		return x.Initiator
+	}
+	return SessionInitiator_SESSION_INITIATOR_UNSPECIFIED
+}
+
+func (x *Session) GetSyncState() LspDbSyncState {
+	if x != nil {
+		return x.SyncState
+	}
+	return LspDbSyncState_LSP_DB_SYNC_STATE_UNSPECIFIED
+}
+
+func (x *Session) GetCreatedAtUnixNano() int64 {
+	if x != nil {
+		return x.CreatedAtUnixNano
+	}
+	return 0
+}
+
+func (x *Session) GetEstablishedAtUnixNano() int64 {
+	if x != nil {
+		return x.EstablishedAtUnixNano
+	}
+	return 0
+}
+
+func (x *Session) GetStats() *SessionStats {
+	if x != nil {
+		return x.Stats
+	}
+	return nil
+}
+
+type SRPolicySession struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PeerAddr      []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
+	State         SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
+	SyncState     LspDbSyncState         `protobuf:"varint,3,opt,name=sync_state,json=syncState,proto3,enum=api.pola.v1.LspDbSyncState" json:"sync_state,omitempty"`
+	SrPolicies    []*SRPolicy            `protobuf:"bytes,4,rep,name=sr_policies,json=srPolicies,proto3" json:"sr_policies,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SRPolicySession) Reset() {
+	*x = SRPolicySession{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SRPolicySession) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SRPolicySession) ProtoMessage() {}
+
+func (x *SRPolicySession) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SRPolicySession.ProtoReflect.Descriptor instead.
+func (*SRPolicySession) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *SRPolicySession) GetPeerAddr() []byte {
+	if x != nil {
+		return x.PeerAddr
+	}
+	return nil
+}
+
+func (x *SRPolicySession) GetState() SessionState {
+	if x != nil {
+		return x.State
+	}
+	return SessionState_SESSION_STATE_UNSPECIFIED
+}
+
+func (x *SRPolicySession) GetSyncState() LspDbSyncState {
+	if x != nil {
+		return x.SyncState
+	}
+	return LspDbSyncState_LSP_DB_SYNC_STATE_UNSPECIFIED
+}
+
+func (x *SRPolicySession) GetSrPolicies() []*SRPolicy {
+	if x != nil {
+		return x.SrPolicies
 	}
 	return nil
 }
@@ -1795,7 +2144,7 @@ type EndpointBehavior struct {
 
 func (x *EndpointBehavior) Reset() {
 	*x = EndpointBehavior{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1807,7 +2156,7 @@ func (x *EndpointBehavior) String() string {
 func (*EndpointBehavior) ProtoMessage() {}
 
 func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1820,7 +2169,7 @@ func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointBehavior.ProtoReflect.Descriptor instead.
 func (*EndpointBehavior) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *EndpointBehavior) GetBehavior() uint32 {
@@ -1856,7 +2205,7 @@ type SidStructure struct {
 
 func (x *SidStructure) Reset() {
 	*x = SidStructure{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1868,7 +2217,7 @@ func (x *SidStructure) String() string {
 func (*SidStructure) ProtoMessage() {}
 
 func (x *SidStructure) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1881,7 +2230,7 @@ func (x *SidStructure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidStructure.ProtoReflect.Descriptor instead.
 func (*SidStructure) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SidStructure) GetLocalBlock() uint32 {
@@ -1921,7 +2270,7 @@ type SID struct {
 
 func (x *SID) Reset() {
 	*x = SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1933,7 +2282,7 @@ func (x *SID) String() string {
 func (*SID) ProtoMessage() {}
 
 func (x *SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1946,7 +2295,7 @@ func (x *SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SID.ProtoReflect.Descriptor instead.
 func (*SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SID) GetSid() string {
@@ -1965,7 +2314,7 @@ type MultiTopoID struct {
 
 func (x *MultiTopoID) Reset() {
 	*x = MultiTopoID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1977,7 +2326,7 @@ func (x *MultiTopoID) String() string {
 func (*MultiTopoID) ProtoMessage() {}
 
 func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1990,7 +2339,7 @@ func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultiTopoID.ProtoReflect.Descriptor instead.
 func (*MultiTopoID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *MultiTopoID) GetMultiTopoId() uint32 {
@@ -2012,7 +2361,7 @@ type LsSrv6SID struct {
 
 func (x *LsSrv6SID) Reset() {
 	*x = LsSrv6SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2024,7 +2373,7 @@ func (x *LsSrv6SID) String() string {
 func (*LsSrv6SID) ProtoMessage() {}
 
 func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2037,7 +2386,7 @@ func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6SID.ProtoReflect.Descriptor instead.
 func (*LsSrv6SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LsSrv6SID) GetSids() []*SID {
@@ -2078,7 +2427,7 @@ type LsPrefix struct {
 
 func (x *LsPrefix) Reset() {
 	*x = LsPrefix{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2090,7 +2439,7 @@ func (x *LsPrefix) String() string {
 func (*LsPrefix) ProtoMessage() {}
 
 func (x *LsPrefix) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2103,7 +2452,7 @@ func (x *LsPrefix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsPrefix.ProtoReflect.Descriptor instead.
 func (*LsPrefix) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LsPrefix) GetPrefix() string {
@@ -2130,7 +2479,7 @@ type Metric struct {
 
 func (x *Metric) Reset() {
 	*x = Metric{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2142,7 +2491,7 @@ func (x *Metric) String() string {
 func (*Metric) ProtoMessage() {}
 
 func (x *Metric) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2155,7 +2504,7 @@ func (x *Metric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metric.ProtoReflect.Descriptor instead.
 func (*Metric) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *Metric) GetType() MetricType {
@@ -2183,7 +2532,7 @@ type Srv6EndXSID struct {
 
 func (x *Srv6EndXSID) Reset() {
 	*x = Srv6EndXSID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2195,7 +2544,7 @@ func (x *Srv6EndXSID) String() string {
 func (*Srv6EndXSID) ProtoMessage() {}
 
 func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2208,7 +2557,7 @@ func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Srv6EndXSID.ProtoReflect.Descriptor instead.
 func (*Srv6EndXSID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Srv6EndXSID) GetEndpointBehavior() uint32 {
@@ -2249,7 +2598,7 @@ type LsLink struct {
 
 func (x *LsLink) Reset() {
 	*x = LsLink{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2261,7 +2610,7 @@ func (x *LsLink) String() string {
 func (*LsLink) ProtoMessage() {}
 
 func (x *LsLink) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2274,7 +2623,7 @@ func (x *LsLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsLink.ProtoReflect.Descriptor instead.
 func (*LsLink) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *LsLink) GetLocalRouterId() string {
@@ -2348,16 +2697,16 @@ type LsNode struct {
 	Hostname      string                 `protobuf:"bytes,4,opt,name=hostname,proto3" json:"hostname,omitempty"`
 	SrgbBegin     uint32                 `protobuf:"varint,5,opt,name=srgb_begin,json=srgbBegin,proto3" json:"srgb_begin,omitempty"`
 	SrgbEnd       uint32                 `protobuf:"varint,6,opt,name=srgb_end,json=srgbEnd,proto3" json:"srgb_end,omitempty"`
-	LsLinks       []*LsLink              `protobuf:"bytes,7,rep,name=ls_links,json=lsLinks,proto3" json:"ls_links,omitempty"`
-	LsPrefixes    []*LsPrefix            `protobuf:"bytes,8,rep,name=ls_prefixes,json=lsPrefixes,proto3" json:"ls_prefixes,omitempty"`
-	LsSrv6Sids    []*LsSrv6SID           `protobuf:"bytes,9,rep,name=ls_srv6_sids,json=lsSrv6Sids,proto3" json:"ls_srv6_sids,omitempty"`
+	Links         []*LsLink              `protobuf:"bytes,7,rep,name=links,proto3" json:"links,omitempty"`
+	Prefixes      []*LsPrefix            `protobuf:"bytes,8,rep,name=prefixes,proto3" json:"prefixes,omitempty"`
+	Srv6Sids      []*LsSrv6SID           `protobuf:"bytes,9,rep,name=srv6_sids,json=srv6Sids,proto3" json:"srv6_sids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *LsNode) Reset() {
 	*x = LsNode{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2369,7 +2718,7 @@ func (x *LsNode) String() string {
 func (*LsNode) ProtoMessage() {}
 
 func (x *LsNode) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2382,7 +2731,7 @@ func (x *LsNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsNode.ProtoReflect.Descriptor instead.
 func (*LsNode) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LsNode) GetAsn() uint32 {
@@ -2427,88 +2776,38 @@ func (x *LsNode) GetSrgbEnd() uint32 {
 	return 0
 }
 
-func (x *LsNode) GetLsLinks() []*LsLink {
+func (x *LsNode) GetLinks() []*LsLink {
 	if x != nil {
-		return x.LsLinks
+		return x.Links
 	}
 	return nil
 }
 
-func (x *LsNode) GetLsPrefixes() []*LsPrefix {
+func (x *LsNode) GetPrefixes() []*LsPrefix {
 	if x != nil {
-		return x.LsPrefixes
+		return x.Prefixes
 	}
 	return nil
 }
 
-func (x *LsNode) GetLsSrv6Sids() []*LsSrv6SID {
+func (x *LsNode) GetSrv6Sids() []*LsSrv6SID {
 	if x != nil {
-		return x.LsSrv6Sids
-	}
-	return nil
-}
-
-type TED struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Enable        bool                   `protobuf:"varint,1,opt,name=enable,proto3" json:"enable,omitempty"`
-	LsNodes       []*LsNode              `protobuf:"bytes,2,rep,name=ls_nodes,json=lsNodes,proto3" json:"ls_nodes,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *TED) Reset() {
-	*x = TED{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TED) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TED) ProtoMessage() {}
-
-func (x *TED) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TED.ProtoReflect.Descriptor instead.
-func (*TED) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
-}
-
-func (x *TED) GetEnable() bool {
-	if x != nil {
-		return x.Enable
-	}
-	return false
-}
-
-func (x *TED) GetLsNodes() []*LsNode {
-	if x != nil {
-		return x.LsNodes
+		return x.Srv6Sids
 	}
 	return nil
 }
 
 type GetSessionListRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	PeerAddr      []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`              // Empty selects every session.
+	IncludeStats  bool                   `protobuf:"varint,2,opt,name=include_stats,json=includeStats,proto3" json:"include_stats,omitempty"` // Include session message statistics.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetSessionListRequest) Reset() {
 	*x = GetSessionListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2520,7 +2819,7 @@ func (x *GetSessionListRequest) String() string {
 func (*GetSessionListRequest) ProtoMessage() {}
 
 func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2533,7 +2832,21 @@ func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListRequest.ProtoReflect.Descriptor instead.
 func (*GetSessionListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *GetSessionListRequest) GetPeerAddr() []byte {
+	if x != nil {
+		return x.PeerAddr
+	}
+	return nil
+}
+
+func (x *GetSessionListRequest) GetIncludeStats() bool {
+	if x != nil {
+		return x.IncludeStats
+	}
+	return false
 }
 
 type GetSessionListResponse struct {
@@ -2545,7 +2858,7 @@ type GetSessionListResponse struct {
 
 func (x *GetSessionListResponse) Reset() {
 	*x = GetSessionListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2557,7 +2870,7 @@ func (x *GetSessionListResponse) String() string {
 func (*GetSessionListResponse) ProtoMessage() {}
 
 func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2570,7 +2883,7 @@ func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListResponse.ProtoReflect.Descriptor instead.
 func (*GetSessionListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetSessionListResponse) GetSessions() []*Session {
@@ -2582,14 +2895,14 @@ func (x *GetSessionListResponse) GetSessions() []*Session {
 
 type GetSRPolicyListRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	SessionAddr   []byte                 `protobuf:"bytes,1,opt,name=session_addr,json=sessionAddr,proto3" json:"session_addr,omitempty"`
+	PeerAddr      []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetSRPolicyListRequest) Reset() {
 	*x = GetSRPolicyListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2601,7 +2914,7 @@ func (x *GetSRPolicyListRequest) String() string {
 func (*GetSRPolicyListRequest) ProtoMessage() {}
 
 func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2614,26 +2927,26 @@ func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListRequest.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
 }
 
-func (x *GetSRPolicyListRequest) GetSessionAddr() []byte {
+func (x *GetSRPolicyListRequest) GetPeerAddr() []byte {
 	if x != nil {
-		return x.SessionAddr
+		return x.PeerAddr
 	}
 	return nil
 }
 
 type GetSRPolicyListResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Sessions      []*Session             `protobuf:"bytes,2,rep,name=sessions,proto3" json:"sessions,omitempty"`
+	Sessions      []*SRPolicySession     `protobuf:"bytes,2,rep,name=sessions,proto3" json:"sessions,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetSRPolicyListResponse) Reset() {
 	*x = GetSRPolicyListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2645,7 +2958,7 @@ func (x *GetSRPolicyListResponse) String() string {
 func (*GetSRPolicyListResponse) ProtoMessage() {}
 
 func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2658,10 +2971,10 @@ func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListResponse.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
 }
 
-func (x *GetSRPolicyListResponse) GetSessions() []*Session {
+func (x *GetSRPolicyListResponse) GetSessions() []*SRPolicySession {
 	if x != nil {
 		return x.Sessions
 	}
@@ -2676,7 +2989,7 @@ type GetTEDRequest struct {
 
 func (x *GetTEDRequest) Reset() {
 	*x = GetTEDRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2688,7 +3001,7 @@ func (x *GetTEDRequest) String() string {
 func (*GetTEDRequest) ProtoMessage() {}
 
 func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2701,20 +3014,20 @@ func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDRequest.ProtoReflect.Descriptor instead.
 func (*GetTEDRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
 }
 
 type GetTEDResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Enable        bool                   `protobuf:"varint,1,opt,name=enable,proto3" json:"enable,omitempty"`
-	LsNodes       []*LsNode              `protobuf:"bytes,2,rep,name=ls_nodes,json=lsNodes,proto3" json:"ls_nodes,omitempty"`
+	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	Nodes         []*LsNode              `protobuf:"bytes,2,rep,name=nodes,proto3" json:"nodes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetTEDResponse) Reset() {
 	*x = GetTEDResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2726,7 +3039,7 @@ func (x *GetTEDResponse) String() string {
 func (*GetTEDResponse) ProtoMessage() {}
 
 func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2739,33 +3052,33 @@ func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDResponse.ProtoReflect.Descriptor instead.
 func (*GetTEDResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
 }
 
-func (x *GetTEDResponse) GetEnable() bool {
+func (x *GetTEDResponse) GetEnabled() bool {
 	if x != nil {
-		return x.Enable
+		return x.Enabled
 	}
 	return false
 }
 
-func (x *GetTEDResponse) GetLsNodes() []*LsNode {
+func (x *GetTEDResponse) GetNodes() []*LsNode {
 	if x != nil {
-		return x.LsNodes
+		return x.Nodes
 	}
 	return nil
 }
 
 type DeleteSessionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Addr          []byte                 `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	PeerAddr      []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DeleteSessionRequest) Reset() {
 	*x = DeleteSessionRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2777,7 +3090,7 @@ func (x *DeleteSessionRequest) String() string {
 func (*DeleteSessionRequest) ProtoMessage() {}
 
 func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2790,26 +3103,25 @@ func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{39}
 }
 
-func (x *DeleteSessionRequest) GetAddr() []byte {
+func (x *DeleteSessionRequest) GetPeerAddr() []byte {
 	if x != nil {
-		return x.Addr
+		return x.PeerAddr
 	}
 	return nil
 }
 
 type DeleteSessionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	IsSuccess     bool                   `protobuf:"varint,1,opt,name=is_success,json=isSuccess,proto3" json:"is_success,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DeleteSessionResponse) Reset() {
 	*x = DeleteSessionResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2821,7 +3133,7 @@ func (x *DeleteSessionResponse) String() string {
 func (*DeleteSessionResponse) ProtoMessage() {}
 
 func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2834,14 +3146,7 @@ func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
-}
-
-func (x *DeleteSessionResponse) GetIsSuccess() bool {
-	if x != nil {
-		return x.IsSuccess
-	}
-	return false
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{40}
 }
 
 var File_api_pola_v1_pola_proto protoreflect.FileDescriptor
@@ -2860,9 +3165,9 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"sid_absent\x18\x05 \x01(\bR\tsidAbsent\"9\n" +
 	"\bWaypoint\x12\x1b\n" +
 	"\trouter_id\x18\x01 \x01(\tR\brouterId\x12\x10\n" +
-	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xbb\x04\n" +
-	"\bSRPolicy\x12*\n" +
-	"\x11pcep_session_addr\x18\x01 \x01(\fR\x0fpcepSessionAddr\x12\x19\n" +
+	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xac\x04\n" +
+	"\bSRPolicy\x12\x1b\n" +
+	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12\x19\n" +
 	"\bsrc_addr\x18\x02 \x01(\fR\asrcAddr\x12\x19\n" +
 	"\bdst_addr\x18\x03 \x01(\fR\adstAddr\x12\"\n" +
 	"\rsrc_router_id\x18\x04 \x01(\tR\vsrcRouterId\x12\"\n" +
@@ -2885,16 +3190,14 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\tsr_policy\x18\x01 \x01(\v2\x15.api.pola.v1.SRPolicyR\bsrPolicy\x12\x10\n" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\x120\n" +
 	"\x14disable_path_compute\x18\x04 \x01(\bR\x12disablePathCompute\x12&\n" +
-	"\x0fno_sid_validate\x18\x05 \x01(\bR\rnoSidValidateJ\x04\b\x03\x10\x04R\fsid_validate\"7\n" +
-	"\x16CreateSRPolicyResponse\x12\x1d\n" +
-	"\n" +
-	"is_success\x18\x01 \x01(\bR\tisSuccess\"]\n" +
+	"\x0fno_sid_validate\x18\x05 \x01(\bR\rnoSidValidateJ\x04\b\x03\x10\x04R\fsid_validate\"*\n" +
+	"\x16CreateSRPolicyResponseJ\x04\b\x01\x10\x02R\n" +
+	"is_success\"]\n" +
 	"\x15DeleteSRPolicyRequest\x122\n" +
 	"\tsr_policy\x18\x01 \x01(\v2\x15.api.pola.v1.SRPolicyR\bsrPolicy\x12\x10\n" +
-	"\x03asn\x18\x02 \x01(\rR\x03asn\"7\n" +
-	"\x16DeleteSRPolicyResponse\x12\x1d\n" +
-	"\n" +
-	"is_success\x18\x01 \x01(\bR\tisSuccess\"\xab\x02\n" +
+	"\x03asn\x18\x02 \x01(\rR\x03asn\"*\n" +
+	"\x16DeleteSRPolicyResponseJ\x04\b\x01\x10\x02R\n" +
+	"is_success\"\xab\x02\n" +
 	"\x12StatefulCapability\x12\x1d\n" +
 	"\n" +
 	"lsp_update\x18\x01 \x01(\bR\tlspUpdate\x12,\n" +
@@ -2948,25 +3251,50 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x0fEffectiveTimers\x12\x1c\n" +
 	"\tkeepalive\x18\x01 \x01(\rR\tkeepalive\x12\x1d\n" +
 	"\n" +
-	"dead_timer\x18\x02 \x01(\rR\tdeadTimer\"\xa6\x05\n" +
-	"\aSession\x12\x12\n" +
-	"\x04addr\x18\x01 \x01(\fR\x04addr\x12/\n" +
-	"\x05state\x18\x02 \x01(\x0e2\x19.api.pola.v1.SessionStateR\x05state\x12\x1b\n" +
-	"\tis_synced\x18\x04 \x01(\bR\bisSynced\x12;\n" +
-	"\fcapabilities\x18\x05 \x03(\v2\x17.api.pola.v1.CapabilityR\fcapabilities\x126\n" +
-	"\vsr_policies\x18\x06 \x03(\v2\x15.api.pola.v1.SRPolicyR\n" +
-	"srPolicies\x12/\n" +
-	"\bpcc_type\x18\a \x01(\x0e2\x14.api.pola.v1.PccTypeR\apccType\x12B\n" +
-	"\x10pcc_capabilities\x18\b \x03(\v2\x17.api.pola.v1.CapabilityR\x0fpccCapabilities\x12=\n" +
-	"\flocal_timers\x18\t \x01(\v2\x1a.api.pola.v1.SessionTimersR\vlocalTimers\x129\n" +
+	"dead_timer\x18\x02 \x01(\rR\tdeadTimer\"8\n" +
+	"\x0eMessageCounter\x12\x12\n" +
+	"\x04sent\x18\x01 \x01(\x04R\x04sent\x12\x12\n" +
+	"\x04rcvd\x18\x02 \x01(\x04R\x04rcvd\"\xee\x03\n" +
+	"\fSessionStats\x129\n" +
+	"\tkeepalive\x18\x01 \x01(\v2\x1b.api.pola.v1.MessageCounterR\tkeepalive\x121\n" +
+	"\x05pcerr\x18\x02 \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05pcerr\x121\n" +
+	"\x05pcntf\x18\x03 \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05pcntf\x123\n" +
+	"\x06report\x18\x04 \x01(\v2\x1b.api.pola.v1.MessageCounterR\x06report\x123\n" +
+	"\x06update\x18\x05 \x01(\v2\x1b.api.pola.v1.MessageCounterR\x06update\x127\n" +
+	"\binitiate\x18\x06 \x01(\v2\x1b.api.pola.v1.MessageCounterR\binitiate\x12+\n" +
+	"\x11unrecognized_rcvd\x18\a \x01(\x04R\x10unrecognizedRcvd\x12!\n" +
+	"\fcorrupt_rcvd\x18\b \x01(\x04R\vcorruptRcvd\x12\"\n" +
+	"\rsess_setup_ok\x18\t \x01(\x04R\vsessSetupOk\x12&\n" +
+	"\x0fsess_setup_fail\x18\n" +
+	" \x01(\x04R\rsessSetupFail\"\xa4\a\n" +
+	"\aSession\x12\x1b\n" +
+	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12/\n" +
+	"\x05state\x18\x02 \x01(\x0e2\x19.api.pola.v1.SessionStateR\x05state\x12F\n" +
+	"\x12local_capabilities\x18\x05 \x03(\v2\x17.api.pola.v1.CapabilityR\x11localCapabilities\x12/\n" +
+	"\bpcc_type\x18\a \x01(\x0e2\x14.api.pola.v1.PccTypeR\apccType\x12D\n" +
+	"\x11peer_capabilities\x18\b \x03(\v2\x17.api.pola.v1.CapabilityR\x10peerCapabilities\x12=\n" +
+	"\flocal_timers\x18\t \x01(\v2\x1a.api.pola.v1.SessionTimersR\vlocalTimers\x12;\n" +
+	"\vpeer_timers\x18\n" +
+	" \x01(\v2\x1a.api.pola.v1.SessionTimersR\n" +
+	"peerTimers\x12-\n" +
+	"\x10local_session_id\x18\v \x01(\rH\x00R\x0elocalSessionId\x88\x01\x01\x12+\n" +
+	"\x0fpeer_session_id\x18\f \x01(\rH\x01R\rpeerSessionId\x88\x01\x01\x12G\n" +
+	"\x10effective_timers\x18\r \x01(\v2\x1c.api.pola.v1.EffectiveTimersR\x0feffectiveTimers\x12;\n" +
+	"\tinitiator\x18\x0e \x01(\x0e2\x1d.api.pola.v1.SessionInitiatorR\tinitiator\x12:\n" +
 	"\n" +
-	"pcc_timers\x18\n" +
-	" \x01(\v2\x1a.api.pola.v1.SessionTimersR\tpccTimers\x12-\n" +
-	"\x10local_session_id\x18\v \x01(\rH\x00R\x0elocalSessionId\x88\x01\x01\x12)\n" +
-	"\x0epcc_session_id\x18\f \x01(\rH\x01R\fpccSessionId\x88\x01\x01\x12G\n" +
-	"\x10effective_timers\x18\r \x01(\v2\x1c.api.pola.v1.EffectiveTimersR\x0feffectiveTimersB\x13\n" +
-	"\x11_local_session_idB\x11\n" +
-	"\x0f_pcc_session_idJ\x04\b\x03\x10\x04R\x04caps\"b\n" +
+	"sync_state\x18\x0f \x01(\x0e2\x1b.api.pola.v1.LspDbSyncStateR\tsyncState\x12/\n" +
+	"\x14created_at_unix_nano\x18\x10 \x01(\x03R\x11createdAtUnixNano\x127\n" +
+	"\x18established_at_unix_nano\x18\x11 \x01(\x03R\x15establishedAtUnixNano\x12/\n" +
+	"\x05stats\x18\x12 \x01(\v2\x19.api.pola.v1.SessionStatsR\x05statsB\x13\n" +
+	"\x11_local_session_idB\x12\n" +
+	"\x10_peer_session_idJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05J\x04\b\x06\x10\aR\x04capsR\tis_syncedR\vsr_policies\"\xd3\x01\n" +
+	"\x0fSRPolicySession\x12\x1b\n" +
+	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12/\n" +
+	"\x05state\x18\x02 \x01(\x0e2\x19.api.pola.v1.SessionStateR\x05state\x12:\n" +
+	"\n" +
+	"sync_state\x18\x03 \x01(\x0e2\x1b.api.pola.v1.LspDbSyncStateR\tsyncState\x126\n" +
+	"\vsr_policies\x18\x04 \x03(\v2\x15.api.pola.v1.SRPolicyR\n" +
+	"srPolicies\"b\n" +
 	"\x10EndpointBehavior\x12\x1a\n" +
 	"\bbehavior\x18\x01 \x01(\rR\bbehavior\x12\x14\n" +
 	"\x05flags\x18\x02 \x01(\rR\x05flags\x12\x1c\n" +
@@ -3010,7 +3338,7 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\tremote_ip\x18\x06 \x01(\tR\bremoteIp\x12-\n" +
 	"\ametrics\x18\a \x03(\v2\x13.api.pola.v1.MetricR\ametrics\x12\x17\n" +
 	"\aadj_sid\x18\b \x01(\rR\x06adjSid\x12=\n" +
-	"\x0esrv6_end_x_sid\x18\t \x01(\v2\x18.api.pola.v1.Srv6EndXSIDR\vsrv6EndXSid\"\xd1\x02\n" +
+	"\x0esrv6_end_x_sid\x18\t \x01(\v2\x18.api.pola.v1.Srv6EndXSIDR\vsrv6EndXSid\"\xc2\x02\n" +
 	"\x06LsNode\x12\x10\n" +
 	"\x03asn\x18\x01 \x01(\rR\x03asn\x12\x1b\n" +
 	"\trouter_id\x18\x02 \x01(\tR\brouterId\x12 \n" +
@@ -3019,31 +3347,27 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\bhostname\x18\x04 \x01(\tR\bhostname\x12\x1d\n" +
 	"\n" +
 	"srgb_begin\x18\x05 \x01(\rR\tsrgbBegin\x12\x19\n" +
-	"\bsrgb_end\x18\x06 \x01(\rR\asrgbEnd\x12.\n" +
-	"\bls_links\x18\a \x03(\v2\x13.api.pola.v1.LsLinkR\alsLinks\x126\n" +
-	"\vls_prefixes\x18\b \x03(\v2\x15.api.pola.v1.LsPrefixR\n" +
-	"lsPrefixes\x128\n" +
-	"\fls_srv6_sids\x18\t \x03(\v2\x16.api.pola.v1.LsSrv6SIDR\n" +
-	"lsSrv6Sids\"M\n" +
-	"\x03TED\x12\x16\n" +
-	"\x06enable\x18\x01 \x01(\bR\x06enable\x12.\n" +
-	"\bls_nodes\x18\x02 \x03(\v2\x13.api.pola.v1.LsNodeR\alsNodes\"\x17\n" +
-	"\x15GetSessionListRequest\"J\n" +
+	"\bsrgb_end\x18\x06 \x01(\rR\asrgbEnd\x12)\n" +
+	"\x05links\x18\a \x03(\v2\x13.api.pola.v1.LsLinkR\x05links\x121\n" +
+	"\bprefixes\x18\b \x03(\v2\x15.api.pola.v1.LsPrefixR\bprefixes\x123\n" +
+	"\tsrv6_sids\x18\t \x03(\v2\x16.api.pola.v1.LsSrv6SIDR\bsrv6Sids\"Y\n" +
+	"\x15GetSessionListRequest\x12\x1b\n" +
+	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12#\n" +
+	"\rinclude_stats\x18\x02 \x01(\bR\fincludeStats\"J\n" +
 	"\x16GetSessionListResponse\x120\n" +
-	"\bsessions\x18\x01 \x03(\v2\x14.api.pola.v1.SessionR\bsessions\";\n" +
-	"\x16GetSRPolicyListRequest\x12!\n" +
-	"\fsession_addr\x18\x01 \x01(\fR\vsessionAddr\"^\n" +
-	"\x17GetSRPolicyListResponse\x120\n" +
-	"\bsessions\x18\x02 \x03(\v2\x14.api.pola.v1.SessionR\bsessionsJ\x04\b\x01\x10\x02R\vsr_policies\"\x0f\n" +
-	"\rGetTEDRequest\"X\n" +
-	"\x0eGetTEDResponse\x12\x16\n" +
-	"\x06enable\x18\x01 \x01(\bR\x06enable\x12.\n" +
-	"\bls_nodes\x18\x02 \x03(\v2\x13.api.pola.v1.LsNodeR\alsNodes\"*\n" +
-	"\x14DeleteSessionRequest\x12\x12\n" +
-	"\x04addr\x18\x01 \x01(\fR\x04addr\"6\n" +
-	"\x15DeleteSessionResponse\x12\x1d\n" +
-	"\n" +
-	"is_success\x18\x01 \x01(\bR\tisSuccess*g\n" +
+	"\bsessions\x18\x01 \x03(\v2\x14.api.pola.v1.SessionR\bsessions\"5\n" +
+	"\x16GetSRPolicyListRequest\x12\x1b\n" +
+	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\"f\n" +
+	"\x17GetSRPolicyListResponse\x128\n" +
+	"\bsessions\x18\x02 \x03(\v2\x1c.api.pola.v1.SRPolicySessionR\bsessionsJ\x04\b\x01\x10\x02R\vsr_policies\"\x0f\n" +
+	"\rGetTEDRequest\"U\n" +
+	"\x0eGetTEDResponse\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12)\n" +
+	"\x05nodes\x18\x02 \x03(\v2\x13.api.pola.v1.LsNodeR\x05nodes\"3\n" +
+	"\x14DeleteSessionRequest\x12\x1b\n" +
+	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\")\n" +
+	"\x15DeleteSessionResponseJ\x04\b\x01\x10\x02R\n" +
+	"is_success*g\n" +
 	"\fSRPolicyType\x12\x1e\n" +
 	"\x1aSR_POLICY_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17SR_POLICY_TYPE_EXPLICIT\x10\x01\x12\x1a\n" +
@@ -3075,7 +3399,16 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x1eCAPABILITY_TYPE_LSP_DB_VERSION\x10\x06\x12\x1d\n" +
 	"\x19CAPABILITY_TYPE_MULTIPATH\x10\a\x12&\n" +
 	"\"CAPABILITY_TYPE_VENDOR_INFORMATION\x10\b\x12\x1b\n" +
-	"\x17CAPABILITY_TYPE_UNKNOWN\x10\t*\x83\x01\n" +
+	"\x17CAPABILITY_TYPE_UNKNOWN\x10\t*p\n" +
+	"\x10SessionInitiator\x12!\n" +
+	"\x1dSESSION_INITIATOR_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17SESSION_INITIATOR_LOCAL\x10\x01\x12\x1c\n" +
+	"\x18SESSION_INITIATOR_REMOTE\x10\x02*\x91\x01\n" +
+	"\x0eLspDbSyncState\x12!\n" +
+	"\x1dLSP_DB_SYNC_STATE_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19LSP_DB_SYNC_STATE_PENDING\x10\x01\x12\x1d\n" +
+	"\x19LSP_DB_SYNC_STATE_ONGOING\x10\x02\x12\x1e\n" +
+	"\x1aLSP_DB_SYNC_STATE_FINISHED\x10\x03*\x83\x01\n" +
 	"\n" +
 	"MetricType\x12\x1b\n" +
 	"\x17METRIC_TYPE_UNSPECIFIED\x10\x00\x12\x13\n" +
@@ -3104,114 +3437,128 @@ func file_api_pola_v1_pola_proto_rawDescGZIP() []byte {
 	return file_api_pola_v1_pola_proto_rawDescData
 }
 
-var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
+var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_api_pola_v1_pola_proto_goTypes = []any{
 	(SRPolicyType)(0),                   // 0: api.pola.v1.SRPolicyType
 	(SRPolicyState)(0),                  // 1: api.pola.v1.SRPolicyState
 	(SessionState)(0),                   // 2: api.pola.v1.SessionState
 	(PccType)(0),                        // 3: api.pola.v1.PccType
 	(CapabilityType)(0),                 // 4: api.pola.v1.CapabilityType
-	(MetricType)(0),                     // 5: api.pola.v1.MetricType
-	(*Segment)(nil),                     // 6: api.pola.v1.Segment
-	(*Waypoint)(nil),                    // 7: api.pola.v1.Waypoint
-	(*SRPolicy)(nil),                    // 8: api.pola.v1.SRPolicy
-	(*CreateSRPolicyRequest)(nil),       // 9: api.pola.v1.CreateSRPolicyRequest
-	(*CreateSRPolicyResponse)(nil),      // 10: api.pola.v1.CreateSRPolicyResponse
-	(*DeleteSRPolicyRequest)(nil),       // 11: api.pola.v1.DeleteSRPolicyRequest
-	(*DeleteSRPolicyResponse)(nil),      // 12: api.pola.v1.DeleteSRPolicyResponse
-	(*StatefulCapability)(nil),          // 13: api.pola.v1.StatefulCapability
-	(*SrCapability)(nil),                // 14: api.pola.v1.SrCapability
-	(*Srv6Capability)(nil),              // 15: api.pola.v1.Srv6Capability
-	(*PathSetupTypeCapability)(nil),     // 16: api.pola.v1.PathSetupTypeCapability
-	(*AssocTypeListCapability)(nil),     // 17: api.pola.v1.AssocTypeListCapability
-	(*LspDbVersionCapability)(nil),      // 18: api.pola.v1.LspDbVersionCapability
-	(*MultipathCapability)(nil),         // 19: api.pola.v1.MultipathCapability
-	(*VendorInformationCapability)(nil), // 20: api.pola.v1.VendorInformationCapability
-	(*UnknownCapability)(nil),           // 21: api.pola.v1.UnknownCapability
-	(*Capability)(nil),                  // 22: api.pola.v1.Capability
-	(*SessionTimers)(nil),               // 23: api.pola.v1.SessionTimers
-	(*EffectiveTimers)(nil),             // 24: api.pola.v1.EffectiveTimers
-	(*Session)(nil),                     // 25: api.pola.v1.Session
-	(*EndpointBehavior)(nil),            // 26: api.pola.v1.EndpointBehavior
-	(*SidStructure)(nil),                // 27: api.pola.v1.SidStructure
-	(*SID)(nil),                         // 28: api.pola.v1.SID
-	(*MultiTopoID)(nil),                 // 29: api.pola.v1.MultiTopoID
-	(*LsSrv6SID)(nil),                   // 30: api.pola.v1.LsSrv6SID
-	(*LsPrefix)(nil),                    // 31: api.pola.v1.LsPrefix
-	(*Metric)(nil),                      // 32: api.pola.v1.Metric
-	(*Srv6EndXSID)(nil),                 // 33: api.pola.v1.Srv6EndXSID
-	(*LsLink)(nil),                      // 34: api.pola.v1.LsLink
-	(*LsNode)(nil),                      // 35: api.pola.v1.LsNode
-	(*TED)(nil),                         // 36: api.pola.v1.TED
-	(*GetSessionListRequest)(nil),       // 37: api.pola.v1.GetSessionListRequest
-	(*GetSessionListResponse)(nil),      // 38: api.pola.v1.GetSessionListResponse
-	(*GetSRPolicyListRequest)(nil),      // 39: api.pola.v1.GetSRPolicyListRequest
-	(*GetSRPolicyListResponse)(nil),     // 40: api.pola.v1.GetSRPolicyListResponse
-	(*GetTEDRequest)(nil),               // 41: api.pola.v1.GetTEDRequest
-	(*GetTEDResponse)(nil),              // 42: api.pola.v1.GetTEDResponse
-	(*DeleteSessionRequest)(nil),        // 43: api.pola.v1.DeleteSessionRequest
-	(*DeleteSessionResponse)(nil),       // 44: api.pola.v1.DeleteSessionResponse
+	(SessionInitiator)(0),               // 5: api.pola.v1.SessionInitiator
+	(LspDbSyncState)(0),                 // 6: api.pola.v1.LspDbSyncState
+	(MetricType)(0),                     // 7: api.pola.v1.MetricType
+	(*Segment)(nil),                     // 8: api.pola.v1.Segment
+	(*Waypoint)(nil),                    // 9: api.pola.v1.Waypoint
+	(*SRPolicy)(nil),                    // 10: api.pola.v1.SRPolicy
+	(*CreateSRPolicyRequest)(nil),       // 11: api.pola.v1.CreateSRPolicyRequest
+	(*CreateSRPolicyResponse)(nil),      // 12: api.pola.v1.CreateSRPolicyResponse
+	(*DeleteSRPolicyRequest)(nil),       // 13: api.pola.v1.DeleteSRPolicyRequest
+	(*DeleteSRPolicyResponse)(nil),      // 14: api.pola.v1.DeleteSRPolicyResponse
+	(*StatefulCapability)(nil),          // 15: api.pola.v1.StatefulCapability
+	(*SrCapability)(nil),                // 16: api.pola.v1.SrCapability
+	(*Srv6Capability)(nil),              // 17: api.pola.v1.Srv6Capability
+	(*PathSetupTypeCapability)(nil),     // 18: api.pola.v1.PathSetupTypeCapability
+	(*AssocTypeListCapability)(nil),     // 19: api.pola.v1.AssocTypeListCapability
+	(*LspDbVersionCapability)(nil),      // 20: api.pola.v1.LspDbVersionCapability
+	(*MultipathCapability)(nil),         // 21: api.pola.v1.MultipathCapability
+	(*VendorInformationCapability)(nil), // 22: api.pola.v1.VendorInformationCapability
+	(*UnknownCapability)(nil),           // 23: api.pola.v1.UnknownCapability
+	(*Capability)(nil),                  // 24: api.pola.v1.Capability
+	(*SessionTimers)(nil),               // 25: api.pola.v1.SessionTimers
+	(*EffectiveTimers)(nil),             // 26: api.pola.v1.EffectiveTimers
+	(*MessageCounter)(nil),              // 27: api.pola.v1.MessageCounter
+	(*SessionStats)(nil),                // 28: api.pola.v1.SessionStats
+	(*Session)(nil),                     // 29: api.pola.v1.Session
+	(*SRPolicySession)(nil),             // 30: api.pola.v1.SRPolicySession
+	(*EndpointBehavior)(nil),            // 31: api.pola.v1.EndpointBehavior
+	(*SidStructure)(nil),                // 32: api.pola.v1.SidStructure
+	(*SID)(nil),                         // 33: api.pola.v1.SID
+	(*MultiTopoID)(nil),                 // 34: api.pola.v1.MultiTopoID
+	(*LsSrv6SID)(nil),                   // 35: api.pola.v1.LsSrv6SID
+	(*LsPrefix)(nil),                    // 36: api.pola.v1.LsPrefix
+	(*Metric)(nil),                      // 37: api.pola.v1.Metric
+	(*Srv6EndXSID)(nil),                 // 38: api.pola.v1.Srv6EndXSID
+	(*LsLink)(nil),                      // 39: api.pola.v1.LsLink
+	(*LsNode)(nil),                      // 40: api.pola.v1.LsNode
+	(*GetSessionListRequest)(nil),       // 41: api.pola.v1.GetSessionListRequest
+	(*GetSessionListResponse)(nil),      // 42: api.pola.v1.GetSessionListResponse
+	(*GetSRPolicyListRequest)(nil),      // 43: api.pola.v1.GetSRPolicyListRequest
+	(*GetSRPolicyListResponse)(nil),     // 44: api.pola.v1.GetSRPolicyListResponse
+	(*GetTEDRequest)(nil),               // 45: api.pola.v1.GetTEDRequest
+	(*GetTEDResponse)(nil),              // 46: api.pola.v1.GetTEDResponse
+	(*DeleteSessionRequest)(nil),        // 47: api.pola.v1.DeleteSessionRequest
+	(*DeleteSessionResponse)(nil),       // 48: api.pola.v1.DeleteSessionResponse
 }
 var file_api_pola_v1_pola_proto_depIdxs = []int32{
 	0,  // 0: api.pola.v1.SRPolicy.type:type_name -> api.pola.v1.SRPolicyType
-	6,  // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
-	5,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
-	7,  // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
+	8,  // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
+	7,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
+	9,  // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
 	1,  // 4: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
-	8,  // 5: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	8,  // 6: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	10, // 5: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	10, // 6: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
 	4,  // 7: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
-	13, // 8: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
-	14, // 9: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
-	15, // 10: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
-	16, // 11: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
-	17, // 12: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
-	18, // 13: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
-	19, // 14: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
-	20, // 15: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
-	21, // 16: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
-	2,  // 17: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
-	22, // 18: api.pola.v1.Session.capabilities:type_name -> api.pola.v1.Capability
-	8,  // 19: api.pola.v1.Session.sr_policies:type_name -> api.pola.v1.SRPolicy
-	3,  // 20: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
-	22, // 21: api.pola.v1.Session.pcc_capabilities:type_name -> api.pola.v1.Capability
-	23, // 22: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
-	23, // 23: api.pola.v1.Session.pcc_timers:type_name -> api.pola.v1.SessionTimers
-	24, // 24: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
-	28, // 25: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
-	26, // 26: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
-	27, // 27: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
-	29, // 28: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
-	5,  // 29: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
-	28, // 30: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
-	27, // 31: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	32, // 32: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	33, // 33: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
-	34, // 34: api.pola.v1.LsNode.ls_links:type_name -> api.pola.v1.LsLink
-	31, // 35: api.pola.v1.LsNode.ls_prefixes:type_name -> api.pola.v1.LsPrefix
-	30, // 36: api.pola.v1.LsNode.ls_srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	35, // 37: api.pola.v1.TED.ls_nodes:type_name -> api.pola.v1.LsNode
-	25, // 38: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	25, // 39: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.Session
-	35, // 40: api.pola.v1.GetTEDResponse.ls_nodes:type_name -> api.pola.v1.LsNode
-	9,  // 41: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	11, // 42: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	37, // 43: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	39, // 44: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	41, // 45: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	43, // 46: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	10, // 47: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	12, // 48: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	38, // 49: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	40, // 50: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	42, // 51: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	44, // 52: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	47, // [47:53] is the sub-list for method output_type
-	41, // [41:47] is the sub-list for method input_type
-	41, // [41:41] is the sub-list for extension type_name
-	41, // [41:41] is the sub-list for extension extendee
-	0,  // [0:41] is the sub-list for field type_name
+	15, // 8: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
+	16, // 9: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
+	17, // 10: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
+	18, // 11: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
+	19, // 12: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
+	20, // 13: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
+	21, // 14: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
+	22, // 15: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
+	23, // 16: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
+	27, // 17: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
+	27, // 18: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
+	27, // 19: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
+	27, // 20: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
+	27, // 21: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
+	27, // 22: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
+	2,  // 23: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
+	24, // 24: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
+	3,  // 25: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
+	24, // 26: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
+	25, // 27: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
+	25, // 28: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
+	26, // 29: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
+	5,  // 30: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
+	6,  // 31: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	28, // 32: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
+	2,  // 33: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
+	6,  // 34: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	10, // 35: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
+	33, // 36: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
+	31, // 37: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	32, // 38: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
+	34, // 39: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
+	7,  // 40: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
+	33, // 41: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
+	32, // 42: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
+	37, // 43: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	38, // 44: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
+	39, // 45: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
+	36, // 46: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
+	35, // 47: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	29, // 48: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	30, // 49: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
+	40, // 50: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
+	11, // 51: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	13, // 52: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	41, // 53: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	43, // 54: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	45, // 55: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	47, // 56: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	12, // 57: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	14, // 58: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	42, // 59: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	44, // 60: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	46, // 61: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	48, // 62: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	57, // [57:63] is the sub-list for method output_type
+	51, // [51:57] is the sub-list for method input_type
+	51, // [51:51] is the sub-list for extension type_name
+	51, // [51:51] is the sub-list for extension extendee
+	0,  // [0:51] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }
@@ -3230,15 +3577,15 @@ func file_api_pola_v1_pola_proto_init() {
 		(*Capability_VendorInformation)(nil),
 		(*Capability_Unknown)(nil),
 	}
-	file_api_pola_v1_pola_proto_msgTypes[19].OneofWrappers = []any{}
-	file_api_pola_v1_pola_proto_msgTypes[25].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[21].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[28].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_pola_v1_pola_proto_rawDesc), len(file_api_pola_v1_pola_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   39,
+			NumEnums:      8,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -1739,7 +1739,7 @@ func (x *EffectiveTimers) GetDeadTimer() uint32 {
 	return 0
 }
 
-// MessageCounter contains the sent and received message counters from RFC 9826 ietf-pcep-stats.
+// MessageCounter contains sent and received message counters.
 type MessageCounter struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Sent          uint64                 `protobuf:"varint,1,opt,name=sent,proto3" json:"sent,omitempty"`
@@ -1792,19 +1792,24 @@ func (x *MessageCounter) GetRcvd() uint64 {
 	return 0
 }
 
-// SessionStats contains the message counters defined by RFC 9826 ietf-pcep-stats.
+// SessionStats contains per-session PCEP message counters.
+// Open and close are Pola-specific additions.
 type SessionStats struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
-	Keepalive        *MessageCounter        `protobuf:"bytes,1,opt,name=keepalive,proto3" json:"keepalive,omitempty"`                                        // keepalive-sent / keepalive-rcvd
-	Pcerr            *MessageCounter        `protobuf:"bytes,2,opt,name=pcerr,proto3" json:"pcerr,omitempty"`                                                // pcerr-sent / pcerr-rcvd
-	Pcntf            *MessageCounter        `protobuf:"bytes,3,opt,name=pcntf,proto3" json:"pcntf,omitempty"`                                                // pcntf-sent / pcntf-rcvd
-	Report           *MessageCounter        `protobuf:"bytes,4,opt,name=report,proto3" json:"report,omitempty"`                                              // rpt-sent / rpt-rcvd (stateful)
-	Update           *MessageCounter        `protobuf:"bytes,5,opt,name=update,proto3" json:"update,omitempty"`                                              // upd-sent / upd-rcvd (stateful)
-	Initiate         *MessageCounter        `protobuf:"bytes,6,opt,name=initiate,proto3" json:"initiate,omitempty"`                                          // pcinitiate-sent / pcinitiate-rcvd (initiation)
-	UnrecognizedRcvd uint64                 `protobuf:"varint,7,opt,name=unrecognized_rcvd,json=unrecognizedRcvd,proto3" json:"unrecognized_rcvd,omitempty"` // unknown-rcvd
-	CorruptRcvd      uint64                 `protobuf:"varint,8,opt,name=corrupt_rcvd,json=corruptRcvd,proto3" json:"corrupt_rcvd,omitempty"`                // corrupt-rcvd
-	SessSetupOk      uint64                 `protobuf:"varint,9,opt,name=sess_setup_ok,json=sessSetupOk,proto3" json:"sess_setup_ok,omitempty"`              // sess-setup-ok (per peer, survives session teardown)
-	SessSetupFail    uint64                 `protobuf:"varint,10,opt,name=sess_setup_fail,json=sessSetupFail,proto3" json:"sess_setup_fail,omitempty"`       // sess-setup-fail (per peer, survives session teardown)
+	Keepalive        *MessageCounter        `protobuf:"bytes,1,opt,name=keepalive,proto3" json:"keepalive,omitempty"`                                        // keepalive-sent / keepalive-rcvd (RFC 9826)
+	Pcerr            *MessageCounter        `protobuf:"bytes,2,opt,name=pcerr,proto3" json:"pcerr,omitempty"`                                                // pcerr-sent / pcerr-rcvd (RFC 9826)
+	Pcntf            *MessageCounter        `protobuf:"bytes,3,opt,name=pcntf,proto3" json:"pcntf,omitempty"`                                                // pcntf-sent / pcntf-rcvd (RFC 9826)
+	Report           *MessageCounter        `protobuf:"bytes,4,opt,name=report,proto3" json:"report,omitempty"`                                              // rpt-sent / rpt-rcvd (RFC 9826, stateful)
+	Update           *MessageCounter        `protobuf:"bytes,5,opt,name=update,proto3" json:"update,omitempty"`                                              // upd-sent / upd-rcvd (RFC 9826, stateful)
+	Initiate         *MessageCounter        `protobuf:"bytes,6,opt,name=initiate,proto3" json:"initiate,omitempty"`                                          // pcinitiate-sent / pcinitiate-rcvd (RFC 9826, initiation)
+	UnrecognizedRcvd uint64                 `protobuf:"varint,7,opt,name=unrecognized_rcvd,json=unrecognizedRcvd,proto3" json:"unrecognized_rcvd,omitempty"` // unknown-rcvd (RFC 9826)
+	CorruptRcvd      uint64                 `protobuf:"varint,8,opt,name=corrupt_rcvd,json=corruptRcvd,proto3" json:"corrupt_rcvd,omitempty"`                // corrupt-rcvd (RFC 9826)
+	SessSetupOk      uint64                 `protobuf:"varint,9,opt,name=sess_setup_ok,json=sessSetupOk,proto3" json:"sess_setup_ok,omitempty"`              // sess-setup-ok (RFC 9826; per peer, survives session teardown)
+	SessSetupFail    uint64                 `protobuf:"varint,10,opt,name=sess_setup_fail,json=sessSetupFail,proto3" json:"sess_setup_fail,omitempty"`       // sess-setup-fail (RFC 9826; per peer, survives session teardown)
+	Open             *MessageCounter        `protobuf:"bytes,11,opt,name=open,proto3" json:"open,omitempty"`                                                 // open-sent / open-rcvd (Pola-specific, not in RFC 9826)
+	Close            *MessageCounter        `protobuf:"bytes,12,opt,name=close,proto3" json:"close,omitempty"`                                               // close-sent / close-rcvd (Pola-specific, not in RFC 9826)
+	Pcreq            *MessageCounter        `protobuf:"bytes,13,opt,name=pcreq,proto3" json:"pcreq,omitempty"`                                               // pcreq-sent / pcreq-rcvd (RFC 9826)
+	Pcrep            *MessageCounter        `protobuf:"bytes,14,opt,name=pcrep,proto3" json:"pcrep,omitempty"`                                               // pcrep-sent / pcrep-rcvd (RFC 9826)
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -1907,6 +1912,34 @@ func (x *SessionStats) GetSessSetupFail() uint64 {
 		return x.SessSetupFail
 	}
 	return 0
+}
+
+func (x *SessionStats) GetOpen() *MessageCounter {
+	if x != nil {
+		return x.Open
+	}
+	return nil
+}
+
+func (x *SessionStats) GetClose() *MessageCounter {
+	if x != nil {
+		return x.Close
+	}
+	return nil
+}
+
+func (x *SessionStats) GetPcreq() *MessageCounter {
+	if x != nil {
+		return x.Pcreq
+	}
+	return nil
+}
+
+func (x *SessionStats) GetPcrep() *MessageCounter {
+	if x != nil {
+		return x.Pcrep
+	}
+	return nil
 }
 
 type Session struct {
@@ -3257,7 +3290,7 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"dead_timer\x18\x02 \x01(\rR\tdeadTimer\"8\n" +
 	"\x0eMessageCounter\x12\x12\n" +
 	"\x04sent\x18\x01 \x01(\x04R\x04sent\x12\x12\n" +
-	"\x04rcvd\x18\x02 \x01(\x04R\x04rcvd\"\xee\x03\n" +
+	"\x04rcvd\x18\x02 \x01(\x04R\x04rcvd\"\xb8\x05\n" +
 	"\fSessionStats\x129\n" +
 	"\tkeepalive\x18\x01 \x01(\v2\x1b.api.pola.v1.MessageCounterR\tkeepalive\x121\n" +
 	"\x05pcerr\x18\x02 \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05pcerr\x121\n" +
@@ -3269,7 +3302,11 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\fcorrupt_rcvd\x18\b \x01(\x04R\vcorruptRcvd\x12\"\n" +
 	"\rsess_setup_ok\x18\t \x01(\x04R\vsessSetupOk\x12&\n" +
 	"\x0fsess_setup_fail\x18\n" +
-	" \x01(\x04R\rsessSetupFail\"\xa4\a\n" +
+	" \x01(\x04R\rsessSetupFail\x12/\n" +
+	"\x04open\x18\v \x01(\v2\x1b.api.pola.v1.MessageCounterR\x04open\x121\n" +
+	"\x05close\x18\f \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05close\x121\n" +
+	"\x05pcreq\x18\r \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05pcreq\x121\n" +
+	"\x05pcrep\x18\x0e \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05pcrep\"\xa4\a\n" +
 	"\aSession\x12\x1b\n" +
 	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12/\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x19.api.pola.v1.SessionStateR\x05state\x12F\n" +
@@ -3517,51 +3554,55 @@ var file_api_pola_v1_pola_proto_depIdxs = []int32{
 	27, // 20: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
 	27, // 21: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
 	27, // 22: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
-	2,  // 23: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
-	24, // 24: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
-	3,  // 25: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
-	24, // 26: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
-	25, // 27: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
-	25, // 28: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
-	26, // 29: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
-	5,  // 30: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
-	6,  // 31: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	28, // 32: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
-	2,  // 33: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
-	6,  // 34: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	10, // 35: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
-	33, // 36: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
-	31, // 37: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
-	32, // 38: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
-	34, // 39: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
-	7,  // 40: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
-	33, // 41: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
-	32, // 42: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	37, // 43: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	38, // 44: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
-	39, // 45: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
-	36, // 46: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
-	35, // 47: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	29, // 48: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	30, // 49: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
-	40, // 50: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
-	11, // 51: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	13, // 52: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	41, // 53: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	43, // 54: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	45, // 55: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	47, // 56: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	12, // 57: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	14, // 58: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	42, // 59: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	44, // 60: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	46, // 61: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	48, // 62: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	57, // [57:63] is the sub-list for method output_type
-	51, // [51:57] is the sub-list for method input_type
-	51, // [51:51] is the sub-list for extension type_name
-	51, // [51:51] is the sub-list for extension extendee
-	0,  // [0:51] is the sub-list for field type_name
+	27, // 23: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
+	27, // 24: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
+	27, // 25: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
+	27, // 26: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
+	2,  // 27: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
+	24, // 28: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
+	3,  // 29: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
+	24, // 30: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
+	25, // 31: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
+	25, // 32: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
+	26, // 33: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
+	5,  // 34: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
+	6,  // 35: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	28, // 36: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
+	2,  // 37: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
+	6,  // 38: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	10, // 39: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
+	33, // 40: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
+	31, // 41: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	32, // 42: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
+	34, // 43: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
+	7,  // 44: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
+	33, // 45: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
+	32, // 46: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
+	37, // 47: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	38, // 48: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
+	39, // 49: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
+	36, // 50: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
+	35, // 51: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	29, // 52: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	30, // 53: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
+	40, // 54: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
+	11, // 55: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	13, // 56: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	41, // 57: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	43, // 58: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	45, // 59: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	47, // 60: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	12, // 61: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	14, // 62: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	42, // 63: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	44, // 64: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	46, // 65: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	48, // 66: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	61, // [61:67] is the sub-list for method output_type
+	55, // [55:61] is the sub-list for method input_type
+	55, // [55:55] is the sub-list for extension type_name
+	55, // [55:55] is the sub-list for extension extendee
+	0,  // [0:55] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -134,21 +134,27 @@ type SessionState int32
 
 const (
 	SessionState_SESSION_STATE_UNSPECIFIED SessionState = 0
-	SessionState_SESSION_STATE_DOWN        SessionState = 1
 	SessionState_SESSION_STATE_UP          SessionState = 2
+	SessionState_SESSION_STATE_TCP_PENDING SessionState = 3
+	SessionState_SESSION_STATE_OPEN_WAIT   SessionState = 4
+	SessionState_SESSION_STATE_KEEP_WAIT   SessionState = 5
 )
 
 // Enum value maps for SessionState.
 var (
 	SessionState_name = map[int32]string{
 		0: "SESSION_STATE_UNSPECIFIED",
-		1: "SESSION_STATE_DOWN",
 		2: "SESSION_STATE_UP",
+		3: "SESSION_STATE_TCP_PENDING",
+		4: "SESSION_STATE_OPEN_WAIT",
+		5: "SESSION_STATE_KEEP_WAIT",
 	}
 	SessionState_value = map[string]int32{
 		"SESSION_STATE_UNSPECIFIED": 0,
-		"SESSION_STATE_DOWN":        1,
 		"SESSION_STATE_UP":          2,
+		"SESSION_STATE_TCP_PENDING": 3,
+		"SESSION_STATE_OPEN_WAIT":   4,
+		"SESSION_STATE_KEEP_WAIT":   5,
 	}
 )
 
@@ -177,6 +183,58 @@ func (x SessionState) Number() protoreflect.EnumNumber {
 // Deprecated: Use SessionState.Descriptor instead.
 func (SessionState) EnumDescriptor() ([]byte, []int) {
 	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
+}
+
+type PccType int32
+
+const (
+	PccType_PCC_TYPE_UNSPECIFIED    PccType = 0
+	PccType_PCC_TYPE_CISCO_LEGACY   PccType = 1
+	PccType_PCC_TYPE_JUNIPER_LEGACY PccType = 2
+	PccType_PCC_TYPE_RFC_COMPLIANT  PccType = 3
+)
+
+// Enum value maps for PccType.
+var (
+	PccType_name = map[int32]string{
+		0: "PCC_TYPE_UNSPECIFIED",
+		1: "PCC_TYPE_CISCO_LEGACY",
+		2: "PCC_TYPE_JUNIPER_LEGACY",
+		3: "PCC_TYPE_RFC_COMPLIANT",
+	}
+	PccType_value = map[string]int32{
+		"PCC_TYPE_UNSPECIFIED":    0,
+		"PCC_TYPE_CISCO_LEGACY":   1,
+		"PCC_TYPE_JUNIPER_LEGACY": 2,
+		"PCC_TYPE_RFC_COMPLIANT":  3,
+	}
+)
+
+func (x PccType) Enum() *PccType {
+	p := new(PccType)
+	*p = x
+	return p
+}
+
+func (x PccType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PccType) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_pola_v1_pola_proto_enumTypes[3].Descriptor()
+}
+
+func (PccType) Type() protoreflect.EnumType {
+	return &file_api_pola_v1_pola_proto_enumTypes[3]
+}
+
+func (x PccType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PccType.Descriptor instead.
+func (PccType) EnumDescriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
 }
 
 type CapabilityType int32
@@ -233,11 +291,11 @@ func (x CapabilityType) String() string {
 }
 
 func (CapabilityType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[3].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[4].Descriptor()
 }
 
 func (CapabilityType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[3]
+	return &file_api_pola_v1_pola_proto_enumTypes[4]
 }
 
 func (x CapabilityType) Number() protoreflect.EnumNumber {
@@ -246,7 +304,7 @@ func (x CapabilityType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CapabilityType.Descriptor instead.
 func (CapabilityType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
 }
 
 type MetricType int32
@@ -288,11 +346,11 @@ func (x MetricType) String() string {
 }
 
 func (MetricType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[4].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[5].Descriptor()
 }
 
 func (MetricType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[4]
+	return &file_api_pola_v1_pola_proto_enumTypes[5]
 }
 
 func (x MetricType) Number() protoreflect.EnumNumber {
@@ -301,17 +359,16 @@ func (x MetricType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use MetricType.Descriptor instead.
 func (MetricType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
 }
 
 type Segment struct {
-	state        protoimpl.MessageState `protogen:"open.v1"`
-	Sid          string                 `protobuf:"bytes,1,opt,name=sid,proto3" json:"sid,omitempty"`
-	SidStructure string                 `protobuf:"bytes,2,opt,name=sid_structure,json=sidStructure,proto3" json:"sid_structure,omitempty"`
-	LocalAddr    string                 `protobuf:"bytes,3,opt,name=local_addr,json=localAddr,proto3" json:"local_addr,omitempty"`
-	RemoteAddr   string                 `protobuf:"bytes,4,opt,name=remote_addr,json=remoteAddr,proto3" json:"remote_addr,omitempty"`
-	// sid_absent indicates that the SID is omitted and the NAI identifies the segment.
-	SidAbsent     bool `protobuf:"varint,5,opt,name=sid_absent,json=sidAbsent,proto3" json:"sid_absent,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sid           string                 `protobuf:"bytes,1,opt,name=sid,proto3" json:"sid,omitempty"`
+	SidStructure  string                 `protobuf:"bytes,2,opt,name=sid_structure,json=sidStructure,proto3" json:"sid_structure,omitempty"`
+	LocalAddr     string                 `protobuf:"bytes,3,opt,name=local_addr,json=localAddr,proto3" json:"local_addr,omitempty"`
+	RemoteAddr    string                 `protobuf:"bytes,4,opt,name=remote_addr,json=remoteAddr,proto3" json:"remote_addr,omitempty"`
+	SidAbsent     bool                   `protobuf:"varint,5,opt,name=sid_absent,json=sidAbsent,proto3" json:"sid_absent,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -590,17 +647,13 @@ func (x *SRPolicy) GetState() SRPolicyState {
 }
 
 type CreateSRPolicyRequest struct {
-	state    protoimpl.MessageState `protogen:"open.v1"`
-	SrPolicy *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
-	// Not required when disable_path_compute is true.
-	Asn uint32 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
-	// Use endpoints and segments provided in the request without TED lookup
-	// or path computation (no CSPF or router-ID resolution).
-	DisablePathCompute bool `protobuf:"varint,4,opt,name=disable_path_compute,json=disablePathCompute,proto3" json:"disable_path_compute,omitempty"`
-	// Skip checking that explicit SIDs exist in the TED.
-	NoSidValidate bool `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	SrPolicy           *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
+	Asn                uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
+	DisablePathCompute bool                   `protobuf:"varint,4,opt,name=disable_path_compute,json=disablePathCompute,proto3" json:"disable_path_compute,omitempty"`
+	NoSidValidate      bool                   `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *CreateSRPolicyRequest) Reset() {
@@ -1495,21 +1548,131 @@ func (*Capability_VendorInformation) isCapability_Detail() {}
 
 func (*Capability_Unknown) isCapability_Detail() {}
 
-type Session struct {
-	state        protoimpl.MessageState `protogen:"open.v1"`
-	Addr         []byte                 `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	State        SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
-	IsSynced     bool                   `protobuf:"varint,4,opt,name=is_synced,json=isSynced,proto3" json:"is_synced,omitempty"`
-	Capabilities []*Capability          `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
-	// Populated by GetSRPolicyList; empty when returned from GetSessionList.
-	SrPolicies    []*SRPolicy `protobuf:"bytes,6,rep,name=sr_policies,json=srPolicies,proto3" json:"sr_policies,omitempty"`
+type SessionTimers struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keepalive     uint32                 `protobuf:"varint,1,opt,name=keepalive,proto3" json:"keepalive,omitempty"`
+	DeadTimer     uint32                 `protobuf:"varint,2,opt,name=dead_timer,json=deadTimer,proto3" json:"dead_timer,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *SessionTimers) Reset() {
+	*x = SessionTimers{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionTimers) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionTimers) ProtoMessage() {}
+
+func (x *SessionTimers) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionTimers.ProtoReflect.Descriptor instead.
+func (*SessionTimers) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *SessionTimers) GetKeepalive() uint32 {
+	if x != nil {
+		return x.Keepalive
+	}
+	return 0
+}
+
+func (x *SessionTimers) GetDeadTimer() uint32 {
+	if x != nil {
+		return x.DeadTimer
+	}
+	return 0
+}
+
+type EffectiveTimers struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keepalive     uint32                 `protobuf:"varint,1,opt,name=keepalive,proto3" json:"keepalive,omitempty"`
+	DeadTimer     uint32                 `protobuf:"varint,2,opt,name=dead_timer,json=deadTimer,proto3" json:"dead_timer,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EffectiveTimers) Reset() {
+	*x = EffectiveTimers{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EffectiveTimers) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EffectiveTimers) ProtoMessage() {}
+
+func (x *EffectiveTimers) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EffectiveTimers.ProtoReflect.Descriptor instead.
+func (*EffectiveTimers) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *EffectiveTimers) GetKeepalive() uint32 {
+	if x != nil {
+		return x.Keepalive
+	}
+	return 0
+}
+
+func (x *EffectiveTimers) GetDeadTimer() uint32 {
+	if x != nil {
+		return x.DeadTimer
+	}
+	return 0
+}
+
+type Session struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Addr            []byte                 `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	State           SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
+	IsSynced        bool                   `protobuf:"varint,4,opt,name=is_synced,json=isSynced,proto3" json:"is_synced,omitempty"`
+	Capabilities    []*Capability          `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	SrPolicies      []*SRPolicy            `protobuf:"bytes,6,rep,name=sr_policies,json=srPolicies,proto3" json:"sr_policies,omitempty"`
+	PccType         PccType                `protobuf:"varint,7,opt,name=pcc_type,json=pccType,proto3,enum=api.pola.v1.PccType" json:"pcc_type,omitempty"`
+	PccCapabilities []*Capability          `protobuf:"bytes,8,rep,name=pcc_capabilities,json=pccCapabilities,proto3" json:"pcc_capabilities,omitempty"`
+	LocalTimers     *SessionTimers         `protobuf:"bytes,9,opt,name=local_timers,json=localTimers,proto3" json:"local_timers,omitempty"`
+	PccTimers       *SessionTimers         `protobuf:"bytes,10,opt,name=pcc_timers,json=pccTimers,proto3" json:"pcc_timers,omitempty"`
+	LocalSessionId  *uint32                `protobuf:"varint,11,opt,name=local_session_id,json=localSessionId,proto3,oneof" json:"local_session_id,omitempty"`
+	PccSessionId    *uint32                `protobuf:"varint,12,opt,name=pcc_session_id,json=pccSessionId,proto3,oneof" json:"pcc_session_id,omitempty"`
+	EffectiveTimers *EffectiveTimers       `protobuf:"bytes,13,opt,name=effective_timers,json=effectiveTimers,proto3" json:"effective_timers,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
 func (x *Session) Reset() {
 	*x = Session{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1521,7 +1684,7 @@ func (x *Session) String() string {
 func (*Session) ProtoMessage() {}
 
 func (x *Session) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1534,7 +1697,7 @@ func (x *Session) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Session.ProtoReflect.Descriptor instead.
 func (*Session) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{17}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *Session) GetAddr() []byte {
@@ -1572,6 +1735,55 @@ func (x *Session) GetSrPolicies() []*SRPolicy {
 	return nil
 }
 
+func (x *Session) GetPccType() PccType {
+	if x != nil {
+		return x.PccType
+	}
+	return PccType_PCC_TYPE_UNSPECIFIED
+}
+
+func (x *Session) GetPccCapabilities() []*Capability {
+	if x != nil {
+		return x.PccCapabilities
+	}
+	return nil
+}
+
+func (x *Session) GetLocalTimers() *SessionTimers {
+	if x != nil {
+		return x.LocalTimers
+	}
+	return nil
+}
+
+func (x *Session) GetPccTimers() *SessionTimers {
+	if x != nil {
+		return x.PccTimers
+	}
+	return nil
+}
+
+func (x *Session) GetLocalSessionId() uint32 {
+	if x != nil && x.LocalSessionId != nil {
+		return *x.LocalSessionId
+	}
+	return 0
+}
+
+func (x *Session) GetPccSessionId() uint32 {
+	if x != nil && x.PccSessionId != nil {
+		return *x.PccSessionId
+	}
+	return 0
+}
+
+func (x *Session) GetEffectiveTimers() *EffectiveTimers {
+	if x != nil {
+		return x.EffectiveTimers
+	}
+	return nil
+}
+
 type EndpointBehavior struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Behavior      uint32                 `protobuf:"varint,1,opt,name=behavior,proto3" json:"behavior,omitempty"`
@@ -1583,7 +1795,7 @@ type EndpointBehavior struct {
 
 func (x *EndpointBehavior) Reset() {
 	*x = EndpointBehavior{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1595,7 +1807,7 @@ func (x *EndpointBehavior) String() string {
 func (*EndpointBehavior) ProtoMessage() {}
 
 func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1608,7 +1820,7 @@ func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointBehavior.ProtoReflect.Descriptor instead.
 func (*EndpointBehavior) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{18}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *EndpointBehavior) GetBehavior() uint32 {
@@ -1644,7 +1856,7 @@ type SidStructure struct {
 
 func (x *SidStructure) Reset() {
 	*x = SidStructure{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1656,7 +1868,7 @@ func (x *SidStructure) String() string {
 func (*SidStructure) ProtoMessage() {}
 
 func (x *SidStructure) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1669,7 +1881,7 @@ func (x *SidStructure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidStructure.ProtoReflect.Descriptor instead.
 func (*SidStructure) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SidStructure) GetLocalBlock() uint32 {
@@ -1709,7 +1921,7 @@ type SID struct {
 
 func (x *SID) Reset() {
 	*x = SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1721,7 +1933,7 @@ func (x *SID) String() string {
 func (*SID) ProtoMessage() {}
 
 func (x *SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1734,7 +1946,7 @@ func (x *SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SID.ProtoReflect.Descriptor instead.
 func (*SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SID) GetSid() string {
@@ -1753,7 +1965,7 @@ type MultiTopoID struct {
 
 func (x *MultiTopoID) Reset() {
 	*x = MultiTopoID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1765,7 +1977,7 @@ func (x *MultiTopoID) String() string {
 func (*MultiTopoID) ProtoMessage() {}
 
 func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1778,7 +1990,7 @@ func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultiTopoID.ProtoReflect.Descriptor instead.
 func (*MultiTopoID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *MultiTopoID) GetMultiTopoId() uint32 {
@@ -1800,7 +2012,7 @@ type LsSrv6SID struct {
 
 func (x *LsSrv6SID) Reset() {
 	*x = LsSrv6SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1812,7 +2024,7 @@ func (x *LsSrv6SID) String() string {
 func (*LsSrv6SID) ProtoMessage() {}
 
 func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1825,7 +2037,7 @@ func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6SID.ProtoReflect.Descriptor instead.
 func (*LsSrv6SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *LsSrv6SID) GetSids() []*SID {
@@ -1866,7 +2078,7 @@ type LsPrefix struct {
 
 func (x *LsPrefix) Reset() {
 	*x = LsPrefix{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1878,7 +2090,7 @@ func (x *LsPrefix) String() string {
 func (*LsPrefix) ProtoMessage() {}
 
 func (x *LsPrefix) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1891,7 +2103,7 @@ func (x *LsPrefix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsPrefix.ProtoReflect.Descriptor instead.
 func (*LsPrefix) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *LsPrefix) GetPrefix() string {
@@ -1918,7 +2130,7 @@ type Metric struct {
 
 func (x *Metric) Reset() {
 	*x = Metric{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1930,7 +2142,7 @@ func (x *Metric) String() string {
 func (*Metric) ProtoMessage() {}
 
 func (x *Metric) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1943,7 +2155,7 @@ func (x *Metric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metric.ProtoReflect.Descriptor instead.
 func (*Metric) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *Metric) GetType() MetricType {
@@ -1971,7 +2183,7 @@ type Srv6EndXSID struct {
 
 func (x *Srv6EndXSID) Reset() {
 	*x = Srv6EndXSID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1983,7 +2195,7 @@ func (x *Srv6EndXSID) String() string {
 func (*Srv6EndXSID) ProtoMessage() {}
 
 func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1996,7 +2208,7 @@ func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Srv6EndXSID.ProtoReflect.Descriptor instead.
 func (*Srv6EndXSID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Srv6EndXSID) GetEndpointBehavior() uint32 {
@@ -2037,7 +2249,7 @@ type LsLink struct {
 
 func (x *LsLink) Reset() {
 	*x = LsLink{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2049,7 +2261,7 @@ func (x *LsLink) String() string {
 func (*LsLink) ProtoMessage() {}
 
 func (x *LsLink) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2062,7 +2274,7 @@ func (x *LsLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsLink.ProtoReflect.Descriptor instead.
 func (*LsLink) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LsLink) GetLocalRouterId() string {
@@ -2145,7 +2357,7 @@ type LsNode struct {
 
 func (x *LsNode) Reset() {
 	*x = LsNode{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2157,7 +2369,7 @@ func (x *LsNode) String() string {
 func (*LsNode) ProtoMessage() {}
 
 func (x *LsNode) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2170,7 +2382,7 @@ func (x *LsNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsNode.ProtoReflect.Descriptor instead.
 func (*LsNode) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *LsNode) GetAsn() uint32 {
@@ -2246,7 +2458,7 @@ type TED struct {
 
 func (x *TED) Reset() {
 	*x = TED{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2258,7 +2470,7 @@ func (x *TED) String() string {
 func (*TED) ProtoMessage() {}
 
 func (x *TED) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2271,7 +2483,7 @@ func (x *TED) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TED.ProtoReflect.Descriptor instead.
 func (*TED) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *TED) GetEnable() bool {
@@ -2296,7 +2508,7 @@ type GetSessionListRequest struct {
 
 func (x *GetSessionListRequest) Reset() {
 	*x = GetSessionListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2308,7 +2520,7 @@ func (x *GetSessionListRequest) String() string {
 func (*GetSessionListRequest) ProtoMessage() {}
 
 func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2321,7 +2533,7 @@ func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListRequest.ProtoReflect.Descriptor instead.
 func (*GetSessionListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
 }
 
 type GetSessionListResponse struct {
@@ -2333,7 +2545,7 @@ type GetSessionListResponse struct {
 
 func (x *GetSessionListResponse) Reset() {
 	*x = GetSessionListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2345,7 +2557,7 @@ func (x *GetSessionListResponse) String() string {
 func (*GetSessionListResponse) ProtoMessage() {}
 
 func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2358,7 +2570,7 @@ func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListResponse.ProtoReflect.Descriptor instead.
 func (*GetSessionListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetSessionListResponse) GetSessions() []*Session {
@@ -2369,16 +2581,15 @@ func (x *GetSessionListResponse) GetSessions() []*Session {
 }
 
 type GetSRPolicyListRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Optional filter: only return policies for the PCEP session with this peer address.
-	SessionAddr   []byte `protobuf:"bytes,1,opt,name=session_addr,json=sessionAddr,proto3" json:"session_addr,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionAddr   []byte                 `protobuf:"bytes,1,opt,name=session_addr,json=sessionAddr,proto3" json:"session_addr,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetSRPolicyListRequest) Reset() {
 	*x = GetSRPolicyListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2390,7 +2601,7 @@ func (x *GetSRPolicyListRequest) String() string {
 func (*GetSRPolicyListRequest) ProtoMessage() {}
 
 func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2403,7 +2614,7 @@ func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListRequest.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetSRPolicyListRequest) GetSessionAddr() []byte {
@@ -2422,7 +2633,7 @@ type GetSRPolicyListResponse struct {
 
 func (x *GetSRPolicyListResponse) Reset() {
 	*x = GetSRPolicyListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2434,7 +2645,7 @@ func (x *GetSRPolicyListResponse) String() string {
 func (*GetSRPolicyListResponse) ProtoMessage() {}
 
 func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2447,7 +2658,7 @@ func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListResponse.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetSRPolicyListResponse) GetSessions() []*Session {
@@ -2465,7 +2676,7 @@ type GetTEDRequest struct {
 
 func (x *GetTEDRequest) Reset() {
 	*x = GetTEDRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2477,7 +2688,7 @@ func (x *GetTEDRequest) String() string {
 func (*GetTEDRequest) ProtoMessage() {}
 
 func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2490,7 +2701,7 @@ func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDRequest.ProtoReflect.Descriptor instead.
 func (*GetTEDRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
 }
 
 type GetTEDResponse struct {
@@ -2503,7 +2714,7 @@ type GetTEDResponse struct {
 
 func (x *GetTEDResponse) Reset() {
 	*x = GetTEDResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2515,7 +2726,7 @@ func (x *GetTEDResponse) String() string {
 func (*GetTEDResponse) ProtoMessage() {}
 
 func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2528,7 +2739,7 @@ func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDResponse.ProtoReflect.Descriptor instead.
 func (*GetTEDResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetTEDResponse) GetEnable() bool {
@@ -2554,7 +2765,7 @@ type DeleteSessionRequest struct {
 
 func (x *DeleteSessionRequest) Reset() {
 	*x = DeleteSessionRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2566,7 +2777,7 @@ func (x *DeleteSessionRequest) String() string {
 func (*DeleteSessionRequest) ProtoMessage() {}
 
 func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2579,7 +2790,7 @@ func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *DeleteSessionRequest) GetAddr() []byte {
@@ -2598,7 +2809,7 @@ type DeleteSessionResponse struct {
 
 func (x *DeleteSessionResponse) Reset() {
 	*x = DeleteSessionResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2610,7 +2821,7 @@ func (x *DeleteSessionResponse) String() string {
 func (*DeleteSessionResponse) ProtoMessage() {}
 
 func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2623,7 +2834,7 @@ func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *DeleteSessionResponse) GetIsSuccess() bool {
@@ -2729,14 +2940,33 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x12vendor_information\x18\t \x01(\v2(.api.pola.v1.VendorInformationCapabilityH\x00R\x11vendorInformation\x12:\n" +
 	"\aunknown\x18\n" +
 	" \x01(\v2\x1e.api.pola.v1.UnknownCapabilityH\x00R\aunknownB\b\n" +
-	"\x06detail\"\xec\x01\n" +
+	"\x06detail\"L\n" +
+	"\rSessionTimers\x12\x1c\n" +
+	"\tkeepalive\x18\x01 \x01(\rR\tkeepalive\x12\x1d\n" +
+	"\n" +
+	"dead_timer\x18\x02 \x01(\rR\tdeadTimer\"N\n" +
+	"\x0fEffectiveTimers\x12\x1c\n" +
+	"\tkeepalive\x18\x01 \x01(\rR\tkeepalive\x12\x1d\n" +
+	"\n" +
+	"dead_timer\x18\x02 \x01(\rR\tdeadTimer\"\xa6\x05\n" +
 	"\aSession\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\fR\x04addr\x12/\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x19.api.pola.v1.SessionStateR\x05state\x12\x1b\n" +
 	"\tis_synced\x18\x04 \x01(\bR\bisSynced\x12;\n" +
 	"\fcapabilities\x18\x05 \x03(\v2\x17.api.pola.v1.CapabilityR\fcapabilities\x126\n" +
 	"\vsr_policies\x18\x06 \x03(\v2\x15.api.pola.v1.SRPolicyR\n" +
-	"srPoliciesJ\x04\b\x03\x10\x04R\x04caps\"b\n" +
+	"srPolicies\x12/\n" +
+	"\bpcc_type\x18\a \x01(\x0e2\x14.api.pola.v1.PccTypeR\apccType\x12B\n" +
+	"\x10pcc_capabilities\x18\b \x03(\v2\x17.api.pola.v1.CapabilityR\x0fpccCapabilities\x12=\n" +
+	"\flocal_timers\x18\t \x01(\v2\x1a.api.pola.v1.SessionTimersR\vlocalTimers\x129\n" +
+	"\n" +
+	"pcc_timers\x18\n" +
+	" \x01(\v2\x1a.api.pola.v1.SessionTimersR\tpccTimers\x12-\n" +
+	"\x10local_session_id\x18\v \x01(\rH\x00R\x0elocalSessionId\x88\x01\x01\x12)\n" +
+	"\x0epcc_session_id\x18\f \x01(\rH\x01R\fpccSessionId\x88\x01\x01\x12G\n" +
+	"\x10effective_timers\x18\r \x01(\v2\x1c.api.pola.v1.EffectiveTimersR\x0feffectiveTimersB\x13\n" +
+	"\x11_local_session_idB\x11\n" +
+	"\x0f_pcc_session_idJ\x04\b\x03\x10\x04R\x04caps\"b\n" +
 	"\x10EndpointBehavior\x12\x1a\n" +
 	"\bbehavior\x18\x01 \x01(\rR\bbehavior\x12\x14\n" +
 	"\x05flags\x18\x02 \x01(\rR\x05flags\x12\x1c\n" +
@@ -2823,11 +3053,18 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x14SR_POLICY_STATE_DOWN\x10\x01\x12\x16\n" +
 	"\x12SR_POLICY_STATE_UP\x10\x02\x12\x1a\n" +
 	"\x16SR_POLICY_STATE_ACTIVE\x10\x03\x12\x1b\n" +
-	"\x17SR_POLICY_STATE_UNKNOWN\x10\x04*[\n" +
+	"\x17SR_POLICY_STATE_UNKNOWN\x10\x04*\xb6\x01\n" +
 	"\fSessionState\x12\x1d\n" +
-	"\x19SESSION_STATE_UNSPECIFIED\x10\x00\x12\x16\n" +
-	"\x12SESSION_STATE_DOWN\x10\x01\x12\x14\n" +
-	"\x10SESSION_STATE_UP\x10\x02*\xd3\x02\n" +
+	"\x19SESSION_STATE_UNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10SESSION_STATE_UP\x10\x02\x12\x1d\n" +
+	"\x19SESSION_STATE_TCP_PENDING\x10\x03\x12\x1b\n" +
+	"\x17SESSION_STATE_OPEN_WAIT\x10\x04\x12\x1b\n" +
+	"\x17SESSION_STATE_KEEP_WAIT\x10\x05\"\x04\b\x01\x10\x01*\x12SESSION_STATE_DOWN*w\n" +
+	"\aPccType\x12\x18\n" +
+	"\x14PCC_TYPE_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15PCC_TYPE_CISCO_LEGACY\x10\x01\x12\x1b\n" +
+	"\x17PCC_TYPE_JUNIPER_LEGACY\x10\x02\x12\x1a\n" +
+	"\x16PCC_TYPE_RFC_COMPLIANT\x10\x03*\xd3\x02\n" +
 	"\x0eCapabilityType\x12\x1f\n" +
 	"\x1bCAPABILITY_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18CAPABILITY_TYPE_STATEFUL\x10\x01\x12\x16\n" +
@@ -2867,106 +3104,114 @@ func file_api_pola_v1_pola_proto_rawDescGZIP() []byte {
 	return file_api_pola_v1_pola_proto_rawDescData
 }
 
-var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
+var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_api_pola_v1_pola_proto_goTypes = []any{
 	(SRPolicyType)(0),                   // 0: api.pola.v1.SRPolicyType
 	(SRPolicyState)(0),                  // 1: api.pola.v1.SRPolicyState
 	(SessionState)(0),                   // 2: api.pola.v1.SessionState
-	(CapabilityType)(0),                 // 3: api.pola.v1.CapabilityType
-	(MetricType)(0),                     // 4: api.pola.v1.MetricType
-	(*Segment)(nil),                     // 5: api.pola.v1.Segment
-	(*Waypoint)(nil),                    // 6: api.pola.v1.Waypoint
-	(*SRPolicy)(nil),                    // 7: api.pola.v1.SRPolicy
-	(*CreateSRPolicyRequest)(nil),       // 8: api.pola.v1.CreateSRPolicyRequest
-	(*CreateSRPolicyResponse)(nil),      // 9: api.pola.v1.CreateSRPolicyResponse
-	(*DeleteSRPolicyRequest)(nil),       // 10: api.pola.v1.DeleteSRPolicyRequest
-	(*DeleteSRPolicyResponse)(nil),      // 11: api.pola.v1.DeleteSRPolicyResponse
-	(*StatefulCapability)(nil),          // 12: api.pola.v1.StatefulCapability
-	(*SrCapability)(nil),                // 13: api.pola.v1.SrCapability
-	(*Srv6Capability)(nil),              // 14: api.pola.v1.Srv6Capability
-	(*PathSetupTypeCapability)(nil),     // 15: api.pola.v1.PathSetupTypeCapability
-	(*AssocTypeListCapability)(nil),     // 16: api.pola.v1.AssocTypeListCapability
-	(*LspDbVersionCapability)(nil),      // 17: api.pola.v1.LspDbVersionCapability
-	(*MultipathCapability)(nil),         // 18: api.pola.v1.MultipathCapability
-	(*VendorInformationCapability)(nil), // 19: api.pola.v1.VendorInformationCapability
-	(*UnknownCapability)(nil),           // 20: api.pola.v1.UnknownCapability
-	(*Capability)(nil),                  // 21: api.pola.v1.Capability
-	(*Session)(nil),                     // 22: api.pola.v1.Session
-	(*EndpointBehavior)(nil),            // 23: api.pola.v1.EndpointBehavior
-	(*SidStructure)(nil),                // 24: api.pola.v1.SidStructure
-	(*SID)(nil),                         // 25: api.pola.v1.SID
-	(*MultiTopoID)(nil),                 // 26: api.pola.v1.MultiTopoID
-	(*LsSrv6SID)(nil),                   // 27: api.pola.v1.LsSrv6SID
-	(*LsPrefix)(nil),                    // 28: api.pola.v1.LsPrefix
-	(*Metric)(nil),                      // 29: api.pola.v1.Metric
-	(*Srv6EndXSID)(nil),                 // 30: api.pola.v1.Srv6EndXSID
-	(*LsLink)(nil),                      // 31: api.pola.v1.LsLink
-	(*LsNode)(nil),                      // 32: api.pola.v1.LsNode
-	(*TED)(nil),                         // 33: api.pola.v1.TED
-	(*GetSessionListRequest)(nil),       // 34: api.pola.v1.GetSessionListRequest
-	(*GetSessionListResponse)(nil),      // 35: api.pola.v1.GetSessionListResponse
-	(*GetSRPolicyListRequest)(nil),      // 36: api.pola.v1.GetSRPolicyListRequest
-	(*GetSRPolicyListResponse)(nil),     // 37: api.pola.v1.GetSRPolicyListResponse
-	(*GetTEDRequest)(nil),               // 38: api.pola.v1.GetTEDRequest
-	(*GetTEDResponse)(nil),              // 39: api.pola.v1.GetTEDResponse
-	(*DeleteSessionRequest)(nil),        // 40: api.pola.v1.DeleteSessionRequest
-	(*DeleteSessionResponse)(nil),       // 41: api.pola.v1.DeleteSessionResponse
+	(PccType)(0),                        // 3: api.pola.v1.PccType
+	(CapabilityType)(0),                 // 4: api.pola.v1.CapabilityType
+	(MetricType)(0),                     // 5: api.pola.v1.MetricType
+	(*Segment)(nil),                     // 6: api.pola.v1.Segment
+	(*Waypoint)(nil),                    // 7: api.pola.v1.Waypoint
+	(*SRPolicy)(nil),                    // 8: api.pola.v1.SRPolicy
+	(*CreateSRPolicyRequest)(nil),       // 9: api.pola.v1.CreateSRPolicyRequest
+	(*CreateSRPolicyResponse)(nil),      // 10: api.pola.v1.CreateSRPolicyResponse
+	(*DeleteSRPolicyRequest)(nil),       // 11: api.pola.v1.DeleteSRPolicyRequest
+	(*DeleteSRPolicyResponse)(nil),      // 12: api.pola.v1.DeleteSRPolicyResponse
+	(*StatefulCapability)(nil),          // 13: api.pola.v1.StatefulCapability
+	(*SrCapability)(nil),                // 14: api.pola.v1.SrCapability
+	(*Srv6Capability)(nil),              // 15: api.pola.v1.Srv6Capability
+	(*PathSetupTypeCapability)(nil),     // 16: api.pola.v1.PathSetupTypeCapability
+	(*AssocTypeListCapability)(nil),     // 17: api.pola.v1.AssocTypeListCapability
+	(*LspDbVersionCapability)(nil),      // 18: api.pola.v1.LspDbVersionCapability
+	(*MultipathCapability)(nil),         // 19: api.pola.v1.MultipathCapability
+	(*VendorInformationCapability)(nil), // 20: api.pola.v1.VendorInformationCapability
+	(*UnknownCapability)(nil),           // 21: api.pola.v1.UnknownCapability
+	(*Capability)(nil),                  // 22: api.pola.v1.Capability
+	(*SessionTimers)(nil),               // 23: api.pola.v1.SessionTimers
+	(*EffectiveTimers)(nil),             // 24: api.pola.v1.EffectiveTimers
+	(*Session)(nil),                     // 25: api.pola.v1.Session
+	(*EndpointBehavior)(nil),            // 26: api.pola.v1.EndpointBehavior
+	(*SidStructure)(nil),                // 27: api.pola.v1.SidStructure
+	(*SID)(nil),                         // 28: api.pola.v1.SID
+	(*MultiTopoID)(nil),                 // 29: api.pola.v1.MultiTopoID
+	(*LsSrv6SID)(nil),                   // 30: api.pola.v1.LsSrv6SID
+	(*LsPrefix)(nil),                    // 31: api.pola.v1.LsPrefix
+	(*Metric)(nil),                      // 32: api.pola.v1.Metric
+	(*Srv6EndXSID)(nil),                 // 33: api.pola.v1.Srv6EndXSID
+	(*LsLink)(nil),                      // 34: api.pola.v1.LsLink
+	(*LsNode)(nil),                      // 35: api.pola.v1.LsNode
+	(*TED)(nil),                         // 36: api.pola.v1.TED
+	(*GetSessionListRequest)(nil),       // 37: api.pola.v1.GetSessionListRequest
+	(*GetSessionListResponse)(nil),      // 38: api.pola.v1.GetSessionListResponse
+	(*GetSRPolicyListRequest)(nil),      // 39: api.pola.v1.GetSRPolicyListRequest
+	(*GetSRPolicyListResponse)(nil),     // 40: api.pola.v1.GetSRPolicyListResponse
+	(*GetTEDRequest)(nil),               // 41: api.pola.v1.GetTEDRequest
+	(*GetTEDResponse)(nil),              // 42: api.pola.v1.GetTEDResponse
+	(*DeleteSessionRequest)(nil),        // 43: api.pola.v1.DeleteSessionRequest
+	(*DeleteSessionResponse)(nil),       // 44: api.pola.v1.DeleteSessionResponse
 }
 var file_api_pola_v1_pola_proto_depIdxs = []int32{
 	0,  // 0: api.pola.v1.SRPolicy.type:type_name -> api.pola.v1.SRPolicyType
-	5,  // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
-	4,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
-	6,  // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
+	6,  // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
+	5,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
+	7,  // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
 	1,  // 4: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
-	7,  // 5: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	7,  // 6: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	3,  // 7: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
-	12, // 8: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
-	13, // 9: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
-	14, // 10: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
-	15, // 11: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
-	16, // 12: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
-	17, // 13: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
-	18, // 14: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
-	19, // 15: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
-	20, // 16: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
+	8,  // 5: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	8,  // 6: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	4,  // 7: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
+	13, // 8: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
+	14, // 9: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
+	15, // 10: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
+	16, // 11: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
+	17, // 12: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
+	18, // 13: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
+	19, // 14: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
+	20, // 15: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
+	21, // 16: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
 	2,  // 17: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
-	21, // 18: api.pola.v1.Session.capabilities:type_name -> api.pola.v1.Capability
-	7,  // 19: api.pola.v1.Session.sr_policies:type_name -> api.pola.v1.SRPolicy
-	25, // 20: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
-	23, // 21: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
-	24, // 22: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
-	26, // 23: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
-	4,  // 24: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
-	25, // 25: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
-	24, // 26: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	29, // 27: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	30, // 28: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
-	31, // 29: api.pola.v1.LsNode.ls_links:type_name -> api.pola.v1.LsLink
-	28, // 30: api.pola.v1.LsNode.ls_prefixes:type_name -> api.pola.v1.LsPrefix
-	27, // 31: api.pola.v1.LsNode.ls_srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	32, // 32: api.pola.v1.TED.ls_nodes:type_name -> api.pola.v1.LsNode
-	22, // 33: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	22, // 34: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.Session
-	32, // 35: api.pola.v1.GetTEDResponse.ls_nodes:type_name -> api.pola.v1.LsNode
-	8,  // 36: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	10, // 37: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	34, // 38: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	36, // 39: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	38, // 40: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	40, // 41: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	9,  // 42: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	11, // 43: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	35, // 44: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	37, // 45: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	39, // 46: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	41, // 47: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	42, // [42:48] is the sub-list for method output_type
-	36, // [36:42] is the sub-list for method input_type
-	36, // [36:36] is the sub-list for extension type_name
-	36, // [36:36] is the sub-list for extension extendee
-	0,  // [0:36] is the sub-list for field type_name
+	22, // 18: api.pola.v1.Session.capabilities:type_name -> api.pola.v1.Capability
+	8,  // 19: api.pola.v1.Session.sr_policies:type_name -> api.pola.v1.SRPolicy
+	3,  // 20: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
+	22, // 21: api.pola.v1.Session.pcc_capabilities:type_name -> api.pola.v1.Capability
+	23, // 22: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
+	23, // 23: api.pola.v1.Session.pcc_timers:type_name -> api.pola.v1.SessionTimers
+	24, // 24: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
+	28, // 25: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
+	26, // 26: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	27, // 27: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
+	29, // 28: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
+	5,  // 29: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
+	28, // 30: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
+	27, // 31: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
+	32, // 32: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	33, // 33: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
+	34, // 34: api.pola.v1.LsNode.ls_links:type_name -> api.pola.v1.LsLink
+	31, // 35: api.pola.v1.LsNode.ls_prefixes:type_name -> api.pola.v1.LsPrefix
+	30, // 36: api.pola.v1.LsNode.ls_srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	35, // 37: api.pola.v1.TED.ls_nodes:type_name -> api.pola.v1.LsNode
+	25, // 38: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	25, // 39: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.Session
+	35, // 40: api.pola.v1.GetTEDResponse.ls_nodes:type_name -> api.pola.v1.LsNode
+	9,  // 41: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	11, // 42: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	37, // 43: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	39, // 44: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	41, // 45: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	43, // 46: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	10, // 47: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	12, // 48: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	38, // 49: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	40, // 50: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	42, // 51: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	44, // 52: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	47, // [47:53] is the sub-list for method output_type
+	41, // [41:47] is the sub-list for method input_type
+	41, // [41:41] is the sub-list for extension type_name
+	41, // [41:41] is the sub-list for extension extendee
+	0,  // [0:41] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }
@@ -2985,14 +3230,15 @@ func file_api_pola_v1_pola_proto_init() {
 		(*Capability_VendorInformation)(nil),
 		(*Capability_Unknown)(nil),
 	}
-	file_api_pola_v1_pola_proto_msgTypes[23].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[19].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[25].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_pola_v1_pola_proto_rawDesc), len(file_api_pola_v1_pola_proto_rawDesc)),
-			NumEnums:      5,
-			NumMessages:   37,
+			NumEnums:      6,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -1034,10 +1034,11 @@ func (x *StatefulCapability) GetColor() bool {
 }
 
 type SrCapability struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	UnlimitedMsd  bool                   `protobuf:"varint,1,opt,name=unlimited_msd,json=unlimitedMsd,proto3" json:"unlimited_msd,omitempty"`
-	NaiSupported  bool                   `protobuf:"varint,2,opt,name=nai_supported,json=naiSupported,proto3" json:"nai_supported,omitempty"`
-	Msd           *uint32                `protobuf:"varint,3,opt,name=msd,proto3,oneof" json:"msd,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	UnlimitedMsd bool                   `protobuf:"varint,1,opt,name=unlimited_msd,json=unlimitedMsd,proto3" json:"unlimited_msd,omitempty"`
+	NaiSupported bool                   `protobuf:"varint,2,opt,name=nai_supported,json=naiSupported,proto3" json:"nai_supported,omitempty"`
+	// Unset when unlimited_msd is true (RFC 8664 §5.1).
+	Msd           *uint32 `protobuf:"varint,3,opt,name=msd,proto3,oneof" json:"msd,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1140,8 +1141,10 @@ func (x *Srv6Capability) GetNaiSupported() bool {
 type PathSetupTypeCapability struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	PathSetupTypes []uint32               `protobuf:"varint,1,rep,packed,name=path_setup_types,json=pathSetupTypes,proto3" json:"path_setup_types,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Per-PST capability sub-TLVs (RFC 8408 §3).
+	SubCapabilities []*Capability `protobuf:"bytes,2,rep,name=sub_capabilities,json=subCapabilities,proto3" json:"sub_capabilities,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *PathSetupTypeCapability) Reset() {
@@ -1177,6 +1180,13 @@ func (*PathSetupTypeCapability) Descriptor() ([]byte, []int) {
 func (x *PathSetupTypeCapability) GetPathSetupTypes() []uint32 {
 	if x != nil {
 		return x.PathSetupTypes
+	}
+	return nil
+}
+
+func (x *PathSetupTypeCapability) GetSubCapabilities() []*Capability {
+	if x != nil {
+		return x.SubCapabilities
 	}
 	return nil
 }
@@ -3256,9 +3266,10 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x03msd\x18\x03 \x01(\rH\x00R\x03msd\x88\x01\x01B\x06\n" +
 	"\x04_msd\"5\n" +
 	"\x0eSrv6Capability\x12#\n" +
-	"\rnai_supported\x18\x01 \x01(\bR\fnaiSupported\"C\n" +
+	"\rnai_supported\x18\x01 \x01(\bR\fnaiSupported\"\x87\x01\n" +
 	"\x17PathSetupTypeCapability\x12(\n" +
-	"\x10path_setup_types\x18\x01 \x03(\rR\x0epathSetupTypes\":\n" +
+	"\x10path_setup_types\x18\x01 \x03(\rR\x0epathSetupTypes\x12B\n" +
+	"\x10sub_capabilities\x18\x02 \x03(\v2\x17.api.pola.v1.CapabilityR\x0fsubCapabilities\":\n" +
 	"\x17AssocTypeListCapability\x12\x1f\n" +
 	"\vassoc_types\x18\x01 \x03(\rR\n" +
 	"assocTypes\"?\n" +
@@ -3547,71 +3558,72 @@ var file_api_pola_v1_pola_proto_depIdxs = []int32{
 	1,  // 4: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
 	10, // 5: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
 	10, // 6: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	4,  // 7: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
-	15, // 8: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
-	16, // 9: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
-	17, // 10: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
-	18, // 11: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
-	19, // 12: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
-	20, // 13: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
-	21, // 14: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
-	22, // 15: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
-	23, // 16: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
-	27, // 17: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
-	27, // 18: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
-	27, // 19: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
-	27, // 20: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
-	27, // 21: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
-	27, // 22: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
-	27, // 23: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
-	27, // 24: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
-	27, // 25: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
-	27, // 26: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
-	2,  // 27: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
-	24, // 28: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
-	3,  // 29: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
-	24, // 30: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
-	25, // 31: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
-	25, // 32: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
-	26, // 33: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
-	5,  // 34: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
-	6,  // 35: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	28, // 36: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
-	2,  // 37: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
-	6,  // 38: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	10, // 39: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
-	33, // 40: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
-	31, // 41: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
-	32, // 42: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
-	34, // 43: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
-	7,  // 44: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
-	33, // 45: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
-	32, // 46: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	37, // 47: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	38, // 48: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
-	39, // 49: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
-	36, // 50: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
-	35, // 51: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	29, // 52: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	30, // 53: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
-	40, // 54: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
-	11, // 55: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	13, // 56: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	41, // 57: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	43, // 58: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	45, // 59: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	47, // 60: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	12, // 61: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	14, // 62: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	42, // 63: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	44, // 64: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	46, // 65: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	48, // 66: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	61, // [61:67] is the sub-list for method output_type
-	55, // [55:61] is the sub-list for method input_type
-	55, // [55:55] is the sub-list for extension type_name
-	55, // [55:55] is the sub-list for extension extendee
-	0,  // [0:55] is the sub-list for field type_name
+	24, // 7: api.pola.v1.PathSetupTypeCapability.sub_capabilities:type_name -> api.pola.v1.Capability
+	4,  // 8: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
+	15, // 9: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
+	16, // 10: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
+	17, // 11: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
+	18, // 12: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
+	19, // 13: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
+	20, // 14: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
+	21, // 15: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
+	22, // 16: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
+	23, // 17: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
+	27, // 18: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
+	27, // 19: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
+	27, // 20: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
+	27, // 21: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
+	27, // 22: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
+	27, // 23: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
+	27, // 24: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
+	27, // 25: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
+	27, // 26: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
+	27, // 27: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
+	2,  // 28: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
+	24, // 29: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
+	3,  // 30: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
+	24, // 31: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
+	25, // 32: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
+	25, // 33: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
+	26, // 34: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
+	5,  // 35: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
+	6,  // 36: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	28, // 37: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
+	2,  // 38: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
+	6,  // 39: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	10, // 40: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
+	33, // 41: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
+	31, // 42: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	32, // 43: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
+	34, // 44: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
+	7,  // 45: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
+	33, // 46: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
+	32, // 47: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
+	37, // 48: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	38, // 49: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
+	39, // 50: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
+	36, // 51: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
+	35, // 52: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	29, // 53: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	30, // 54: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
+	40, // 55: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
+	11, // 56: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	13, // 57: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	41, // 58: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	43, // 59: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	45, // 60: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	47, // 61: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	12, // 62: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	14, // 63: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	42, // 64: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	44, // 65: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	46, // 66: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	48, // 67: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	62, // [62:68] is the sub-list for method output_type
+	56, // [56:62] is the sub-list for method input_type
+	56, // [56:56] is the sub-list for extension type_name
+	56, // [56:56] is the sub-list for extension extendee
+	0,  // [0:56] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -1037,7 +1037,7 @@ type SrCapability struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	UnlimitedMsd  bool                   `protobuf:"varint,1,opt,name=unlimited_msd,json=unlimitedMsd,proto3" json:"unlimited_msd,omitempty"`
 	NaiSupported  bool                   `protobuf:"varint,2,opt,name=nai_supported,json=naiSupported,proto3" json:"nai_supported,omitempty"`
-	Msd           uint32                 `protobuf:"varint,3,opt,name=msd,proto3" json:"msd,omitempty"`
+	Msd           *uint32                `protobuf:"varint,3,opt,name=msd,proto3,oneof" json:"msd,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1087,8 +1087,8 @@ func (x *SrCapability) GetNaiSupported() bool {
 }
 
 func (x *SrCapability) GetMsd() uint32 {
-	if x != nil {
-		return x.Msd
+	if x != nil && x.Msd != nil {
+		return *x.Msd
 	}
 	return 0
 }
@@ -1910,22 +1910,24 @@ func (x *SessionStats) GetSessSetupFail() uint64 {
 }
 
 type Session struct {
-	state                 protoimpl.MessageState `protogen:"open.v1"`
-	PeerAddr              []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
-	State                 SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
-	LocalCapabilities     []*Capability          `protobuf:"bytes,5,rep,name=local_capabilities,json=localCapabilities,proto3" json:"local_capabilities,omitempty"`
-	PccType               PccType                `protobuf:"varint,7,opt,name=pcc_type,json=pccType,proto3,enum=api.pola.v1.PccType" json:"pcc_type,omitempty"`
-	PeerCapabilities      []*Capability          `protobuf:"bytes,8,rep,name=peer_capabilities,json=peerCapabilities,proto3" json:"peer_capabilities,omitempty"`
-	LocalTimers           *SessionTimers         `protobuf:"bytes,9,opt,name=local_timers,json=localTimers,proto3" json:"local_timers,omitempty"`
-	PeerTimers            *SessionTimers         `protobuf:"bytes,10,opt,name=peer_timers,json=peerTimers,proto3" json:"peer_timers,omitempty"`
-	LocalSessionId        *uint32                `protobuf:"varint,11,opt,name=local_session_id,json=localSessionId,proto3,oneof" json:"local_session_id,omitempty"`
-	PeerSessionId         *uint32                `protobuf:"varint,12,opt,name=peer_session_id,json=peerSessionId,proto3,oneof" json:"peer_session_id,omitempty"`
-	EffectiveTimers       *EffectiveTimers       `protobuf:"bytes,13,opt,name=effective_timers,json=effectiveTimers,proto3" json:"effective_timers,omitempty"`
-	Initiator             SessionInitiator       `protobuf:"varint,14,opt,name=initiator,proto3,enum=api.pola.v1.SessionInitiator" json:"initiator,omitempty"`
-	SyncState             LspDbSyncState         `protobuf:"varint,15,opt,name=sync_state,json=syncState,proto3,enum=api.pola.v1.LspDbSyncState" json:"sync_state,omitempty"`
-	CreatedAtUnixNano     int64                  `protobuf:"varint,16,opt,name=created_at_unix_nano,json=createdAtUnixNano,proto3" json:"created_at_unix_nano,omitempty"`             // Unix time in nanoseconds; 0 = unset.
-	EstablishedAtUnixNano int64                  `protobuf:"varint,17,opt,name=established_at_unix_nano,json=establishedAtUnixNano,proto3" json:"established_at_unix_nano,omitempty"` // Unix time in nanoseconds; 0 = not established.
-	Stats                 *SessionStats          `protobuf:"bytes,18,opt,name=stats,proto3" json:"stats,omitempty"`                                                                   // Populated only when include_stats is true.
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	PeerAddr          []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
+	State             SessionState           `protobuf:"varint,2,opt,name=state,proto3,enum=api.pola.v1.SessionState" json:"state,omitempty"`
+	LocalCapabilities []*Capability          `protobuf:"bytes,5,rep,name=local_capabilities,json=localCapabilities,proto3" json:"local_capabilities,omitempty"`
+	PccType           PccType                `protobuf:"varint,7,opt,name=pcc_type,json=pccType,proto3,enum=api.pola.v1.PccType" json:"pcc_type,omitempty"`
+	PeerCapabilities  []*Capability          `protobuf:"bytes,8,rep,name=peer_capabilities,json=peerCapabilities,proto3" json:"peer_capabilities,omitempty"`
+	LocalTimers       *SessionTimers         `protobuf:"bytes,9,opt,name=local_timers,json=localTimers,proto3" json:"local_timers,omitempty"`
+	PeerTimers        *SessionTimers         `protobuf:"bytes,10,opt,name=peer_timers,json=peerTimers,proto3" json:"peer_timers,omitempty"`
+	LocalSessionId    *uint32                `protobuf:"varint,11,opt,name=local_session_id,json=localSessionId,proto3,oneof" json:"local_session_id,omitempty"`
+	PeerSessionId     *uint32                `protobuf:"varint,12,opt,name=peer_session_id,json=peerSessionId,proto3,oneof" json:"peer_session_id,omitempty"`
+	// Valid when state is SESSION_STATE_UP. Do not infer readiness from
+	// presence or zero values; RFC 5440 permits a negotiated Keepalive of 0.
+	EffectiveTimers       *EffectiveTimers `protobuf:"bytes,13,opt,name=effective_timers,json=effectiveTimers,proto3" json:"effective_timers,omitempty"`
+	Initiator             SessionInitiator `protobuf:"varint,14,opt,name=initiator,proto3,enum=api.pola.v1.SessionInitiator" json:"initiator,omitempty"`
+	SyncState             LspDbSyncState   `protobuf:"varint,15,opt,name=sync_state,json=syncState,proto3,enum=api.pola.v1.LspDbSyncState" json:"sync_state,omitempty"`
+	CreatedAtUnixNano     int64            `protobuf:"varint,16,opt,name=created_at_unix_nano,json=createdAtUnixNano,proto3" json:"created_at_unix_nano,omitempty"`             // Unix time in nanoseconds; 0 = unset.
+	EstablishedAtUnixNano int64            `protobuf:"varint,17,opt,name=established_at_unix_nano,json=establishedAtUnixNano,proto3" json:"established_at_unix_nano,omitempty"` // Unix time in nanoseconds; 0 = not established.
+	Stats                 *SessionStats    `protobuf:"bytes,18,opt,name=stats,proto3" json:"stats,omitempty"`                                                                   // Populated only when include_stats is true.
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -3206,11 +3208,12 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x10triggered_resync\x18\x04 \x01(\bR\x0ftriggeredResync\x12$\n" +
 	"\x0edelta_lsp_sync\x18\x05 \x01(\bR\fdeltaLspSync\x124\n" +
 	"\x16triggered_initial_sync\x18\x06 \x01(\bR\x14triggeredInitialSync\x12\x14\n" +
-	"\x05color\x18\a \x01(\bR\x05color\"j\n" +
+	"\x05color\x18\a \x01(\bR\x05color\"w\n" +
 	"\fSrCapability\x12#\n" +
 	"\runlimited_msd\x18\x01 \x01(\bR\funlimitedMsd\x12#\n" +
-	"\rnai_supported\x18\x02 \x01(\bR\fnaiSupported\x12\x10\n" +
-	"\x03msd\x18\x03 \x01(\rR\x03msd\"5\n" +
+	"\rnai_supported\x18\x02 \x01(\bR\fnaiSupported\x12\x15\n" +
+	"\x03msd\x18\x03 \x01(\rH\x00R\x03msd\x88\x01\x01B\x06\n" +
+	"\x04_msd\"5\n" +
 	"\x0eSrv6Capability\x12#\n" +
 	"\rnai_supported\x18\x01 \x01(\bR\fnaiSupported\"C\n" +
 	"\x17PathSetupTypeCapability\x12(\n" +
@@ -3566,6 +3569,7 @@ func file_api_pola_v1_pola_proto_init() {
 	if File_api_pola_v1_pola_proto != nil {
 		return
 	}
+	file_api_pola_v1_pola_proto_msgTypes[8].OneofWrappers = []any{}
 	file_api_pola_v1_pola_proto_msgTypes[16].OneofWrappers = []any{
 		(*Capability_Stateful)(nil),
 		(*Capability_Sr)(nil),

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -1961,6 +1961,7 @@ type Session struct {
 	CreatedAtUnixNano     int64            `protobuf:"varint,16,opt,name=created_at_unix_nano,json=createdAtUnixNano,proto3" json:"created_at_unix_nano,omitempty"`             // Unix time in nanoseconds; 0 = unset.
 	EstablishedAtUnixNano int64            `protobuf:"varint,17,opt,name=established_at_unix_nano,json=establishedAtUnixNano,proto3" json:"established_at_unix_nano,omitempty"` // Unix time in nanoseconds; 0 = not established.
 	Stats                 *SessionStats    `protobuf:"bytes,18,opt,name=stats,proto3" json:"stats,omitempty"`                                                                   // Populated only when include_stats is true.
+	UptimeNanos           int64            `protobuf:"varint,19,opt,name=uptime_nanos,json=uptimeNanos,proto3" json:"uptime_nanos,omitempty"`                                   // Duration since session establishment in nanoseconds; 0 = not established.
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -2098,6 +2099,13 @@ func (x *Session) GetStats() *SessionStats {
 		return x.Stats
 	}
 	return nil
+}
+
+func (x *Session) GetUptimeNanos() int64 {
+	if x != nil {
+		return x.UptimeNanos
+	}
+	return 0
 }
 
 type SRPolicySession struct {
@@ -3306,7 +3314,7 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x04open\x18\v \x01(\v2\x1b.api.pola.v1.MessageCounterR\x04open\x121\n" +
 	"\x05close\x18\f \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05close\x121\n" +
 	"\x05pcreq\x18\r \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05pcreq\x121\n" +
-	"\x05pcrep\x18\x0e \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05pcrep\"\xa4\a\n" +
+	"\x05pcrep\x18\x0e \x01(\v2\x1b.api.pola.v1.MessageCounterR\x05pcrep\"\xc7\a\n" +
 	"\aSession\x12\x1b\n" +
 	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12/\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x19.api.pola.v1.SessionStateR\x05state\x12F\n" +
@@ -3325,7 +3333,8 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"sync_state\x18\x0f \x01(\x0e2\x1b.api.pola.v1.LspDbSyncStateR\tsyncState\x12/\n" +
 	"\x14created_at_unix_nano\x18\x10 \x01(\x03R\x11createdAtUnixNano\x127\n" +
 	"\x18established_at_unix_nano\x18\x11 \x01(\x03R\x15establishedAtUnixNano\x12/\n" +
-	"\x05stats\x18\x12 \x01(\v2\x19.api.pola.v1.SessionStatsR\x05statsB\x13\n" +
+	"\x05stats\x18\x12 \x01(\v2\x19.api.pola.v1.SessionStatsR\x05stats\x12!\n" +
+	"\fuptime_nanos\x18\x13 \x01(\x03R\vuptimeNanosB\x13\n" +
 	"\x11_local_session_idB\x12\n" +
 	"\x10_peer_session_idJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05J\x04\b\x06\x10\aR\x04capsR\tis_syncedR\vsr_policies\"\xd3\x01\n" +
 	"\x0fSRPolicySession\x12\x1b\n" +

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -130,7 +130,7 @@ message StatefulCapability {
 message SrCapability {
   bool unlimited_msd = 1;
   bool nai_supported = 2;
-  uint32 msd = 3;
+  optional uint32 msd = 3;
 }
 
 message Srv6Capability {
@@ -239,6 +239,8 @@ message Session {
   SessionTimers peer_timers = 10;
   optional uint32 local_session_id = 11;
   optional uint32 peer_session_id = 12;
+  // Valid when state is SESSION_STATE_UP. Do not infer readiness from
+  // presence or zero values; RFC 5440 permits a negotiated Keepalive of 0.
   EffectiveTimers effective_timers = 13;
   SessionInitiator initiator = 14;
   LspDbSyncState sync_state = 15;

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -206,24 +206,29 @@ enum LspDbSyncState {
   LSP_DB_SYNC_STATE_FINISHED = 3;
 }
 
-// MessageCounter contains the sent and received message counters from RFC 9826 ietf-pcep-stats.
+// MessageCounter contains sent and received message counters.
 message MessageCounter {
   uint64 sent = 1;
   uint64 rcvd = 2;
 }
 
-// SessionStats contains the message counters defined by RFC 9826 ietf-pcep-stats.
+// SessionStats contains per-session PCEP message counters.
+// Open and close are Pola-specific additions.
 message SessionStats {
-  MessageCounter keepalive = 1; // keepalive-sent / keepalive-rcvd
-  MessageCounter pcerr = 2; // pcerr-sent / pcerr-rcvd
-  MessageCounter pcntf = 3; // pcntf-sent / pcntf-rcvd
-  MessageCounter report = 4; // rpt-sent / rpt-rcvd (stateful)
-  MessageCounter update = 5; // upd-sent / upd-rcvd (stateful)
-  MessageCounter initiate = 6; // pcinitiate-sent / pcinitiate-rcvd (initiation)
-  uint64 unrecognized_rcvd = 7; // unknown-rcvd
-  uint64 corrupt_rcvd = 8; // corrupt-rcvd
-  uint64 sess_setup_ok = 9; // sess-setup-ok (per peer, survives session teardown)
-  uint64 sess_setup_fail = 10; // sess-setup-fail (per peer, survives session teardown)
+  MessageCounter keepalive = 1; // keepalive-sent / keepalive-rcvd (RFC 9826)
+  MessageCounter pcerr = 2; // pcerr-sent / pcerr-rcvd (RFC 9826)
+  MessageCounter pcntf = 3; // pcntf-sent / pcntf-rcvd (RFC 9826)
+  MessageCounter report = 4; // rpt-sent / rpt-rcvd (RFC 9826, stateful)
+  MessageCounter update = 5; // upd-sent / upd-rcvd (RFC 9826, stateful)
+  MessageCounter initiate = 6; // pcinitiate-sent / pcinitiate-rcvd (RFC 9826, initiation)
+  uint64 unrecognized_rcvd = 7; // unknown-rcvd (RFC 9826)
+  uint64 corrupt_rcvd = 8; // corrupt-rcvd (RFC 9826)
+  uint64 sess_setup_ok = 9; // sess-setup-ok (RFC 9826; per peer, survives session teardown)
+  uint64 sess_setup_fail = 10; // sess-setup-fail (RFC 9826; per peer, survives session teardown)
+  MessageCounter open = 11; // open-sent / open-rcvd (Pola-specific, not in RFC 9826)
+  MessageCounter close = 12; // close-sent / close-rcvd (Pola-specific, not in RFC 9826)
+  MessageCounter pcreq = 13; // pcreq-sent / pcreq-rcvd (RFC 9826)
+  MessageCounter pcrep = 14; // pcrep-sent / pcrep-rcvd (RFC 9826)
 }
 
 message Session {

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -130,6 +130,7 @@ message StatefulCapability {
 message SrCapability {
   bool unlimited_msd = 1;
   bool nai_supported = 2;
+  // Unset when unlimited_msd is true (RFC 8664 §5.1).
   optional uint32 msd = 3;
 }
 
@@ -139,6 +140,8 @@ message Srv6Capability {
 
 message PathSetupTypeCapability {
   repeated uint32 path_setup_types = 1;
+  // Per-PST capability sub-TLVs (RFC 8408 §3).
+  repeated Capability sub_capabilities = 2;
 }
 
 message AssocTypeListCapability {

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -10,12 +10,12 @@ package api.pola.v1;
 option go_package = "github.com/nttcom/pola/api/pola/v1";
 
 service PCEService {
-  rpc CreateSRPolicy (CreateSRPolicyRequest) returns (CreateSRPolicyResponse);
-  rpc DeleteSRPolicy (DeleteSRPolicyRequest) returns (DeleteSRPolicyResponse);
-  rpc GetSessionList (GetSessionListRequest) returns (GetSessionListResponse);
-  rpc GetSRPolicyList (GetSRPolicyListRequest) returns (GetSRPolicyListResponse);
-  rpc GetTED (GetTEDRequest) returns (GetTEDResponse);
-  rpc DeleteSession (DeleteSessionRequest) returns (DeleteSessionResponse);
+  rpc CreateSRPolicy(CreateSRPolicyRequest) returns (CreateSRPolicyResponse);
+  rpc DeleteSRPolicy(DeleteSRPolicyRequest) returns (DeleteSRPolicyResponse);
+  rpc GetSessionList(GetSessionListRequest) returns (GetSessionListResponse);
+  rpc GetSRPolicyList(GetSRPolicyListRequest) returns (GetSRPolicyListResponse);
+  rpc GetTED(GetTEDRequest) returns (GetTEDResponse);
+  rpc DeleteSession(DeleteSessionRequest) returns (DeleteSessionResponse);
 }
 
 message Segment {
@@ -34,7 +34,7 @@ enum SRPolicyType {
 
 message Waypoint {
   string router_id = 1;
-  string sid = 2; // optional: explicit SID override
+  string sid = 2; // Optional: explicit SID override
 }
 
 enum SRPolicyState {
@@ -46,7 +46,7 @@ enum SRPolicyState {
 }
 
 message SRPolicy {
-  bytes pcep_session_addr = 1;
+  bytes peer_addr = 1;
   bytes src_addr = 2;
   bytes dst_addr = 3;
   string src_router_id = 4;
@@ -67,13 +67,14 @@ message CreateSRPolicyRequest {
   SRPolicy sr_policy = 1;
   uint32 asn = 2;
   reserved 3;
-  reserved "sid_validate";
   bool disable_path_compute = 4;
   bool no_sid_validate = 5;
+  reserved "sid_validate";
 }
 
 message CreateSRPolicyResponse {
-  bool is_success = 1;
+  reserved 1;
+  reserved "is_success";
 }
 
 message DeleteSRPolicyRequest {
@@ -82,17 +83,18 @@ message DeleteSRPolicyRequest {
 }
 
 message DeleteSRPolicyResponse {
-  bool is_success = 1;
+  reserved 1;
+  reserved "is_success";
 }
 
 enum SessionState {
   SESSION_STATE_UNSPECIFIED = 0;
   reserved 1;
-  reserved "SESSION_STATE_DOWN";
   SESSION_STATE_UP = 2;
   SESSION_STATE_TCP_PENDING = 3;
   SESSION_STATE_OPEN_WAIT = 4;
   SESSION_STATE_KEEP_WAIT = 5;
+  reserved "SESSION_STATE_DOWN";
 }
 
 enum PccType {
@@ -189,21 +191,68 @@ message EffectiveTimers {
   uint32 dead_timer = 2;
 }
 
+// RFC 9826 ietf-pcep: /pcep/entity/peers/peer/sessions/session/initiator
+enum SessionInitiator {
+  SESSION_INITIATOR_UNSPECIFIED = 0;
+  SESSION_INITIATOR_LOCAL = 1;
+  SESSION_INITIATOR_REMOTE = 2;
+}
+
+// LSP-DB synchronization state defined by RFC 8231 and exposed by RFC 9826.
+enum LspDbSyncState {
+  LSP_DB_SYNC_STATE_UNSPECIFIED = 0;
+  LSP_DB_SYNC_STATE_PENDING = 1;
+  LSP_DB_SYNC_STATE_ONGOING = 2;
+  LSP_DB_SYNC_STATE_FINISHED = 3;
+}
+
+// MessageCounter contains the sent and received message counters from RFC 9826 ietf-pcep-stats.
+message MessageCounter {
+  uint64 sent = 1;
+  uint64 rcvd = 2;
+}
+
+// SessionStats contains the message counters defined by RFC 9826 ietf-pcep-stats.
+message SessionStats {
+  MessageCounter keepalive = 1; // keepalive-sent / keepalive-rcvd
+  MessageCounter pcerr = 2; // pcerr-sent / pcerr-rcvd
+  MessageCounter pcntf = 3; // pcntf-sent / pcntf-rcvd
+  MessageCounter report = 4; // rpt-sent / rpt-rcvd (stateful)
+  MessageCounter update = 5; // upd-sent / upd-rcvd (stateful)
+  MessageCounter initiate = 6; // pcinitiate-sent / pcinitiate-rcvd (initiation)
+  uint64 unrecognized_rcvd = 7; // unknown-rcvd
+  uint64 corrupt_rcvd = 8; // corrupt-rcvd
+  uint64 sess_setup_ok = 9; // sess-setup-ok (per peer, survives session teardown)
+  uint64 sess_setup_fail = 10; // sess-setup-fail (per peer, survives session teardown)
+}
+
 message Session {
-  bytes addr = 1;
+  bytes peer_addr = 1;
   SessionState state = 2;
   reserved 3;
-  reserved "caps";
-  bool is_synced = 4;
-  repeated Capability capabilities = 5;
-  repeated SRPolicy sr_policies = 6;
+  reserved 4;
+  repeated Capability local_capabilities = 5;
+  reserved 6;
   PccType pcc_type = 7;
-  repeated Capability pcc_capabilities = 8;
+  repeated Capability peer_capabilities = 8;
   SessionTimers local_timers = 9;
-  SessionTimers pcc_timers = 10;
+  SessionTimers peer_timers = 10;
   optional uint32 local_session_id = 11;
-  optional uint32 pcc_session_id = 12;
+  optional uint32 peer_session_id = 12;
   EffectiveTimers effective_timers = 13;
+  SessionInitiator initiator = 14;
+  LspDbSyncState sync_state = 15;
+  int64 created_at_unix_nano = 16; // Unix time in nanoseconds; 0 = unset.
+  int64 established_at_unix_nano = 17; // Unix time in nanoseconds; 0 = not established.
+  SessionStats stats = 18; // Populated only when include_stats is true.
+  reserved "caps", "is_synced", "sr_policies";
+}
+
+message SRPolicySession {
+  bytes peer_addr = 1;
+  SessionState state = 2;
+  LspDbSyncState sync_state = 3;
+  repeated SRPolicy sr_policies = 4;
 }
 
 message EndpointBehavior {
@@ -229,9 +278,9 @@ message MultiTopoID {
 
 message LsSrv6SID {
   repeated SID sids = 1;
-	EndpointBehavior endpoint_behavior = 2;
+  EndpointBehavior endpoint_behavior = 2;
   SidStructure sid_structure = 3;
-	repeated MultiTopoID multi_topo_ids = 4;
+  repeated MultiTopoID multi_topo_ids = 4;
 }
 
 message LsPrefix {
@@ -277,17 +326,14 @@ message LsNode {
   string hostname = 4;
   uint32 srgb_begin = 5;
   uint32 srgb_end = 6;
-  repeated LsLink ls_links = 7;
-  repeated LsPrefix ls_prefixes = 8;
-  repeated LsSrv6SID ls_srv6_sids = 9;
-}
-
-message TED {
-  bool enable = 1;
-  repeated LsNode ls_nodes = 2;
+  repeated LsLink links = 7;
+  repeated LsPrefix prefixes = 8;
+  repeated LsSrv6SID srv6_sids = 9;
 }
 
 message GetSessionListRequest {
+  bytes peer_addr = 1; // Empty selects every session.
+  bool include_stats = 2; // Include session message statistics.
 }
 
 message GetSessionListResponse {
@@ -295,27 +341,27 @@ message GetSessionListResponse {
 }
 
 message GetSRPolicyListRequest {
-  bytes session_addr = 1;
+  bytes peer_addr = 1;
 }
 
 message GetSRPolicyListResponse {
   reserved 1;
   reserved "sr_policies";
-  repeated Session sessions = 2;
+  repeated SRPolicySession sessions = 2;
 }
 
-message GetTEDRequest {
-}
+message GetTEDRequest {}
 
 message GetTEDResponse {
-  bool enable = 1;
-  repeated LsNode ls_nodes = 2;
+  bool enabled = 1;
+  repeated LsNode nodes = 2;
 }
 
 message DeleteSessionRequest {
-  bytes addr = 1;
+  bytes peer_addr = 1;
 }
 
 message DeleteSessionResponse {
-  bool is_success = 1;
+  reserved 1;
+  reserved "is_success";
 }

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -23,7 +23,6 @@ message Segment {
   string sid_structure = 2;
   string local_addr = 3;
   string remote_addr = 4;
-  // sid_absent indicates that the SID is omitted and the NAI identifies the segment.
   bool sid_absent = 5;
 }
 
@@ -66,18 +65,10 @@ message SRPolicy {
 
 message CreateSRPolicyRequest {
   SRPolicy sr_policy = 1;
-
-  // Not required when disable_path_compute is true.
   uint32 asn = 2;
-
   reserved 3;
   reserved "sid_validate";
-
-  // Use endpoints and segments provided in the request without TED lookup
-  // or path computation (no CSPF or router-ID resolution).
   bool disable_path_compute = 4;
-
-  // Skip checking that explicit SIDs exist in the TED.
   bool no_sid_validate = 5;
 }
 
@@ -96,8 +87,19 @@ message DeleteSRPolicyResponse {
 
 enum SessionState {
   SESSION_STATE_UNSPECIFIED = 0;
-  SESSION_STATE_DOWN = 1;
+  reserved 1;
+  reserved "SESSION_STATE_DOWN";
   SESSION_STATE_UP = 2;
+  SESSION_STATE_TCP_PENDING = 3;
+  SESSION_STATE_OPEN_WAIT = 4;
+  SESSION_STATE_KEEP_WAIT = 5;
+}
+
+enum PccType {
+  PCC_TYPE_UNSPECIFIED = 0;
+  PCC_TYPE_CISCO_LEGACY = 1;
+  PCC_TYPE_JUNIPER_LEGACY = 2;
+  PCC_TYPE_RFC_COMPLIANT = 3;
 }
 
 enum CapabilityType {
@@ -177,6 +179,16 @@ message Capability {
   }
 }
 
+message SessionTimers {
+  uint32 keepalive = 1;
+  uint32 dead_timer = 2;
+}
+
+message EffectiveTimers {
+  uint32 keepalive = 1;
+  uint32 dead_timer = 2;
+}
+
 message Session {
   bytes addr = 1;
   SessionState state = 2;
@@ -184,8 +196,14 @@ message Session {
   reserved "caps";
   bool is_synced = 4;
   repeated Capability capabilities = 5;
-  // Populated by GetSRPolicyList; empty when returned from GetSessionList.
   repeated SRPolicy sr_policies = 6;
+  PccType pcc_type = 7;
+  repeated Capability pcc_capabilities = 8;
+  SessionTimers local_timers = 9;
+  SessionTimers pcc_timers = 10;
+  optional uint32 local_session_id = 11;
+  optional uint32 pcc_session_id = 12;
+  EffectiveTimers effective_timers = 13;
 }
 
 message EndpointBehavior {
@@ -277,7 +295,6 @@ message GetSessionListResponse {
 }
 
 message GetSRPolicyListRequest {
-  // Optional filter: only return policies for the PCEP session with this peer address.
   bytes session_addr = 1;
 }
 

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -252,6 +252,7 @@ message Session {
   int64 created_at_unix_nano = 16; // Unix time in nanoseconds; 0 = unset.
   int64 established_at_unix_nano = 17; // Unix time in nanoseconds; 0 = not established.
   SessionStats stats = 18; // Populated only when include_stats is true.
+  int64 uptime_nanos = 19; // Duration since session establishment in nanoseconds; 0 = not established.
   reserved "caps", "is_synced", "sr_policies";
 }
 

--- a/api/pola/v1/pola.zap.go
+++ b/api/pola/v1/pola.zap.go
@@ -103,7 +103,20 @@ func (x *Srv6Capability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 // MarshalLogObject implements zapcore.ObjectMarshaler for PathSetupTypeCapability.
 func (x *PathSetupTypeCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	return enc.AddReflected("PathSetupTypes", x.GetPathSetupTypes())
+	if err := enc.AddReflected("PathSetupTypes", x.GetPathSetupTypes()); err != nil {
+		return err
+	}
+	if subCapabilities := x.GetSubCapabilities(); len(subCapabilities) > 0 {
+		return enc.AddArray("SubCapabilities", zapcore.ArrayMarshalerFunc(func(ae zapcore.ArrayEncoder) error {
+			for _, subCapability := range subCapabilities {
+				if err := ae.AppendObject(subCapability); err != nil {
+					return err
+				}
+			}
+			return nil
+		}))
+	}
+	return nil
 }
 
 // MarshalLogObject implements zapcore.ObjectMarshaler for AssocTypeListCapability.

--- a/api/pola/v1/pola.zap.go
+++ b/api/pola/v1/pola.zap.go
@@ -46,3 +46,95 @@ func (x *Segment) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("SID", x.GetSid())
 	return nil
 }
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for Capability.
+func (x *Capability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("Type", x.GetType().String())
+	switch detail := x.GetDetail().(type) {
+	case *Capability_Stateful:
+		return enc.AddObject("Stateful", detail.Stateful)
+	case *Capability_Sr:
+		return enc.AddObject("Sr", detail.Sr)
+	case *Capability_Srv6:
+		return enc.AddObject("Srv6", detail.Srv6)
+	case *Capability_PathSetupType:
+		return enc.AddObject("PathSetupType", detail.PathSetupType)
+	case *Capability_AssocTypeList:
+		return enc.AddObject("AssocTypeList", detail.AssocTypeList)
+	case *Capability_LspDbVersion:
+		return enc.AddObject("LspDbVersion", detail.LspDbVersion)
+	case *Capability_Multipath:
+		return enc.AddObject("Multipath", detail.Multipath)
+	case *Capability_VendorInformation:
+		return enc.AddObject("VendorInformation", detail.VendorInformation)
+	case *Capability_Unknown:
+		return enc.AddObject("Unknown", detail.Unknown)
+	}
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for StatefulCapability.
+func (x *StatefulCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddBool("LspUpdate", x.GetLspUpdate())
+	enc.AddBool("IncludeDbVersion", x.GetIncludeDbVersion())
+	enc.AddBool("LspInstantiation", x.GetLspInstantiation())
+	enc.AddBool("TriggeredResync", x.GetTriggeredResync())
+	enc.AddBool("DeltaLspSync", x.GetDeltaLspSync())
+	enc.AddBool("TriggeredInitialSync", x.GetTriggeredInitialSync())
+	enc.AddBool("Color", x.GetColor())
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for SrCapability.
+func (x *SrCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddBool("UnlimitedMsd", x.GetUnlimitedMsd())
+	enc.AddBool("NaiSupported", x.GetNaiSupported())
+	if x.Msd != nil {
+		enc.AddUint32("Msd", x.GetMsd())
+	}
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for Srv6Capability.
+func (x *Srv6Capability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddBool("NaiSupported", x.GetNaiSupported())
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for PathSetupTypeCapability.
+func (x *PathSetupTypeCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return enc.AddReflected("PathSetupTypes", x.GetPathSetupTypes())
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for AssocTypeListCapability.
+func (x *AssocTypeListCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return enc.AddReflected("AssocTypes", x.GetAssocTypes())
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for LspDbVersionCapability.
+func (x *LspDbVersionCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint64("VersionNumber", x.GetVersionNumber())
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for MultipathCapability.
+func (x *MultipathCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint32("MaxMultipaths", x.GetMaxMultipaths())
+	enc.AddBool("Weighted", x.GetWeighted())
+	enc.AddBool("OppositeDir", x.GetOppositeDir())
+	enc.AddBool("ForwardClass", x.GetForwardClass())
+	enc.AddBool("CompositePath", x.GetCompositePath())
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for VendorInformationCapability.
+func (x *VendorInformationCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint32("EnterpriseNumber", x.GetEnterpriseNumber())
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler for UnknownCapability.
+func (x *UnknownCapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint32("TlvType", x.GetTlvType())
+	return nil
+}

--- a/api/pola/v1/pola.zap.go
+++ b/api/pola/v1/pola.zap.go
@@ -14,8 +14,8 @@ import (
 // MarshalLogObject implements zapcore.ObjectMarshaler for SRPolicy.
 func (x *SRPolicy) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	// Convert IP address slices to netip.Addr
-	ssAddr, _ := netip.AddrFromSlice(x.GetPcepSessionAddr())
-	enc.AddString("PCEPSessionAddr", ssAddr.String())
+	peerAddr, _ := netip.AddrFromSlice(x.GetPeerAddr())
+	enc.AddString("PeerAddr", peerAddr.String())
 	srcAddr, _ := netip.AddrFromSlice(x.GetSrcAddr())
 	enc.AddString("SrcAddr", srcAddr.String())
 	dstAddr, _ := netip.AddrFromSlice(x.GetDstAddr())

--- a/api/pola/v1/pola_zap_test.go
+++ b/api/pola/v1/pola_zap_test.go
@@ -56,6 +56,40 @@ func TestCapability_MarshalLogObject_Sr(t *testing.T) {
 	assert.Equal(t, uint32(0), sr["Msd"])
 }
 
+func TestPathSetupTypeCapability_MarshalLogObject_SubCapabilities(t *testing.T) {
+	cap := &PathSetupTypeCapability{
+		PathSetupTypes: []uint32{1},
+		SubCapabilities: []*Capability{
+			{
+				Type: CapabilityType_CAPABILITY_TYPE_SR,
+				Detail: &Capability_Sr{Sr: &SrCapability{
+					UnlimitedMsd: true,
+				}},
+			},
+		},
+	}
+
+	enc := zapcore.NewMapObjectEncoder()
+	require.NoError(t, cap.MarshalLogObject(enc))
+
+	subCapabilities, ok := enc.Fields["SubCapabilities"].([]any)
+	require.True(t, ok, "SubCapabilities field must be an array")
+	require.Len(t, subCapabilities, 1)
+
+	sr, ok := subCapabilities[0].(map[string]any)["Sr"].(map[string]any)
+	require.True(t, ok, "Sr field must be a nested object")
+	assert.Equal(t, true, sr["UnlimitedMsd"])
+}
+
+func TestPathSetupTypeCapability_MarshalLogObject_NoSubCapabilities(t *testing.T) {
+	cap := &PathSetupTypeCapability{PathSetupTypes: []uint32{1}}
+
+	enc := zapcore.NewMapObjectEncoder()
+	require.NoError(t, cap.MarshalLogObject(enc))
+
+	assert.NotContains(t, enc.Fields, "SubCapabilities")
+}
+
 func TestCapability_MarshalLogObject_NoDetail(t *testing.T) {
 	cap := &Capability{Type: CapabilityType_CAPABILITY_TYPE_UNSPECIFIED}
 

--- a/api/pola/v1/pola_zap_test.go
+++ b/api/pola/v1/pola_zap_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSrCapability_MarshalLogObject(t *testing.T) {
+	cap := &SrCapability{NaiSupported: true, Msd: proto.Uint32(8)}
+
+	enc := zapcore.NewMapObjectEncoder()
+	require.NoError(t, cap.MarshalLogObject(enc))
+
+	assert.Equal(t, map[string]any{
+		"UnlimitedMsd": false,
+		"NaiSupported": true,
+		"Msd":          uint32(8),
+	}, enc.Fields)
+}
+
+func TestSrCapability_MarshalLogObject_MsdNotAdvertised(t *testing.T) {
+	cap := &SrCapability{NaiSupported: true}
+
+	enc := zapcore.NewMapObjectEncoder()
+	require.NoError(t, cap.MarshalLogObject(enc))
+
+	assert.Equal(t, map[string]any{
+		"UnlimitedMsd": false,
+		"NaiSupported": true,
+	}, enc.Fields)
+}
+
+func TestCapability_MarshalLogObject_Sr(t *testing.T) {
+	cap := &Capability{
+		Type: CapabilityType_CAPABILITY_TYPE_SR,
+		Detail: &Capability_Sr{Sr: &SrCapability{
+			Msd: proto.Uint32(0),
+		}},
+	}
+
+	enc := zapcore.NewMapObjectEncoder()
+	require.NoError(t, cap.MarshalLogObject(enc))
+
+	assert.Equal(t, "CAPABILITY_TYPE_SR", enc.Fields["Type"])
+	sr, ok := enc.Fields["Sr"].(map[string]any)
+	require.True(t, ok, "Sr field must be a nested object")
+	assert.Equal(t, uint32(0), sr["Msd"])
+}
+
+func TestCapability_MarshalLogObject_NoDetail(t *testing.T) {
+	cap := &Capability{Type: CapabilityType_CAPABILITY_TYPE_UNSPECIFIED}
+
+	enc := zapcore.NewMapObjectEncoder()
+	require.NoError(t, cap.MarshalLogObject(enc))
+
+	assert.Equal(t, "CAPABILITY_TYPE_UNSPECIFIED", enc.Fields["Type"])
+	assert.NotContains(t, enc.Fields, "Sr")
+}

--- a/api/pola/v1/session_effective_timers.go
+++ b/api/pola/v1/session_effective_timers.go
@@ -6,20 +6,18 @@
 package v1
 
 // EffectiveKeepalive reports the session's effective Keepalive and whether
-// it is meaningful. Before SESSION_STATE_UP, EffectiveTimers is a zero-value
-// placeholder, while Keepalive=0 is a valid negotiated value (RFC 5440 §7.3).
+// it is available.
 func EffectiveKeepalive(state SessionState, effective *EffectiveTimers) (value uint32, ok bool) {
-	if state != SessionState_SESSION_STATE_UP {
+	if state != SessionState_SESSION_STATE_UP || effective == nil {
 		return 0, false
 	}
 	return effective.GetKeepalive(), true
 }
 
 // EffectiveDeadTimer reports the session's effective DeadTimer and whether
-// it is meaningful. Before SESSION_STATE_UP, EffectiveTimers is a zero-value
-// placeholder.
+// it is available.
 func EffectiveDeadTimer(state SessionState, effective *EffectiveTimers) (value uint32, ok bool) {
-	if state != SessionState_SESSION_STATE_UP {
+	if state != SessionState_SESSION_STATE_UP || effective == nil {
 		return 0, false
 	}
 	return effective.GetDeadTimer(), true

--- a/api/pola/v1/session_effective_timers.go
+++ b/api/pola/v1/session_effective_timers.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package v1
+
+// EffectiveKeepalive reports the session's effective Keepalive and whether
+// it is meaningful. Before SESSION_STATE_UP, EffectiveTimers is a zero-value
+// placeholder, while Keepalive=0 is a valid negotiated value (RFC 5440 §7.3).
+func EffectiveKeepalive(state SessionState, effective *EffectiveTimers) (value uint32, ok bool) {
+	if state != SessionState_SESSION_STATE_UP {
+		return 0, false
+	}
+	return effective.GetKeepalive(), true
+}
+
+// EffectiveDeadTimer reports the session's effective DeadTimer and whether
+// it is meaningful. Before SESSION_STATE_UP, EffectiveTimers is a zero-value
+// placeholder.
+func EffectiveDeadTimer(state SessionState, effective *EffectiveTimers) (value uint32, ok bool) {
+	if state != SessionState_SESSION_STATE_UP {
+		return 0, false
+	}
+	return effective.GetDeadTimer(), true
+}

--- a/api/pola/v1/session_effective_timers_test.go
+++ b/api/pola/v1/session_effective_timers_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package v1
+
+import "testing"
+
+func TestEffectiveKeepalive(t *testing.T) {
+	effective := &EffectiveTimers{Keepalive: 30, DeadTimer: 120}
+
+	if v, ok := EffectiveKeepalive(SessionState_SESSION_STATE_UP, effective); v != 30 || !ok {
+		t.Errorf("got (%d, %v), want (30, true)", v, ok)
+	}
+	if v, ok := EffectiveKeepalive(SessionState_SESSION_STATE_KEEP_WAIT, effective); v != 0 || ok {
+		t.Errorf("got (%d, %v), want (0, false)", v, ok)
+	}
+	if v, ok := EffectiveKeepalive(SessionState_SESSION_STATE_UP, nil); v != 0 || !ok {
+		t.Errorf("got (%d, %v), want (0, true)", v, ok)
+	}
+}
+
+func TestEffectiveDeadTimer(t *testing.T) {
+	effective := &EffectiveTimers{Keepalive: 30, DeadTimer: 120}
+
+	if v, ok := EffectiveDeadTimer(SessionState_SESSION_STATE_UP, effective); v != 120 || !ok {
+		t.Errorf("got (%d, %v), want (120, true)", v, ok)
+	}
+	if v, ok := EffectiveDeadTimer(SessionState_SESSION_STATE_TCP_PENDING, effective); v != 0 || ok {
+		t.Errorf("got (%d, %v), want (0, false)", v, ok)
+	}
+}

--- a/api/pola/v1/session_effective_timers_test.go
+++ b/api/pola/v1/session_effective_timers_test.go
@@ -16,8 +16,8 @@ func TestEffectiveKeepalive(t *testing.T) {
 	if v, ok := EffectiveKeepalive(SessionState_SESSION_STATE_KEEP_WAIT, effective); v != 0 || ok {
 		t.Errorf("got (%d, %v), want (0, false)", v, ok)
 	}
-	if v, ok := EffectiveKeepalive(SessionState_SESSION_STATE_UP, nil); v != 0 || !ok {
-		t.Errorf("got (%d, %v), want (0, true)", v, ok)
+	if v, ok := EffectiveKeepalive(SessionState_SESSION_STATE_UP, nil); v != 0 || ok {
+		t.Errorf("got (%d, %v), want (0, false)", v, ok)
 	}
 }
 
@@ -28,6 +28,9 @@ func TestEffectiveDeadTimer(t *testing.T) {
 		t.Errorf("got (%d, %v), want (120, true)", v, ok)
 	}
 	if v, ok := EffectiveDeadTimer(SessionState_SESSION_STATE_TCP_PENDING, effective); v != 0 || ok {
+		t.Errorf("got (%d, %v), want (0, false)", v, ok)
+	}
+	if v, ok := EffectiveDeadTimer(SessionState_SESSION_STATE_UP, nil); v != 0 || ok {
 		t.Errorf("got (%d, %v), want (0, false)", v, ok)
 	}
 }

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -184,7 +184,7 @@ Session: 192.0.2.2 (State: up, LSP-DB Sync: finished)
     SegmentList: 16003 -> 16001
 
 Session: 2001:db8::1 (State: keep-wait, LSP-DB Sync: pending)
-  No SR Policies: session is still synchronizing.
+  No SR Policies: session is not established.
 ```
 
 JSON formatted response

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -28,9 +28,9 @@ go install ./...
 
 ## Command Reference
 
-### pola session \[-j\]
+### pola session [-j]
 
-Displays the peer addresses of the active session, sorted by address.
+Displays PCEP sessions, sorted by peer address.
 
 JSON formatted response
 
@@ -38,7 +38,13 @@ JSON formatted response
 [
   {
     "Addr": "192.0.2.1",
-    "State": "SESSION_STATE_UP",
+    "State": "UP",
+    "LocalSessionID": 1,
+    "PccSessionID": 1,
+    "LocalTimers": { "Keepalive": 30, "DeadTimer": 120 },
+    "PccTimers": { "Keepalive": 10, "DeadTimer": 40 },
+    "EffectiveTimers": { "Keepalive": 30, "DeadTimer": 40 },
+    "PccType": "RFC_COMPLIANT",
     "Capabilities": [
       {
         "Type": "STATEFUL",
@@ -61,19 +67,40 @@ JSON formatted response
         }
       }
     ],
+    "PccCapabilities": [
+      {
+        "Type": "SR",
+        "Detail": {
+          "UnlimitedMSD": false,
+          "NAISupported": true,
+          "MSD": 16
+        }
+      }
+    ],
     "IsSynced": true
   }
 ]
 ```
 
-`Capabilities` is the list of advertised capability TLVs, one entry per TLV.
-`Type` identifies the TLV, and `Detail` carries its type-specific fields
-(e.g. `MSD` for the SR capability, `VersionNumber` for LSP-DB-Version); it is
-omitted for TLVs with no fields beyond their type.
+`State` is the current PCEP session state: `TCP_PENDING`, `OPEN_WAIT`,
+`KEEP_WAIT`, or `UP`.
 
-### pola session delete *Address* \[-j\]
+`LocalSessionID` and `PccSessionID` are the PCEP session IDs advertised by
+Pola and the PCC, respectively. They are omitted until the corresponding
+Open message is received.
 
-Deletes the specified session.
+`LocalTimers` and `PccTimers` show the PCEP timers advertised by Pola and the
+PCC. `EffectiveTimers` shows the timers currently applied by Pola. These
+fields are omitted while the session is in `TCP_PENDING` or `OPEN_WAIT`.
+
+`Capabilities` lists capabilities advertised by Pola, while `PccCapabilities`
+lists those advertised by the PCC. `PccType` is the PCC type detected from its
+capabilities. `IsSynced` indicates whether initial state synchronization has
+completed.
+
+### pola session delete *Address* [-j]
+
+Deletes the session with the specified peer address.
 
 JSON formatted response
 
@@ -83,19 +110,31 @@ JSON formatted response
 }
 ```
 
-### pola sr-policy list \[-j\] \[--session *address*\]
+### pola sr-policy list [-j] [--session *address*]
 
-Displays the SR Policies managed by polad, grouped by PCEP session and sorted
-by session address. Pass `--session` to only show policies on the session
-with that peer address.
+Displays SR Policies managed by polad, grouped by PCEP session and sorted by
+peer address. `--session` filters by peer address.
+
+All connected sessions are included. Use `IsSynced` to distinguish an
+unsynchronized session from a synced session with no SR Policies.
 
 JSON formatted response
 
 ```json
 [
   {
-    "peerAddr": "192.0.2.2",
-    "srPolicies": [
+    "Addr": "192.0.2.2",
+    "State": "UP",
+    "LocalSessionID": 1,
+    "PccSessionID": 1,
+    "LocalTimers": { "Keepalive": 30, "DeadTimer": 120 },
+    "PccTimers": { "Keepalive": 30, "DeadTimer": 120 },
+    "EffectiveTimers": { "Keepalive": 30, "DeadTimer": 120 },
+    "PccType": "RFC_COMPLIANT",
+    "Capabilities": [],
+    "PccCapabilities": [],
+    "IsSynced": true,
+    "SRPolicies": [
       {
         "plspId": 1,
         "policyName": "sample_policy1",
@@ -116,50 +155,40 @@ JSON formatted response
     ]
   },
   {
-    "peerAddr": "2001:0db8::1",
-    "srPolicies": [
-      {
-        "plspId": 1,
-        "policyName": "sample_policy2",
-        "segmentList": [
-          {
-            "sid": "2001:0db8:1005::",
-            "localAddr": "2001:0db8::5",
-            "sidStructure": "32,16,0,80"
-          }
-        ],
-        "srcAddr": "2001:0db8::1",
-        "dstAddr": "2001:0db8::2",
-        "color": 888,
-        "preference": 100,
-        "lspId": 1,
-        "state": "active",
-        "type": "dynamic",
-        "metric": "te"
-      }
-    ]
+    "Addr": "2001:0db8::1",
+    "State": "KEEP_WAIT",
+    "LocalSessionID": 2,
+    "PccSessionID": 3,
+    "LocalTimers": { "Keepalive": 30, "DeadTimer": 120 },
+    "PccTimers": { "Keepalive": 30, "DeadTimer": 120 },
+    "EffectiveTimers": { "Keepalive": 30, "DeadTimer": 120 },
+    "PccType": "CISCO_LEGACY",
+    "Capabilities": [],
+    "PccCapabilities": [],
+    "IsSynced": false,
+    "SRPolicies": []
   }
 ]
 ```
 
 Notes:
 
-- Policies appear in this list only after their first PCRpt is received.
-- `lspId` is omitted when the reported LSP-ID is zero. `plspId` and `state`
-  reflect the latest PCRpt received.
+- Policies appear in `SRPolicies` only after their first PCRpt is received, so
+  a session that is not yet synced reports an empty list.
+- `lspId` is omitted when zero. `plspId` and `state` reflect the latest PCRpt.
 - `srcRouterId`/`dstRouterId` are resolved from TED loopback addresses and are
   omitted when no matching node is found.
-- `segmentList` entries include `localAddr`/`remoteAddr` when the SID carries
-  NAI information. SRv6 segments may also include `sidStructure`.
-- `type` and `metric` reflect the candidate-path settings used when the policy
-  was created by `pola sr-policy add`. They are omitted for policies discovered
-  from the router or after a polad restart.
+- `segmentList` includes NAI addresses when available and may include
+  `sidStructure` for SRv6 segments.
+- `type` and `metric` are retained only for policies created by
+  `pola sr-policy add`; they are unavailable for policies discovered from the
+  router or after a polad restart.
 
 ### pola sr-policy add -f `filepath`
 
-Create a new SR Policy **using TED**
+Create a new SR Policy **using TED**.
 
-#### Case: Dynamic Path calculate
+#### Dynamic path
 
 YAML input format
 
@@ -172,8 +201,10 @@ srPolicy:
   dstRouterID: 0000.0aff.0004
   color: 100
   type: dynamic
-  metric: igp / te / delay
+  metric: igp
 ```
+
+`metric` can be `igp`, `te`, or `delay`.
 
 JSON formatted response
 
@@ -183,7 +214,7 @@ JSON formatted response
 }
 ```
 
-#### Case: Explicit Path
+#### Explicit path
 
 Each SID may include address information for the NAI.
 
@@ -212,11 +243,11 @@ JSON formatted response
 }
 ```
 
-#### Case: Explicit Path (endpoint addresses)
+#### Explicit path with endpoint addresses
 
 Instead of `srcRouterID`/`dstRouterID`, endpoints can be given directly as
-`srcAddr`/`dstAddr`. This form bypasses path computation: no CSPF and no
-router-ID resolution, so it accepts only `type: explicit` and takes the
+`srcAddr`/`dstAddr`. This form bypasses path computation: no CSPF or router-ID
+resolution is performed, so it accepts only `type: explicit` and takes the
 segment list verbatim.
 
 Each SID is still validated against the TED, so with `ted.enable: false` this
@@ -278,7 +309,7 @@ Notes:
   SID, anycast SID, static labels) always require `--no-sid-validate`.
 - The `-s` shorthand was removed in 1.4.0; use the long flag.
 
-### pola ted \[-j\]
+### pola ted [-j]
 
 Displays the TED managed by polad.
 

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -59,11 +59,12 @@ Session #0: 192.0.2.1
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
     Local only:
-      msd=10
+      SR-PCE-CAPABILITY [RFC8664]: MSD=10
     Peer only:
-      assoctype=9
-      color
-      msd=16
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: MSD=16
+      ASSOC-TYPE-LIST [RFC8697]:
+        9 P2MP SR Policy Association (draft)
   Session Creation:  2026-08-19T09:30:05Z
   Initiator:         remote
   Stats:
@@ -109,11 +110,11 @@ JSON formatted response (`pola session detail -j`)
         "unrecognizedTlvTypes": [],
         "other": []
       },
-      "localOnly": [{ "name": "msd", "value": "10" }],
+      "localOnly": [{ "capability": "SR", "items": ["MSD=10"] }],
       "peerOnly": [
-        { "name": "assoctype", "value": "9" },
-        { "name": "color" },
-        { "name": "msd", "value": "16" }
+        { "capability": "STATEFUL", "items": ["Color"] },
+        { "capability": "SR", "items": ["MSD=16"] },
+        { "capability": "ASSOC_TYPE_LIST", "items": ["9 P2MP SR Policy Association (draft)"] }
       ]
     },
     "sessionCreation": "2026-08-19T09:30:05Z",

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -28,75 +28,109 @@ go install ./...
 
 ## Command Reference
 
-### pola session [-j]
+### pola session [peer-address] [detail] [-j]
 
 Displays PCEP sessions, sorted by peer address.
 
-JSON formatted response
+- `peer-address` optionally filters sessions by peer address.
+- `detail` includes additional session information and message statistics.
+- `-j` outputs JSON.
+
+Without arguments, all sessions are shown in summary form.
+
+Text formatted response (`pola session detail`)
+
+```text
+Session #0: 192.0.2.1
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:12:22
+  Session ID:        Local=1, Peer=7
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     10    10
+    DeadTimer  120    40    40
+  Capabilities:
+    Common:
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR, SR-NAI-Supported
+      ASSOC-TYPE-LIST [RFC8697]: 6 SR Policy Association
+    Local only:        msd=10
+    Peer only:         assoctype:9, color, msd=16
+  Session Creation:  2026-08-19T09:30:05Z
+  Initiator:         remote
+  Stats:
+               Sent  Rcvd
+    Keepalive  25    25
+    PCErr      0     0
+    PCNtf      0     0
+    Report     0     3
+    Update     1     0
+    Initiate   1     0
+    Unrecognized Rcvd: 0
+    Corrupt Rcvd:      0
+    Session Setup:     ok=1, fail=0
+```
+
+JSON formatted response (`pola session detail -j`)
 
 ```json
 [
   {
-    "Addr": "192.0.2.1",
-    "State": "UP",
-    "LocalSessionID": 1,
-    "PccSessionID": 1,
-    "LocalTimers": { "Keepalive": 30, "DeadTimer": 120 },
-    "PccTimers": { "Keepalive": 10, "DeadTimer": 40 },
-    "EffectiveTimers": { "Keepalive": 30, "DeadTimer": 40 },
-    "PccType": "RFC_COMPLIANT",
-    "Capabilities": [
-      {
-        "Type": "STATEFUL",
-        "Detail": {
-          "LSPUpdate": true,
-          "IncludeDBVersion": false,
-          "LSPInstantiation": true,
-          "TriggeredResync": false,
-          "DeltaLSPSync": false,
-          "TriggeredInitialSync": false,
-          "Color": false
-        }
+    "peerAddress": "192.0.2.1",
+    "state": "up",
+    "lspDbSync": "finished",
+    "upTime": "00:12:22",
+    "role": "active-stateful-pce",
+    "sessionId": { "local": 1, "peer": 7 },
+    "timers": {
+      "keepalive": { "local": 30, "peer": 10, "effective": 10 },
+      "deadTimer": { "local": 120, "peer": 40, "effective": 40 }
+    },
+    "transport": { "protocol": "tcp", "auth": "none" },
+    "capabilities": {
+      "common": {
+        "stateful": true,
+        "update": true,
+        "instantiation": true,
+        "pathSetupTypes": [],
+        "associationTypes": [6],
+        "unrecognizedTlvTypes": []
       },
-      {
-        "Type": "SR",
-        "Detail": {
-          "UnlimitedMSD": false,
-          "NAISupported": true,
-          "MSD": 10
-        }
-      }
-    ],
-    "PccCapabilities": [
-      {
-        "Type": "SR",
-        "Detail": {
-          "UnlimitedMSD": false,
-          "NAISupported": true,
-          "MSD": 16
-        }
-      }
-    ],
-    "IsSynced": true
+      "localOnly": [{ "name": "msd", "value": "10" }],
+      "peerOnly": [
+        { "name": "assoctype", "value": "9" },
+        { "name": "color" },
+        { "name": "msd", "value": "16" }
+      ]
+    },
+    "sessionCreation": "2026-08-19T09:30:05Z",
+    "initiator": "remote",
+    "stats": {
+      "keepalive": { "sent": 25, "rcvd": 25 },
+      "pcerr": { "sent": 0, "rcvd": 0 },
+      "pcntf": { "sent": 0, "rcvd": 0 },
+      "report": { "sent": 0, "rcvd": 3 },
+      "update": { "sent": 1, "rcvd": 0 },
+      "initiate": { "sent": 1, "rcvd": 0 },
+      "unrecognizedRcvd": 0,
+      "corruptRcvd": 0,
+      "sessionSetup": { "ok": 1, "fail": 0 }
+    }
   }
 ]
 ```
 
-`State` is the current PCEP session state: `TCP_PENDING`, `OPEN_WAIT`,
-`KEEP_WAIT`, or `UP`.
+Field reference:
 
-`LocalSessionID` and `PccSessionID` are the PCEP session IDs advertised by
-Pola and the PCC, respectively. They are omitted until the corresponding
-Open message is received.
-
-`LocalTimers` and `PccTimers` show the PCEP timers advertised by Pola and the
-PCC. `EffectiveTimers` shows the timers currently applied by Pola. These
-fields are omitted while the session is in `TCP_PENDING` or `OPEN_WAIT`.
-
-`Capabilities` lists capabilities advertised by Pola, while `PccCapabilities`
-lists those advertised by the PCC. `PccType` is the PCC type detected from its
-capabilities. `IsSynced` indicates whether initial state synchronization has
-completed.
+- `sessionId.local`/`peer` are omitted until the corresponding Open
+  message has been exchanged.
+- `lspDbSync` indicates the LSP-DB synchronization state and uses the
+  same vocabulary as `pola sr-policy list`.
+- `stats` contains RFC 9826 message counters. Session setup counters
+  persist across reconnects.
 
 ### pola session delete *Address* [-j]
 
@@ -110,31 +144,43 @@ JSON formatted response
 }
 ```
 
-### pola sr-policy list [-j] [--session *address*]
+### pola sr-policy list [-j] [--peer *address*]
 
-Displays SR Policies managed by polad, grouped by PCEP session and sorted by
-peer address. `--session` filters by peer address.
+Displays SR Policies managed by polad, grouped by PCEP peer and sorted by
+peer address. `--peer` filters by peer address.
 
-All connected sessions are included. Use `IsSynced` to distinguish an
-unsynchronized session from a synced session with no SR Policies.
+All connected sessions are included. Use `lspDbSync` to distinguish an
+unsynchronized session (`pending` or `ongoing`) from a synced session
+(`finished`) with no SR Policies.
+
+Text formatted response
+
+```text
+Session: 192.0.2.2 (State: up, LSP-DB Sync: finished)
+  PolicyName: sample_policy1
+    PlspID: 1
+    LSPID: 1
+    State: up
+    Type: explicit
+    SrcAddr: 192.0.2.2 (0000.0aff.0002)
+    DstAddr: 192.0.2.1 (0000.0aff.0001)
+    Color: 999
+    Preference: 100
+    SegmentList: 16003 -> 16001
+
+Session: 2001:db8::1 (State: keep-wait, LSP-DB Sync: pending)
+  No SR Policies: session is still synchronizing.
+```
 
 JSON formatted response
 
 ```json
 [
   {
-    "Addr": "192.0.2.2",
-    "State": "UP",
-    "LocalSessionID": 1,
-    "PccSessionID": 1,
-    "LocalTimers": { "Keepalive": 30, "DeadTimer": 120 },
-    "PccTimers": { "Keepalive": 30, "DeadTimer": 120 },
-    "EffectiveTimers": { "Keepalive": 30, "DeadTimer": 120 },
-    "PccType": "RFC_COMPLIANT",
-    "Capabilities": [],
-    "PccCapabilities": [],
-    "IsSynced": true,
-    "SRPolicies": [
+    "peerAddress": "192.0.2.2",
+    "state": "up",
+    "lspDbSync": "finished",
+    "srPolicies": [
       {
         "plspId": 1,
         "policyName": "sample_policy1",
@@ -155,34 +201,22 @@ JSON formatted response
     ]
   },
   {
-    "Addr": "2001:0db8::1",
-    "State": "KEEP_WAIT",
-    "LocalSessionID": 2,
-    "PccSessionID": 3,
-    "LocalTimers": { "Keepalive": 30, "DeadTimer": 120 },
-    "PccTimers": { "Keepalive": 30, "DeadTimer": 120 },
-    "EffectiveTimers": { "Keepalive": 30, "DeadTimer": 120 },
-    "PccType": "CISCO_LEGACY",
-    "Capabilities": [],
-    "PccCapabilities": [],
-    "IsSynced": false,
-    "SRPolicies": []
+    "peerAddress": "2001:db8::1",
+    "state": "keep-wait",
+    "lspDbSync": "pending",
+    "srPolicies": []
   }
 ]
 ```
 
 Notes:
 
-- Policies appear in `SRPolicies` only after their first PCRpt is received, so
-  a session that is not yet synced reports an empty list.
-- `lspId` is omitted when zero. `plspId` and `state` reflect the latest PCRpt.
-- `srcRouterId`/`dstRouterId` are resolved from TED loopback addresses and are
-  omitted when no matching node is found.
-- `segmentList` includes NAI addresses when available and may include
-  `sidStructure` for SRv6 segments.
-- `type` and `metric` are retained only for policies created by
-  `pola sr-policy add`; they are unavailable for policies discovered from the
-  router or after a polad restart.
+- `state` and `lspDbSync` use the same vocabulary as `pola session`.
+- Policies appear after the first PCRpt is received.
+- `lspId` is omitted when zero.
+- `srcRouterId`/`dstRouterId` are resolved from TED.
+- `type` and `metric` are available for policies created by
+  `pola sr-policy add`.
 
 ### pola sr-policy add -f `filepath`
 
@@ -251,8 +285,7 @@ resolution is performed, so it accepts only `type: explicit` and takes the
 segment list verbatim.
 
 Each SID is still validated against the TED, so with `ted.enable: false` this
-form additionally needs
-[`--no-sid-validate`](#pola-sr-policy-add--f-filepath---no-sid-validate).
+form additionally requires `--no-sid-validate`.
 
 For each SID, specify the address information required to construct the NAI.
 `localAddr` is required for SRv6 SIDs but optional for SR-MPLS labels.
@@ -262,6 +295,7 @@ See [JSON schema](../../docs/schemas/cli/policy.json) for input details.
 YAML input format
 
 ```yaml
+asn: 65000
 srPolicy:
   pcepSessionAddr: "2001:0db8::1"
   srcAddr: "2001:0db8::1"
@@ -269,12 +303,6 @@ srPolicy:
   name: "policy-name"
   color: 100
   segmentList:
-    - sid: "2001:0db8:1005::"
-      localAddr: "2001:0db8::5"
-      sidStructure: "32,16,0,80"
-    - sid: "2001:0db8:1006::"
-      localAddr: "2001:0db8::6"
-      sidStructure: "32,16,0,80"
     - sid: "2001:0db8:1005::"
       localAddr: "2001:0db8::5"
       sidStructure: "32,16,0,80"
@@ -293,172 +321,120 @@ JSON formatted response
 
 ### pola sr-policy add -f `filepath` --no-sid-validate
 
-Skips the check that every explicit SID exists in the TED. Without the flag,
-the request fails if any SID is missing from the TED, including when the TED is
-disabled or not yet synchronized. With the flag, the policy is provisioned and
-both the CLI and polad log a warning.
+Skips validation of explicit SIDs against the TED.
 
-Notes:
-
-- Dynamic paths and `waypoints[].sid` overrides are not validated.
-- Validation is best-effort: the TED is populated asynchronously via BGP-LS,
-  so results can lag behind the actual topology.
-- For SRv6 uSID containers, only the locator portion is checked, not the
-  full SID.
-- SID types not represented in the TED (Binding SID, Flex-Algorithm prefix
-  SID, anycast SID, static labels) always require `--no-sid-validate`.
-- The `-s` shorthand was removed in 1.4.0; use the long flag.
+> [!NOTE]
+> SID validation depends on the asynchronously populated BGP-LS TED and may
+> not reflect the current network topology. Use this option for SIDs that
+> cannot be represented in the TED.
 
 ### pola ted [-j]
 
-Displays the TED managed by polad.
+Displays the TED managed by polad, sorted by router ID. If TED is disabled by
+polad, the command returns a non-zero exit status with an error message on
+stderr, in both text and `-j` mode.
 
-JSON formatted response
+Text formatted response
+
+```text
+Node #0: 0000.0aff.0001
+  Hostname: host1
+  ISIS Area ID: 490000
+  SRGB: 16000 - 24000
+  Prefixes:
+    10.0.0.0/30
+    10.255.0.1/32
+      index: 1
+  Links:
+    Local: 10.0.0.1 Remote: 10.0.0.2
+      RemoteRouterID: 0000.0aff.0002
+      Metrics:
+        igp: 10
+      Adj-SID: 17
+      SRv6 End.X SID:
+        EndpointBehavior: ENDX
+        SIDs: [2001:db8:1::1]
+        SID Structure: Block: 32, Node: 16, Func: 16, Arg: 0
+  SRv6 SIDs:
+    SIDs: [2001:db8:1::]
+    Block: 32, Node: 16, Func: 16, Arg: 0
+    EndpointBehavior: END, Flags: 0, Algorithm: 0
+    MultiTopoIDs: []
+
+Node #1: 0000.0aff.0002
+  Hostname: host2
+  ISIS Area ID: 490000
+  SRGB: 16000 - 24000
+  Prefixes:
+    10.0.0.0/30
+    10.255.0.2/32
+      index: 2
+  Links:
+  SRv6 SIDs:
+```
+
+JSON formatted response. The top level is an array of nodes, matching the
+other commands' output; there is no wrapping `ted` object. A link's `localIp`/`remoteIp` is omitted when the BGP-LS descriptor
+does not contain an interface address.
 
 ```json
-{
-  "ted": [
-    {
-      "asn": 65000,
-      "hostname": "host1",
-      "isisAreaID": "490000",
-      "links": [
-        {
-          "adjSid": 17,
-          "localIP": "10.0.1.1",
-          "metrics": [
-            {
-              "type": "IGP",
-              "value": 10
-            }
-          ],
-          "remoteIP": "10.0.1.2",
-          "remoteNode": "0000.0aff.0003"
-        },
-        {
-          "adjSid": 18,
-          "localIP": "10.0.0.1",
-          "metrics": [
-            {
-              "type": "IGP",
-              "value": 10
-            }
-          ],
-          "remoteIP": "10.0.0.2",
-          "remoteNode": "0000.0aff.0002"
+[
+  {
+    "asn": 65000,
+    "routerId": "0000.0aff.0001",
+    "hostname": "host1",
+    "isisAreaId": "490000",
+    "srgb": { "begin": 16000, "end": 24000 },
+    "prefixes": [
+      { "prefix": "10.0.0.0/30" },
+      { "prefix": "10.255.0.1/32", "sidIndex": 1 }
+    ],
+    "links": [
+      {
+        "localIp": "10.0.0.1",
+        "remoteIp": "10.0.0.2",
+        "remoteRouterId": "0000.0aff.0002",
+        "metrics": [{ "type": "igp", "value": 10 }],
+        "adjSid": 17,
+        "srv6EndXSid": {
+          "endpointBehavior": { "behavior": 5, "name": "ENDX" },
+          "sids": ["2001:db8:1::1"],
+          "sidStructure": { "localBlock": 32, "localNode": 16, "localFunc": 16, "localArg": 0 }
         }
-      ],
-      "prefixes": [
-        {
-          "prefix": "10.0.1.0/30"
-        },
-        {
-          "prefix": "10.0.0.0/30"
-        },
-        {
-          "prefix": "10.255.0.1/32",
-          "sidIndex": 1
-        }
-      ],
-      "routerID": "0000.0aff.0001",
-      "srgbBegin": 16000,
-      "srgbEnd": 24000
-    },
-    {
-      "asn": 65000,
-      "hostname": "host2",
-      "isisAreaID": "490000",
-      "links": [
-        {
-          "adjSid": 17,
-          "localIP": "10.0.1.2",
-          "metrics": [
-            {
-              "type": "IGP",
-              "value": 10
-            }
-          ],
-          "remoteIP": "10.0.1.1",
-          "remoteNode": "0000.0aff.0001"
-        },
-        {
-          "adjSid": 16,
-          "localIP": "10.0.2.2",
-          "metrics": [
-            {
-              "type": "IGP",
-              "value": 10
-            }
-          ],
-          "remoteIP": "10.0.2.1",
-          "remoteNode": "0000.0aff.0002"
-        }
-      ],
-      "prefixes": [
-        {
-          "prefix": "10.255.0.3/32",
-          "sidIndex": 3
-        },
-        {
-          "prefix": "10.0.2.0/30"
-        },
-        {
-          "prefix": "10.0.1.0/30"
-        }
-      ],
-      "routerID": "0000.0aff.0003",
-      "srgbBegin": 16000,
-      "srgbEnd": 24000
-    },
-    {
-      "asn": 65000,
-      "hostname": "host3",
-      "isisAreaID": "490000",
-      "links": [
-        {
-          "adjSid": 24001,
-          "localIP": "10.0.0.2",
-          "metrics": [
-            {
-              "type": "IGP",
-              "value": 10
-            }
-          ],
-          "remoteIP": "10.0.0.1",
-          "remoteNode": "0000.0aff.0001"
-        },
-        {
-          "adjSid": 24003,
-          "localIP": "10.0.2.1",
-          "metrics": [
-            {
-              "type": "IGP",
-              "value": 10
-            }
-          ],
-          "remoteIP": "10.0.2.2",
-          "remoteNode": "0000.0aff.0201"
-        }
-      ],
-      "prefixes": [
-        {
-          "prefix": "10.0.2.0/30"
-        },
-        {
-          "prefix": "10.0.0.0/30"
-        },
-        {
-          "prefix": "10.255.0.2/32",
-          "sidIndex": 2
-        }
-      ],
-      "routerID": "0000.0aff.0002",
-      "srgbBegin": 16000,
-      "srgbEnd": 24000
-    }
-  ]
-}
+      }
+    ],
+    "srv6Sids": [
+      {
+        "sids": ["2001:db8:1::"],
+        "endpointBehavior": { "behavior": 1, "name": "END", "flags": 0, "algorithm": 0 },
+        "sidStructure": { "localBlock": 32, "localNode": 16, "localFunc": 16, "localArg": 0 },
+        "multiTopoIds": []
+      }
+    ]
+  },
+  {
+    "asn": 65000,
+    "routerId": "0000.0aff.0002",
+    "hostname": "host2",
+    "isisAreaId": "490000",
+    "srgb": { "begin": 16000, "end": 24000 },
+    "prefixes": [
+      { "prefix": "10.0.0.0/30" },
+      { "prefix": "10.255.0.2/32", "sidIndex": 2 }
+    ],
+    "links": [],
+    "srv6Sids": []
+  }
+]
 ```
+
+Notes:
+
+- `metrics[].type` is a lowercase token (`igp`, `te`, `delay`, `hopcount`),
+  matching the metric vocabulary used elsewhere.
+- `endpointBehavior.flags`/`.algorithm` are present for node SRv6 SIDs
+  (`srv6Sids`) but omitted for adjacency SIDs (`links[].srv6EndXSid`), which
+  carry only the behavior.
 
 ## Completion
 

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -50,22 +50,31 @@ Session #0: 192.0.2.1
   Transport:         tcp, auth=none
   Timers:
                Local  Peer  Effective
-    Keepalive  30     10    10
+    Keepalive  30     10    30
     DeadTimer  120    40    40
   Capabilities:
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       SR-PCE-CAPABILITY [RFC8664]: SR, SR-NAI-Supported
-      ASSOC-TYPE-LIST [RFC8697]: 6 SR Policy Association
-    Local only:        msd=10
-    Peer only:         assoctype:9, color, msd=16
+      ASSOC-TYPE-LIST [RFC8697]:
+        6 SR Policy Association
+    Local only:
+      msd=10
+    Peer only:
+      assoctype=9
+      color
+      msd=16
   Session Creation:  2026-08-19T09:30:05Z
   Initiator:         remote
   Stats:
                Sent  Rcvd
+    Open       1     1
     Keepalive  25    25
+    Close      0     0
     PCErr      0     0
     PCNtf      0     0
+    PCReq      0     0
+    PCRep      0     0
     Report     0     3
     Update     1     0
     Initiate   1     0
@@ -86,7 +95,7 @@ JSON formatted response (`pola session detail -j`)
     "role": "active-stateful-pce",
     "sessionId": { "local": 1, "peer": 7 },
     "timers": {
-      "keepalive": { "local": 30, "peer": 10, "effective": 10 },
+      "keepalive": { "local": 30, "peer": 10, "effective": 30 },
       "deadTimer": { "local": 120, "peer": 40, "effective": 40 }
     },
     "transport": { "protocol": "tcp", "auth": "none" },
@@ -97,7 +106,8 @@ JSON formatted response (`pola session detail -j`)
         "instantiation": true,
         "pathSetupTypes": [],
         "associationTypes": [6],
-        "unrecognizedTlvTypes": []
+        "unrecognizedTlvTypes": [],
+        "other": []
       },
       "localOnly": [{ "name": "msd", "value": "10" }],
       "peerOnly": [
@@ -109,9 +119,13 @@ JSON formatted response (`pola session detail -j`)
     "sessionCreation": "2026-08-19T09:30:05Z",
     "initiator": "remote",
     "stats": {
+      "open": { "sent": 1, "rcvd": 1 },
       "keepalive": { "sent": 25, "rcvd": 25 },
+      "close": { "sent": 0, "rcvd": 0 },
       "pcerr": { "sent": 0, "rcvd": 0 },
       "pcntf": { "sent": 0, "rcvd": 0 },
+      "pcreq": { "sent": 0, "rcvd": 0 },
+      "pcrep": { "sent": 0, "rcvd": 0 },
       "report": { "sent": 0, "rcvd": 3 },
       "update": { "sent": 1, "rcvd": 0 },
       "initiate": { "sent": 1, "rcvd": 0 },

--- a/cmd/pola/errreason.go
+++ b/cmd/pola/errreason.go
@@ -11,5 +11,6 @@ const (
 	reasonDestinationUnreach   = "DESTINATION_UNREACHABLE"
 	reasonMetricNotCarried     = "METRIC_NOT_CARRIED"
 	reasonPCEPSessionNotSynced = "PCEP_SESSION_NOT_SYNCED"
+	reasonPCEPSessionNotFound  = "PCEP_SESSION_NOT_FOUND"
 	reasonSIDValidationFailed  = "SID_VALIDATION_FAILED"
 )

--- a/cmd/pola/fake_client_test.go
+++ b/cmd/pola/fake_client_test.go
@@ -15,6 +15,7 @@ import (
 type fakePCEServiceClient struct {
 	pb.PCEServiceClient
 
+	sessionListReq  *pb.GetSessionListRequest
 	sessionListResp *pb.GetSessionListResponse
 	sessionListErr  error
 
@@ -35,7 +36,8 @@ type fakePCEServiceClient struct {
 	tedErr  error
 }
 
-func (f *fakePCEServiceClient) GetSessionList(_ context.Context, _ *pb.GetSessionListRequest, _ ...grpc.CallOption) (*pb.GetSessionListResponse, error) {
+func (f *fakePCEServiceClient) GetSessionList(_ context.Context, in *pb.GetSessionListRequest, _ ...grpc.CallOption) (*pb.GetSessionListResponse, error) {
+	f.sessionListReq = in
 	return f.sessionListResp, f.sessionListErr
 }
 
@@ -57,7 +59,7 @@ func (f *fakePCEServiceClient) CreateSRPolicy(_ context.Context, in *pb.CreateSR
 	if f.createSRPolicyErr != nil {
 		return nil, f.createSRPolicyErr
 	}
-	return &pb.CreateSRPolicyResponse{IsSuccess: true}, nil
+	return &pb.CreateSRPolicyResponse{}, nil
 }
 
 func (f *fakePCEServiceClient) DeleteSRPolicy(_ context.Context, in *pb.DeleteSRPolicyRequest, _ ...grpc.CallOption) (*pb.DeleteSRPolicyResponse, error) {
@@ -65,7 +67,7 @@ func (f *fakePCEServiceClient) DeleteSRPolicy(_ context.Context, in *pb.DeleteSR
 	if f.deleteSRPolicyErr != nil {
 		return nil, f.deleteSRPolicyErr
 	}
-	return &pb.DeleteSRPolicyResponse{IsSuccess: true}, nil
+	return &pb.DeleteSRPolicyResponse{}, nil
 }
 
 func (f *fakePCEServiceClient) GetTED(_ context.Context, _ *pb.GetTEDRequest, _ ...grpc.CallOption) (*pb.GetTEDResponse, error) {

--- a/cmd/pola/fake_client_test.go
+++ b/cmd/pola/fake_client_test.go
@@ -21,6 +21,7 @@ type fakePCEServiceClient struct {
 	deleteSessionReq *pb.DeleteSessionRequest
 	deleteSessionErr error
 
+	srPolicyListReq  *pb.GetSRPolicyListRequest
 	srPolicyListResp *pb.GetSRPolicyListResponse
 	srPolicyListErr  error
 
@@ -46,7 +47,8 @@ func (f *fakePCEServiceClient) DeleteSession(_ context.Context, in *pb.DeleteSes
 	return &pb.DeleteSessionResponse{}, nil
 }
 
-func (f *fakePCEServiceClient) GetSRPolicyList(_ context.Context, _ *pb.GetSRPolicyListRequest, _ ...grpc.CallOption) (*pb.GetSRPolicyListResponse, error) {
+func (f *fakePCEServiceClient) GetSRPolicyList(_ context.Context, in *pb.GetSRPolicyListRequest, _ ...grpc.CallOption) (*pb.GetSRPolicyListResponse, error) {
+	f.srPolicyListReq = in
 	return f.srPolicyListResp, f.srPolicyListErr
 }
 

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -16,6 +16,7 @@ import (
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/table"
+	"google.golang.org/protobuf/proto"
 )
 
 func withTimeout() (context.Context, context.CancelFunc) {
@@ -181,7 +182,7 @@ type UnknownCapability struct {
 	TLVType uint32
 }
 
-// Strings returns the human-readable flags for this capability.
+// Strings returns a human-readable representation of this capability.
 func (c UnknownCapability) Strings() []string {
 	return []string{fmt.Sprintf("unknown_type_%d", c.TLVType)}
 }
@@ -197,7 +198,7 @@ type Capability struct {
 	Detail capabilityDetail
 }
 
-// Strings returns the human-readable flags for this capability's TLV.
+// Strings returns a human-readable representation of this capability.
 func (c Capability) Strings() []string {
 	if c.Detail == nil {
 		return []string{c.Type}
@@ -205,21 +206,50 @@ func (c Capability) Strings() []string {
 	return c.Detail.Strings()
 }
 
-// Session represents a PCEP session with its capabilities and synchronization state.
-type Session struct {
-	Addr         netip.Addr
-	State        string
-	Capabilities []Capability
-	IsSynced     bool
+// SessionTimers holds the timers advertised by a PCEP speaker.
+type SessionTimers struct {
+	Keepalive uint32
+	DeadTimer uint32
 }
 
-// CapStrings flattens the human-readable flags of all capabilities into a single list.
+// EffectiveTimers holds the timers currently applied by Pola.
+type EffectiveTimers struct {
+	Keepalive uint32
+	DeadTimer uint32
+}
+
+// Session represents a PCEP session.
+type Session struct {
+	Addr            netip.Addr
+	State           string
+	LocalSessionID  *uint32
+	PccSessionID    *uint32
+	LocalTimers     *SessionTimers
+	PccTimers       *SessionTimers
+	EffectiveTimers EffectiveTimers
+	PccType         string
+	Capabilities    []Capability
+	PccCapabilities []Capability
+	IsSynced        bool
+	SRPolicies      []table.SRPolicy
+}
+
+// CapStrings returns human-readable representations of Pola's capabilities.
 func (s Session) CapStrings() []string {
-	var caps []string
-	for _, c := range s.Capabilities {
-		caps = append(caps, c.Strings()...)
+	return capStrings(s.Capabilities)
+}
+
+// PccCapStrings returns human-readable representations of the PCC's capabilities.
+func (s Session) PccCapStrings() []string {
+	return capStrings(s.PccCapabilities)
+}
+
+func capStrings(caps []Capability) []string {
+	var out []string
+	for _, c := range caps {
+		out = append(out, c.Strings()...)
 	}
-	return caps
+	return out
 }
 
 // capabilityFromPB converts a gRPC Capability into its typed client-side representation.
@@ -266,6 +296,45 @@ func capabilityFromPB(c *pb.Capability) Capability {
 	return cap
 }
 
+func sessionFromPB(pbss *pb.Session) (Session, error) {
+	addr, ok := netip.AddrFromSlice(pbss.GetAddr())
+	if !ok {
+		return Session{}, fmt.Errorf("invalid session address: %v", pbss.GetAddr())
+	}
+
+	ss := Session{
+		Addr:  addr,
+		State: strings.TrimPrefix(pbss.GetState().String(), "SESSION_STATE_"),
+		EffectiveTimers: EffectiveTimers{
+			Keepalive: pbss.GetEffectiveTimers().GetKeepalive(),
+			DeadTimer: pbss.GetEffectiveTimers().GetDeadTimer(),
+		},
+		PccType:         strings.TrimPrefix(pbss.GetPccType().String(), "PCC_TYPE_"),
+		IsSynced:        pbss.GetIsSynced(),
+		Capabilities:    []Capability{},
+		PccCapabilities: []Capability{},
+	}
+	if pbss.LocalSessionId != nil {
+		ss.LocalSessionID = proto.Uint32(pbss.GetLocalSessionId())
+	}
+	if pbss.PccSessionId != nil {
+		ss.PccSessionID = proto.Uint32(pbss.GetPccSessionId())
+	}
+	if t := pbss.GetLocalTimers(); t != nil {
+		ss.LocalTimers = &SessionTimers{Keepalive: t.GetKeepalive(), DeadTimer: t.GetDeadTimer()}
+	}
+	if t := pbss.GetPccTimers(); t != nil {
+		ss.PccTimers = &SessionTimers{Keepalive: t.GetKeepalive(), DeadTimer: t.GetDeadTimer()}
+	}
+	for _, c := range pbss.GetCapabilities() {
+		ss.Capabilities = append(ss.Capabilities, capabilityFromPB(c))
+	}
+	for _, c := range pbss.GetPccCapabilities() {
+		ss.PccCapabilities = append(ss.PccCapabilities, capabilityFromPB(c))
+	}
+	return ss, nil
+}
+
 // GetSessions retrieves the list of PCEP sessions from the PCE server.
 func GetSessions(client pb.PCEServiceClient) ([]Session, error) {
 	ctx, cancel := withTimeout()
@@ -278,19 +347,9 @@ func GetSessions(client pb.PCEServiceClient) ([]Session, error) {
 
 	var sessions []Session
 	for _, pbss := range ret.GetSessions() {
-		addr, ok := netip.AddrFromSlice(pbss.GetAddr())
-		if !ok {
-			return nil, fmt.Errorf("invalid session address: %v", pbss.GetAddr())
-		}
-
-		ss := Session{
-			Addr:         addr,
-			State:        pbss.State.String(),
-			IsSynced:     pbss.GetIsSynced(),
-			Capabilities: []Capability{},
-		}
-		for _, c := range pbss.GetCapabilities() {
-			ss.Capabilities = append(ss.Capabilities, capabilityFromPB(c))
+		ss, err := sessionFromPB(pbss)
+		if err != nil {
+			return nil, err
 		}
 		sessions = append(sessions, ss)
 	}
@@ -310,15 +369,9 @@ func DeleteSession(client pb.PCEServiceClient, req *pb.DeleteSessionRequest) err
 	return nil
 }
 
-// SessionSRPolicies groups the SR Policies managed over a single PCEP session.
-type SessionSRPolicies struct {
-	Addr       netip.Addr       `json:"peerAddr"`
-	SRPolicies []table.SRPolicy `json:"srPolicies"`
-}
-
-// GetSRPolicyList returns SR Policies grouped by PCEP session in stable order.
-// If sessionAddr is valid, only the matching session is returned.
-func GetSRPolicyList(client pb.PCEServiceClient, sessionAddr netip.Addr) ([]SessionSRPolicies, error) {
+// GetSRPolicyList returns SR Policies grouped by PCEP session,
+// optionally filtered by session address.
+func GetSRPolicyList(client pb.PCEServiceClient, sessionAddr netip.Addr) ([]Session, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
@@ -332,23 +385,23 @@ func GetSRPolicyList(client pb.PCEServiceClient, sessionAddr netip.Addr) ([]Sess
 		return nil, err
 	}
 
-	sessions := make([]SessionSRPolicies, 0, len(ret.GetSessions()))
+	sessions := make([]Session, 0, len(ret.GetSessions()))
 	for _, pbSession := range ret.GetSessions() {
-		peerAddr, ok := netip.AddrFromSlice(pbSession.GetAddr())
-		if !ok {
-			return nil, fmt.Errorf("invalid session address: %v", pbSession.GetAddr())
+		ss, err := sessionFromPB(pbSession)
+		if err != nil {
+			return nil, err
 		}
 
-		policies := make([]table.SRPolicy, 0, len(pbSession.GetSrPolicies()))
+		ss.SRPolicies = make([]table.SRPolicy, 0, len(pbSession.GetSrPolicies()))
 		for _, p := range pbSession.GetSrPolicies() {
 			policy, err := convertSRPolicy(p)
 			if err != nil {
 				return nil, err
 			}
-			policies = append(policies, policy)
+			ss.SRPolicies = append(ss.SRPolicies, policy)
 		}
 
-		sessions = append(sessions, SessionSRPolicies{Addr: peerAddr, SRPolicies: policies})
+		sessions = append(sessions, ss)
 	}
 
 	return sessions, nil

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -220,18 +220,22 @@ type EffectiveTimers struct {
 	DeadTimer *uint32
 }
 
-// MessageCounter is a sent/rcvd counter pair (RFC 9826 ietf-pcep-stats).
+// MessageCounter contains sent and received message counters.
 type MessageCounter struct {
 	Sent uint64
 	Rcvd uint64
 }
 
-// SessionStats holds the RFC 9826 ietf-pcep-stats message counters of a
-// session. It is nil unless requested via GetSessions' includeStats.
+// SessionStats contains per-session PCEP message counters.
+// Open and Close are Pola-specific additions.
 type SessionStats struct {
+	Open             MessageCounter
 	Keepalive        MessageCounter
+	Close            MessageCounter
 	PCErr            MessageCounter
 	PCNtf            MessageCounter
+	PCReq            MessageCounter
+	PCRep            MessageCounter
 	Report           MessageCounter
 	Update           MessageCounter
 	Initiate         MessageCounter
@@ -412,9 +416,13 @@ func messageCounterFromPB(c *pb.MessageCounter) MessageCounter {
 
 func sessionStatsFromPB(s *pb.SessionStats) *SessionStats {
 	return &SessionStats{
+		Open:             messageCounterFromPB(s.GetOpen()),
 		Keepalive:        messageCounterFromPB(s.GetKeepalive()),
+		Close:            messageCounterFromPB(s.GetClose()),
 		PCErr:            messageCounterFromPB(s.GetPcerr()),
 		PCNtf:            messageCounterFromPB(s.GetPcntf()),
+		PCReq:            messageCounterFromPB(s.GetPcreq()),
+		PCRep:            messageCounterFromPB(s.GetPcrep()),
 		Report:           messageCounterFromPB(s.GetReport()),
 		Update:           messageCounterFromPB(s.GetUpdate()),
 		Initiate:         messageCounterFromPB(s.GetInitiate()),

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -97,9 +97,11 @@ func (c SRv6Capability) Strings() []string {
 	return ret
 }
 
-// PathSetupTypeCapability holds the raw PathSetupType values advertised by the peer.
+// PathSetupTypeCapability holds the raw PathSetupType values advertised by the peer,
+// along with any per-PST capability sub-TLVs (RFC 8408).
 type PathSetupTypeCapability struct {
-	PathSetupTypes []uint32
+	PathSetupTypes  []uint32
+	SubCapabilities []Capability
 }
 
 // Strings returns the human-readable flags for this capability.
@@ -295,7 +297,11 @@ func capabilityFromPB(c *pb.Capability) Capability {
 	case *pb.Capability_Srv6:
 		cap.Detail = SRv6Capability{NAISupported: detail.Srv6.GetNaiSupported()}
 	case *pb.Capability_PathSetupType:
-		cap.Detail = PathSetupTypeCapability{PathSetupTypes: detail.PathSetupType.GetPathSetupTypes()}
+		pst := PathSetupTypeCapability{PathSetupTypes: detail.PathSetupType.GetPathSetupTypes()}
+		for _, sub := range detail.PathSetupType.GetSubCapabilities() {
+			pst.SubCapabilities = append(pst.SubCapabilities, capabilityFromPB(sub))
+		}
+		cap.Detail = pst
 	case *pb.Capability_AssocTypeList:
 		cap.Detail = AssocTypeListCapability{AssocTypes: detail.AssocTypeList.GetAssocTypes()}
 	case *pb.Capability_LspDbVersion:

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -220,14 +220,13 @@ type EffectiveTimers struct {
 	DeadTimer *uint32
 }
 
-// MessageCounter contains sent and received message counters.
+// MessageCounter mirrors one RFC 9826 sent/rcvd counter pair.
 type MessageCounter struct {
 	Sent uint64
 	Rcvd uint64
 }
 
-// SessionStats contains per-session PCEP message counters.
-// Open and Close are Pola-specific additions.
+// SessionStats contains per-session PCEP statistics.
 type SessionStats struct {
 	Open             MessageCounter
 	Keepalive        MessageCounter
@@ -261,6 +260,7 @@ type Session struct {
 	SyncState         string
 	CreatedAt         time.Time
 	EstablishedAt     time.Time
+	UptimeNanos       int64
 	Stats             *SessionStats
 }
 
@@ -362,6 +362,7 @@ func sessionFromPB(pbss *pb.Session) (Session, error) {
 	if n := pbss.GetEstablishedAtUnixNano(); n != 0 {
 		ss.EstablishedAt = time.Unix(0, n)
 	}
+	ss.UptimeNanos = pbss.GetUptimeNanos()
 	if s := pbss.GetStats(); s != nil {
 		ss.Stats = sessionStatsFromPB(s)
 	}

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
+	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/nttcom/pola/pkg/table"
-	"google.golang.org/protobuf/proto"
 )
 
 func withTimeout() (context.Context, context.CancelFunc) {
@@ -65,16 +65,17 @@ func (c StatefulCapability) Strings() []string {
 type SRCapability struct {
 	UnlimitedMSD bool
 	NAISupported bool
-	MSD          uint32
+	MSD          *uint32
 }
 
 // Strings returns the human-readable flags for this capability.
 func (c SRCapability) Strings() []string {
 	ret := []string{"SR"}
-	if c.UnlimitedMSD {
+	switch {
+	case c.UnlimitedMSD:
 		ret = append(ret, "Unlimited-SID-Depth")
-	} else {
-		ret = append(ret, fmt.Sprintf("MSD=%d", c.MSD))
+	case c.MSD != nil:
+		ret = append(ret, fmt.Sprintf("MSD=%d", *c.MSD))
 	}
 	if c.NAISupported {
 		ret = append(ret, "SR-NAI-Supported")
@@ -174,7 +175,7 @@ type VendorInformationCapability struct {
 
 // Strings returns the human-readable flags for this capability.
 func (c VendorInformationCapability) Strings() []string {
-	return []string{fmt.Sprintf("Vendor-Info(%d)", c.EnterpriseNumber)}
+	return []string{pcep.EnterpriseNumber(c.EnterpriseNumber).DisplayLabel()}
 }
 
 // UnknownCapability holds the raw TLV type of a capability Pola does not recognize.
@@ -213,43 +214,58 @@ type SessionTimers struct {
 }
 
 // EffectiveTimers holds the timers currently applied by Pola.
+// Keepalive and DeadTimer are nil until the session reaches SESSION_STATE_UP.
 type EffectiveTimers struct {
-	Keepalive uint32
-	DeadTimer uint32
+	Keepalive *uint32
+	DeadTimer *uint32
+}
+
+// MessageCounter is a sent/rcvd counter pair (RFC 9826 ietf-pcep-stats).
+type MessageCounter struct {
+	Sent uint64
+	Rcvd uint64
+}
+
+// SessionStats holds the RFC 9826 ietf-pcep-stats message counters of a
+// session. It is nil unless requested via GetSessions' includeStats.
+type SessionStats struct {
+	Keepalive        MessageCounter
+	PCErr            MessageCounter
+	PCNtf            MessageCounter
+	Report           MessageCounter
+	Update           MessageCounter
+	Initiate         MessageCounter
+	UnrecognizedRcvd uint64
+	CorruptRcvd      uint64
+	SessSetupOK      uint64
+	SessSetupFail    uint64
 }
 
 // Session represents a PCEP session.
 type Session struct {
-	Addr            netip.Addr
-	State           string
-	LocalSessionID  *uint32
-	PccSessionID    *uint32
-	LocalTimers     *SessionTimers
-	PccTimers       *SessionTimers
-	EffectiveTimers EffectiveTimers
-	PccType         string
-	Capabilities    []Capability
-	PccCapabilities []Capability
-	IsSynced        bool
-	SRPolicies      []table.SRPolicy
+	PeerAddr          netip.Addr
+	State             string
+	LocalSessionID    *uint32
+	PeerSessionID     *uint32
+	LocalTimers       *SessionTimers
+	PeerTimers        *SessionTimers
+	EffectiveTimers   EffectiveTimers
+	PccType           string
+	LocalCapabilities []Capability
+	PeerCapabilities  []Capability
+	Initiator         string
+	SyncState         string
+	CreatedAt         time.Time
+	EstablishedAt     time.Time
+	Stats             *SessionStats
 }
 
-// CapStrings returns human-readable representations of Pola's capabilities.
-func (s Session) CapStrings() []string {
-	return capStrings(s.Capabilities)
-}
-
-// PccCapStrings returns human-readable representations of the PCC's capabilities.
-func (s Session) PccCapStrings() []string {
-	return capStrings(s.PccCapabilities)
-}
-
-func capStrings(caps []Capability) []string {
-	var out []string
-	for _, c := range caps {
-		out = append(out, c.Strings()...)
-	}
-	return out
+// SRPolicySession groups SR Policies by PCEP peer.
+type SRPolicySession struct {
+	PeerAddr   netip.Addr
+	State      string
+	SyncState  string
+	SRPolicies []table.SRPolicy
 }
 
 // capabilityFromPB converts a gRPC Capability into its typed client-side representation.
@@ -270,7 +286,7 @@ func capabilityFromPB(c *pb.Capability) Capability {
 		cap.Detail = SRCapability{
 			UnlimitedMSD: detail.Sr.GetUnlimitedMsd(),
 			NAISupported: detail.Sr.GetNaiSupported(),
-			MSD:          detail.Sr.GetMsd(),
+			MSD:          detail.Sr.Msd,
 		}
 	case *pb.Capability_Srv6:
 		cap.Detail = SRv6Capability{NAISupported: detail.Srv6.GetNaiSupported()}
@@ -297,50 +313,129 @@ func capabilityFromPB(c *pb.Capability) Capability {
 }
 
 func sessionFromPB(pbss *pb.Session) (Session, error) {
-	addr, ok := netip.AddrFromSlice(pbss.GetAddr())
+	addr, ok := netip.AddrFromSlice(pbss.GetPeerAddr())
 	if !ok {
-		return Session{}, fmt.Errorf("invalid session address: %v", pbss.GetAddr())
+		return Session{}, fmt.Errorf("invalid session address: %v", pbss.GetPeerAddr())
 	}
 
 	ss := Session{
-		Addr:  addr,
-		State: strings.TrimPrefix(pbss.GetState().String(), "SESSION_STATE_"),
-		EffectiveTimers: EffectiveTimers{
-			Keepalive: pbss.GetEffectiveTimers().GetKeepalive(),
-			DeadTimer: pbss.GetEffectiveTimers().GetDeadTimer(),
-		},
-		PccType:         strings.TrimPrefix(pbss.GetPccType().String(), "PCC_TYPE_"),
-		IsSynced:        pbss.GetIsSynced(),
-		Capabilities:    []Capability{},
-		PccCapabilities: []Capability{},
+		PeerAddr:          addr,
+		State:             sessionStateFromPB(pbss.GetState()),
+		PccType:           strings.TrimPrefix(pbss.GetPccType().String(), "PCC_TYPE_"),
+		LocalCapabilities: []Capability{},
+		PeerCapabilities:  []Capability{},
+	}
+	if v, ok := pb.EffectiveKeepalive(pbss.GetState(), pbss.GetEffectiveTimers()); ok {
+		ss.EffectiveTimers.Keepalive = new(v)
+	}
+	if v, ok := pb.EffectiveDeadTimer(pbss.GetState(), pbss.GetEffectiveTimers()); ok {
+		ss.EffectiveTimers.DeadTimer = new(v)
 	}
 	if pbss.LocalSessionId != nil {
-		ss.LocalSessionID = proto.Uint32(pbss.GetLocalSessionId())
+		ss.LocalSessionID = new(pbss.GetLocalSessionId())
 	}
-	if pbss.PccSessionId != nil {
-		ss.PccSessionID = proto.Uint32(pbss.GetPccSessionId())
+	if pbss.PeerSessionId != nil {
+		ss.PeerSessionID = new(pbss.GetPeerSessionId())
 	}
 	if t := pbss.GetLocalTimers(); t != nil {
 		ss.LocalTimers = &SessionTimers{Keepalive: t.GetKeepalive(), DeadTimer: t.GetDeadTimer()}
 	}
-	if t := pbss.GetPccTimers(); t != nil {
-		ss.PccTimers = &SessionTimers{Keepalive: t.GetKeepalive(), DeadTimer: t.GetDeadTimer()}
+	if t := pbss.GetPeerTimers(); t != nil {
+		ss.PeerTimers = &SessionTimers{Keepalive: t.GetKeepalive(), DeadTimer: t.GetDeadTimer()}
 	}
-	for _, c := range pbss.GetCapabilities() {
-		ss.Capabilities = append(ss.Capabilities, capabilityFromPB(c))
+	for _, c := range pbss.GetLocalCapabilities() {
+		ss.LocalCapabilities = append(ss.LocalCapabilities, capabilityFromPB(c))
 	}
-	for _, c := range pbss.GetPccCapabilities() {
-		ss.PccCapabilities = append(ss.PccCapabilities, capabilityFromPB(c))
+	for _, c := range pbss.GetPeerCapabilities() {
+		ss.PeerCapabilities = append(ss.PeerCapabilities, capabilityFromPB(c))
 	}
+
+	ss.Initiator = initiatorFromPB(pbss.GetInitiator())
+	ss.SyncState = syncStateFromPB(pbss.GetSyncState())
+	if n := pbss.GetCreatedAtUnixNano(); n != 0 {
+		ss.CreatedAt = time.Unix(0, n)
+	}
+	if n := pbss.GetEstablishedAtUnixNano(); n != 0 {
+		ss.EstablishedAt = time.Unix(0, n)
+	}
+	if s := pbss.GetStats(); s != nil {
+		ss.Stats = sessionStatsFromPB(s)
+	}
+
 	return ss, nil
 }
 
-// GetSessions retrieves the list of PCEP sessions from the PCE server.
-func GetSessions(client pb.PCEServiceClient) ([]Session, error) {
+// initiatorFromPB converts a gRPC SessionInitiator to its CLI/JSON display value.
+func initiatorFromPB(initiator pb.SessionInitiator) string {
+	switch initiator {
+	case pb.SessionInitiator_SESSION_INITIATOR_LOCAL:
+		return "local"
+	case pb.SessionInitiator_SESSION_INITIATOR_REMOTE:
+		return "remote"
+	default:
+		return "unknown"
+	}
+}
+
+// sessionStateFromPB converts a gRPC SessionState to its CLI/JSON display value.
+func sessionStateFromPB(state pb.SessionState) string {
+	switch state {
+	case pb.SessionState_SESSION_STATE_UP:
+		return "up"
+	case pb.SessionState_SESSION_STATE_TCP_PENDING:
+		return "tcp-pending"
+	case pb.SessionState_SESSION_STATE_OPEN_WAIT:
+		return "open-wait"
+	case pb.SessionState_SESSION_STATE_KEEP_WAIT:
+		return "keep-wait"
+	default:
+		return "unknown"
+	}
+}
+
+func syncStateFromPB(state pb.LspDbSyncState) string {
+	switch state {
+	case pb.LspDbSyncState_LSP_DB_SYNC_STATE_PENDING:
+		return "pending"
+	case pb.LspDbSyncState_LSP_DB_SYNC_STATE_ONGOING:
+		return "ongoing"
+	case pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED:
+		return "finished"
+	default:
+		return "unknown"
+	}
+}
+
+func messageCounterFromPB(c *pb.MessageCounter) MessageCounter {
+	return MessageCounter{Sent: c.GetSent(), Rcvd: c.GetRcvd()}
+}
+
+func sessionStatsFromPB(s *pb.SessionStats) *SessionStats {
+	return &SessionStats{
+		Keepalive:        messageCounterFromPB(s.GetKeepalive()),
+		PCErr:            messageCounterFromPB(s.GetPcerr()),
+		PCNtf:            messageCounterFromPB(s.GetPcntf()),
+		Report:           messageCounterFromPB(s.GetReport()),
+		Update:           messageCounterFromPB(s.GetUpdate()),
+		Initiate:         messageCounterFromPB(s.GetInitiate()),
+		UnrecognizedRcvd: s.GetUnrecognizedRcvd(),
+		CorruptRcvd:      s.GetCorruptRcvd(),
+		SessSetupOK:      s.GetSessSetupOk(),
+		SessSetupFail:    s.GetSessSetupFail(),
+	}
+}
+
+// GetSessions retrieves PCEP sessions, optionally filtered by peer address.
+func GetSessions(client pb.PCEServiceClient, addr netip.Addr, includeStats bool) ([]Session, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
-	ret, err := client.GetSessionList(ctx, &pb.GetSessionListRequest{})
+	req := &pb.GetSessionListRequest{IncludeStats: includeStats}
+	if addr.IsValid() {
+		req.PeerAddr = addr.AsSlice()
+	}
+
+	ret, err := client.GetSessionList(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +452,7 @@ func GetSessions(client pb.PCEServiceClient) ([]Session, error) {
 	return sessions, nil
 }
 
-// DeleteSession sends a delete session request to the PCE server.
+// DeleteSession requests deletion of a PCEP session.
 func DeleteSession(client pb.PCEServiceClient, req *pb.DeleteSessionRequest) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
@@ -369,15 +464,15 @@ func DeleteSession(client pb.PCEServiceClient, req *pb.DeleteSessionRequest) err
 	return nil
 }
 
-// GetSRPolicyList returns SR Policies grouped by PCEP session,
-// optionally filtered by session address.
-func GetSRPolicyList(client pb.PCEServiceClient, sessionAddr netip.Addr) ([]Session, error) {
+// GetSRPolicyList returns SR Policies grouped by PCEP peer,
+// optionally filtered by peer address.
+func GetSRPolicyList(client pb.PCEServiceClient, peerAddr netip.Addr) ([]SRPolicySession, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
 	req := &pb.GetSRPolicyListRequest{}
-	if sessionAddr.IsValid() {
-		req.SessionAddr = sessionAddr.AsSlice()
+	if peerAddr.IsValid() {
+		req.PeerAddr = peerAddr.AsSlice()
 	}
 
 	ret, err := client.GetSRPolicyList(ctx, req)
@@ -385,11 +480,17 @@ func GetSRPolicyList(client pb.PCEServiceClient, sessionAddr netip.Addr) ([]Sess
 		return nil, err
 	}
 
-	sessions := make([]Session, 0, len(ret.GetSessions()))
+	sessions := make([]SRPolicySession, 0, len(ret.GetSessions()))
 	for _, pbSession := range ret.GetSessions() {
-		ss, err := sessionFromPB(pbSession)
-		if err != nil {
-			return nil, err
+		addr, ok := netip.AddrFromSlice(pbSession.GetPeerAddr())
+		if !ok {
+			return nil, fmt.Errorf("invalid session address: %v", pbSession.GetPeerAddr())
+		}
+
+		ss := SRPolicySession{
+			PeerAddr:  addr,
+			State:     sessionStateFromPB(pbSession.GetState()),
+			SyncState: syncStateFromPB(pbSession.GetSyncState()),
 		}
 
 		ss.SRPolicies = make([]table.SRPolicy, 0, len(pbSession.GetSrPolicies()))
@@ -583,7 +684,7 @@ func GetTED(client pb.PCEServiceClient) (*table.LsTED, error) {
 		return nil, err
 	}
 
-	if !ret.GetEnable() {
+	if !ret.GetEnabled() {
 		return nil, nil
 	}
 
@@ -591,9 +692,9 @@ func GetTED(client pb.PCEServiceClient) (*table.LsTED, error) {
 		Nodes: make(map[string]*table.LsNode),
 	}
 
-	initializeLsNodes(ted, ret.GetLsNodes())
+	initializeLsNodes(ted, ret.GetNodes())
 
-	for _, node := range ret.GetLsNodes() {
+	for _, node := range ret.GetNodes() {
 		if err := addLsNode(ted, node); err != nil {
 			return nil, err
 		}
@@ -616,7 +717,7 @@ func initializeLsNodes(ted *table.LsTED, nodes []*pb.LsNode) {
 }
 
 func addLsNode(ted *table.LsTED, node *pb.LsNode) error {
-	for _, link := range node.GetLsLinks() {
+	for _, link := range node.GetLinks() {
 		localNode := ted.Nodes[link.LocalRouterId]
 		remoteNode := ted.Nodes[link.RemoteRouterId]
 		lsLink, err := createLsLink(localNode, remoteNode, link)
@@ -626,7 +727,7 @@ func addLsNode(ted *table.LsTED, node *pb.LsNode) error {
 		ted.Nodes[node.GetRouterId()].Links = append(ted.Nodes[node.GetRouterId()].Links, lsLink)
 	}
 
-	for _, prefix := range node.LsPrefixes {
+	for _, prefix := range node.GetPrefixes() {
 		lsPrefix, err := createLsPrefix(ted.Nodes[node.GetRouterId()], prefix)
 		if err != nil {
 			return err
@@ -634,7 +735,7 @@ func addLsNode(ted *table.LsTED, node *pb.LsNode) error {
 		ted.Nodes[node.GetRouterId()].Prefixes = append(ted.Nodes[node.GetRouterId()].Prefixes, lsPrefix)
 	}
 
-	for _, srv6SID := range node.LsSrv6Sids {
+	for _, srv6SID := range node.GetSrv6Sids() {
 		lsSrv6SID := createSrv6SID(ted.Nodes[node.GetRouterId()], srv6SID)
 		ted.Nodes[node.GetRouterId()].SRv6SIDs = append(ted.Nodes[node.GetRouterId()].SRv6SIDs, lsSrv6SID)
 	}

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -295,6 +295,54 @@ func TestGetSessions_WithCapabilities(t *testing.T) {
 	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: 10}}}, sessions[0].Capabilities)
 }
 
+func TestGetSessions_WithPccCapabilities(t *testing.T) {
+	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
+		Sessions: []*pb.Session{
+			{
+				Addr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State: pb.SessionState_SESSION_STATE_UP,
+				PccCapabilities: []*pb.Capability{
+					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
+				},
+			},
+		},
+	}}
+
+	sessions, err := GetSessions(client)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: 10}}}, sessions[0].PccCapabilities)
+	assert.Equal(t, []string{"SR", "MSD=10"}, sessions[0].PccCapStrings())
+}
+
+func TestGetSessions_WithSessionIDsAndTimers(t *testing.T) {
+	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
+		Sessions: []*pb.Session{
+			{
+				Addr:           netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:          pb.SessionState_SESSION_STATE_UP,
+				LocalSessionId: proto.Uint32(1),
+				PccSessionId:   proto.Uint32(2),
+				LocalTimers:    &pb.SessionTimers{Keepalive: 30, DeadTimer: 120},
+				PccTimers:      &pb.SessionTimers{Keepalive: 10, DeadTimer: 40},
+			},
+		},
+	}}
+
+	sessions, err := GetSessions(client)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+
+	require.NotNil(t, sessions[0].LocalSessionID)
+	assert.Equal(t, uint32(1), *sessions[0].LocalSessionID)
+	require.NotNil(t, sessions[0].PccSessionID)
+	assert.Equal(t, uint32(2), *sessions[0].PccSessionID)
+	require.NotNil(t, sessions[0].LocalTimers)
+	assert.Equal(t, SessionTimers{Keepalive: 30, DeadTimer: 120}, *sessions[0].LocalTimers)
+	require.NotNil(t, sessions[0].PccTimers)
+	assert.Equal(t, SessionTimers{Keepalive: 10, DeadTimer: 40}, *sessions[0].PccTimers)
+}
+
 func TestGetSessions_Errors(t *testing.T) {
 	t.Run("client error propagates", func(t *testing.T) {
 		client := &fakeClient{sessionListErr: assert.AnError}

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -271,6 +271,8 @@ func TestGetSessions_NoCapabilitiesIsEmptySlice(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 
+	assert.Equal(t, "up", sessions[0].State)
+
 	require.NotNil(t, sessions[0].LocalCapabilities)
 	assert.Empty(t, sessions[0].LocalCapabilities)
 
@@ -286,7 +288,7 @@ func TestGetSessions_WithCapabilities(t *testing.T) {
 				PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
 				State:    pb.SessionState_SESSION_STATE_UP,
 				LocalCapabilities: []*pb.Capability{
-					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
+					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: proto.Uint32(10)}}},
 				},
 			},
 		},
@@ -295,7 +297,7 @@ func TestGetSessions_WithCapabilities(t *testing.T) {
 	sessions, err := GetSessions(client, netip.Addr{}, false)
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
-	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: 10}}}, sessions[0].LocalCapabilities)
+	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: proto.Uint32(10)}}}, sessions[0].LocalCapabilities)
 }
 
 func TestGetSessions_WithPccCapabilities(t *testing.T) {
@@ -305,7 +307,7 @@ func TestGetSessions_WithPccCapabilities(t *testing.T) {
 				PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
 				State:    pb.SessionState_SESSION_STATE_UP,
 				PeerCapabilities: []*pb.Capability{
-					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
+					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: proto.Uint32(10)}}},
 				},
 			},
 		},
@@ -314,7 +316,7 @@ func TestGetSessions_WithPccCapabilities(t *testing.T) {
 	sessions, err := GetSessions(client, netip.Addr{}, false)
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
-	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: 10}}}, sessions[0].PeerCapabilities)
+	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: proto.Uint32(10)}}}, sessions[0].PeerCapabilities)
 }
 
 func TestGetSessions_WithSessionIDsAndTimers(t *testing.T) {
@@ -343,6 +345,25 @@ func TestGetSessions_WithSessionIDsAndTimers(t *testing.T) {
 	assert.Equal(t, SessionTimers{Keepalive: 30, DeadTimer: 120}, *sessions[0].LocalTimers)
 	require.NotNil(t, sessions[0].PeerTimers)
 	assert.Equal(t, SessionTimers{Keepalive: 10, DeadTimer: 40}, *sessions[0].PeerTimers)
+}
+
+func TestGetSessions_EffectiveTimersIgnoredBeforeUp(t *testing.T) {
+	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
+		Sessions: []*pb.Session{
+			{
+				PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:    pb.SessionState_SESSION_STATE_KEEP_WAIT,
+				// A well-behaved server leaves EffectiveTimers nil before Up,
+				// but the client must not trust that convention blindly.
+				EffectiveTimers: &pb.EffectiveTimers{Keepalive: 30, DeadTimer: 120},
+			},
+		},
+	}}
+
+	sessions, err := GetSessions(client, netip.Addr{}, false)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, EffectiveTimers{}, sessions[0].EffectiveTimers)
 }
 
 func TestGetSessions_TimestampsInitiatorSyncStateAndStats(t *testing.T) {
@@ -423,6 +444,24 @@ func TestSyncStateFromPB(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tt.want, syncStateFromPB(tt.in))
+		})
+	}
+}
+
+func TestSessionStateFromPB(t *testing.T) {
+	tests := map[string]struct {
+		in   pb.SessionState
+		want string
+	}{
+		"up":          {pb.SessionState_SESSION_STATE_UP, "up"},
+		"tcp-pending": {pb.SessionState_SESSION_STATE_TCP_PENDING, "tcp-pending"},
+		"open-wait":   {pb.SessionState_SESSION_STATE_OPEN_WAIT, "open-wait"},
+		"keep-wait":   {pb.SessionState_SESSION_STATE_KEEP_WAIT, "keep-wait"},
+		"unspecified": {pb.SessionState_SESSION_STATE_UNSPECIFIED, "unknown"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sessionStateFromPB(tt.in))
 		})
 	}
 }
@@ -516,7 +555,9 @@ func TestCapabilityDetail_Strings(t *testing.T) {
 		},
 		{name: "Stateful with no flags", detail: StatefulCapability{}, want: []string{"Stateful"}},
 		{name: "SR unlimited MSD with NAI support", detail: SRCapability{UnlimitedMSD: true, NAISupported: true}, want: []string{"SR", "Unlimited-SID-Depth", "SR-NAI-Supported"}},
-		{name: "SR bounded MSD without NAI support", detail: SRCapability{MSD: 10}, want: []string{"SR", "MSD=10"}},
+		{name: "SR bounded MSD without NAI support", detail: SRCapability{MSD: proto.Uint32(10)}, want: []string{"SR", "MSD=10"}},
+		{name: "SR MSD advertised as zero", detail: SRCapability{MSD: proto.Uint32(0)}, want: []string{"SR", "MSD=0"}},
+		{name: "SR MSD not advertised", detail: SRCapability{}, want: []string{"SR"}},
 		{name: "SRv6 with NAI support", detail: SRv6Capability{NAISupported: true}, want: []string{"SRv6", "SRv6-NAI-Supported"}},
 		{name: "SRv6 without NAI support", detail: SRv6Capability{}, want: []string{"SRv6"}},
 		{name: "PathSetupType SR-TE (1) and SRv6-TE (3)", detail: PathSetupTypeCapability{PathSetupTypes: []uint32{1, 3}}, want: []string{"SR-TE", "SRv6-TE"}},
@@ -529,7 +570,8 @@ func TestCapabilityDetail_Strings(t *testing.T) {
 			want:   []string{"Multipath", "MaxMultipaths=4", "Weighted", "OppositeDir", "ForwardClass", "CompositePath"},
 		},
 		{name: "Multipath with no flags", detail: MultipathCapability{MaxMultipaths: 2}, want: []string{"Multipath", "MaxMultipaths=2"}},
-		{name: "VendorInformation", detail: VendorInformationCapability{EnterpriseNumber: 9}, want: []string{"Vendor-Info(9)"}},
+		{name: "VendorInformation known PEN", detail: VendorInformationCapability{EnterpriseNumber: 9}, want: []string{"9 (Cisco Systems, Inc.)"}},
+		{name: "VendorInformation unknown PEN", detail: VendorInformationCapability{EnterpriseNumber: 99999}, want: []string{"99999 (Unknown)"}},
 		{name: "Unknown TLV", detail: UnknownCapability{TLVType: 42}, want: []string{"unknown_type_42"}},
 	}
 	for _, tt := range tests {
@@ -546,7 +588,7 @@ func TestCapability_Strings(t *testing.T) {
 	})
 
 	t.Run("typed Detail is unaffected", func(t *testing.T) {
-		cap := Capability{Type: "SR", Detail: SRCapability{MSD: 10}}
+		cap := Capability{Type: "SR", Detail: SRCapability{MSD: proto.Uint32(10)}}
 		assert.Equal(t, []string{"SR", "MSD=10"}, cap.Strings())
 	})
 }
@@ -564,8 +606,8 @@ func TestCapabilityFromPB(t *testing.T) {
 		},
 		{
 			name:  "SR",
-			pbCap: &pb.Capability{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{UnlimitedMsd: true, NaiSupported: true, Msd: 5}}},
-			want:  Capability{Type: "SR", Detail: SRCapability{UnlimitedMSD: true, NAISupported: true, MSD: 5}},
+			pbCap: &pb.Capability{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{UnlimitedMsd: true, NaiSupported: true, Msd: proto.Uint32(5)}}},
+			want:  Capability{Type: "SR", Detail: SRCapability{UnlimitedMSD: true, NAISupported: true, MSD: proto.Uint32(5)}},
 		},
 		{
 			name:  "SRv6",
@@ -732,6 +774,7 @@ func TestGetSRPolicyList(t *testing.T) {
 		client := &fakeClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
 			Sessions: []*pb.SRPolicySession{{
 				PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:    pb.SessionState_SESSION_STATE_UP,
 				SrPolicies: []*pb.SRPolicy{{
 					PolicyName: "pol1",
 					SrcAddr:    netip.MustParseAddr("192.0.2.1").AsSlice(),
@@ -743,6 +786,7 @@ func TestGetSRPolicyList(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 		assert.Equal(t, "192.0.2.1", got[0].PeerAddr.String())
+		assert.Equal(t, "up", got[0].State)
 		require.Len(t, got[0].SRPolicies, 1)
 		assert.Equal(t, "pol1", got[0].SRPolicies[0].Name)
 	})

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"net/netip"
 	"testing"
+	"time"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/table"
@@ -24,6 +25,7 @@ type fakeClient struct {
 
 	sessionListResp *pb.GetSessionListResponse
 	sessionListErr  error
+	sessionListReq  *pb.GetSessionListRequest
 
 	deleteSessionErr error
 
@@ -37,7 +39,8 @@ type fakeClient struct {
 	tedErr  error
 }
 
-func (f *fakeClient) GetSessionList(_ context.Context, _ *pb.GetSessionListRequest, _ ...grpc.CallOption) (*pb.GetSessionListResponse, error) {
+func (f *fakeClient) GetSessionList(_ context.Context, req *pb.GetSessionListRequest, _ ...grpc.CallOption) (*pb.GetSessionListResponse, error) {
+	f.sessionListReq = req
 	return f.sessionListResp, f.sessionListErr
 }
 
@@ -56,14 +59,14 @@ func (f *fakeClient) CreateSRPolicy(_ context.Context, _ *pb.CreateSRPolicyReque
 	if f.createSRPolicyErr != nil {
 		return nil, f.createSRPolicyErr
 	}
-	return &pb.CreateSRPolicyResponse{IsSuccess: true}, nil
+	return &pb.CreateSRPolicyResponse{}, nil
 }
 
 func (f *fakeClient) DeleteSRPolicy(_ context.Context, _ *pb.DeleteSRPolicyRequest, _ ...grpc.CallOption) (*pb.DeleteSRPolicyResponse, error) {
 	if f.deleteSRPolicyErr != nil {
 		return nil, f.deleteSRPolicyErr
 	}
-	return &pb.DeleteSRPolicyResponse{IsSuccess: true}, nil
+	return &pb.DeleteSRPolicyResponse{}, nil
 }
 
 func (f *fakeClient) GetTED(_ context.Context, _ *pb.GetTEDRequest, _ ...grpc.CallOption) (*pb.GetTEDResponse, error) {
@@ -258,103 +261,226 @@ func TestGetSessions_NoCapabilitiesIsEmptySlice(t *testing.T) {
 	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
 		Sessions: []*pb.Session{
 			{
-				Addr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
-				State: pb.SessionState_SESSION_STATE_UP,
+				PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:    pb.SessionState_SESSION_STATE_UP,
 			},
 		},
 	}}
 
-	sessions, err := GetSessions(client)
+	sessions, err := GetSessions(client, netip.Addr{}, false)
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 
-	require.NotNil(t, sessions[0].Capabilities)
-	assert.Empty(t, sessions[0].Capabilities)
+	require.NotNil(t, sessions[0].LocalCapabilities)
+	assert.Empty(t, sessions[0].LocalCapabilities)
 
 	marshaled, err := json.Marshal(sessions[0])
 	require.NoError(t, err)
-	assert.Contains(t, string(marshaled), `"Capabilities":[]`)
+	assert.Contains(t, string(marshaled), `"LocalCapabilities":[]`)
 }
 
 func TestGetSessions_WithCapabilities(t *testing.T) {
 	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
 		Sessions: []*pb.Session{
 			{
-				Addr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
-				State: pb.SessionState_SESSION_STATE_UP,
-				Capabilities: []*pb.Capability{
+				PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:    pb.SessionState_SESSION_STATE_UP,
+				LocalCapabilities: []*pb.Capability{
 					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
 				},
 			},
 		},
 	}}
 
-	sessions, err := GetSessions(client)
+	sessions, err := GetSessions(client, netip.Addr{}, false)
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
-	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: 10}}}, sessions[0].Capabilities)
+	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: 10}}}, sessions[0].LocalCapabilities)
 }
 
 func TestGetSessions_WithPccCapabilities(t *testing.T) {
 	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
 		Sessions: []*pb.Session{
 			{
-				Addr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
-				State: pb.SessionState_SESSION_STATE_UP,
-				PccCapabilities: []*pb.Capability{
+				PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:    pb.SessionState_SESSION_STATE_UP,
+				PeerCapabilities: []*pb.Capability{
 					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
 				},
 			},
 		},
 	}}
 
-	sessions, err := GetSessions(client)
+	sessions, err := GetSessions(client, netip.Addr{}, false)
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
-	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: 10}}}, sessions[0].PccCapabilities)
-	assert.Equal(t, []string{"SR", "MSD=10"}, sessions[0].PccCapStrings())
+	assert.Equal(t, []Capability{{Type: "SR", Detail: SRCapability{MSD: 10}}}, sessions[0].PeerCapabilities)
 }
 
 func TestGetSessions_WithSessionIDsAndTimers(t *testing.T) {
 	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
 		Sessions: []*pb.Session{
 			{
-				Addr:           netip.MustParseAddr("192.0.2.1").AsSlice(),
+				PeerAddr:       netip.MustParseAddr("192.0.2.1").AsSlice(),
 				State:          pb.SessionState_SESSION_STATE_UP,
 				LocalSessionId: proto.Uint32(1),
-				PccSessionId:   proto.Uint32(2),
+				PeerSessionId:  proto.Uint32(2),
 				LocalTimers:    &pb.SessionTimers{Keepalive: 30, DeadTimer: 120},
-				PccTimers:      &pb.SessionTimers{Keepalive: 10, DeadTimer: 40},
+				PeerTimers:     &pb.SessionTimers{Keepalive: 10, DeadTimer: 40},
 			},
 		},
 	}}
 
-	sessions, err := GetSessions(client)
+	sessions, err := GetSessions(client, netip.Addr{}, false)
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 
 	require.NotNil(t, sessions[0].LocalSessionID)
 	assert.Equal(t, uint32(1), *sessions[0].LocalSessionID)
-	require.NotNil(t, sessions[0].PccSessionID)
-	assert.Equal(t, uint32(2), *sessions[0].PccSessionID)
+	require.NotNil(t, sessions[0].PeerSessionID)
+	assert.Equal(t, uint32(2), *sessions[0].PeerSessionID)
 	require.NotNil(t, sessions[0].LocalTimers)
 	assert.Equal(t, SessionTimers{Keepalive: 30, DeadTimer: 120}, *sessions[0].LocalTimers)
-	require.NotNil(t, sessions[0].PccTimers)
-	assert.Equal(t, SessionTimers{Keepalive: 10, DeadTimer: 40}, *sessions[0].PccTimers)
+	require.NotNil(t, sessions[0].PeerTimers)
+	assert.Equal(t, SessionTimers{Keepalive: 10, DeadTimer: 40}, *sessions[0].PeerTimers)
+}
+
+func TestGetSessions_TimestampsInitiatorSyncStateAndStats(t *testing.T) {
+	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
+		Sessions: []*pb.Session{
+			{
+				PeerAddr:              netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:                 pb.SessionState_SESSION_STATE_UP,
+				Initiator:             pb.SessionInitiator_SESSION_INITIATOR_REMOTE,
+				SyncState:             pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
+				CreatedAtUnixNano:     1000,
+				EstablishedAtUnixNano: 2000,
+				Stats: &pb.SessionStats{
+					Keepalive:        &pb.MessageCounter{Sent: 1, Rcvd: 2},
+					Pcerr:            &pb.MessageCounter{Sent: 3, Rcvd: 4},
+					Pcntf:            &pb.MessageCounter{Rcvd: 5},
+					Report:           &pb.MessageCounter{Rcvd: 6},
+					Update:           &pb.MessageCounter{Sent: 7},
+					Initiate:         &pb.MessageCounter{Sent: 8},
+					UnrecognizedRcvd: 9,
+					CorruptRcvd:      10,
+					SessSetupOk:      11,
+					SessSetupFail:    12,
+				},
+			},
+		},
+	}}
+
+	sessions, err := GetSessions(client, netip.Addr{}, true)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+
+	ss := sessions[0]
+	assert.Equal(t, "remote", ss.Initiator)
+	assert.Equal(t, "finished", ss.SyncState)
+	assert.Equal(t, time.Unix(0, 1000), ss.CreatedAt)
+	assert.Equal(t, time.Unix(0, 2000), ss.EstablishedAt)
+
+	require.NotNil(t, ss.Stats)
+	assert.Equal(t, MessageCounter{Sent: 1, Rcvd: 2}, ss.Stats.Keepalive)
+	assert.Equal(t, MessageCounter{Sent: 3, Rcvd: 4}, ss.Stats.PCErr)
+	assert.Equal(t, MessageCounter{Sent: 0, Rcvd: 5}, ss.Stats.PCNtf)
+	assert.Equal(t, MessageCounter{Sent: 0, Rcvd: 6}, ss.Stats.Report)
+	assert.Equal(t, MessageCounter{Sent: 7, Rcvd: 0}, ss.Stats.Update)
+	assert.Equal(t, MessageCounter{Sent: 8, Rcvd: 0}, ss.Stats.Initiate)
+	assert.Equal(t, uint64(9), ss.Stats.UnrecognizedRcvd)
+	assert.Equal(t, uint64(10), ss.Stats.CorruptRcvd)
+	assert.Equal(t, uint64(11), ss.Stats.SessSetupOK)
+	assert.Equal(t, uint64(12), ss.Stats.SessSetupFail)
+}
+
+func TestInitiatorFromPB(t *testing.T) {
+	tests := map[string]struct {
+		in   pb.SessionInitiator
+		want string
+	}{
+		"local":       {pb.SessionInitiator_SESSION_INITIATOR_LOCAL, "local"},
+		"remote":      {pb.SessionInitiator_SESSION_INITIATOR_REMOTE, "remote"},
+		"unspecified": {pb.SessionInitiator_SESSION_INITIATOR_UNSPECIFIED, "unknown"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, initiatorFromPB(tt.in))
+		})
+	}
+}
+
+func TestSyncStateFromPB(t *testing.T) {
+	tests := map[string]struct {
+		in   pb.LspDbSyncState
+		want string
+	}{
+		"pending":     {pb.LspDbSyncState_LSP_DB_SYNC_STATE_PENDING, "pending"},
+		"ongoing":     {pb.LspDbSyncState_LSP_DB_SYNC_STATE_ONGOING, "ongoing"},
+		"finished":    {pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED, "finished"},
+		"unspecified": {pb.LspDbSyncState_LSP_DB_SYNC_STATE_UNSPECIFIED, "unknown"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, syncStateFromPB(tt.in))
+		})
+	}
+}
+
+func TestGetSessions_ZeroTimestampsAndUnsetEnumsStayZero(t *testing.T) {
+	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
+		Sessions: []*pb.Session{
+			{PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(), State: pb.SessionState_SESSION_STATE_OPEN_WAIT},
+		},
+	}}
+
+	sessions, err := GetSessions(client, netip.Addr{}, false)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+
+	ss := sessions[0]
+	assert.Equal(t, "unknown", ss.Initiator)
+	assert.Equal(t, "unknown", ss.SyncState)
+	assert.True(t, ss.CreatedAt.IsZero())
+	assert.True(t, ss.EstablishedAt.IsZero())
+	assert.Nil(t, ss.Stats)
+}
+
+func TestGetSessions_PassesFilterAddrAndIncludeStats(t *testing.T) {
+	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{}}
+	addr := netip.MustParseAddr("192.0.2.1")
+
+	_, err := GetSessions(client, addr, true)
+	require.NoError(t, err)
+
+	require.NotNil(t, client.sessionListReq)
+	assert.Equal(t, addr.AsSlice(), client.sessionListReq.GetPeerAddr())
+	assert.True(t, client.sessionListReq.GetIncludeStats())
+}
+
+func TestGetSessions_NoFilterAddrLeavesSessionAddrEmpty(t *testing.T) {
+	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{}}
+
+	_, err := GetSessions(client, netip.Addr{}, false)
+	require.NoError(t, err)
+
+	require.NotNil(t, client.sessionListReq)
+	assert.Empty(t, client.sessionListReq.GetPeerAddr())
+	assert.False(t, client.sessionListReq.GetIncludeStats())
 }
 
 func TestGetSessions_Errors(t *testing.T) {
 	t.Run("client error propagates", func(t *testing.T) {
 		client := &fakeClient{sessionListErr: assert.AnError}
-		_, err := GetSessions(client)
+		_, err := GetSessions(client, netip.Addr{}, false)
 		require.ErrorIs(t, err, assert.AnError)
 	})
 
 	t.Run("malformed session address", func(t *testing.T) {
 		client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
-			Sessions: []*pb.Session{{Addr: []byte{1, 2, 3}}},
+			Sessions: []*pb.Session{{PeerAddr: []byte{1, 2, 3}}},
 		}}
-		_, err := GetSessions(client)
+		_, err := GetSessions(client, netip.Addr{}, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid session address")
 	})
@@ -363,7 +489,7 @@ func TestGetSessions_Errors(t *testing.T) {
 func TestDeleteSession(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		client := &fakeClient{}
-		err := DeleteSession(client, &pb.DeleteSessionRequest{Addr: netip.MustParseAddr("192.0.2.1").AsSlice()})
+		err := DeleteSession(client, &pb.DeleteSessionRequest{PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice()})
 		require.NoError(t, err)
 	})
 
@@ -423,14 +549,6 @@ func TestCapability_Strings(t *testing.T) {
 		cap := Capability{Type: "SR", Detail: SRCapability{MSD: 10}}
 		assert.Equal(t, []string{"SR", "MSD=10"}, cap.Strings())
 	})
-}
-
-func TestSession_CapStrings(t *testing.T) {
-	s := Session{Capabilities: []Capability{
-		{Type: "SR", Detail: SRCapability{MSD: 10}},
-		{Type: "SRV6", Detail: SRv6Capability{NAISupported: true}},
-	}}
-	assert.Equal(t, []string{"SR", "MSD=10", "SRv6", "SRv6-NAI-Supported"}, s.CapStrings())
 }
 
 func TestCapabilityFromPB(t *testing.T) {
@@ -612,8 +730,8 @@ func TestConvertSRPolicy(t *testing.T) {
 func TestGetSRPolicyList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		client := &fakeClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
-			Sessions: []*pb.Session{{
-				Addr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+			Sessions: []*pb.SRPolicySession{{
+				PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
 				SrPolicies: []*pb.SRPolicy{{
 					PolicyName: "pol1",
 					SrcAddr:    netip.MustParseAddr("192.0.2.1").AsSlice(),
@@ -624,7 +742,7 @@ func TestGetSRPolicyList(t *testing.T) {
 		got, err := GetSRPolicyList(client, netip.MustParseAddr("192.0.2.1"))
 		require.NoError(t, err)
 		require.Len(t, got, 1)
-		assert.Equal(t, "192.0.2.1", got[0].Addr.String())
+		assert.Equal(t, "192.0.2.1", got[0].PeerAddr.String())
 		require.Len(t, got[0].SRPolicies, 1)
 		assert.Equal(t, "pol1", got[0].SRPolicies[0].Name)
 	})
@@ -637,7 +755,7 @@ func TestGetSRPolicyList(t *testing.T) {
 
 	t.Run("invalid session address", func(t *testing.T) {
 		client := &fakeClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
-			Sessions: []*pb.Session{{Addr: []byte{1, 2, 3}}},
+			Sessions: []*pb.SRPolicySession{{PeerAddr: []byte{1, 2, 3}}},
 		}}
 		_, err := GetSRPolicyList(client, netip.Addr{})
 		require.Error(t, err)
@@ -645,8 +763,8 @@ func TestGetSRPolicyList(t *testing.T) {
 
 	t.Run("policy conversion error propagates", func(t *testing.T) {
 		client := &fakeClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
-			Sessions: []*pb.Session{{
-				Addr:       netip.MustParseAddr("192.0.2.1").AsSlice(),
+			Sessions: []*pb.SRPolicySession{{
+				PeerAddr:   netip.MustParseAddr("192.0.2.1").AsSlice(),
 				SrPolicies: []*pb.SRPolicy{{SrcAddr: []byte{1, 2, 3}}},
 			}},
 		}}
@@ -678,7 +796,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 }
 
 func TestGetTED_Disabled(t *testing.T) {
-	ted, err := GetTED(&fakeClient{tedResp: &pb.GetTEDResponse{Enable: false}})
+	ted, err := GetTED(&fakeClient{tedResp: &pb.GetTEDResponse{Enabled: false}})
 	require.NoError(t, err)
 	assert.Nil(t, ted)
 }
@@ -696,7 +814,7 @@ func TestGetTED_Success(t *testing.T) {
 		IsisAreaId: "49.0001",
 		SrgbBegin:  16000,
 		SrgbEnd:    23999,
-		LsLinks: []*pb.LsLink{
+		Links: []*pb.LsLink{
 			{
 				LocalRouterId:  "0000.0aff.0001",
 				RemoteRouterId: "0000.0aff.0002",
@@ -720,11 +838,11 @@ func TestGetTED_Success(t *testing.T) {
 				RemoteRouterId: "0000.0aff.0002",
 			},
 		},
-		LsPrefixes: []*pb.LsPrefix{
+		Prefixes: []*pb.LsPrefix{
 			{Prefix: "10.0.0.1/32", SidIndex: proto.Uint32(1)},
 			{Prefix: "10.0.0.2/32"},
 		},
-		LsSrv6Sids: []*pb.LsSrv6SID{
+		Srv6Sids: []*pb.LsSrv6SID{
 			{
 				Sids:             []*pb.SID{{Sid: "2001:db8:1::"}},
 				EndpointBehavior: &pb.EndpointBehavior{Behavior: uint32(table.BehaviorEND), Flags: 1, Algorithm: 0},
@@ -735,7 +853,7 @@ func TestGetTED_Success(t *testing.T) {
 	}
 	nodeB := &pb.LsNode{Asn: 65000, RouterId: "0000.0aff.0002"}
 
-	client := &fakeClient{tedResp: &pb.GetTEDResponse{Enable: true, LsNodes: []*pb.LsNode{nodeA, nodeB}}}
+	client := &fakeClient{tedResp: &pb.GetTEDResponse{Enabled: true, Nodes: []*pb.LsNode{nodeA, nodeB}}}
 	ted, err := GetTED(client)
 	require.NoError(t, err)
 	require.NotNil(t, ted)
@@ -783,16 +901,16 @@ func TestGetTED_Success(t *testing.T) {
 
 func TestGetTED_PropagatesConversionErrors(t *testing.T) {
 	t.Run("invalid link IP", func(t *testing.T) {
-		node := &pb.LsNode{RouterId: "0000.0aff.0001", LsLinks: []*pb.LsLink{
+		node := &pb.LsNode{RouterId: "0000.0aff.0001", Links: []*pb.LsLink{
 			{LocalRouterId: "0000.0aff.0001", RemoteRouterId: "0000.0aff.0001", LocalIp: "not-an-ip"},
 		}}
-		_, err := GetTED(&fakeClient{tedResp: &pb.GetTEDResponse{Enable: true, LsNodes: []*pb.LsNode{node}}})
+		_, err := GetTED(&fakeClient{tedResp: &pb.GetTEDResponse{Enabled: true, Nodes: []*pb.LsNode{node}}})
 		require.Error(t, err)
 	})
 
 	t.Run("invalid prefix", func(t *testing.T) {
-		node := &pb.LsNode{RouterId: "0000.0aff.0001", LsPrefixes: []*pb.LsPrefix{{Prefix: "not-a-prefix"}}}
-		_, err := GetTED(&fakeClient{tedResp: &pb.GetTEDResponse{Enable: true, LsNodes: []*pb.LsNode{node}}})
+		node := &pb.LsNode{RouterId: "0000.0aff.0001", Prefixes: []*pb.LsPrefix{{Prefix: "not-a-prefix"}}}
+		_, err := GetTED(&fakeClient{tedResp: &pb.GetTEDResponse{Enabled: true, Nodes: []*pb.LsNode{node}}})
 		require.Error(t, err)
 	})
 }
@@ -837,8 +955,8 @@ func TestAddLsNode_InvalidSrv6SID(t *testing.T) {
 		"0000.0aff.0001": table.NewLsNode(65000, "0000.0aff.0001"),
 	}}
 	node := &pb.LsNode{
-		RouterId:   "0000.0aff.0001",
-		LsPrefixes: []*pb.LsPrefix{{Prefix: "not-a-prefix"}},
+		RouterId: "0000.0aff.0001",
+		Prefixes: []*pb.LsPrefix{{Prefix: "not-a-prefix"}},
 	}
 
 	err := addLsNode(ted, node)

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -366,6 +366,27 @@ func TestGetSessions_EffectiveTimersIgnoredBeforeUp(t *testing.T) {
 	assert.Equal(t, EffectiveTimers{}, sessions[0].EffectiveTimers)
 }
 
+func TestGetSessions_EffectiveTimersPopulatedWhenUp(t *testing.T) {
+	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
+		Sessions: []*pb.Session{
+			{
+				PeerAddr:        netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:           pb.SessionState_SESSION_STATE_UP,
+				EffectiveTimers: &pb.EffectiveTimers{Keepalive: 30, DeadTimer: 120},
+			},
+		},
+	}}
+
+	sessions, err := GetSessions(client, netip.Addr{}, false)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+
+	assert.NotNil(t, sessions[0].EffectiveTimers.Keepalive)
+	assert.Equal(t, uint32(30), *sessions[0].EffectiveTimers.Keepalive)
+	assert.NotNil(t, sessions[0].EffectiveTimers.DeadTimer)
+	assert.Equal(t, uint32(120), *sessions[0].EffectiveTimers.DeadTimer)
+}
+
 func TestGetSessions_TimestampsInitiatorSyncStateAndStats(t *testing.T) {
 	client := &fakeClient{sessionListResp: &pb.GetSessionListResponse{
 		Sessions: []*pb.Session{

--- a/cmd/pola/grpc/grpc_client_test.go
+++ b/cmd/pola/grpc/grpc_client_test.go
@@ -620,6 +620,23 @@ func TestCapabilityFromPB(t *testing.T) {
 			want:  Capability{Type: "PATH_SETUP_TYPE", Detail: PathSetupTypeCapability{PathSetupTypes: []uint32{1, 3}}},
 		},
 		{
+			name: "PathSetupType with SR/SRv6 sub-capabilities",
+			pbCap: &pb.Capability{Type: pb.CapabilityType_CAPABILITY_TYPE_PATH_SETUP_TYPE, Detail: &pb.Capability_PathSetupType{PathSetupType: &pb.PathSetupTypeCapability{
+				PathSetupTypes: []uint32{1, 3},
+				SubCapabilities: []*pb.Capability{
+					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{UnlimitedMsd: true}}},
+					{Type: pb.CapabilityType_CAPABILITY_TYPE_SRV6, Detail: &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{}}},
+				},
+			}}},
+			want: Capability{Type: "PATH_SETUP_TYPE", Detail: PathSetupTypeCapability{
+				PathSetupTypes: []uint32{1, 3},
+				SubCapabilities: []Capability{
+					{Type: "SR", Detail: SRCapability{UnlimitedMSD: true}},
+					{Type: "SRV6", Detail: SRv6Capability{}},
+				},
+			}},
+		},
+		{
 			name:  "AssocTypeList",
 			pbCap: &pb.Capability{Type: pb.CapabilityType_CAPABILITY_TYPE_ASSOC_TYPE_LIST, Detail: &pb.Capability_AssocTypeList{AssocTypeList: &pb.AssocTypeListCapability{AssocTypes: []uint32{6}}}},
 			want:  Capability{Type: "ASSOC_TYPE_LIST", Detail: AssocTypeListCapability{AssocTypes: []uint32{6}}},

--- a/cmd/pola/output.go
+++ b/cmd/pola/output.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 )
@@ -18,20 +17,13 @@ type outputFormat int
 const (
 	outputText outputFormat = iota
 	outputJSON
-	outputYANG
 )
 
-func resolveOutputFormat(jsonFlag, yangFlag bool) (outputFormat, error) {
-	if jsonFlag && yangFlag {
-		return outputText, errors.New("-j and -y are mutually exclusive")
-	}
+func resolveOutputFormat(jsonFlag bool) outputFormat {
 	if jsonFlag {
-		return outputJSON, nil
+		return outputJSON
 	}
-	if yangFlag {
-		return outputText, errors.New("YANG output is not implemented")
-	}
-	return outputText, nil
+	return outputText
 }
 
 type statusResult struct {

--- a/cmd/pola/output.go
+++ b/cmd/pola/output.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// outputFormat selects how command output is rendered.
+type outputFormat int
+
+const (
+	outputText outputFormat = iota
+	outputJSON
+	outputYANG
+)
+
+func resolveOutputFormat(jsonFlag, yangFlag bool) (outputFormat, error) {
+	if jsonFlag && yangFlag {
+		return outputText, errors.New("-j and -y are mutually exclusive")
+	}
+	if jsonFlag {
+		return outputJSON, nil
+	}
+	if yangFlag {
+		return outputText, errors.New("YANG output is not implemented")
+	}
+	return outputText, nil
+}
+
+type statusResult struct {
+	Status string `json:"status"`
+}
+
+func writeJSON(w io.Writer, v any) error {
+	out, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(out))
+	return err
+}

--- a/cmd/pola/output_test.go
+++ b/cmd/pola/output_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveOutputFormat(t *testing.T) {
+	assert.Equal(t, outputText, resolveOutputFormat(false))
+	assert.Equal(t, outputJSON, resolveOutputFormat(true))
+}
+
+type erroringWriter struct{}
+
+func (erroringWriter) Write([]byte) (int, error) { return 0, assert.AnError }
+
+func TestWriteJSON_PropagatesWriteError(t *testing.T) {
+	err := writeJSON(erroringWriter{}, []sessionView{{}})
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestWriteJSON_PropagatesMarshalError(t *testing.T) {
+	err := writeJSON(&bytes.Buffer{}, make(chan int))
+	require.Error(t, err)
+}

--- a/cmd/pola/session.go
+++ b/cmd/pola/session.go
@@ -8,6 +8,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
@@ -29,6 +30,20 @@ func newSessionCmd() *cobra.Command {
 	return cmd
 }
 
+func displaySessionID(sessionID *uint32) string {
+	if sessionID == nil {
+		return "-"
+	}
+	return strconv.FormatUint(uint64(*sessionID), 10)
+}
+
+func timersDisplay(timers *grpc.SessionTimers) string {
+	if timers == nil {
+		return "-"
+	}
+	return fmt.Sprintf("Keepalive %d, DeadTimer %d", timers.Keepalive, timers.DeadTimer)
+}
+
 func showSession(jsonFlag bool) error {
 	sessions, err := grpc.GetSessions(client)
 
@@ -37,18 +52,24 @@ func showSession(jsonFlag bool) error {
 	}
 
 	if jsonFlag {
-		// Output JSON format
 		outputJSON, err := json.Marshal(sessions)
 		if err != nil {
 			return err
 		}
 		fmt.Println(string(outputJSON))
 	} else {
-		// Output user-friendly format
 		for i, ss := range sessions {
 			fmt.Printf("sessionAddr(%d): %s\n", i, ss.Addr.String())
 			fmt.Printf("  State: %s\n", ss.State)
-			fmt.Printf("  Capabilities: %s\n", strings.Join(ss.CapStrings(), ", "))
+			fmt.Printf("  SessionID (Pola): %s, SessionID (PCC): %s\n",
+				displaySessionID(ss.LocalSessionID), displaySessionID(ss.PccSessionID))
+			fmt.Printf("  Advertised (Pola): %s\n", timersDisplay(ss.LocalTimers))
+			fmt.Printf("  Advertised (PCC):  %s\n", timersDisplay(ss.PccTimers))
+			fmt.Printf("  Effective: Keepalive %d, DeadTimer %d\n",
+				ss.EffectiveTimers.Keepalive, ss.EffectiveTimers.DeadTimer)
+			fmt.Printf("  PccType: %s\n", ss.PccType)
+			fmt.Printf("  Capabilities (Pola): %s\n", strings.Join(ss.CapStrings(), ", "))
+			fmt.Printf("  Capabilities (PCC): %s\n", strings.Join(ss.PccCapStrings(), ", "))
 			fmt.Printf("  IsSynced: %t\n", ss.IsSynced)
 		}
 	}

--- a/cmd/pola/session.go
+++ b/cmd/pola/session.go
@@ -6,10 +6,11 @@
 package main
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
-	"strconv"
-	"strings"
+	"io"
+	"net/netip"
+	"os"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
 	"github.com/spf13/cobra"
@@ -17,12 +18,15 @@ import (
 
 func newSessionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "session",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if err := showSession(jsonFmt); err != nil {
+		Use:   "session [peer-address] [detail]",
+		Short: "Show PCEP sessions",
+		Args:  cobra.MaximumNArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			addr, detail, err := parseSessionArgs(args)
+			if err != nil {
 				return err
 			}
-			return nil
+			return showSession(os.Stdout, addr, detail, resolveOutputFormat(jsonFmt))
 		},
 	}
 
@@ -30,48 +34,60 @@ func newSessionCmd() *cobra.Command {
 	return cmd
 }
 
-func displaySessionID(sessionID *uint32) string {
-	if sessionID == nil {
-		return "-"
+// parseSessionArgs parses an optional peer address and "detail" argument.
+func parseSessionArgs(args []string) (netip.Addr, bool, error) {
+	var addr netip.Addr
+	detail := false
+	for _, arg := range args {
+		if arg == "detail" {
+			if detail {
+				return netip.Addr{}, false, errors.New(`"detail" specified more than once`)
+			}
+			detail = true
+			continue
+		}
+		if addr.IsValid() {
+			return netip.Addr{}, false, fmt.Errorf("unexpected argument %q\nUsage: pola session [peer-address] [detail]", arg)
+		}
+		parsed, err := netip.ParseAddr(arg)
+		if err != nil {
+			return netip.Addr{}, false, fmt.Errorf("invalid peer address %q: %w", arg, err)
+		}
+		addr = parsed
 	}
-	return strconv.FormatUint(uint64(*sessionID), 10)
+	return addr, detail, nil
 }
 
-func timersDisplay(timers *grpc.SessionTimers) string {
-	if timers == nil {
-		return "-"
-	}
-	return fmt.Sprintf("Keepalive %d, DeadTimer %d", timers.Keepalive, timers.DeadTimer)
-}
-
-func showSession(jsonFlag bool) error {
-	sessions, err := grpc.GetSessions(client)
-
+func showSession(w io.Writer, addr netip.Addr, detail bool, format outputFormat) error {
+	sessions, err := grpc.GetSessions(client, addr, detail)
 	if err != nil {
 		return err
 	}
 
-	if jsonFlag {
-		outputJSON, err := json.Marshal(sessions)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(outputJSON))
-	} else {
-		for i, ss := range sessions {
-			fmt.Printf("sessionAddr(%d): %s\n", i, ss.Addr.String())
-			fmt.Printf("  State: %s\n", ss.State)
-			fmt.Printf("  SessionID (Pola): %s, SessionID (PCC): %s\n",
-				displaySessionID(ss.LocalSessionID), displaySessionID(ss.PccSessionID))
-			fmt.Printf("  Advertised (Pola): %s\n", timersDisplay(ss.LocalTimers))
-			fmt.Printf("  Advertised (PCC):  %s\n", timersDisplay(ss.PccTimers))
-			fmt.Printf("  Effective: Keepalive %d, DeadTimer %d\n",
-				ss.EffectiveTimers.Keepalive, ss.EffectiveTimers.DeadTimer)
-			fmt.Printf("  PccType: %s\n", ss.PccType)
-			fmt.Printf("  Capabilities (Pola): %s\n", strings.Join(ss.CapStrings(), ", "))
-			fmt.Printf("  Capabilities (PCC): %s\n", strings.Join(ss.PccCapStrings(), ", "))
-			fmt.Printf("  IsSynced: %t\n", ss.IsSynced)
-		}
+	if len(sessions) == 0 {
+		return writeNoSessions(w, addr, format)
 	}
-	return nil
+
+	views := make([]sessionView, 0, len(sessions))
+	for _, ss := range sessions {
+		views = append(views, newSessionView(ss, detail))
+	}
+
+	if format == outputJSON {
+		return writeJSON(w, views)
+	}
+	return writeSessionText(w, views)
+}
+
+func writeNoSessions(w io.Writer, addr netip.Addr, format outputFormat) error {
+	if format == outputJSON {
+		_, err := fmt.Fprintln(w, "[]")
+		return err
+	}
+	if addr.IsValid() {
+		_, err := fmt.Fprintf(w, "No PCEP session for %s.\n", addr)
+		return err
+	}
+	_, err := fmt.Fprintln(w, "No PCEP sessions connected.")
+	return err
 }

--- a/cmd/pola/session_capability.go
+++ b/cmd/pola/session_capability.go
@@ -88,23 +88,19 @@ func (c capabilitiesView) commonLines() []capDisplayLine {
 	return commonCapabilityLines(c.rawCommon)
 }
 
-// commonCapView exposes selected capability dimensions shared by both sides.
-// It is not an exhaustive representation; other common capabilities remain
-// visible in the text output.
+// commonCapView exposes capabilities shared by both sides.
 type commonCapView struct {
 	Stateful       bool     `json:"stateful"`
 	Update         bool     `json:"update"`
 	Instantiation  bool     `json:"instantiation"`
 	PathSetupTypes []string `json:"pathSetupTypes"`
-
-	// SRMSD and SRv6MSD are set only when both sides advertise the same value;
-	// mismatches remain in localOnly/peerOnly.
-	// SRv6MSD is currently always nil because the wire decoder and gRPC schema
-	// do not carry the RFC 9603 MSD field yet.
-	SRMSD                *uint32  `json:"srMsd,omitempty"`
-	SRv6MSD              *uint32  `json:"srv6Msd,omitempty"`
-	AssociationTypes     []uint32 `json:"associationTypes"`
-	UnrecognizedTLVTypes []uint32 `json:"unrecognizedTlvTypes"`
+	// SRMSD and SRv6MSD are set only when both sides advertise the same value.
+	// SRv6MSD is unavailable until RFC 9603 MSD is supported by the decoder and gRPC schema.
+	SRMSD                *uint32          `json:"srMsd,omitempty"`
+	SRv6MSD              *uint32          `json:"srv6Msd,omitempty"`
+	AssociationTypes     []uint32         `json:"associationTypes"`
+	UnrecognizedTLVTypes []uint32         `json:"unrecognizedTlvTypes"`
+	Other                []capabilityView `json:"other"`
 }
 
 func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesView {
@@ -115,6 +111,7 @@ func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesVi
 			PathSetupTypes:       []string{},
 			AssociationTypes:     []uint32{},
 			UnrecognizedTLVTypes: []uint32{},
+			Other:                []capabilityView{},
 		},
 		LocalOnly: onlyCapabilities(sets.localOnly),
 		PeerOnly:  onlyCapabilities(sets.peerOnly),
@@ -128,6 +125,12 @@ func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesVi
 	slices.Sort(view.Common.PathSetupTypes)
 	slices.Sort(view.Common.AssociationTypes)
 	slices.Sort(view.Common.UnrecognizedTLVTypes)
+	slices.SortFunc(view.Common.Other, func(a, b capabilityView) int {
+		if c := cmp.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Value, b.Value)
+	})
 
 	return view
 }
@@ -143,7 +146,7 @@ func parseTokenUint32(token, prefix string) (uint32, bool) {
 	return uint32(n), true
 }
 
-func applyStatefulFeature(common *commonCapView, token string) {
+func applyStatefulFeature(common *commonCapView, token string) bool {
 	switch token {
 	case "Stateful":
 		common.Stateful = true
@@ -151,28 +154,38 @@ func applyStatefulFeature(common *commonCapView, token string) {
 		common.Update = true
 	case "Instantiation":
 		common.Instantiation = true
+	default:
+		return false
 	}
+	return true
 }
 
 func applyCommonFeature(common *commonCapView, f capFeature) {
 	switch f.group {
 	case "STATEFUL":
-		applyStatefulFeature(common, f.token)
+		if applyStatefulFeature(common, f.token) {
+			return
+		}
 	case "PATH_SETUP_TYPE":
 		common.PathSetupTypes = append(common.PathSetupTypes, f.token)
+		return
 	case "SR":
 		if n, ok := parseTokenUint32(f.token, "MSD="); ok {
 			common.SRMSD = &n
+			return
 		}
 	case "ASSOC_TYPE_LIST":
 		if n, ok := parseTokenUint32(f.token, "AssocType:"); ok {
 			common.AssociationTypes = append(common.AssociationTypes, n)
+			return
 		}
 	case "UNKNOWN":
 		if n, ok := parseTokenUint32(f.token, "unknown_type_"); ok {
 			common.UnrecognizedTLVTypes = append(common.UnrecognizedTLVTypes, n)
+			return
 		}
 	}
+	common.Other = append(common.Other, capabilityViewFromToken(f.token))
 }
 
 func onlyTokens(features []capFeature) []string {

--- a/cmd/pola/session_capability.go
+++ b/cmd/pola/session_capability.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/nttcom/pola/cmd/pola/grpc"
+	"github.com/nttcom/pola/pkg/packet/pcep"
+)
+
+// capFeature is one comparable capability token. Capabilities are compared
+// at token granularity because a TLV may be present on both sides while
+// individual flags or values differ.
+type capFeature struct {
+	group string
+	token string
+}
+
+func capabilitiesFeatures(caps []grpc.Capability) []capFeature {
+	features := make([]capFeature, 0, len(caps))
+	for _, c := range caps {
+		for _, token := range c.Strings() {
+			features = append(features, capFeature{group: c.Type, token: token})
+		}
+	}
+	return features
+}
+
+type capabilitySets struct {
+	common    []capFeature
+	localOnly []capFeature
+	peerOnly  []capFeature
+}
+
+func splitCapabilities(localCaps, peerCaps []grpc.Capability) capabilitySets {
+	local := capabilitiesFeatures(localCaps)
+	peer := capabilitiesFeatures(peerCaps)
+
+	peerSet := make(map[capFeature]struct{}, len(peer))
+	for _, f := range peer {
+		peerSet[f] = struct{}{}
+	}
+	localSet := make(map[capFeature]struct{}, len(local))
+	for _, f := range local {
+		localSet[f] = struct{}{}
+	}
+
+	var sets capabilitySets
+	for _, f := range local {
+		if _, ok := peerSet[f]; ok {
+			sets.common = append(sets.common, f)
+		} else {
+			sets.localOnly = append(sets.localOnly, f)
+		}
+	}
+	for _, f := range peer {
+		if _, ok := localSet[f]; !ok {
+			sets.peerOnly = append(sets.peerOnly, f)
+		}
+	}
+	return sets
+}
+
+type capabilityView struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+type capabilitiesView struct {
+	Common    commonCapView    `json:"common"`
+	LocalOnly []capabilityView `json:"localOnly"`
+	PeerOnly  []capabilityView `json:"peerOnly"`
+
+	// rawCommon retains the raw grouped tokens needed by the text renderer.
+	rawCommon []capFeature
+}
+
+func (c capabilitiesView) commonLines() []capDisplayLine {
+	return commonCapabilityLines(c.rawCommon)
+}
+
+// commonCapView exposes selected capability dimensions shared by both sides.
+// It is not an exhaustive representation; other common capabilities remain
+// visible in the text output.
+type commonCapView struct {
+	Stateful       bool     `json:"stateful"`
+	Update         bool     `json:"update"`
+	Instantiation  bool     `json:"instantiation"`
+	PathSetupTypes []string `json:"pathSetupTypes"`
+
+	// SRMSD and SRv6MSD are set only when both sides advertise the same value;
+	// mismatches remain in localOnly/peerOnly.
+	// SRv6MSD is currently always nil because the wire decoder and gRPC schema
+	// do not carry the RFC 9603 MSD field yet.
+	SRMSD                *uint32  `json:"srMsd,omitempty"`
+	SRv6MSD              *uint32  `json:"srv6Msd,omitempty"`
+	AssociationTypes     []uint32 `json:"associationTypes"`
+	UnrecognizedTLVTypes []uint32 `json:"unrecognizedTlvTypes"`
+}
+
+func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesView {
+	sets := splitCapabilities(localCaps, peerCaps)
+
+	view := capabilitiesView{
+		Common: commonCapView{
+			PathSetupTypes:       []string{},
+			AssociationTypes:     []uint32{},
+			UnrecognizedTLVTypes: []uint32{},
+		},
+		LocalOnly: onlyCapabilities(sets.localOnly),
+		PeerOnly:  onlyCapabilities(sets.peerOnly),
+		rawCommon: sets.common,
+	}
+
+	for _, f := range sets.common {
+		applyCommonFeature(&view.Common, f)
+	}
+
+	slices.Sort(view.Common.PathSetupTypes)
+	slices.Sort(view.Common.AssociationTypes)
+	slices.Sort(view.Common.UnrecognizedTLVTypes)
+
+	return view
+}
+
+func parseTokenUint32(token, prefix string) (uint32, bool) {
+	if !strings.HasPrefix(token, prefix) {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(strings.TrimPrefix(token, prefix), 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(n), true
+}
+
+func applyStatefulFeature(common *commonCapView, token string) {
+	switch token {
+	case "Stateful":
+		common.Stateful = true
+	case "Update":
+		common.Update = true
+	case "Instantiation":
+		common.Instantiation = true
+	}
+}
+
+func applyCommonFeature(common *commonCapView, f capFeature) {
+	switch f.group {
+	case "STATEFUL":
+		applyStatefulFeature(common, f.token)
+	case "PATH_SETUP_TYPE":
+		common.PathSetupTypes = append(common.PathSetupTypes, f.token)
+	case "SR":
+		if n, ok := parseTokenUint32(f.token, "MSD="); ok {
+			common.SRMSD = &n
+		}
+	case "ASSOC_TYPE_LIST":
+		if n, ok := parseTokenUint32(f.token, "AssocType:"); ok {
+			common.AssociationTypes = append(common.AssociationTypes, n)
+		}
+	case "UNKNOWN":
+		if n, ok := parseTokenUint32(f.token, "unknown_type_"); ok {
+			common.UnrecognizedTLVTypes = append(common.UnrecognizedTLVTypes, n)
+		}
+	}
+}
+
+func onlyTokens(features []capFeature) []string {
+	seen := make(map[string]struct{}, len(features))
+	out := make([]string, 0, len(features))
+	for _, f := range features {
+		token := strings.ToLower(f.token)
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		out = append(out, token)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func onlyCapabilities(features []capFeature) []capabilityView {
+	tokens := onlyTokens(features)
+	views := make([]capabilityView, 0, len(tokens))
+	for _, token := range tokens {
+		views = append(views, capabilityViewFromToken(token))
+	}
+	return views
+}
+
+func capabilityViewFromToken(token string) capabilityView {
+	if i := strings.IndexAny(token, "=:"); i >= 0 {
+		return capabilityView{Name: token[:i], Value: token[i+1:]}
+	}
+	return capabilityView{Name: token}
+}
+
+// capGroupLabels maps capability types to their display labels.
+// STATEFUL is listed explicitly because it has two defining RFCs.
+var capGroupLabels = map[string]string{
+	"STATEFUL":           "STATEFUL-PCE-CAPABILITY [RFC8231/8281]",
+	"SR":                 "SR-PCE-CAPABILITY [RFC8664]",
+	"SRV6":               "SRv6-PCE-CAPABILITY [RFC9603]",
+	"PATH_SETUP_TYPE":    "PATH-SETUP-TYPE-CAPABILITY [RFC8408]",
+	"ASSOC_TYPE_LIST":    "ASSOC-TYPE-LIST [RFC8697]",
+	"LSP_DB_VERSION":     "LSP-DB-VERSION [RFC8232]",
+	"MULTIPATH":          "MULTIPATH-CAP [draft-ietf-pce-multipath]",
+	"VENDOR_INFORMATION": "VENDOR-INFORMATION [RFC7470]",
+}
+
+func capGroupLabel(group string) string {
+	if label, ok := capGroupLabels[group]; ok {
+		return label
+	}
+	return group
+}
+
+var capGroupOrder = map[string]int{
+	"VENDOR_INFORMATION": int(pcep.TLVVendorInformation),
+	"STATEFUL":           int(pcep.TLVStatefulPCECapability),
+	"LSP_DB_VERSION":     int(pcep.TLVLSPDBVersion),
+	"SR":                 int(pcep.TLVSRPCECapability),
+	"SRV6":               int(pcep.TLVSRv6PCECapability),
+	"PATH_SETUP_TYPE":    int(pcep.TLVPathSetupTypeCapability),
+	"ASSOC_TYPE_LIST":    int(pcep.TLVAssocTypeList),
+	"MULTIPATH":          int(pcep.TLVMultipathCap),
+}
+
+func capGroupOrderKey(group string) int {
+	if key, ok := capGroupOrder[group]; ok {
+		return key
+	}
+	return math.MaxInt
+}
+
+func assocTypeLabel(n uint32) string {
+	if n > math.MaxUint16 {
+		return fmt.Sprintf("%d (out-of-range for AssocType)", n)
+	}
+	return fmt.Sprintf("%d %s", n, pcep.AssocType(n).String())
+}
+
+// unrecognizedTLVItem names a TLV using the registry, or notes why it has no
+// assigned name, for display under the "Unrecognized TLVs" group.
+func unrecognizedTLVItem(tlvType uint32) string {
+	if tlvType > math.MaxUint16 {
+		return fmt.Sprintf("type=%d: out of TLV registry range, no RFC", tlvType)
+	}
+	t := pcep.TLVType(tlvType)
+	name := t.Name()
+	ref := t.Reference()
+
+	switch {
+	case name == "":
+		return fmt.Sprintf("type=%d: unassigned/vendor-specific, no RFC", tlvType)
+	case ref == "vendor-specific":
+		return fmt.Sprintf("type=%d: vendor-specific, no RFC", tlvType)
+	default:
+		return fmt.Sprintf("type=%d: %s (%s)", tlvType, name, ref)
+	}
+}
+
+// capDisplayLine represents a capability group and its optional items.
+type capDisplayLine struct {
+	Header string
+	Items  []string
+}
+
+// commonCapabilityLines renders capability groups as display lines.
+// ASSOC_TYPE_LIST and UNKNOWN render as a heading with one item per entry.
+func commonCapabilityLines(common []capFeature) []capDisplayLine {
+	order := make([]string, 0)
+	tokensByGroup := make(map[string][]string)
+	for _, f := range common {
+		if _, ok := tokensByGroup[f.group]; !ok {
+			order = append(order, f.group)
+		}
+		tokensByGroup[f.group] = append(tokensByGroup[f.group], f.token)
+	}
+	slices.SortFunc(order, func(a, b string) int {
+		return cmp.Compare(capGroupOrderKey(a), capGroupOrderKey(b))
+	})
+
+	var lines []capDisplayLine
+	for _, group := range order {
+		switch group {
+		case "ASSOC_TYPE_LIST":
+			items := make([]string, 0, len(tokensByGroup[group]))
+			for _, token := range tokensByGroup[group] {
+				if n, ok := parseTokenUint32(token, "AssocType:"); ok {
+					items = append(items, assocTypeLabel(n))
+				}
+			}
+			lines = append(lines, capDisplayLine{Header: capGroupLabel(group), Items: items})
+		case "UNKNOWN":
+			items := make([]string, 0, len(tokensByGroup[group]))
+			for _, token := range tokensByGroup[group] {
+				if n, ok := parseTokenUint32(token, "unknown_type_"); ok {
+					items = append(items, unrecognizedTLVItem(n))
+				}
+			}
+			lines = append(lines, capDisplayLine{Header: "Unrecognized TLVs", Items: items})
+		default:
+			lines = append(lines, capDisplayLine{Header: capGroupLabel(group) + ": " + strings.Join(tokensByGroup[group], ", ")})
+		}
+	}
+	return lines
+}

--- a/cmd/pola/session_capability.go
+++ b/cmd/pola/session_capability.go
@@ -17,19 +17,37 @@ import (
 	"github.com/nttcom/pola/pkg/packet/pcep"
 )
 
-// capFeature is one comparable capability token. Capabilities are compared
-// at token granularity because a TLV may be present on both sides while
-// individual flags or values differ.
+// capFeature is a comparable capability token.
 type capFeature struct {
 	group string
 	token string
 }
 
+// capabilitiesFeatures flattens capabilities into deduplicated
+// (group, token) features, preserving first-seen order.
 func capabilitiesFeatures(caps []grpc.Capability) []capFeature {
+	seen := make(map[capFeature]struct{})
 	features := make([]capFeature, 0, len(caps))
 	for _, c := range caps {
-		for _, token := range c.Strings() {
-			features = append(features, capFeature{group: c.Type, token: token})
+		features = appendCapabilityFeatures(features, seen, c)
+	}
+	return features
+}
+
+// appendCapabilityFeatures adds c's tokens and recursively processes
+// PATH-SETUP-TYPE-CAPABILITY sub-capabilities.
+func appendCapabilityFeatures(features []capFeature, seen map[capFeature]struct{}, c grpc.Capability) []capFeature {
+	for _, token := range c.Strings() {
+		f := capFeature{group: c.Type, token: token}
+		if _, ok := seen[f]; ok {
+			continue
+		}
+		seen[f] = struct{}{}
+		features = append(features, f)
+	}
+	if pst, ok := c.Detail.(grpc.PathSetupTypeCapability); ok {
+		for _, sub := range pst.SubCapabilities {
+			features = appendCapabilityFeatures(features, seen, sub)
 		}
 	}
 	return features
@@ -70,37 +88,34 @@ func splitCapabilities(localCaps, peerCaps []grpc.Capability) capabilitySets {
 	return sets
 }
 
-type capabilityView struct {
-	Name  string `json:"name"`
-	Value string `json:"value,omitempty"`
+// capGroupView is a capability group and its human-readable items.
+type capGroupView struct {
+	Capability string   `json:"capability"`
+	Items      []string `json:"items"`
 }
 
 type capabilitiesView struct {
-	Common    commonCapView    `json:"common"`
-	LocalOnly []capabilityView `json:"localOnly"`
-	PeerOnly  []capabilityView `json:"peerOnly"`
+	Common    commonCapView  `json:"common"`
+	LocalOnly []capGroupView `json:"localOnly"`
+	PeerOnly  []capGroupView `json:"peerOnly"`
 
-	// rawCommon retains the raw grouped tokens needed by the text renderer.
-	rawCommon []capFeature
+	// commonGroups holds grouped common capabilities for text output.
+	commonGroups []capGroupView
 }
 
 func (c capabilitiesView) commonLines() []capDisplayLine {
-	return commonCapabilityLines(c.rawCommon)
+	return capabilityLines(c.commonGroups)
 }
 
 // commonCapView exposes capabilities shared by both sides.
 type commonCapView struct {
-	Stateful       bool     `json:"stateful"`
-	Update         bool     `json:"update"`
-	Instantiation  bool     `json:"instantiation"`
-	PathSetupTypes []string `json:"pathSetupTypes"`
-	// SRMSD and SRv6MSD are set only when both sides advertise the same value.
-	// SRv6MSD is unavailable until RFC 9603 MSD is supported by the decoder and gRPC schema.
-	SRMSD                *uint32          `json:"srMsd,omitempty"`
-	SRv6MSD              *uint32          `json:"srv6Msd,omitempty"`
-	AssociationTypes     []uint32         `json:"associationTypes"`
-	UnrecognizedTLVTypes []uint32         `json:"unrecognizedTlvTypes"`
-	Other                []capabilityView `json:"other"`
+	Stateful             bool           `json:"stateful"`
+	Update               bool           `json:"update"`
+	Instantiation        bool           `json:"instantiation"`
+	PathSetupTypes       []string       `json:"pathSetupTypes"`
+	AssociationTypes     []uint32       `json:"associationTypes"`
+	UnrecognizedTLVTypes []uint32       `json:"unrecognizedTlvTypes"`
+	Other                []capGroupView `json:"other"`
 }
 
 func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesView {
@@ -111,26 +126,23 @@ func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesVi
 			PathSetupTypes:       []string{},
 			AssociationTypes:     []uint32{},
 			UnrecognizedTLVTypes: []uint32{},
-			Other:                []capabilityView{},
 		},
-		LocalOnly: onlyCapabilities(sets.localOnly),
-		PeerOnly:  onlyCapabilities(sets.peerOnly),
-		rawCommon: sets.common,
+		LocalOnly:    capabilityGroups(sets.localOnly),
+		PeerOnly:     capabilityGroups(sets.peerOnly),
+		commonGroups: capabilityGroups(sets.common),
 	}
 
+	var otherFeatures []capFeature
 	for _, f := range sets.common {
-		applyCommonFeature(&view.Common, f)
+		if !applyCommonFeature(&view.Common, f) {
+			otherFeatures = append(otherFeatures, f)
+		}
 	}
+	view.Common.Other = capabilityGroups(otherFeatures)
 
 	slices.Sort(view.Common.PathSetupTypes)
 	slices.Sort(view.Common.AssociationTypes)
 	slices.Sort(view.Common.UnrecognizedTLVTypes)
-	slices.SortFunc(view.Common.Other, func(a, b capabilityView) int {
-		if c := cmp.Compare(a.Name, b.Name); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.Value, b.Value)
-	})
 
 	return view
 }
@@ -160,63 +172,76 @@ func applyStatefulFeature(common *commonCapView, token string) bool {
 	return true
 }
 
-func applyCommonFeature(common *commonCapView, f capFeature) {
+// applyCommonFeature applies f to common and reports whether it was consumed.
+func applyCommonFeature(common *commonCapView, f capFeature) bool {
 	switch f.group {
 	case "STATEFUL":
-		if applyStatefulFeature(common, f.token) {
-			return
-		}
+		return applyStatefulFeature(common, f.token)
 	case "PATH_SETUP_TYPE":
 		common.PathSetupTypes = append(common.PathSetupTypes, f.token)
-		return
-	case "SR":
-		if n, ok := parseTokenUint32(f.token, "MSD="); ok {
-			common.SRMSD = &n
-			return
-		}
+		return true
 	case "ASSOC_TYPE_LIST":
 		if n, ok := parseTokenUint32(f.token, "AssocType:"); ok {
 			common.AssociationTypes = append(common.AssociationTypes, n)
-			return
+			return true
 		}
 	case "UNKNOWN":
 		if n, ok := parseTokenUint32(f.token, "unknown_type_"); ok {
 			common.UnrecognizedTLVTypes = append(common.UnrecognizedTLVTypes, n)
-			return
+			return true
 		}
 	}
-	common.Other = append(common.Other, capabilityViewFromToken(f.token))
+	return false
 }
 
-func onlyTokens(features []capFeature) []string {
-	seen := make(map[string]struct{}, len(features))
-	out := make([]string, 0, len(features))
+// capabilityGroups groups features by capability and formats their items
+// according to the capability type.
+func capabilityGroups(features []capFeature) []capGroupView {
+	order := make([]string, 0)
+	tokensByGroup := make(map[string][]string)
 	for _, f := range features {
-		token := strings.ToLower(f.token)
-		if _, ok := seen[token]; ok {
-			continue
+		if _, ok := tokensByGroup[f.group]; !ok {
+			order = append(order, f.group)
 		}
-		seen[token] = struct{}{}
-		out = append(out, token)
+		tokensByGroup[f.group] = append(tokensByGroup[f.group], f.token)
 	}
-	slices.Sort(out)
-	return out
+	slices.SortFunc(order, func(a, b string) int {
+		return cmp.Compare(capGroupOrderKey(a), capGroupOrderKey(b))
+	})
+
+	groups := make([]capGroupView, 0, len(order))
+	for _, group := range order {
+		groups = append(groups, capGroupView{Capability: group, Items: groupItems(group, tokensByGroup[group])})
+	}
+	return groups
 }
 
-func onlyCapabilities(features []capFeature) []capabilityView {
-	tokens := onlyTokens(features)
-	views := make([]capabilityView, 0, len(tokens))
+func groupItems(group string, tokens []string) []string {
+	switch group {
+	case "ASSOC_TYPE_LIST":
+		return sortedUint32Labels(tokens, "AssocType:", assocTypeLabel)
+	case "UNKNOWN":
+		return sortedUint32Labels(tokens, "unknown_type_", unrecognizedTLVItem)
+	default:
+		return tokens
+	}
+}
+
+// sortedUint32Labels sorts token values numerically and renders them with label.
+func sortedUint32Labels(tokens []string, prefix string, label func(uint32) string) []string {
+	ns := make([]uint32, 0, len(tokens))
 	for _, token := range tokens {
-		views = append(views, capabilityViewFromToken(token))
+		if n, ok := parseTokenUint32(token, prefix); ok {
+			ns = append(ns, n)
+		}
 	}
-	return views
-}
+	slices.Sort(ns)
 
-func capabilityViewFromToken(token string) capabilityView {
-	if i := strings.IndexAny(token, "=:"); i >= 0 {
-		return capabilityView{Name: token[:i], Value: token[i+1:]}
+	items := make([]string, len(ns))
+	for i, n := range ns {
+		items[i] = label(n)
 	}
-	return capabilityView{Name: token}
+	return items
 }
 
 // capGroupLabels maps capability types to their display labels.
@@ -290,42 +315,17 @@ type capDisplayLine struct {
 	Items  []string
 }
 
-// commonCapabilityLines renders capability groups as display lines.
-// ASSOC_TYPE_LIST and UNKNOWN render as a heading with one item per entry.
-func commonCapabilityLines(common []capFeature) []capDisplayLine {
-	order := make([]string, 0)
-	tokensByGroup := make(map[string][]string)
-	for _, f := range common {
-		if _, ok := tokensByGroup[f.group]; !ok {
-			order = append(order, f.group)
-		}
-		tokensByGroup[f.group] = append(tokensByGroup[f.group], f.token)
-	}
-	slices.SortFunc(order, func(a, b string) int {
-		return cmp.Compare(capGroupOrderKey(a), capGroupOrderKey(b))
-	})
-
-	var lines []capDisplayLine
-	for _, group := range order {
-		switch group {
+// capabilityLines renders capability groups as display lines.
+func capabilityLines(groups []capGroupView) []capDisplayLine {
+	lines := make([]capDisplayLine, 0, len(groups))
+	for _, group := range groups {
+		switch group.Capability {
 		case "ASSOC_TYPE_LIST":
-			items := make([]string, 0, len(tokensByGroup[group]))
-			for _, token := range tokensByGroup[group] {
-				if n, ok := parseTokenUint32(token, "AssocType:"); ok {
-					items = append(items, assocTypeLabel(n))
-				}
-			}
-			lines = append(lines, capDisplayLine{Header: capGroupLabel(group), Items: items})
+			lines = append(lines, capDisplayLine{Header: capGroupLabel(group.Capability), Items: group.Items})
 		case "UNKNOWN":
-			items := make([]string, 0, len(tokensByGroup[group]))
-			for _, token := range tokensByGroup[group] {
-				if n, ok := parseTokenUint32(token, "unknown_type_"); ok {
-					items = append(items, unrecognizedTLVItem(n))
-				}
-			}
-			lines = append(lines, capDisplayLine{Header: "Unrecognized TLVs", Items: items})
+			lines = append(lines, capDisplayLine{Header: "Unrecognized TLVs", Items: group.Items})
 		default:
-			lines = append(lines, capDisplayLine{Header: capGroupLabel(group) + ": " + strings.Join(tokensByGroup[group], ", ")})
+			lines = append(lines, capDisplayLine{Header: capGroupLabel(group.Capability) + ": " + strings.Join(group.Items, ", ")})
 		}
 	}
 	return lines

--- a/cmd/pola/session_capability_test.go
+++ b/cmd/pola/session_capability_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
+	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -202,6 +203,86 @@ func TestCommonCapabilityLines_UnknownGroupSortsLast(t *testing.T) {
 	lines := commonCapabilityLines(common)
 	assert.Equal(t, "MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath", lines[0].Header)
 	assert.Equal(t, "Unrecognized TLVs", lines[1].Header)
+}
+
+func TestBuildCapabilitiesView_UntypedCommonCapabilitiesLandInOther(t *testing.T) {
+	caps := []grpc.Capability{
+		{Type: "VENDOR_INFORMATION", Detail: grpc.VendorInformationCapability{EnterpriseNumber: uint32(pcep.EnterpriseNumberJuniper)}},
+		{Type: "MULTIPATH", Detail: grpc.MultipathCapability{MaxMultipaths: 4, Weighted: true}},
+		{Type: "LSP_DB_VERSION", Detail: grpc.LSPDBVersionCapability{VersionNumber: 1}},
+		{Type: "SRV6", Detail: grpc.SRv6Capability{NAISupported: true}},
+		{Type: "STATEFUL", Detail: grpc.StatefulCapability{TriggeredResync: true}},
+	}
+
+	view := buildCapabilitiesView(caps, caps)
+
+	assert.Contains(t, view.Common.Other, capabilityView{Name: pcep.EnterpriseNumberJuniper.DisplayLabel()})
+	assert.Contains(t, view.Common.Other, capabilityView{Name: "Multipath"})
+	assert.Contains(t, view.Common.Other, capabilityView{Name: "MaxMultipaths", Value: "4"})
+	assert.Contains(t, view.Common.Other, capabilityView{Name: "Weighted"})
+	assert.Contains(t, view.Common.Other, capabilityView{Name: "LSP-DB-VERSION"})
+	assert.Contains(t, view.Common.Other, capabilityView{Name: "SRv6-NAI-Supported"})
+	assert.Contains(t, view.Common.Other, capabilityView{Name: "Triggered-Resync"})
+	assert.True(t, view.Common.Stateful)
+	assert.NotContains(t, view.Common.Other, capabilityView{Name: "Stateful"})
+}
+
+func TestBuildCapabilitiesView_OtherPreservesOriginalTokenCasing(t *testing.T) {
+	caps := []grpc.Capability{
+		{Type: "VENDOR_INFORMATION", Detail: grpc.VendorInformationCapability{EnterpriseNumber: uint32(pcep.EnterpriseNumberJuniper)}},
+	}
+
+	view := buildCapabilitiesView(caps, caps)
+
+	require.Len(t, view.Common.Other, 1)
+	assert.Contains(t, view.Common.Other[0].Name, "Juniper")
+}
+
+func TestBuildCapabilitiesView_OtherIsSortedByNameThenValue(t *testing.T) {
+	caps := []grpc.Capability{
+		{Type: "MULTIPATH", Detail: grpc.MultipathCapability{MaxMultipaths: 4, Weighted: true, OppositeDir: true}},
+		{Type: "STATEFUL", Detail: grpc.StatefulCapability{TriggeredResync: true, Color: true}},
+	}
+
+	expected := []capabilityView{
+		{Name: "Color"},
+		{Name: "MaxMultipaths", Value: "4"},
+		{Name: "Multipath"},
+		{Name: "OppositeDir"},
+		{Name: "Triggered-Resync"},
+		{Name: "Weighted"},
+	}
+
+	view1 := buildCapabilitiesView(caps, caps)
+	view2 := buildCapabilitiesView(caps, caps)
+
+	assert.Equal(t, expected, view1.Common.Other)
+	assert.Equal(t, view1.Common.Other, view2.Common.Other, "Other must be sorted deterministically across calls")
+}
+
+func TestBuildCapabilitiesView_OtherTiesOnNameSortByValue(t *testing.T) {
+	caps := []grpc.Capability{
+		{Type: "MULTIPATH", Detail: grpc.MultipathCapability{MaxMultipaths: 8}},
+		{Type: "MULTIPATH", Detail: grpc.MultipathCapability{MaxMultipaths: 4}},
+	}
+
+	view := buildCapabilitiesView(caps, caps)
+
+	require.GreaterOrEqual(t, len(view.Common.Other), 2)
+	assert.Equal(t, capabilityView{Name: "MaxMultipaths", Value: "4"}, view.Common.Other[0])
+	assert.Equal(t, capabilityView{Name: "MaxMultipaths", Value: "8"}, view.Common.Other[1])
+}
+
+func TestBuildCapabilitiesView_TypedFieldsDoNotDuplicateIntoOther(t *testing.T) {
+	caps := []grpc.Capability{
+		{Type: "STATEFUL", Detail: grpc.StatefulCapability{LSPUpdate: true, LSPInstantiation: true}},
+		{Type: "SR", Detail: grpc.SRCapability{MSD: proto.Uint32(10)}},
+		{Type: "ASSOC_TYPE_LIST", Detail: grpc.AssocTypeListCapability{AssocTypes: []uint32{6}}},
+	}
+
+	view := buildCapabilitiesView(caps, caps)
+
+	assert.Equal(t, []capabilityView{{Name: "SR"}}, view.Common.Other)
 }
 
 func TestCommonCapabilityLines_SingleAssocTypeStillUsesHeadingForm(t *testing.T) {

--- a/cmd/pola/session_capability_test.go
+++ b/cmd/pola/session_capability_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"testing"
+
+	"github.com/nttcom/pola/cmd/pola/grpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestBuildCapabilitiesView_StatefulFlagDiffersFallsToOnlySets(t *testing.T) {
+	// The TLV is common, but Color is local-only, so capabilities are compared
+	// at token granularity.
+	local := []grpc.Capability{
+		{Type: "STATEFUL", Detail: grpc.StatefulCapability{LSPUpdate: true, LSPInstantiation: true, Color: true}},
+	}
+	peer := []grpc.Capability{
+		{Type: "STATEFUL", Detail: grpc.StatefulCapability{LSPUpdate: true, LSPInstantiation: true}},
+	}
+
+	view := buildCapabilitiesView(local, peer)
+
+	assert.True(t, view.Common.Stateful)
+	assert.True(t, view.Common.Update)
+	assert.True(t, view.Common.Instantiation)
+	assert.Equal(t, []capabilityView{{Name: "color"}}, view.LocalOnly)
+	assert.Empty(t, view.PeerOnly)
+}
+
+func TestBuildCapabilitiesView_MismatchedMSDFallsToBothOnlySets(t *testing.T) {
+	local := []grpc.Capability{{Type: "SR", Detail: grpc.SRCapability{MSD: proto.Uint32(10)}}}
+	peer := []grpc.Capability{{Type: "SR", Detail: grpc.SRCapability{MSD: proto.Uint32(16)}}}
+
+	view := buildCapabilitiesView(local, peer)
+
+	assert.Nil(t, view.Common.SRMSD, "MSD mismatch must not appear in common")
+	assert.Equal(t, []capabilityView{{Name: "msd", Value: "10"}}, view.LocalOnly)
+	assert.Equal(t, []capabilityView{{Name: "msd", Value: "16"}}, view.PeerOnly)
+}
+
+func TestBuildCapabilitiesView_MatchingMSDIsCommon(t *testing.T) {
+	local := []grpc.Capability{{Type: "SR", Detail: grpc.SRCapability{MSD: proto.Uint32(10)}}}
+	peer := []grpc.Capability{{Type: "SR", Detail: grpc.SRCapability{MSD: proto.Uint32(10)}}}
+
+	view := buildCapabilitiesView(local, peer)
+
+	require.NotNil(t, view.Common.SRMSD)
+	assert.Equal(t, uint32(10), *view.Common.SRMSD)
+	assert.Empty(t, view.LocalOnly)
+	assert.Empty(t, view.PeerOnly)
+}
+
+func TestBuildCapabilitiesView_AssociationTypesAndUnrecognizedTLVs(t *testing.T) {
+	caps := []grpc.Capability{
+		{Type: "ASSOC_TYPE_LIST", Detail: grpc.AssocTypeListCapability{AssocTypes: []uint32{6, 9}}},
+		{Type: "UNKNOWN", Detail: grpc.UnknownCapability{TLVType: 73}},
+	}
+
+	view := buildCapabilitiesView(caps, caps)
+
+	assert.Equal(t, []uint32{6, 9}, view.Common.AssociationTypes)
+	assert.Equal(t, []uint32{73}, view.Common.UnrecognizedTLVTypes)
+}
+
+func TestBuildCapabilitiesView_CapabilityAbsentFromOneSideIsWhollyOnOtherSide(t *testing.T) {
+	local := []grpc.Capability{
+		{Type: "MULTIPATH", Detail: grpc.MultipathCapability{MaxMultipaths: 4}},
+	}
+
+	view := buildCapabilitiesView(local, nil)
+
+	assert.Contains(t, view.LocalOnly, capabilityView{Name: "multipath"})
+	assert.Contains(t, view.LocalOnly, capabilityView{Name: "maxmultipaths", Value: "4"})
+	assert.Empty(t, view.PeerOnly)
+}
+
+func TestBuildCapabilitiesView_EmptyBothSidesProducesEmptySlicesNotNil(t *testing.T) {
+	view := buildCapabilitiesView(nil, nil)
+
+	assert.NotNil(t, view.Common.PathSetupTypes)
+	assert.Empty(t, view.Common.PathSetupTypes)
+	assert.NotNil(t, view.Common.AssociationTypes)
+	assert.NotNil(t, view.Common.UnrecognizedTLVTypes)
+	assert.NotNil(t, view.LocalOnly)
+	assert.NotNil(t, view.PeerOnly)
+}
+
+func TestOnlyTokens_DeduplicatesAndSorts(t *testing.T) {
+	features := []capFeature{
+		{group: "STATEFUL", token: "Color"},
+		{group: "OTHER", token: "Color"}, // same token, different group
+		{group: "SR", token: "MSD=10"},
+	}
+
+	got := onlyTokens(features)
+	assert.Equal(t, []string{"color", "msd=10"}, got)
+}
+
+func TestUnrecognizedTLVItem(t *testing.T) {
+	tests := map[string]struct {
+		tlvType uint32
+		want    string
+	}{
+		"RFC-defined":      {0x38, "type=56: SRPOLICY-POL-NAME (draft-ietf-pce-segment-routing-policy-cp-14)"},
+		"vendor-specific":  {0xffe3, "type=65507: vendor-specific, no RFC"},
+		"fully unassigned": {0xdead, "type=57005: unassigned/vendor-specific, no RFC"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, unrecognizedTLVItem(tt.tlvType))
+		})
+	}
+}
+
+func TestAssocTypeLabel(t *testing.T) {
+	assert.Equal(t, "6 SR Policy Association", assocTypeLabel(6))
+	assert.Equal(t, "9 P2MP SR Policy Association (draft)", assocTypeLabel(9))
+	assert.Equal(t, "65535 Unknown AssocType (0xffff)", assocTypeLabel(0xffff))
+}
+
+func TestAssocTypeLabel_OutOfRange(t *testing.T) {
+	assert.Equal(t, "65536 (out-of-range for AssocType)", assocTypeLabel(0x10000))
+}
+
+func TestUnrecognizedTLVItem_OutOfRange(t *testing.T) {
+	assert.Equal(t, "type=65536: out of TLV registry range, no RFC", unrecognizedTLVItem(0x10000))
+}
+
+func TestParseTokenUint32_NonNumericSuffixReturnsFalse(t *testing.T) {
+	_, ok := parseTokenUint32("MSD=notanumber", "MSD=")
+	assert.False(t, ok)
+}
+
+func TestBuildCapabilitiesView_CommonPathSetupTypesAreCollected(t *testing.T) {
+	caps := []grpc.Capability{
+		{Type: "PATH_SETUP_TYPE", Detail: grpc.PathSetupTypeCapability{PathSetupTypes: []uint32{1, 3}}},
+	}
+
+	view := buildCapabilitiesView(caps, caps)
+	assert.Equal(t, []string{"SR-TE", "SRv6-TE"}, view.Common.PathSetupTypes)
+}
+
+func TestCapGroupLabel_UnknownGroupReturnsGroupItself(t *testing.T) {
+	assert.Equal(t, "FOO", capGroupLabel("FOO"))
+}
+
+func TestCommonCapabilityLines_GroupsByTLVExceptAssocTypeAndUnknown(t *testing.T) {
+	common := []capFeature{
+		{group: "STATEFUL", token: "Stateful"},
+		{group: "STATEFUL", token: "Update"},
+		{group: "ASSOC_TYPE_LIST", token: "AssocType:6"},
+		{group: "ASSOC_TYPE_LIST", token: "AssocType:9"},
+		{group: "UNKNOWN", token: "unknown_type_73"},
+	}
+
+	lines := commonCapabilityLines(common)
+	assert.Equal(t, []capDisplayLine{
+		{Header: "STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update"},
+		{Header: "ASSOC-TYPE-LIST [RFC8697]", Items: []string{
+			"6 SR Policy Association",
+			"9 P2MP SR Policy Association (draft)",
+		}},
+		{Header: "Unrecognized TLVs", Items: []string{
+			"type=73: SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11)",
+		}},
+	}, lines)
+}
+
+func TestCommonCapabilityLines_OrdersByTLVTypeRegardlessOfInputOrder(t *testing.T) {
+	common := []capFeature{
+		{group: "MULTIPATH", token: "Multipath"},
+		{group: "SR", token: "SR"},
+		{group: "VENDOR_INFORMATION", token: "2636 (Juniper Networks, Inc.)"},
+		{group: "STATEFUL", token: "Stateful"},
+	}
+
+	lines := commonCapabilityLines(common)
+	var headers []string
+	for _, line := range lines {
+		headers = append(headers, line.Header)
+	}
+	assert.Equal(t, []string{
+		"VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)",
+		"STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful",
+		"SR-PCE-CAPABILITY [RFC8664]: SR",
+		"MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath",
+	}, headers)
+}
+
+func TestCommonCapabilityLines_UnknownGroupSortsLast(t *testing.T) {
+	common := []capFeature{
+		{group: "UNKNOWN", token: "unknown_type_73"},
+		{group: "MULTIPATH", token: "Multipath"},
+	}
+
+	lines := commonCapabilityLines(common)
+	assert.Equal(t, "MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath", lines[0].Header)
+	assert.Equal(t, "Unrecognized TLVs", lines[1].Header)
+}
+
+func TestCommonCapabilityLines_SingleAssocTypeStillUsesHeadingForm(t *testing.T) {
+	common := []capFeature{
+		{group: "ASSOC_TYPE_LIST", token: "AssocType:6"},
+	}
+
+	lines := commonCapabilityLines(common)
+	assert.Equal(t, []capDisplayLine{
+		{Header: "ASSOC-TYPE-LIST [RFC8697]", Items: []string{"6 SR Policy Association"}},
+	}, lines)
+}

--- a/cmd/pola/session_capability_test.go
+++ b/cmd/pola/session_capability_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestBuildCapabilitiesView_StatefulFlagDiffersFallsToOnlySets(t *testing.T) {
-	// The TLV is common, but Color is local-only, so capabilities are compared
-	// at token granularity.
 	local := []grpc.Capability{
 		{Type: "STATEFUL", Detail: grpc.StatefulCapability{LSPUpdate: true, LSPInstantiation: true, Color: true}},
 	}
@@ -30,7 +28,7 @@ func TestBuildCapabilitiesView_StatefulFlagDiffersFallsToOnlySets(t *testing.T) 
 	assert.True(t, view.Common.Stateful)
 	assert.True(t, view.Common.Update)
 	assert.True(t, view.Common.Instantiation)
-	assert.Equal(t, []capabilityView{{Name: "color"}}, view.LocalOnly)
+	assert.Equal(t, []capGroupView{{Capability: "STATEFUL", Items: []string{"Color"}}}, view.LocalOnly)
 	assert.Empty(t, view.PeerOnly)
 }
 
@@ -40,9 +38,10 @@ func TestBuildCapabilitiesView_MismatchedMSDFallsToBothOnlySets(t *testing.T) {
 
 	view := buildCapabilitiesView(local, peer)
 
-	assert.Nil(t, view.Common.SRMSD, "MSD mismatch must not appear in common")
-	assert.Equal(t, []capabilityView{{Name: "msd", Value: "10"}}, view.LocalOnly)
-	assert.Equal(t, []capabilityView{{Name: "msd", Value: "16"}}, view.PeerOnly)
+	assert.Equal(t, []capGroupView{{Capability: "SR", Items: []string{"SR"}}}, view.Common.Other,
+		"the shared \"SR\" token must appear in common, but the mismatched MSD must not")
+	assert.Equal(t, []capGroupView{{Capability: "SR", Items: []string{"MSD=10"}}}, view.LocalOnly)
+	assert.Equal(t, []capGroupView{{Capability: "SR", Items: []string{"MSD=16"}}}, view.PeerOnly)
 }
 
 func TestBuildCapabilitiesView_MatchingMSDIsCommon(t *testing.T) {
@@ -51,8 +50,7 @@ func TestBuildCapabilitiesView_MatchingMSDIsCommon(t *testing.T) {
 
 	view := buildCapabilitiesView(local, peer)
 
-	require.NotNil(t, view.Common.SRMSD)
-	assert.Equal(t, uint32(10), *view.Common.SRMSD)
+	assert.Equal(t, []capGroupView{{Capability: "SR", Items: []string{"SR", "MSD=10"}}}, view.Common.Other)
 	assert.Empty(t, view.LocalOnly)
 	assert.Empty(t, view.PeerOnly)
 }
@@ -76,9 +74,43 @@ func TestBuildCapabilitiesView_CapabilityAbsentFromOneSideIsWhollyOnOtherSide(t 
 
 	view := buildCapabilitiesView(local, nil)
 
-	assert.Contains(t, view.LocalOnly, capabilityView{Name: "multipath"})
-	assert.Contains(t, view.LocalOnly, capabilityView{Name: "maxmultipaths", Value: "4"})
+	require.Len(t, view.LocalOnly, 1)
+	assert.Equal(t, "MULTIPATH", view.LocalOnly[0].Capability)
+	assert.Contains(t, view.LocalOnly[0].Items, "Multipath")
+	assert.Contains(t, view.LocalOnly[0].Items, "MaxMultipaths=4")
 	assert.Empty(t, view.PeerOnly)
+}
+
+func TestBuildCapabilitiesView_PathSetupTypeSubCapabilitiesActAsOwnGroups(t *testing.T) {
+	local := []grpc.Capability{
+		{Type: "PATH_SETUP_TYPE", Detail: grpc.PathSetupTypeCapability{
+			PathSetupTypes: []uint32{1, 3},
+			SubCapabilities: []grpc.Capability{
+				{Type: "SR", Detail: grpc.SRCapability{UnlimitedMSD: true}},
+				{Type: "SRV6", Detail: grpc.SRv6Capability{}},
+			},
+		}},
+	}
+	peer := []grpc.Capability{
+		{Type: "PATH_SETUP_TYPE", Detail: grpc.PathSetupTypeCapability{PathSetupTypes: []uint32{1, 3}}},
+		{Type: "SR", Detail: grpc.SRCapability{MSD: proto.Uint32(0)}},
+		{Type: "SRV6", Detail: grpc.SRv6Capability{}},
+	}
+
+	view := buildCapabilitiesView(local, peer)
+
+	lines := view.commonLines()
+	headers := make([]string, len(lines))
+	for i, l := range lines {
+		headers[i] = l.Header
+	}
+	assert.Contains(t, headers, "SR-PCE-CAPABILITY [RFC8664]: SR",
+		"SR sub-capability must render as its own common group")
+	assert.Contains(t, headers, "SRv6-PCE-CAPABILITY [RFC9603]: SRv6",
+		"SRv6 sub-capability must render as its own common group")
+
+	assert.Equal(t, []capGroupView{{Capability: "SR", Items: []string{"Unlimited-SID-Depth"}}}, view.LocalOnly)
+	assert.Equal(t, []capGroupView{{Capability: "SR", Items: []string{"MSD=0"}}}, view.PeerOnly)
 }
 
 func TestBuildCapabilitiesView_EmptyBothSidesProducesEmptySlicesNotNil(t *testing.T) {
@@ -92,15 +124,32 @@ func TestBuildCapabilitiesView_EmptyBothSidesProducesEmptySlicesNotNil(t *testin
 	assert.NotNil(t, view.PeerOnly)
 }
 
-func TestOnlyTokens_DeduplicatesAndSorts(t *testing.T) {
-	features := []capFeature{
-		{group: "STATEFUL", token: "Color"},
-		{group: "OTHER", token: "Color"}, // same token, different group
-		{group: "SR", token: "MSD=10"},
+func TestCapabilitiesFeatures_DeduplicatesByGroupAndToken(t *testing.T) {
+	caps := []grpc.Capability{
+		{Type: "SR", Detail: grpc.SRCapability{UnlimitedMSD: true}},
 	}
 
-	got := onlyTokens(features)
-	assert.Equal(t, []string{"color", "msd=10"}, got)
+	got := capabilitiesFeatures(caps)
+	assert.Equal(t, []capFeature{{group: "SR", token: "SR"}, {group: "SR", token: "Unlimited-SID-Depth"}}, got)
+}
+
+func TestBuildCapabilitiesView_PeerSRAdvertisedTopLevelAndNestedDedupesToOneCommonEntry(t *testing.T) {
+	peer := []grpc.Capability{
+		{Type: "SR", Detail: grpc.SRCapability{UnlimitedMSD: true}},
+		{Type: "PATH_SETUP_TYPE", Detail: grpc.PathSetupTypeCapability{
+			PathSetupTypes: []uint32{1},
+			SubCapabilities: []grpc.Capability{
+				{Type: "SR", Detail: grpc.SRCapability{UnlimitedMSD: true}},
+			},
+		}},
+	}
+
+	view := buildCapabilitiesView(peer, peer)
+
+	require.Len(t, view.Common.Other, 1)
+	assert.Equal(t, capGroupView{Capability: "SR", Items: []string{"SR", "Unlimited-SID-Depth"}}, view.Common.Other[0])
+	assert.Empty(t, view.LocalOnly)
+	assert.Empty(t, view.PeerOnly)
 }
 
 func TestUnrecognizedTLVItem(t *testing.T) {
@@ -138,6 +187,11 @@ func TestParseTokenUint32_NonNumericSuffixReturnsFalse(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestParseTokenUint32_PrefixMismatchReturnsFalse(t *testing.T) {
+	_, ok := parseTokenUint32("AssocType:6", "MSD=")
+	assert.False(t, ok)
+}
+
 func TestBuildCapabilitiesView_CommonPathSetupTypesAreCollected(t *testing.T) {
 	caps := []grpc.Capability{
 		{Type: "PATH_SETUP_TYPE", Detail: grpc.PathSetupTypeCapability{PathSetupTypes: []uint32{1, 3}}},
@@ -160,7 +214,7 @@ func TestCommonCapabilityLines_GroupsByTLVExceptAssocTypeAndUnknown(t *testing.T
 		{group: "UNKNOWN", token: "unknown_type_73"},
 	}
 
-	lines := commonCapabilityLines(common)
+	lines := capabilityLines(capabilityGroups(common))
 	assert.Equal(t, []capDisplayLine{
 		{Header: "STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update"},
 		{Header: "ASSOC-TYPE-LIST [RFC8697]", Items: []string{
@@ -181,7 +235,7 @@ func TestCommonCapabilityLines_OrdersByTLVTypeRegardlessOfInputOrder(t *testing.
 		{group: "STATEFUL", token: "Stateful"},
 	}
 
-	lines := commonCapabilityLines(common)
+	lines := capabilityLines(capabilityGroups(common))
 	var headers []string
 	for _, line := range lines {
 		headers = append(headers, line.Header)
@@ -200,7 +254,7 @@ func TestCommonCapabilityLines_UnknownGroupSortsLast(t *testing.T) {
 		{group: "MULTIPATH", token: "Multipath"},
 	}
 
-	lines := commonCapabilityLines(common)
+	lines := capabilityLines(capabilityGroups(common))
 	assert.Equal(t, "MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath", lines[0].Header)
 	assert.Equal(t, "Unrecognized TLVs", lines[1].Header)
 }
@@ -216,15 +270,19 @@ func TestBuildCapabilitiesView_UntypedCommonCapabilitiesLandInOther(t *testing.T
 
 	view := buildCapabilitiesView(caps, caps)
 
-	assert.Contains(t, view.Common.Other, capabilityView{Name: pcep.EnterpriseNumberJuniper.DisplayLabel()})
-	assert.Contains(t, view.Common.Other, capabilityView{Name: "Multipath"})
-	assert.Contains(t, view.Common.Other, capabilityView{Name: "MaxMultipaths", Value: "4"})
-	assert.Contains(t, view.Common.Other, capabilityView{Name: "Weighted"})
-	assert.Contains(t, view.Common.Other, capabilityView{Name: "LSP-DB-VERSION"})
-	assert.Contains(t, view.Common.Other, capabilityView{Name: "SRv6-NAI-Supported"})
-	assert.Contains(t, view.Common.Other, capabilityView{Name: "Triggered-Resync"})
+	otherByGroup := make(map[string][]string, len(view.Common.Other))
+	for _, g := range view.Common.Other {
+		otherByGroup[g.Capability] = g.Items
+	}
+	assert.Contains(t, otherByGroup["VENDOR_INFORMATION"], pcep.EnterpriseNumberJuniper.DisplayLabel())
+	assert.Contains(t, otherByGroup["MULTIPATH"], "Multipath")
+	assert.Contains(t, otherByGroup["MULTIPATH"], "MaxMultipaths=4")
+	assert.Contains(t, otherByGroup["MULTIPATH"], "Weighted")
+	assert.Contains(t, otherByGroup["LSP_DB_VERSION"], "LSP-DB-VERSION")
+	assert.Contains(t, otherByGroup["SRV6"], "SRv6-NAI-Supported")
+	assert.Contains(t, otherByGroup["STATEFUL"], "Triggered-Resync")
 	assert.True(t, view.Common.Stateful)
-	assert.NotContains(t, view.Common.Other, capabilityView{Name: "Stateful"})
+	assert.NotContains(t, otherByGroup["STATEFUL"], "Stateful")
 }
 
 func TestBuildCapabilitiesView_OtherPreservesOriginalTokenCasing(t *testing.T) {
@@ -235,42 +293,26 @@ func TestBuildCapabilitiesView_OtherPreservesOriginalTokenCasing(t *testing.T) {
 	view := buildCapabilitiesView(caps, caps)
 
 	require.Len(t, view.Common.Other, 1)
-	assert.Contains(t, view.Common.Other[0].Name, "Juniper")
+	require.Len(t, view.Common.Other[0].Items, 1)
+	assert.Contains(t, view.Common.Other[0].Items[0], "Juniper")
 }
 
-func TestBuildCapabilitiesView_OtherIsSortedByNameThenValue(t *testing.T) {
+func TestBuildCapabilitiesView_OtherIsGroupedDeterministically(t *testing.T) {
 	caps := []grpc.Capability{
 		{Type: "MULTIPATH", Detail: grpc.MultipathCapability{MaxMultipaths: 4, Weighted: true, OppositeDir: true}},
 		{Type: "STATEFUL", Detail: grpc.StatefulCapability{TriggeredResync: true, Color: true}},
 	}
 
-	expected := []capabilityView{
-		{Name: "Color"},
-		{Name: "MaxMultipaths", Value: "4"},
-		{Name: "Multipath"},
-		{Name: "OppositeDir"},
-		{Name: "Triggered-Resync"},
-		{Name: "Weighted"},
+	expected := []capGroupView{
+		{Capability: "STATEFUL", Items: []string{"Triggered-Resync", "Color"}},
+		{Capability: "MULTIPATH", Items: []string{"Multipath", "MaxMultipaths=4", "Weighted", "OppositeDir"}},
 	}
 
 	view1 := buildCapabilitiesView(caps, caps)
 	view2 := buildCapabilitiesView(caps, caps)
 
 	assert.Equal(t, expected, view1.Common.Other)
-	assert.Equal(t, view1.Common.Other, view2.Common.Other, "Other must be sorted deterministically across calls")
-}
-
-func TestBuildCapabilitiesView_OtherTiesOnNameSortByValue(t *testing.T) {
-	caps := []grpc.Capability{
-		{Type: "MULTIPATH", Detail: grpc.MultipathCapability{MaxMultipaths: 8}},
-		{Type: "MULTIPATH", Detail: grpc.MultipathCapability{MaxMultipaths: 4}},
-	}
-
-	view := buildCapabilitiesView(caps, caps)
-
-	require.GreaterOrEqual(t, len(view.Common.Other), 2)
-	assert.Equal(t, capabilityView{Name: "MaxMultipaths", Value: "4"}, view.Common.Other[0])
-	assert.Equal(t, capabilityView{Name: "MaxMultipaths", Value: "8"}, view.Common.Other[1])
+	assert.Equal(t, view1.Common.Other, view2.Common.Other, "Other must be grouped deterministically across calls")
 }
 
 func TestBuildCapabilitiesView_TypedFieldsDoNotDuplicateIntoOther(t *testing.T) {
@@ -282,7 +324,7 @@ func TestBuildCapabilitiesView_TypedFieldsDoNotDuplicateIntoOther(t *testing.T) 
 
 	view := buildCapabilitiesView(caps, caps)
 
-	assert.Equal(t, []capabilityView{{Name: "SR"}}, view.Common.Other)
+	assert.Equal(t, []capGroupView{{Capability: "SR", Items: []string{"SR", "MSD=10"}}}, view.Common.Other)
 }
 
 func TestCommonCapabilityLines_SingleAssocTypeStillUsesHeadingForm(t *testing.T) {
@@ -290,8 +332,46 @@ func TestCommonCapabilityLines_SingleAssocTypeStillUsesHeadingForm(t *testing.T)
 		{group: "ASSOC_TYPE_LIST", token: "AssocType:6"},
 	}
 
-	lines := commonCapabilityLines(common)
+	lines := capabilityLines(capabilityGroups(common))
 	assert.Equal(t, []capDisplayLine{
 		{Header: "ASSOC-TYPE-LIST [RFC8697]", Items: []string{"6 SR Policy Association"}},
 	}, lines)
+}
+
+func TestBuildCapabilitiesView_PeerOnlyUnrecognizedTLVUsesRegistryLabel(t *testing.T) {
+	peer := []grpc.Capability{
+		{Type: "UNKNOWN", Detail: grpc.UnknownCapability{TLVType: 73}},
+	}
+
+	view := buildCapabilitiesView(nil, peer)
+
+	assert.Equal(t, []capGroupView{{
+		Capability: "UNKNOWN",
+		Items:      []string{"type=73: SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11)"},
+	}}, view.PeerOnly)
+}
+
+func TestBuildCapabilitiesView_LocalOnlyAssocTypeUsesRegistryLabel(t *testing.T) {
+	local := []grpc.Capability{
+		{Type: "ASSOC_TYPE_LIST", Detail: grpc.AssocTypeListCapability{AssocTypes: []uint32{6}}},
+	}
+
+	view := buildCapabilitiesView(local, nil)
+
+	assert.Equal(t, []capGroupView{{
+		Capability: "ASSOC_TYPE_LIST",
+		Items:      []string{"6 SR Policy Association"},
+	}}, view.LocalOnly)
+}
+
+func TestBuildCapabilitiesView_VendorInformationTokenIsNotLowercased(t *testing.T) {
+	peer := []grpc.Capability{
+		{Type: "VENDOR_INFORMATION", Detail: grpc.VendorInformationCapability{EnterpriseNumber: uint32(pcep.EnterpriseNumberJuniper)}},
+	}
+
+	view := buildCapabilitiesView(nil, peer)
+
+	require.Len(t, view.PeerOnly, 1)
+	require.Len(t, view.PeerOnly[0].Items, 1)
+	assert.Contains(t, view.PeerOnly[0].Items[0], "Juniper")
 }

--- a/cmd/pola/session_delete.go
+++ b/cmd/pola/session_delete.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"os"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/cmd/pola/grpc"
@@ -39,16 +40,15 @@ func newSessionDeleteCmd() *cobra.Command {
 
 func deleteSession(session netip.Addr, jsonFlag bool) error {
 	request := &pb.DeleteSessionRequest{
-		Addr: session.AsSlice(),
+		PeerAddr: session.AsSlice(),
 	}
 	err := grpc.DeleteSession(client, request)
 	if err != nil {
 		return err
 	}
 	if jsonFlag {
-		fmt.Printf("{\"status\": \"success\"}\n")
-	} else {
-		fmt.Printf("success!\n")
+		return writeJSON(os.Stdout, statusResult{Status: "success"})
 	}
+	fmt.Printf("success!\n")
 	return nil
 }

--- a/cmd/pola/session_delete.go
+++ b/cmd/pola/session_delete.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newSessionDeleteCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"del"},
 		SilenceUsage: true,
@@ -34,6 +34,7 @@ func newSessionDeleteCmd() *cobra.Command {
 			return nil
 		},
 	}
+	return cmd
 }
 
 func deleteSession(session netip.Addr, jsonFlag bool) error {

--- a/cmd/pola/session_delete_test.go
+++ b/cmd/pola/session_delete_test.go
@@ -59,7 +59,7 @@ func TestDeleteSession(t *testing.T) {
 		want     string
 	}{
 		{"plain text success", false, "success!\n"},
-		{"json success", true, "{\"status\": \"success\"}\n"},
+		{"json success", true, "{\"status\":\"success\"}\n"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestDeleteSession(t *testing.T) {
 			})
 			assert.Equal(t, tt.want, out)
 			require.NotNil(t, fake.deleteSessionReq)
-			assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), fake.deleteSessionReq.Addr)
+			assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), fake.deleteSessionReq.PeerAddr)
 		})
 	}
 

--- a/cmd/pola/session_test.go
+++ b/cmd/pola/session_test.go
@@ -135,8 +135,8 @@ func TestShowSession_Text(t *testing.T) {
 	assert.Contains(t, out, "Up Time:           00:12:22")
 	assert.Contains(t, out, "Session ID:        Local=1, Peer=7")
 	assert.Contains(t, out, "STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update")
-	assert.Contains(t, out, "    Local only:\n      msd=10\n")
-	assert.Contains(t, out, "    Peer only:\n      msd=16\n")
+	assert.Contains(t, out, "    Local only:\n      SR-PCE-CAPABILITY [RFC8664]: MSD=10\n")
+	assert.Contains(t, out, "    Peer only:\n      SR-PCE-CAPABILITY [RFC8664]: MSD=16\n")
 	assert.Contains(t, out, "Session Creation:  2026-08-19T09:30:00Z")
 	assert.Contains(t, out, "Initiator:         remote")
 	assert.Contains(t, out, "Session Setup:     ok=1, fail=0")
@@ -181,8 +181,8 @@ func TestShowSession_Text_CapabilityGrouping(t *testing.T) {
 		"        9 P2MP SR Policy Association (draft)\n")
 	assert.Contains(t, out, "      Unrecognized TLVs:\n"+
 		"        type=73: SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11)\n")
-	assert.Contains(t, out, "    Local only:\n      -\n")
-	assert.Contains(t, out, "    Peer only:\n      -\n")
+	assert.Contains(t, out, "Local only:        -\n")
+	assert.Contains(t, out, "Peer only:         -\n")
 	assert.NotContains(t, out, "ASSOC-TYPE-LIST [RFC8697]: 2 Disjoint Association")
 }
 

--- a/cmd/pola/session_test.go
+++ b/cmd/pola/session_test.go
@@ -97,11 +97,11 @@ func sessionFixture() *pb.Session {
 		PccType: pb.PccType_PCC_TYPE_RFC_COMPLIANT,
 		LocalCapabilities: []*pb.Capability{
 			{Type: pb.CapabilityType_CAPABILITY_TYPE_STATEFUL, Detail: &pb.Capability_Stateful{Stateful: &pb.StatefulCapability{LspUpdate: true}}},
-			{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
+			{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: proto.Uint32(10)}}},
 		},
 		PeerCapabilities: []*pb.Capability{
 			{Type: pb.CapabilityType_CAPABILITY_TYPE_STATEFUL, Detail: &pb.Capability_Stateful{Stateful: &pb.StatefulCapability{LspUpdate: true}}},
-			{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 16}}},
+			{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: proto.Uint32(16)}}},
 		},
 		Initiator:             pb.SessionInitiator_SESSION_INITIATOR_REMOTE,
 		SyncState:             pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
@@ -137,11 +137,58 @@ func TestShowSession_Text(t *testing.T) {
 	assert.Contains(t, out, "Up Time:           00:12:22")
 	assert.Contains(t, out, "Session ID:        Local=1, Peer=7")
 	assert.Contains(t, out, "STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update")
-	assert.Contains(t, out, "Local only:        msd=10")
-	assert.Contains(t, out, "Peer only:         msd=16")
+	assert.Contains(t, out, "    Local only:\n      msd=10\n")
+	assert.Contains(t, out, "    Peer only:\n      msd=16\n")
 	assert.Contains(t, out, "Session Creation:  2026-08-19T09:30:00Z")
 	assert.Contains(t, out, "Initiator:         remote")
 	assert.Contains(t, out, "Session Setup:     ok=1, fail=0")
+}
+
+func TestShowSession_Text_CapabilityGrouping(t *testing.T) {
+	nowFunc = func() time.Time { return time.Date(2026, 8, 19, 9, 42, 27, 0, time.UTC) }
+	t.Cleanup(func() { nowFunc = time.Now })
+
+	fixture := sessionFixture()
+	assocTypeList := &pb.Capability{
+		Type: pb.CapabilityType_CAPABILITY_TYPE_ASSOC_TYPE_LIST,
+		Detail: &pb.Capability_AssocTypeList{AssocTypeList: &pb.AssocTypeListCapability{
+			AssocTypes: []uint32{2, 3, 5, 6, 9},
+		}},
+	}
+	unknownTLV := &pb.Capability{
+		Type:   pb.CapabilityType_CAPABILITY_TYPE_UNKNOWN,
+		Detail: &pb.Capability_Unknown{Unknown: &pb.UnknownCapability{TlvType: 73}},
+	}
+	fixture.LocalCapabilities = []*pb.Capability{
+		fixture.LocalCapabilities[0], // STATEFUL
+		{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: proto.Uint32(10)}}},
+		assocTypeList,
+		unknownTLV,
+	}
+	fixture.PeerCapabilities = []*pb.Capability{
+		fixture.PeerCapabilities[0], // STATEFUL
+		{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: proto.Uint32(10)}}},
+		assocTypeList,
+		unknownTLV,
+	}
+
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{Sessions: []*pb.Session{fixture}}}
+
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, netip.Addr{}, true, outputText))
+	out := buf.String()
+
+	assert.Contains(t, out, "      ASSOC-TYPE-LIST [RFC8697]:\n"+
+		"        2 Disjoint Association\n"+
+		"        3 Policy Association\n"+
+		"        5 Double Sided Bidirectional LSP Association\n"+
+		"        6 SR Policy Association\n"+
+		"        9 P2MP SR Policy Association (draft)\n")
+	assert.Contains(t, out, "      Unrecognized TLVs:\n"+
+		"        type=73: SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11)\n")
+	assert.Contains(t, out, "    Local only:\n      -\n")
+	assert.Contains(t, out, "    Peer only:\n      -\n")
+	assert.NotContains(t, out, "ASSOC-TYPE-LIST [RFC8697]: 2 Disjoint Association")
 }
 
 func TestShowSession_JSON(t *testing.T) {

--- a/cmd/pola/session_test.go
+++ b/cmd/pola/session_test.go
@@ -6,9 +6,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/netip"
 	"testing"
+	"time"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/stretchr/testify/assert"
@@ -30,95 +32,231 @@ func TestNewSessionCmd_RunE(t *testing.T) {
 	require.ErrorIs(t, err, assert.AnError)
 }
 
-func TestShowSession(t *testing.T) {
-	newFake := func() *fakePCEServiceClient {
-		return &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{
-			Sessions: []*pb.Session{
-				{
-					Addr:            netip.MustParseAddr("192.0.2.1").AsSlice(),
-					State:           pb.SessionState_SESSION_STATE_UP,
-					IsSynced:        true,
-					LocalSessionId:  proto.Uint32(1),
-					PccSessionId:    proto.Uint32(7),
-					LocalTimers:     &pb.SessionTimers{Keepalive: 30, DeadTimer: 120},
-					PccTimers:       &pb.SessionTimers{Keepalive: 10, DeadTimer: 40},
-					EffectiveTimers: &pb.EffectiveTimers{Keepalive: 30, DeadTimer: 40},
-					PccType:         pb.PccType_PCC_TYPE_RFC_COMPLIANT,
-					Capabilities: []*pb.Capability{
-						{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
-					},
-					PccCapabilities: []*pb.Capability{
-						{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 16}}},
-					},
-				},
-			},
-		}}
+func TestNewSessionCmd_PassesParsedArgs(t *testing.T) {
+	jsonFmt = false
+	cmd := newSessionCmd()
+	client = &fakePCEServiceClient{}
+
+	captureStdout(t, func() {
+		require.NoError(t, cmd.RunE(cmd, []string{"192.0.2.1", "detail"}))
+	})
+
+	require.NotNil(t, client.(*fakePCEServiceClient).sessionListReq)
+	req := client.(*fakePCEServiceClient).sessionListReq
+	assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), req.GetPeerAddr())
+	assert.True(t, req.GetIncludeStats())
+}
+
+func TestParseSessionArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantAddr   string
+		wantDetail bool
+		wantErr    bool
+	}{
+		{name: "no args", args: []string{}},
+		{name: "addr only", args: []string{"192.0.2.1"}, wantAddr: "192.0.2.1"},
+		{name: "detail only", args: []string{"detail"}, wantDetail: true},
+		{name: "addr then detail", args: []string{"192.0.2.1", "detail"}, wantAddr: "192.0.2.1", wantDetail: true},
+		{name: "detail then addr", args: []string{"detail", "192.0.2.1"}, wantAddr: "192.0.2.1", wantDetail: true},
+		{name: "invalid address", args: []string{"not-an-addr"}, wantErr: true},
+		{name: "duplicate detail", args: []string{"detail", "detail"}, wantErr: true},
+		{name: "two addresses", args: []string{"192.0.2.1", "192.0.2.2"}, wantErr: true},
 	}
 
-	t.Run("plain text format", func(t *testing.T) {
-		client = newFake()
-		out := captureStdout(t, func() {
-			require.NoError(t, showSession(false))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, detail, err := parseSessionArgs(tt.args)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantAddr == "" {
+				assert.False(t, addr.IsValid())
+			} else {
+				assert.Equal(t, netip.MustParseAddr(tt.wantAddr), addr)
+			}
+			assert.Equal(t, tt.wantDetail, detail)
 		})
-		assert.Equal(t, "sessionAddr(0): 192.0.2.1\n"+
-			"  State: UP\n"+
-			"  SessionID (Pola): 1, SessionID (PCC): 7\n"+
-			"  Advertised (Pola): Keepalive 30, DeadTimer 120\n"+
-			"  Advertised (PCC):  Keepalive 10, DeadTimer 40\n"+
-			"  Effective: Keepalive 30, DeadTimer 40\n"+
-			"  PccType: RFC_COMPLIANT\n"+
-			"  Capabilities (Pola): SR, MSD=10\n"+
-			"  Capabilities (PCC): SR, MSD=16\n"+
-			"  IsSynced: true\n", out)
-	})
+	}
+}
 
-	t.Run("json format", func(t *testing.T) {
-		client = newFake()
-		out := captureStdout(t, func() {
-			require.NoError(t, showSession(true))
-		})
+func sessionFixture() *pb.Session {
+	return &pb.Session{
+		PeerAddr:       netip.MustParseAddr("192.0.2.1").AsSlice(),
+		State:          pb.SessionState_SESSION_STATE_UP,
+		LocalSessionId: proto.Uint32(1),
+		PeerSessionId:  proto.Uint32(7),
+		LocalTimers:    &pb.SessionTimers{Keepalive: 30, DeadTimer: 120},
+		PeerTimers:     &pb.SessionTimers{Keepalive: 10, DeadTimer: 40},
+		EffectiveTimers: &pb.EffectiveTimers{
+			Keepalive: 10, DeadTimer: 40,
+		},
+		PccType: pb.PccType_PCC_TYPE_RFC_COMPLIANT,
+		LocalCapabilities: []*pb.Capability{
+			{Type: pb.CapabilityType_CAPABILITY_TYPE_STATEFUL, Detail: &pb.Capability_Stateful{Stateful: &pb.StatefulCapability{LspUpdate: true}}},
+			{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
+		},
+		PeerCapabilities: []*pb.Capability{
+			{Type: pb.CapabilityType_CAPABILITY_TYPE_STATEFUL, Detail: &pb.Capability_Stateful{Stateful: &pb.StatefulCapability{LspUpdate: true}}},
+			{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 16}}},
+		},
+		Initiator:             pb.SessionInitiator_SESSION_INITIATOR_REMOTE,
+		SyncState:             pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
+		CreatedAtUnixNano:     time.Date(2026, 8, 19, 9, 30, 0, 0, time.UTC).UnixNano(),
+		EstablishedAtUnixNano: time.Date(2026, 8, 19, 9, 30, 5, 0, time.UTC).UnixNano(),
+		Stats: &pb.SessionStats{
+			Keepalive:     &pb.MessageCounter{Sent: 3, Rcvd: 3},
+			Pcerr:         &pb.MessageCounter{Sent: 0, Rcvd: 0},
+			Pcntf:         &pb.MessageCounter{Rcvd: 0},
+			Report:        &pb.MessageCounter{Rcvd: 5},
+			Update:        &pb.MessageCounter{Sent: 2},
+			Initiate:      &pb.MessageCounter{Sent: 1},
+			SessSetupOk:   1,
+			SessSetupFail: 0,
+		},
+	}
+}
 
-		var decoded []map[string]any
-		require.NoError(t, json.Unmarshal([]byte(out), &decoded))
-		require.Len(t, decoded, 1)
-		assert.Equal(t, "192.0.2.1", decoded[0]["Addr"])
-		assert.Equal(t, "UP", decoded[0]["State"])
-		assert.Equal(t, true, decoded[0]["IsSynced"])
-	})
+func TestShowSession_Text(t *testing.T) {
+	nowFunc = func() time.Time { return time.Date(2026, 8, 19, 9, 42, 27, 0, time.UTC) }
+	t.Cleanup(func() { nowFunc = time.Now })
 
-	t.Run("advertised values are omitted before the Open exchange", func(t *testing.T) {
-		client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{
-			Sessions: []*pb.Session{{
-				Addr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
-				State: pb.SessionState_SESSION_STATE_OPEN_WAIT,
-			}},
-		}}
-		out := captureStdout(t, func() {
-			require.NoError(t, showSession(false))
-		})
-		assert.Contains(t, out, "State: OPEN_WAIT")
-		assert.Contains(t, out, "SessionID (Pola): -, SessionID (PCC): -")
-		assert.Contains(t, out, "Advertised (Pola): -")
-	})
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{Sessions: []*pb.Session{sessionFixture()}}}
 
-	t.Run("a session ID of zero is distinguished from an unset one", func(t *testing.T) {
-		client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{
-			Sessions: []*pb.Session{{
-				Addr:           netip.MustParseAddr("192.0.2.1").AsSlice(),
-				State:          pb.SessionState_SESSION_STATE_UP,
-				LocalSessionId: proto.Uint32(0),
-				PccSessionId:   proto.Uint32(0),
-			}},
-		}}
-		out := captureStdout(t, func() {
-			require.NoError(t, showSession(false))
-		})
-		assert.Contains(t, out, "SessionID (Pola): 0, SessionID (PCC): 0")
-	})
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, netip.Addr{}, true, outputText))
+	out := buf.String()
 
-	t.Run("grpc error propagates", func(t *testing.T) {
-		client = &fakePCEServiceClient{sessionListErr: assert.AnError}
-		err := showSession(false)
-		require.ErrorIs(t, err, assert.AnError)
-	})
+	assert.Contains(t, out, "Session #0: 192.0.2.1")
+	assert.Contains(t, out, "State:             up")
+	assert.Contains(t, out, "LSP-DB Sync:       finished")
+	assert.Contains(t, out, "Role:              active-stateful-pce")
+	assert.Contains(t, out, "Up Time:           00:12:22")
+	assert.Contains(t, out, "Session ID:        Local=1, Peer=7")
+	assert.Contains(t, out, "STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update")
+	assert.Contains(t, out, "Local only:        msd=10")
+	assert.Contains(t, out, "Peer only:         msd=16")
+	assert.Contains(t, out, "Session Creation:  2026-08-19T09:30:00Z")
+	assert.Contains(t, out, "Initiator:         remote")
+	assert.Contains(t, out, "Session Setup:     ok=1, fail=0")
+}
+
+func TestShowSession_JSON(t *testing.T) {
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{Sessions: []*pb.Session{sessionFixture()}}}
+
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, netip.Addr{}, false, outputJSON))
+
+	var decoded []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	require.Len(t, decoded, 1)
+
+	summary := decoded[0]
+	assert.Equal(t, "192.0.2.1", summary["peerAddress"])
+	assert.Equal(t, "up", summary["state"])
+	assert.Equal(t, "finished", summary["lspDbSync"])
+	assert.Equal(t, "active-stateful-pce", summary["role"])
+
+	// Summary output must not include detail-only fields.
+	assert.NotContains(t, summary, "sessionCreation")
+	assert.NotContains(t, summary, "initiator")
+	assert.NotContains(t, summary, "stats")
+}
+
+func TestShowSession_JSONDetailAddsWithoutChangingSummaryKeys(t *testing.T) {
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{Sessions: []*pb.Session{sessionFixture()}}}
+
+	var summaryBuf, detailBuf bytes.Buffer
+	require.NoError(t, showSession(&summaryBuf, netip.Addr{}, false, outputJSON))
+	require.NoError(t, showSession(&detailBuf, netip.Addr{}, true, outputJSON))
+
+	var summary, detail []map[string]any
+	require.NoError(t, json.Unmarshal(summaryBuf.Bytes(), &summary))
+	require.NoError(t, json.Unmarshal(detailBuf.Bytes(), &detail))
+	require.Len(t, summary, 1)
+	require.Len(t, detail, 1)
+
+	for k, v := range summary[0] {
+		assert.Equal(t, v, detail[0][k], "detail must not change summary key %q", k)
+	}
+	assert.Contains(t, detail[0], "sessionCreation")
+	assert.Contains(t, detail[0], "initiator")
+	assert.Contains(t, detail[0], "lspDbSync")
+	assert.Contains(t, detail[0], "stats")
+}
+
+func TestShowSession_AdvertisedValuesUnsetBeforeOpenExchange(t *testing.T) {
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{Sessions: []*pb.Session{{
+		PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+		State:    pb.SessionState_SESSION_STATE_OPEN_WAIT,
+	}}}}
+
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, netip.Addr{}, false, outputText))
+	out := buf.String()
+
+	assert.Contains(t, out, "State:             open-wait")
+	assert.Contains(t, out, "Session ID:        Local=-, Peer=-")
+	assert.NotContains(t, out, "Up Time:")
+}
+
+func TestShowSession_SessionIDZeroDistinguishedFromUnset(t *testing.T) {
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{Sessions: []*pb.Session{{
+		PeerAddr:       netip.MustParseAddr("192.0.2.1").AsSlice(),
+		State:          pb.SessionState_SESSION_STATE_UP,
+		LocalSessionId: proto.Uint32(0),
+		PeerSessionId:  proto.Uint32(0),
+	}}}}
+
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, netip.Addr{}, false, outputText))
+	assert.Contains(t, buf.String(), "Session ID:        Local=0, Peer=0")
+}
+
+func TestShowSession_NoSessionsText(t *testing.T) {
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{}}
+
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, netip.Addr{}, false, outputText))
+	assert.Equal(t, "No PCEP sessions connected.\n", buf.String())
+}
+
+func TestShowSession_NoSessionForAddrText(t *testing.T) {
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{}}
+	addr := netip.MustParseAddr("192.0.2.9")
+
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, addr, false, outputText))
+	assert.Equal(t, "No PCEP session for 192.0.2.9.\n", buf.String())
+}
+
+func TestShowSession_NoSessionsJSON(t *testing.T) {
+	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{}}
+
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, netip.Addr{}, false, outputJSON))
+	assert.Equal(t, "[]\n", buf.String())
+}
+
+func TestShowSession_GRPCErrorPropagates(t *testing.T) {
+	client = &fakePCEServiceClient{sessionListErr: assert.AnError}
+	var buf bytes.Buffer
+	err := showSession(&buf, netip.Addr{}, false, outputText)
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestShowSession_PassesAddrFilterAndDetailFlag(t *testing.T) {
+	fake := &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{}}
+	client = fake
+	addr := netip.MustParseAddr("192.0.2.1")
+
+	var buf bytes.Buffer
+	require.NoError(t, showSession(&buf, addr, true, outputText))
+
+	require.NotNil(t, fake.sessionListReq)
+	assert.Equal(t, addr.AsSlice(), fake.sessionListReq.GetPeerAddr())
+	assert.True(t, fake.sessionListReq.GetIncludeStats())
 }

--- a/cmd/pola/session_test.go
+++ b/cmd/pola/session_test.go
@@ -107,6 +107,7 @@ func sessionFixture() *pb.Session {
 		SyncState:             pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 		CreatedAtUnixNano:     time.Date(2026, 8, 19, 9, 30, 0, 0, time.UTC).UnixNano(),
 		EstablishedAtUnixNano: time.Date(2026, 8, 19, 9, 30, 5, 0, time.UTC).UnixNano(),
+		UptimeNanos:           742000000000, // 12 minutes 22 seconds in nanoseconds
 		Stats: &pb.SessionStats{
 			Keepalive:     &pb.MessageCounter{Sent: 3, Rcvd: 3},
 			Pcerr:         &pb.MessageCounter{Sent: 0, Rcvd: 0},
@@ -121,9 +122,6 @@ func sessionFixture() *pb.Session {
 }
 
 func TestShowSession_Text(t *testing.T) {
-	nowFunc = func() time.Time { return time.Date(2026, 8, 19, 9, 42, 27, 0, time.UTC) }
-	t.Cleanup(func() { nowFunc = time.Now })
-
 	client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{Sessions: []*pb.Session{sessionFixture()}}}
 
 	var buf bytes.Buffer
@@ -145,9 +143,6 @@ func TestShowSession_Text(t *testing.T) {
 }
 
 func TestShowSession_Text_CapabilityGrouping(t *testing.T) {
-	nowFunc = func() time.Time { return time.Date(2026, 8, 19, 9, 42, 27, 0, time.UTC) }
-	t.Cleanup(func() { nowFunc = time.Now })
-
 	fixture := sessionFixture()
 	assocTypeList := &pb.Capability{
 		Type: pb.CapabilityType_CAPABILITY_TYPE_ASSOC_TYPE_LIST,

--- a/cmd/pola/session_test.go
+++ b/cmd/pola/session_test.go
@@ -13,6 +13,7 @@ import (
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestNewSessionCmd_RunE(t *testing.T) {
@@ -34,11 +35,20 @@ func TestShowSession(t *testing.T) {
 		return &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{
 			Sessions: []*pb.Session{
 				{
-					Addr:     netip.MustParseAddr("192.0.2.1").AsSlice(),
-					State:    pb.SessionState_SESSION_STATE_UP,
-					IsSynced: true,
+					Addr:            netip.MustParseAddr("192.0.2.1").AsSlice(),
+					State:           pb.SessionState_SESSION_STATE_UP,
+					IsSynced:        true,
+					LocalSessionId:  proto.Uint32(1),
+					PccSessionId:    proto.Uint32(7),
+					LocalTimers:     &pb.SessionTimers{Keepalive: 30, DeadTimer: 120},
+					PccTimers:       &pb.SessionTimers{Keepalive: 10, DeadTimer: 40},
+					EffectiveTimers: &pb.EffectiveTimers{Keepalive: 30, DeadTimer: 40},
+					PccType:         pb.PccType_PCC_TYPE_RFC_COMPLIANT,
 					Capabilities: []*pb.Capability{
 						{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
+					},
+					PccCapabilities: []*pb.Capability{
+						{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 16}}},
 					},
 				},
 			},
@@ -50,7 +60,16 @@ func TestShowSession(t *testing.T) {
 		out := captureStdout(t, func() {
 			require.NoError(t, showSession(false))
 		})
-		assert.Equal(t, "sessionAddr(0): 192.0.2.1\n  State: SESSION_STATE_UP\n  Capabilities: SR, MSD=10\n  IsSynced: true\n", out)
+		assert.Equal(t, "sessionAddr(0): 192.0.2.1\n"+
+			"  State: UP\n"+
+			"  SessionID (Pola): 1, SessionID (PCC): 7\n"+
+			"  Advertised (Pola): Keepalive 30, DeadTimer 120\n"+
+			"  Advertised (PCC):  Keepalive 10, DeadTimer 40\n"+
+			"  Effective: Keepalive 30, DeadTimer 40\n"+
+			"  PccType: RFC_COMPLIANT\n"+
+			"  Capabilities (Pola): SR, MSD=10\n"+
+			"  Capabilities (PCC): SR, MSD=16\n"+
+			"  IsSynced: true\n", out)
 	})
 
 	t.Run("json format", func(t *testing.T) {
@@ -63,8 +82,38 @@ func TestShowSession(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(out), &decoded))
 		require.Len(t, decoded, 1)
 		assert.Equal(t, "192.0.2.1", decoded[0]["Addr"])
-		assert.Equal(t, "SESSION_STATE_UP", decoded[0]["State"])
+		assert.Equal(t, "UP", decoded[0]["State"])
 		assert.Equal(t, true, decoded[0]["IsSynced"])
+	})
+
+	t.Run("advertised values are omitted before the Open exchange", func(t *testing.T) {
+		client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{
+			Sessions: []*pb.Session{{
+				Addr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State: pb.SessionState_SESSION_STATE_OPEN_WAIT,
+			}},
+		}}
+		out := captureStdout(t, func() {
+			require.NoError(t, showSession(false))
+		})
+		assert.Contains(t, out, "State: OPEN_WAIT")
+		assert.Contains(t, out, "SessionID (Pola): -, SessionID (PCC): -")
+		assert.Contains(t, out, "Advertised (Pola): -")
+	})
+
+	t.Run("a session ID of zero is distinguished from an unset one", func(t *testing.T) {
+		client = &fakePCEServiceClient{sessionListResp: &pb.GetSessionListResponse{
+			Sessions: []*pb.Session{{
+				Addr:           netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:          pb.SessionState_SESSION_STATE_UP,
+				LocalSessionId: proto.Uint32(0),
+				PccSessionId:   proto.Uint32(0),
+			}},
+		}}
+		out := captureStdout(t, func() {
+			require.NoError(t, showSession(false))
+		})
+		assert.Contains(t, out, "SessionID (Pola): 0, SessionID (PCC): 0")
 	})
 
 	t.Run("grpc error propagates", func(t *testing.T) {

--- a/cmd/pola/session_text.go
+++ b/cmd/pola/session_text.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+)
+
+func writeSessionText(w io.Writer, views []sessionView) error {
+	for i, v := range views {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if err := writeSessionSummary(w, i, v); err != nil {
+			return err
+		}
+		if v.isDetail() {
+			if err := writeSessionDetail(w, v); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeLabeledLine(w io.Writer, indent int, label, value string) error {
+	_, err := fmt.Fprintf(w, "%s%-18s %s\n", strings.Repeat(" ", indent), label+":", value)
+	return err
+}
+
+func writeSessionSummary(w io.Writer, index int, v sessionView) error {
+	if _, err := fmt.Fprintf(w, "Session #%d: %s\n", index, v.PeerAddress); err != nil {
+		return err
+	}
+
+	fields := []struct{ label, value string }{
+		{"State", v.State},
+		{"LSP-DB Sync", v.LSPDBSync},
+		{"Role", v.Role},
+	}
+	if v.UpTime != "" {
+		fields = append(fields, struct{ label, value string }{"Up Time", v.UpTime})
+	}
+	fields = append(fields,
+		struct{ label, value string }{"Session ID", formatSessionID(v.SessionID)},
+		struct{ label, value string }{"Transport", v.Transport.Protocol + ", auth=" + v.Transport.Auth},
+	)
+	for _, f := range fields {
+		if err := writeLabeledLine(w, 2, f.label, f.value); err != nil {
+			return err
+		}
+	}
+
+	if err := writeTimerTable(w, v.Timers); err != nil {
+		return err
+	}
+	return writeCapabilitySections(w, v.Capabilities)
+}
+
+func writeSessionDetail(w io.Writer, v sessionView) error {
+	if v.SessionCreation != "" {
+		if err := writeLabeledLine(w, 2, "Session Creation", v.SessionCreation); err != nil {
+			return err
+		}
+	}
+	if v.Initiator != "" {
+		if err := writeLabeledLine(w, 2, "Initiator", v.Initiator); err != nil {
+			return err
+		}
+	}
+	if v.Stats != nil {
+		return writeStatsTable(w, *v.Stats)
+	}
+	return nil
+}
+
+func formatSessionID(id sessionIDView) string {
+	return "Local=" + formatOptionalUint32(id.Local) + ", Peer=" + formatOptionalUint32(id.Peer)
+}
+
+func formatOptionalUint32(v *uint32) string {
+	if v == nil {
+		return "-"
+	}
+	return strconv.FormatUint(uint64(*v), 10)
+}
+
+// formatTimerValue formats a negotiated timer value.
+// A value of 0 disables the timer per RFC 5440 §7.3.
+func formatTimerValue(v *uint32) string {
+	if v == nil {
+		return "-"
+	}
+	if *v == 0 {
+		return "disabled"
+	}
+	return strconv.FormatUint(uint64(*v), 10)
+}
+
+func writeTimerTable(w io.Writer, timers timersView) error {
+	if _, err := fmt.Fprintln(w, "  Timers:"); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "    \tLocal\tPeer\tEffective"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(tw, "    Keepalive\t%s\t%s\t%s\n",
+		formatTimerValue(timers.Keepalive.Local), formatTimerValue(timers.Keepalive.Peer),
+		formatTimerValue(timers.Keepalive.Effective)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(tw, "    DeadTimer\t%s\t%s\t%s\n",
+		formatTimerValue(timers.DeadTimer.Local), formatTimerValue(timers.DeadTimer.Peer),
+		formatTimerValue(timers.DeadTimer.Effective)); err != nil {
+		return err
+	}
+	return tw.Flush()
+}
+
+func writeCapabilitySections(w io.Writer, c capabilitiesView) error {
+	if _, err := fmt.Fprintln(w, "  Capabilities:"); err != nil {
+		return err
+	}
+	if err := writeCommonCapabilityLines(w, c); err != nil {
+		return err
+	}
+	if err := writeOnlyLine(w, "Local only", c.LocalOnly); err != nil {
+		return err
+	}
+	return writeOnlyLine(w, "Peer only", c.PeerOnly)
+}
+
+func writeCommonCapabilityLines(w io.Writer, c capabilitiesView) error {
+	lines := c.commonLines()
+	if len(lines) == 0 {
+		return writeLabeledLine(w, 4, "Common", "-")
+	}
+	if _, err := fmt.Fprintln(w, "    Common:"); err != nil {
+		return err
+	}
+	for _, line := range lines {
+		if line.Items == nil {
+			if _, err := fmt.Fprintf(w, "      %s\n", line.Header); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := writeGroupedLine(w, 6, line.Header, line.Items); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeOnlyLine(w io.Writer, label string, caps []capabilityView) error {
+	tokens := make([]string, len(caps))
+	for i, c := range caps {
+		tokens[i] = formatCapabilityToken(c)
+	}
+	return writeGroupedLine(w, 4, label, tokens)
+}
+
+// writeGroupedLine writes a heading followed by each item on its own
+// indented line, or "-" when there are no items.
+func writeGroupedLine(w io.Writer, indent int, header string, items []string) error {
+	if _, err := fmt.Fprintf(w, "%s%s:\n", strings.Repeat(" ", indent), header); err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		items = []string{"-"}
+	}
+	itemIndent := strings.Repeat(" ", indent+2)
+	for _, item := range items {
+		if _, err := fmt.Fprintf(w, "%s%s\n", itemIndent, item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatCapabilityToken(c capabilityView) string {
+	if c.Value == "" {
+		return c.Name
+	}
+	return c.Name + "=" + c.Value
+}
+
+func writeStatsTable(w io.Writer, s statsView) error {
+	if _, err := fmt.Fprintln(w, "  Stats:"); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "    \tSent\tRcvd"); err != nil {
+		return err
+	}
+	counters := []struct {
+		name string
+		c    counterView
+	}{
+		{"Open", s.Open},
+		{"Keepalive", s.Keepalive},
+		{"Close", s.Close},
+		{"PCErr", s.PCErr},
+		{"PCNtf", s.PCNtf},
+		{"PCReq", s.PCReq},
+		{"PCRep", s.PCRep},
+		{"Report", s.Report},
+		{"Update", s.Update},
+		{"Initiate", s.Initiate},
+	}
+	for _, c := range counters {
+		if _, err := fmt.Fprintf(tw, "    %s\t%d\t%d\n", c.name, c.c.Sent, c.c.Rcvd); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if err := writeLabeledLine(w, 4, "Unrecognized Rcvd", strconv.FormatUint(s.UnrecognizedRcvd, 10)); err != nil {
+		return err
+	}
+	if err := writeLabeledLine(w, 4, "Corrupt Rcvd", strconv.FormatUint(s.CorruptRcvd, 10)); err != nil {
+		return err
+	}
+	setup := fmt.Sprintf("ok=%d, fail=%d", s.SessionSetup.OK, s.SessionSetup.Fail)
+	return writeLabeledLine(w, 4, "Session Setup", setup)
+}

--- a/cmd/pola/session_text.go
+++ b/cmd/pola/session_text.go
@@ -132,21 +132,21 @@ func writeCapabilitySections(w io.Writer, c capabilitiesView) error {
 	if _, err := fmt.Fprintln(w, "  Capabilities:"); err != nil {
 		return err
 	}
-	if err := writeCommonCapabilityLines(w, c); err != nil {
+	if err := writeCapabilityGroupSection(w, "Common", c.commonLines()); err != nil {
 		return err
 	}
-	if err := writeOnlyLine(w, "Local only", c.LocalOnly); err != nil {
+	if err := writeCapabilityGroupSection(w, "Local only", capabilityLines(c.LocalOnly)); err != nil {
 		return err
 	}
-	return writeOnlyLine(w, "Peer only", c.PeerOnly)
+	return writeCapabilityGroupSection(w, "Peer only", capabilityLines(c.PeerOnly))
 }
 
-func writeCommonCapabilityLines(w io.Writer, c capabilitiesView) error {
-	lines := c.commonLines()
+// writeCapabilityGroupSection writes a labeled capability section.
+func writeCapabilityGroupSection(w io.Writer, label string, lines []capDisplayLine) error {
 	if len(lines) == 0 {
-		return writeLabeledLine(w, 4, "Common", "-")
+		return writeLabeledLine(w, 4, label, "-")
 	}
-	if _, err := fmt.Fprintln(w, "    Common:"); err != nil {
+	if _, err := fmt.Fprintf(w, "    %s:\n", label); err != nil {
 		return err
 	}
 	for _, line := range lines {
@@ -161,14 +161,6 @@ func writeCommonCapabilityLines(w io.Writer, c capabilitiesView) error {
 		}
 	}
 	return nil
-}
-
-func writeOnlyLine(w io.Writer, label string, caps []capabilityView) error {
-	tokens := make([]string, len(caps))
-	for i, c := range caps {
-		tokens[i] = formatCapabilityToken(c)
-	}
-	return writeGroupedLine(w, 4, label, tokens)
 }
 
 // writeGroupedLine writes a heading followed by each item on its own
@@ -187,13 +179,6 @@ func writeGroupedLine(w io.Writer, indent int, header string, items []string) er
 		}
 	}
 	return nil
-}
-
-func formatCapabilityToken(c capabilityView) string {
-	if c.Value == "" {
-		return c.Name
-	}
-	return c.Name + "=" + c.Value
 }
 
 func writeStatsTable(w io.Writer, s statsView) error {

--- a/cmd/pola/session_text_test.go
+++ b/cmd/pola/session_text_test.go
@@ -34,9 +34,9 @@ func fullSessionViewFixture() sessionView {
 				Stateful: true, Update: true,
 				PathSetupTypes: []string{}, AssociationTypes: []uint32{}, UnrecognizedTLVTypes: []uint32{},
 			},
-			LocalOnly: []capabilityView{{Name: "msd", Value: "10"}},
-			PeerOnly:  []capabilityView{{Name: "msd", Value: "16"}},
-			rawCommon: []capFeature{{group: "STATEFUL", token: "Stateful"}, {group: "STATEFUL", token: "Update"}},
+			LocalOnly:    []capGroupView{{Capability: "SR", Items: []string{"MSD=10"}}},
+			PeerOnly:     []capGroupView{{Capability: "SR", Items: []string{"MSD=16"}}},
+			commonGroups: []capGroupView{{Capability: "STATEFUL", Items: []string{"Stateful", "Update"}}},
 		},
 		SessionCreation: "2026-08-19T09:30:00Z",
 		Initiator:       "remote",
@@ -108,22 +108,32 @@ func TestWriteSessionText_PropagatesWriteErrors(t *testing.T) {
 
 func TestWriteGroupedLine_PropagatesWriteErrorOnNonFirstItem(t *testing.T) {
 	c := capabilitiesView{
-		LocalOnly: []capabilityView{{Name: "msd", Value: "10"}, {Name: "sr-pce-capability"}},
+		LocalOnly: []capGroupView{{Capability: "ASSOC_TYPE_LIST", Items: []string{"6 SR Policy Association"}}},
 	}
 
-	w := &condFailWriter{fail: containsFail("sr-pce-capability")}
+	w := &condFailWriter{fail: containsFail("SR Policy Association")}
 	err := writeCapabilitySections(w, c)
 	require.Error(t, err)
 }
 
-func TestWriteCommonCapabilityLines_PropagatesGroupedLineWriteError(t *testing.T) {
+func TestWriteCapabilityGroupSection_PropagatesGroupedLineWriteError(t *testing.T) {
 	c := capabilitiesView{
-		rawCommon: []capFeature{{group: "ASSOC_TYPE_LIST", token: "AssocType:6"}},
+		commonGroups: []capGroupView{{Capability: "ASSOC_TYPE_LIST", Items: []string{"6 SR Policy Association"}}},
 	}
 
 	w := &condFailWriter{fail: containsFail("ASSOC-TYPE-LIST")}
-	err := writeCommonCapabilityLines(w, c)
+	err := writeCapabilityGroupSection(w, "Common", c.commonLines())
 	require.Error(t, err)
+}
+
+func TestWriteGroupedLine_EmptyItemsRendersDash(t *testing.T) {
+	c := capabilitiesView{
+		LocalOnly: []capGroupView{{Capability: "ASSOC_TYPE_LIST", Items: []string{}}},
+	}
+
+	var buf strings.Builder
+	require.NoError(t, writeCapabilitySections(&buf, c))
+	assert.Contains(t, buf.String(), "      ASSOC-TYPE-LIST [RFC8697]:\n        -\n")
 }
 
 func TestFormatTimerValue(t *testing.T) {
@@ -132,9 +142,4 @@ func TestFormatTimerValue(t *testing.T) {
 	assert.Equal(t, "-", formatTimerValue(nil))
 	assert.Equal(t, "disabled", formatTimerValue(&zero))
 	assert.Equal(t, "30", formatTimerValue(&v))
-}
-
-func TestFormatCapabilityToken(t *testing.T) {
-	assert.Equal(t, "color", formatCapabilityToken(capabilityView{Name: "color"}))
-	assert.Equal(t, "msd=10", formatCapabilityToken(capabilityView{Name: "msd", Value: "10"}))
 }

--- a/cmd/pola/session_text_test.go
+++ b/cmd/pola/session_text_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fullSessionViewFixture() sessionView {
+	local, peer := uint32(1), uint32(7)
+	lk, pk, ld, pd := uint32(30), uint32(10), uint32(120), uint32(40)
+	ek, ed := uint32(10), uint32(40)
+	return sessionView{
+		PeerAddress: "192.0.2.1",
+		State:       "up",
+		LSPDBSync:   "finished",
+		UpTime:      "00:12:22",
+		Role:        "active-stateful-pce",
+		SessionID:   sessionIDView{Local: &local, Peer: &peer},
+		Timers: timersView{
+			Keepalive: timerTriple{Local: &lk, Peer: &pk, Effective: &ek},
+			DeadTimer: timerTriple{Local: &ld, Peer: &pd, Effective: &ed},
+		},
+		Transport: transportView{Protocol: "tcp", Auth: "none"},
+		Capabilities: capabilitiesView{
+			Common: commonCapView{
+				Stateful: true, Update: true,
+				PathSetupTypes: []string{}, AssociationTypes: []uint32{}, UnrecognizedTLVTypes: []uint32{},
+			},
+			LocalOnly: []capabilityView{{Name: "msd", Value: "10"}},
+			PeerOnly:  []capabilityView{{Name: "msd", Value: "16"}},
+			rawCommon: []capFeature{{group: "STATEFUL", token: "Stateful"}, {group: "STATEFUL", token: "Update"}},
+		},
+		SessionCreation: "2026-08-19T09:30:00Z",
+		Initiator:       "remote",
+		Stats: &statsView{
+			Keepalive: counterView{Sent: 3, Rcvd: 3},
+			PCErr:     counterView{Sent: 0, Rcvd: 0},
+			Report:    counterView{Rcvd: 5},
+		},
+	}
+}
+
+func TestWriteSessionText_DetailWithNilStatsRendersWithoutError(t *testing.T) {
+	v := fullSessionViewFixture()
+	v.Stats = nil
+
+	w := &condFailWriter{}
+	require.NoError(t, writeSessionText(w, []sessionView{v}))
+	assert.NotContains(t, w.buf.String(), "Stats:")
+}
+
+// blankLineAfterFail matches the first bare newline after a write containing
+// sub. This avoids matching newlines emitted internally by tabwriter.Flush.
+func blankLineAfterFail(sub string) func(string) bool {
+	armed := false
+	return func(s string) bool {
+		if armed && s == "\n" {
+			return true
+		}
+		if strings.Contains(s, sub) {
+			armed = true
+		}
+		return false
+	}
+}
+
+func TestWriteSessionText_PropagatesWriteErrors(t *testing.T) {
+	v := fullSessionViewFixture()
+	views := []sessionView{v}
+	twoViews := []sessionView{v, v}
+
+	tests := []struct {
+		name  string
+		views []sessionView
+		fail  func(string) bool
+	}{
+		{"blank line between sessions", twoViews, blankLineAfterFail("Session Setup:")},
+		{"session header", views, containsFail("Session #0")},
+		{"labeled field", views, containsFail("State:")},
+		{"timer table header", views, containsFail("Timers:")},
+		{"session creation label", views, containsFail("Session Creation:")},
+		{"initiator label", views, containsFail("Initiator:")},
+		{"capabilities header", views, containsFail("Capabilities:")},
+		{"common capabilities header", views, containsFail("Common:")},
+		{"common capabilities line", views, containsFail("STATEFUL-PCE-CAPABILITY")},
+		{"local only line", views, containsFail("Local only:")},
+		{"stats header", views, containsFail("  Stats:")},
+		{"stats table flush", views, containsFail("PCErr")},
+		{"unrecognized rcvd", views, containsFail("Unrecognized Rcvd:")},
+		{"corrupt rcvd", views, containsFail("Corrupt Rcvd:")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &condFailWriter{fail: tt.fail}
+			err := writeSessionText(w, tt.views)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestWriteGroupedLine_PropagatesWriteErrorOnNonFirstItem(t *testing.T) {
+	c := capabilitiesView{
+		LocalOnly: []capabilityView{{Name: "msd", Value: "10"}, {Name: "sr-pce-capability"}},
+	}
+
+	w := &condFailWriter{fail: containsFail("sr-pce-capability")}
+	err := writeCapabilitySections(w, c)
+	require.Error(t, err)
+}
+
+func TestWriteCommonCapabilityLines_PropagatesGroupedLineWriteError(t *testing.T) {
+	c := capabilitiesView{
+		rawCommon: []capFeature{{group: "ASSOC_TYPE_LIST", token: "AssocType:6"}},
+	}
+
+	w := &condFailWriter{fail: containsFail("ASSOC-TYPE-LIST")}
+	err := writeCommonCapabilityLines(w, c)
+	require.Error(t, err)
+}
+
+func TestFormatTimerValue(t *testing.T) {
+	zero := uint32(0)
+	v := uint32(30)
+	assert.Equal(t, "-", formatTimerValue(nil))
+	assert.Equal(t, "disabled", formatTimerValue(&zero))
+	assert.Equal(t, "30", formatTimerValue(&v))
+}
+
+func TestFormatCapabilityToken(t *testing.T) {
+	assert.Equal(t, "color", formatCapabilityToken(capabilityView{Name: "color"}))
+	assert.Equal(t, "msd=10", formatCapabilityToken(capabilityView{Name: "msd", Value: "10"}))
+}

--- a/cmd/pola/session_view.go
+++ b/cmd/pola/session_view.go
@@ -12,9 +12,6 @@ import (
 	"github.com/nttcom/pola/cmd/pola/grpc"
 )
 
-// nowFunc is a variable so tests can use a deterministic clock.
-var nowFunc = time.Now
-
 // sessionView fields follow the operator-facing reading order.
 type sessionView struct {
 	PeerAddress  string           `json:"peerAddress"`
@@ -162,8 +159,8 @@ func newSessionView(ss grpc.Session, detail bool) sessionView {
 		Capabilities: buildCapabilitiesView(ss.LocalCapabilities, ss.PeerCapabilities),
 	}
 
-	if !ss.EstablishedAt.IsZero() {
-		v.UpTime = formatUpTime(nowFunc().Sub(ss.EstablishedAt))
+	if ss.UptimeNanos > 0 {
+		v.UpTime = formatUpTime(time.Duration(ss.UptimeNanos))
 	}
 
 	if detail {

--- a/cmd/pola/session_view.go
+++ b/cmd/pola/session_view.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nttcom/pola/cmd/pola/grpc"
+)
+
+// nowFunc is a variable so tests can use a deterministic clock.
+var nowFunc = time.Now
+
+// sessionView fields follow the operator-facing reading order.
+type sessionView struct {
+	PeerAddress  string           `json:"peerAddress"`
+	State        string           `json:"state"`
+	LSPDBSync    string           `json:"lspDbSync"`
+	UpTime       string           `json:"upTime,omitempty"`
+	Role         string           `json:"role"`
+	SessionID    sessionIDView    `json:"sessionId"`
+	Timers       timersView       `json:"timers"`
+	Transport    transportView    `json:"transport"`
+	Capabilities capabilitiesView `json:"capabilities"`
+
+	// Detail-only fields; omitted from summary output.
+	SessionCreation string     `json:"sessionCreation,omitempty"`
+	Initiator       string     `json:"initiator,omitempty"`
+	Stats           *statsView `json:"stats,omitempty"`
+}
+
+func (v sessionView) isDetail() bool {
+	return v.SessionCreation != "" || v.Initiator != "" || v.Stats != nil
+}
+
+type sessionIDView struct {
+	Local *uint32 `json:"local,omitempty"`
+	Peer  *uint32 `json:"peer,omitempty"`
+}
+
+type timersView struct {
+	Keepalive timerTriple `json:"keepalive"`
+	DeadTimer timerTriple `json:"deadTimer"`
+}
+
+// timerTriple carries the three RFC 5440 §5.5.3 timer values.
+// Local and Peer are nil until the corresponding Open message is exchanged.
+// Effective is nil until the session reaches SESSION_STATE_UP.
+type timerTriple struct {
+	Local     *uint32 `json:"local"`
+	Peer      *uint32 `json:"peer"`
+	Effective *uint32 `json:"effective"`
+}
+
+type transportView struct {
+	Protocol string `json:"protocol"`
+	Auth     string `json:"auth"`
+}
+
+type counterView struct {
+	Sent uint64 `json:"sent"`
+	Rcvd uint64 `json:"rcvd"`
+}
+
+type sessionSetupView struct {
+	OK   uint64 `json:"ok"`
+	Fail uint64 `json:"fail"`
+}
+
+// statsView maps per-session PCEP statistics to the CLI/JSON representation.
+// Most fields correspond to RFC 9826 ietf-pcep-stats; open and close are
+// Pola-specific additions for session lifecycle visibility.
+type statsView struct {
+	Open             counterView      `json:"open"`
+	Keepalive        counterView      `json:"keepalive"`
+	Close            counterView      `json:"close"`
+	PCErr            counterView      `json:"pcerr"`
+	PCNtf            counterView      `json:"pcntf"`
+	PCReq            counterView      `json:"pcreq"`
+	PCRep            counterView      `json:"pcrep"`
+	Report           counterView      `json:"report"`
+	Update           counterView      `json:"update"`
+	Initiate         counterView      `json:"initiate"`
+	UnrecognizedRcvd uint64           `json:"unrecognizedRcvd"`
+	CorruptRcvd      uint64           `json:"corruptRcvd"`
+	SessionSetup     sessionSetupView `json:"sessionSetup"`
+}
+
+// sessionRole reports Pola's PCE role based on its own advertised U-flag.
+func sessionRole(localCaps []grpc.Capability) string {
+	for _, c := range localCaps {
+		if sc, ok := c.Detail.(grpc.StatefulCapability); ok {
+			if sc.LSPUpdate {
+				return "active-stateful-pce"
+			}
+			return "passive-stateful-pce"
+		}
+	}
+	return "stateless-pce"
+}
+
+// formatUpTime formats a non-negative duration as "HH:MM:SS". Hours are not
+// capped at 24, so durations over a day are rendered with hours greater than 24.
+func formatUpTime(d time.Duration) string {
+	total := max(int64(d.Seconds()), 0)
+	hours := total / 3600
+	minutes := (total % 3600) / 60
+	seconds := total % 60
+	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+}
+
+func timersViewFrom(local, peer *grpc.SessionTimers, effective grpc.EffectiveTimers) timersView {
+	var localKeepalive, localDeadTimer, peerKeepalive, peerDeadTimer *uint32
+	if local != nil {
+		localKeepalive = new(local.Keepalive)
+		localDeadTimer = new(local.DeadTimer)
+	}
+	if peer != nil {
+		peerKeepalive = new(peer.Keepalive)
+		peerDeadTimer = new(peer.DeadTimer)
+	}
+	return timersView{
+		Keepalive: timerTriple{Local: localKeepalive, Peer: peerKeepalive, Effective: effective.Keepalive},
+		DeadTimer: timerTriple{Local: localDeadTimer, Peer: peerDeadTimer, Effective: effective.DeadTimer},
+	}
+}
+
+func statsViewFrom(s grpc.SessionStats) *statsView {
+	toCounter := func(c grpc.MessageCounter) counterView { return counterView{Sent: c.Sent, Rcvd: c.Rcvd} }
+	return &statsView{
+		Open:             toCounter(s.Open),
+		Keepalive:        toCounter(s.Keepalive),
+		Close:            toCounter(s.Close),
+		PCErr:            toCounter(s.PCErr),
+		PCNtf:            toCounter(s.PCNtf),
+		PCReq:            toCounter(s.PCReq),
+		PCRep:            toCounter(s.PCRep),
+		Report:           toCounter(s.Report),
+		Update:           toCounter(s.Update),
+		Initiate:         toCounter(s.Initiate),
+		UnrecognizedRcvd: s.UnrecognizedRcvd,
+		CorruptRcvd:      s.CorruptRcvd,
+		SessionSetup:     sessionSetupView{OK: s.SessSetupOK, Fail: s.SessSetupFail},
+	}
+}
+
+// newSessionView derives the CLI/JSON view from a grpc.Session.
+// Detail mode adds session creation time, initiator, and statistics.
+func newSessionView(ss grpc.Session, detail bool) sessionView {
+	v := sessionView{
+		PeerAddress:  ss.PeerAddr.String(),
+		State:        ss.State,
+		LSPDBSync:    ss.SyncState,
+		Role:         sessionRole(ss.LocalCapabilities),
+		SessionID:    sessionIDView{Local: ss.LocalSessionID, Peer: ss.PeerSessionID},
+		Timers:       timersViewFrom(ss.LocalTimers, ss.PeerTimers, ss.EffectiveTimers),
+		Transport:    transportView{Protocol: "tcp", Auth: "none"},
+		Capabilities: buildCapabilitiesView(ss.LocalCapabilities, ss.PeerCapabilities),
+	}
+
+	if !ss.EstablishedAt.IsZero() {
+		v.UpTime = formatUpTime(nowFunc().Sub(ss.EstablishedAt))
+	}
+
+	if detail {
+		if !ss.CreatedAt.IsZero() {
+			v.SessionCreation = ss.CreatedAt.UTC().Format(time.RFC3339)
+		}
+		v.Initiator = ss.Initiator
+		if ss.Stats != nil {
+			v.Stats = statsViewFrom(*ss.Stats)
+		}
+	}
+
+	return v
+}

--- a/cmd/pola/session_view_test.go
+++ b/cmd/pola/session_view_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/nttcom/pola/cmd/pola/grpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionRole(t *testing.T) {
+	tests := map[string]struct {
+		caps []grpc.Capability
+		want string
+	}{
+		"no stateful capability": {nil, "stateless-pce"},
+		"active (U=1)": {
+			[]grpc.Capability{{Type: "STATEFUL", Detail: grpc.StatefulCapability{LSPUpdate: true}}},
+			"active-stateful-pce",
+		},
+		"passive (U=0)": {
+			[]grpc.Capability{{Type: "STATEFUL", Detail: grpc.StatefulCapability{LSPUpdate: false}}},
+			"passive-stateful-pce",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sessionRole(tt.caps))
+		})
+	}
+}
+
+func TestSessionRole_IgnoresPeerCapabilities(t *testing.T) {
+	localCaps := []grpc.Capability{{Type: "STATEFUL", Detail: grpc.StatefulCapability{LSPUpdate: true}}}
+	ss := grpc.Session{
+		PeerAddr:          netip.MustParseAddr("192.0.2.1"),
+		State:             "up",
+		LocalCapabilities: localCaps,
+		PeerCapabilities:  []grpc.Capability{{Type: "STATEFUL", Detail: grpc.StatefulCapability{LSPUpdate: false}}},
+	}
+	v := newSessionView(ss, false)
+	assert.Equal(t, "active-stateful-pce", v.Role)
+}
+
+func TestFormatUpTime(t *testing.T) {
+	tests := map[string]struct {
+		d    time.Duration
+		want string
+	}{
+		"zero":                    {0, "00:00:00"},
+		"typical":                 {12*time.Hour + 22*time.Minute + 5*time.Second, "12:22:05"},
+		"over 24 hours":           {30*time.Hour + 5*time.Minute, "30:05:00"},
+		"negative clamps to zero": {-5 * time.Second, "00:00:00"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatUpTime(tt.d))
+		})
+	}
+}
+
+func TestNewSessionView_UpTimeOmittedUnlessEstablished(t *testing.T) {
+	nowFunc = func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { nowFunc = time.Now })
+
+	notEstablished := grpc.Session{PeerAddr: netip.MustParseAddr("192.0.2.1"), State: "open-wait"}
+	assert.Empty(t, newSessionView(notEstablished, false).UpTime)
+
+	established := grpc.Session{
+		PeerAddr:      netip.MustParseAddr("192.0.2.1"),
+		State:         "up",
+		EstablishedAt: time.Date(2025, 12, 31, 23, 0, 0, 0, time.UTC),
+	}
+	assert.Equal(t, "01:00:00", newSessionView(established, false).UpTime)
+}
+
+func TestNewSessionView_DetailFieldsOnlyPopulatedWhenRequested(t *testing.T) {
+	ss := grpc.Session{
+		PeerAddr:  netip.MustParseAddr("192.0.2.1"),
+		State:     "up",
+		CreatedAt: time.Date(2026, 8, 19, 9, 30, 0, 0, time.UTC),
+		Initiator: "remote",
+		SyncState: "finished",
+		Stats:     &grpc.SessionStats{SessSetupOK: 1},
+	}
+
+	summary := newSessionView(ss, false)
+	assert.Empty(t, summary.SessionCreation)
+	assert.Empty(t, summary.Initiator)
+	assert.Equal(t, "finished", summary.LSPDBSync)
+	assert.Nil(t, summary.Stats)
+	assert.False(t, summary.isDetail())
+
+	detail := newSessionView(ss, true)
+	assert.Equal(t, "2026-08-19T09:30:00Z", detail.SessionCreation)
+	assert.Equal(t, "remote", detail.Initiator)
+	assert.Equal(t, "finished", detail.LSPDBSync)
+	require.NotNil(t, detail.Stats)
+	assert.Equal(t, uint64(1), detail.Stats.SessionSetup.OK)
+	assert.True(t, detail.isDetail())
+}
+
+func TestTimersViewFrom_NilTimersYieldNilLocalAndPeer(t *testing.T) {
+	keepalive, deadTimer := uint32(30), uint32(120)
+	tv := timersViewFrom(nil, nil, grpc.EffectiveTimers{Keepalive: &keepalive, DeadTimer: &deadTimer})
+	assert.Nil(t, tv.Keepalive.Local)
+	assert.Nil(t, tv.Keepalive.Peer)
+	require.NotNil(t, tv.Keepalive.Effective)
+	assert.Equal(t, uint32(30), *tv.Keepalive.Effective)
+	assert.Nil(t, tv.DeadTimer.Local)
+	assert.Nil(t, tv.DeadTimer.Peer)
+	require.NotNil(t, tv.DeadTimer.Effective)
+	assert.Equal(t, uint32(120), *tv.DeadTimer.Effective)
+}
+
+func TestTimersViewFrom_PopulatedTimers(t *testing.T) {
+	local := &grpc.SessionTimers{Keepalive: 30, DeadTimer: 120}
+	peer := &grpc.SessionTimers{Keepalive: 10, DeadTimer: 40}
+	keepalive, deadTimer := uint32(10), uint32(40)
+
+	tv := timersViewFrom(local, peer, grpc.EffectiveTimers{Keepalive: &keepalive, DeadTimer: &deadTimer})
+	require.NotNil(t, tv.Keepalive.Local)
+	require.NotNil(t, tv.Keepalive.Peer)
+	assert.Equal(t, uint32(30), *tv.Keepalive.Local)
+	assert.Equal(t, uint32(10), *tv.Keepalive.Peer)
+}
+
+func TestTimersViewFrom_EffectiveNilBeforeUpDistinguishesFromKeepaliveZero(t *testing.T) {
+	tv := timersViewFrom(nil, nil, grpc.EffectiveTimers{})
+	assert.Nil(t, tv.Keepalive.Effective)
+	assert.Nil(t, tv.DeadTimer.Effective)
+}

--- a/cmd/pola/session_view_test.go
+++ b/cmd/pola/session_view_test.go
@@ -67,9 +67,6 @@ func TestFormatUpTime(t *testing.T) {
 }
 
 func TestNewSessionView_UpTimeOmittedUnlessEstablished(t *testing.T) {
-	nowFunc = func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) }
-	t.Cleanup(func() { nowFunc = time.Now })
-
 	notEstablished := grpc.Session{PeerAddr: netip.MustParseAddr("192.0.2.1"), State: "open-wait"}
 	assert.Empty(t, newSessionView(notEstablished, false).UpTime)
 
@@ -77,6 +74,7 @@ func TestNewSessionView_UpTimeOmittedUnlessEstablished(t *testing.T) {
 		PeerAddr:      netip.MustParseAddr("192.0.2.1"),
 		State:         "up",
 		EstablishedAt: time.Date(2025, 12, 31, 23, 0, 0, 0, time.UTC),
+		UptimeNanos:   3600000000000, // 1 hour in nanoseconds
 	}
 	assert.Equal(t, "01:00:00", newSessionView(established, false).UpTime)
 }

--- a/cmd/pola/sr_policy_add.go
+++ b/cmd/pola/sr_policy_add.go
@@ -149,6 +149,8 @@ func translateCreateSRPolicyError(err error) error {
 			return fmt.Errorf("%s\n  hint: the PCE has not finished syncing the TED yet; retry shortly", msg)
 		case reasonPCEPSessionNotSynced:
 			return fmt.Errorf("%s\n  hint: check that a PCEP session to the target PCC is established and synced", msg)
+		case reasonPCEPSessionNotFound:
+			return fmt.Errorf("%s\n  hint: run `pola session` to check the PCEP session address", msg)
 		case reasonDestinationUnreach:
 			return fmt.Errorf("%s\n  hint: no path exists to the destination in the current topology", msg)
 		case reasonMetricNotCarried:

--- a/cmd/pola/sr_policy_add.go
+++ b/cmd/pola/sr_policy_add.go
@@ -119,10 +119,9 @@ func addSRPolicy(input inputFormat, jsonFlag bool, noSIDValidate bool) error {
 	}
 
 	if jsonFlag {
-		fmt.Printf("{\"status\": \"success\"}\n")
-	} else {
-		fmt.Printf("success!\n")
+		return writeJSON(os.Stdout, statusResult{Status: "success"})
 	}
+	fmt.Printf("success!\n")
 
 	return nil
 }
@@ -198,13 +197,13 @@ func addSRPolicyWithEndpointAddr(input inputFormat, noSIDValidate bool) error {
 		segmentList = append(segmentList, pbSeg)
 	}
 	srPolicy := &pb.SRPolicy{
-		PcepSessionAddr: input.SRPolicy.PCEPSessionAddr.AsSlice(),
-		SrcAddr:         input.SRPolicy.SrcAddr.AsSlice(),
-		DstAddr:         input.SRPolicy.DstAddr.AsSlice(),
-		SegmentList:     segmentList,
-		Color:           input.SRPolicy.Color,
-		PolicyName:      input.SRPolicy.Name,
-		Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+		PeerAddr:    input.SRPolicy.PCEPSessionAddr.AsSlice(),
+		SrcAddr:     input.SRPolicy.SrcAddr.AsSlice(),
+		DstAddr:     input.SRPolicy.DstAddr.AsSlice(),
+		SegmentList: segmentList,
+		Color:       input.SRPolicy.Color,
+		PolicyName:  input.SRPolicy.Name,
+		Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 	}
 
 	request := &pb.CreateSRPolicyRequest{
@@ -230,15 +229,15 @@ func addSRPolicyWithRouterID(input inputFormat, noSIDValidate bool) error {
 	}
 
 	srPolicy := &pb.SRPolicy{
-		PcepSessionAddr: input.SRPolicy.PCEPSessionAddr.AsSlice(),
-		SrcRouterId:     input.SRPolicy.SrcRouterID,
-		DstRouterId:     input.SRPolicy.DstRouterID,
-		Color:           input.SRPolicy.Color,
-		PolicyName:      input.SRPolicy.Name,
-		Type:            srPolicyType,
-		SegmentList:     segmentList,
-		Metric:          metric,
-		Waypoints:       waypoints,
+		PeerAddr:    input.SRPolicy.PCEPSessionAddr.AsSlice(),
+		SrcRouterId: input.SRPolicy.SrcRouterID,
+		DstRouterId: input.SRPolicy.DstRouterID,
+		Color:       input.SRPolicy.Color,
+		PolicyName:  input.SRPolicy.Name,
+		Type:        srPolicyType,
+		SegmentList: segmentList,
+		Metric:      metric,
+		Waypoints:   waypoints,
 	}
 
 	req := &pb.CreateSRPolicyRequest{

--- a/cmd/pola/sr_policy_add_test.go
+++ b/cmd/pola/sr_policy_add_test.go
@@ -30,6 +30,7 @@ func TestReasonConstantsMatchServer(t *testing.T) {
 	assert.Equal(t, server.ReasonDestinationUnreachable, reasonDestinationUnreach)
 	assert.Equal(t, server.ReasonMetricNotCarried, reasonMetricNotCarried)
 	assert.Equal(t, server.ReasonPCEPSessionNotSynced, reasonPCEPSessionNotSynced)
+	assert.Equal(t, server.ReasonPCEPSessionNotFound, reasonPCEPSessionNotFound)
 	assert.Equal(t, server.ReasonSIDValidationFailed, reasonSIDValidationFailed)
 }
 
@@ -52,6 +53,7 @@ func TestTranslateCreateSRPolicyError(t *testing.T) {
 		{"TED disabled gets a TED hint, not the SID hint", newErr(codes.FailedPrecondition, "TED_DISABLED", "ted is disabled"), "enable TED sync"},
 		{"TED not synced gets a retry hint", newErr(codes.FailedPrecondition, "TED_NOT_SYNCED", "no node in TED"), "retry shortly"},
 		{"unsynced PCEP session gets a session hint", newErr(codes.FailedPrecondition, "PCEP_SESSION_NOT_SYNCED", "no synced session with 10.0.0.1"), "PCEP session"},
+		{"missing PCEP session gets a `pola session` hint", newErr(codes.NotFound, "PCEP_SESSION_NOT_FOUND", "no session with address 10.0.0.1 found"), "pola session"},
 		{"unreachable destination gets a topology hint", newErr(codes.FailedPrecondition, "DESTINATION_UNREACHABLE", "next node not found"), "no path exists"},
 		{"uncarried metric gets a metric hint", newErr(codes.FailedPrecondition, "METRIC_NOT_CARRIED", "metric METRIC_TYPE_TE not defined"), "not advertised"},
 		{"invalid argument gets no hint", newErr(codes.InvalidArgument, "INVALID_REQUEST", "ASN must not be zero"), ""},

--- a/cmd/pola/sr_policy_add_test.go
+++ b/cmd/pola/sr_policy_add_test.go
@@ -293,13 +293,13 @@ func TestAddSRPolicyWithEndpointAddr(t *testing.T) {
 
 		require.NotNil(t, fake.createSRPolicyReq)
 		want := &pb.SRPolicy{
-			PcepSessionAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
-			SrcAddr:         netip.MustParseAddr("192.0.2.1").AsSlice(),
-			DstAddr:         netip.MustParseAddr("192.0.2.2").AsSlice(),
-			SegmentList:     []*pb.Segment{{Sid: "16003", LocalAddr: "192.0.2.1", RemoteAddr: "192.0.2.2", SidStructure: "32,16,0,80"}},
-			Color:           100,
-			PolicyName:      "pol1",
-			Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+			PeerAddr:    netip.MustParseAddr("192.0.2.1").AsSlice(),
+			SrcAddr:     netip.MustParseAddr("192.0.2.1").AsSlice(),
+			DstAddr:     netip.MustParseAddr("192.0.2.2").AsSlice(),
+			SegmentList: []*pb.Segment{{Sid: "16003", LocalAddr: "192.0.2.1", RemoteAddr: "192.0.2.2", SidStructure: "32,16,0,80"}},
+			Color:       100,
+			PolicyName:  "pol1",
+			Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 		}
 		assert.Equal(t, want, fake.createSRPolicyReq.SrPolicy)
 		assert.Equal(t, uint32(65000), fake.createSRPolicyReq.Asn)
@@ -337,14 +337,14 @@ func TestAddSRPolicyWithRouterID(t *testing.T) {
 
 		require.NotNil(t, fake.createSRPolicyReq)
 		want := &pb.SRPolicy{
-			PcepSessionAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
-			SrcRouterId:     "0000.0aff.0001",
-			DstRouterId:     "0000.0aff.0002",
-			Color:           100,
-			PolicyName:      "pol1",
-			Type:            pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-			Metric:          pb.MetricType_METRIC_TYPE_DELAY,
-			Waypoints:       []*pb.Waypoint{{RouterId: "0000.0aff.0003"}},
+			PeerAddr:    netip.MustParseAddr("192.0.2.1").AsSlice(),
+			SrcRouterId: "0000.0aff.0001",
+			DstRouterId: "0000.0aff.0002",
+			Color:       100,
+			PolicyName:  "pol1",
+			Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
+			Metric:      pb.MetricType_METRIC_TYPE_DELAY,
+			Waypoints:   []*pb.Waypoint{{RouterId: "0000.0aff.0003"}},
 		}
 		assert.Equal(t, want, fake.createSRPolicyReq.SrPolicy)
 		assert.Equal(t, uint32(65000), fake.createSRPolicyReq.Asn)

--- a/cmd/pola/sr_policy_delete.go
+++ b/cmd/pola/sr_policy_delete.go
@@ -72,10 +72,10 @@ func deleteSRPolicy(input inputFormat, jsonFlag bool) error {
 	}
 
 	srPolicy := &pb.SRPolicy{
-		PcepSessionAddr: input.SRPolicy.PCEPSessionAddr.AsSlice(),
-		DstAddr:         input.SRPolicy.DstAddr.AsSlice(),
-		Color:           input.SRPolicy.Color,
-		PolicyName:      input.SRPolicy.Name,
+		PeerAddr:   input.SRPolicy.PCEPSessionAddr.AsSlice(),
+		DstAddr:    input.SRPolicy.DstAddr.AsSlice(),
+		Color:      input.SRPolicy.Color,
+		PolicyName: input.SRPolicy.Name,
 	}
 	inputData := &pb.DeleteSRPolicyRequest{
 		SrPolicy: srPolicy,
@@ -89,10 +89,9 @@ func deleteSRPolicy(input inputFormat, jsonFlag bool) error {
 	}
 
 	if jsonFlag {
-		fmt.Printf("{\"status\": \"success\"}\n")
-	} else {
-		fmt.Printf("success!\n")
+		return writeJSON(os.Stdout, statusResult{Status: "success"})
 	}
+	fmt.Printf("success!\n")
 
 	return nil
 }

--- a/cmd/pola/sr_policy_delete_test.go
+++ b/cmd/pola/sr_policy_delete_test.go
@@ -104,7 +104,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 		assert.Equal(t, "success!\n", out)
 
 		require.NotNil(t, fake.deleteSRPolicyReq)
-		assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), fake.deleteSRPolicyReq.SrPolicy.PcepSessionAddr)
+		assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), fake.deleteSRPolicyReq.SrPolicy.PeerAddr)
 		assert.Equal(t, netip.MustParseAddr("192.0.2.2").AsSlice(), fake.deleteSRPolicyReq.SrPolicy.DstAddr)
 		assert.Equal(t, uint32(100), fake.deleteSRPolicyReq.SrPolicy.Color)
 		assert.Equal(t, "pol1", fake.deleteSRPolicyReq.SrPolicy.PolicyName)

--- a/cmd/pola/sr_policy_list.go
+++ b/cmd/pola/sr_policy_list.go
@@ -40,12 +40,7 @@ func writeSRPolicyList(w io.Writer, peerAddr netip.Addr, format outputFormat) er
 	}
 
 	if len(sessions) == 0 {
-		if format == outputJSON {
-			_, err := fmt.Fprintln(w, "[]")
-			return err
-		}
-		_, err := fmt.Fprintln(w, "No PCEP sessions connected.")
-		return err
+		return writeNoSessions(w, peerAddr, format)
 	}
 
 	views := make([]srPolicySessionView, 0, len(sessions))

--- a/cmd/pola/sr_policy_list.go
+++ b/cmd/pola/sr_policy_list.go
@@ -30,11 +30,7 @@ func showSRPolicyList(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	format, err := resolveOutputFormat(jsonFmt, false)
-	if err != nil {
-		return err
-	}
-	return writeSRPolicyList(os.Stdout, peerAddr, format)
+	return writeSRPolicyList(os.Stdout, peerAddr, resolveOutputFormat(jsonFmt))
 }
 
 func writeSRPolicyList(w io.Writer, peerAddr netip.Addr, format outputFormat) error {

--- a/cmd/pola/sr_policy_list.go
+++ b/cmd/pola/sr_policy_list.go
@@ -6,14 +6,14 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
+	"io"
 	"net/netip"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
-	"github.com/nttcom/pola/pkg/table"
 )
 
 func newSRPolicyListCmd() *cobra.Command {
@@ -21,140 +21,59 @@ func newSRPolicyListCmd() *cobra.Command {
 		Use:  "list",
 		RunE: showSRPolicyList,
 	}
-	cmd.Flags().String("session", "", "filter by PCEP session peer address")
+	cmd.Flags().String("peer", "", "filter by PCEP peer address")
 	return cmd
 }
 
 func showSRPolicyList(cmd *cobra.Command, _ []string) error {
-	jsonFlag, err := cmd.Flags().GetBool("json")
-	if err != nil {
-		return fmt.Errorf("failed to retrieve 'json' flag: %w", err)
-	}
-
-	sessionAddr, err := sessionAddrFlag(cmd)
+	peerAddr, err := peerAddrFlag(cmd)
 	if err != nil {
 		return err
 	}
-	sessions, err := grpc.GetSRPolicyList(client, sessionAddr)
+	format, err := resolveOutputFormat(jsonFmt, false)
+	if err != nil {
+		return err
+	}
+	return writeSRPolicyList(os.Stdout, peerAddr, format)
+}
+
+func writeSRPolicyList(w io.Writer, peerAddr netip.Addr, format outputFormat) error {
+	sessions, err := grpc.GetSRPolicyList(client, peerAddr)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve SR policy list: %w", err)
 	}
 
-	if jsonFlag {
-		outputJSON, err := json.Marshal(sessions)
-		if err != nil {
-			return fmt.Errorf("failed to marshal SR policy list to JSON: %w", err)
-		}
-		fmt.Println(string(outputJSON))
-		return nil
-	}
-
 	if len(sessions) == 0 {
-		fmt.Println("No PCEP sessions connected.")
-		return nil
-	}
-	for _, session := range sessions {
-		printSRPolicySession(session)
-	}
-	return nil
-}
-
-func printSRPolicySession(session grpc.Session) {
-	fmt.Printf("Session: %s (State: %s, IsSynced: %t)\n",
-		session.Addr.String(), session.State, session.IsSynced)
-	if len(session.SRPolicies) == 0 {
-		if session.IsSynced {
-			fmt.Println("  No SR Policies.")
-		} else {
-			fmt.Println("  No SR Policies: session is still synchronizing.")
+		if format == outputJSON {
+			_, err := fmt.Fprintln(w, "[]")
+			return err
 		}
+		_, err := fmt.Fprintln(w, "No PCEP sessions connected.")
+		return err
 	}
-	for _, policy := range session.SRPolicies {
-		printSRPolicy(policy)
+
+	views := make([]srPolicySessionView, 0, len(sessions))
+	for _, ss := range sessions {
+		views = append(views, newSRPolicySessionView(ss))
 	}
-	fmt.Println()
+
+	if format == outputJSON {
+		return writeJSON(w, views)
+	}
+	return writeSRPolicyText(w, views)
 }
 
-func printSRPolicy(policy table.SRPolicy) {
-	fmt.Printf("  PolicyName: %s\n", policy.Name)
-	fmt.Printf("    PlspID: %d\n", policy.PlspID)
-	fmt.Printf("    LSPID: %d\n", policy.LSPID)
-	fmt.Printf("    State: %s\n", policy.State)
-	if policy.Type != "" {
-		fmt.Printf("    Type: %s\n", policy.Type)
-	}
-	if policy.Metric != table.UnspecifiedMetric {
-		fmt.Printf("    Metric: %s\n", policy.Metric.DisplayString())
-	}
-	fmt.Printf("    SrcAddr: %s\n", srcDstDisplay(policy.SrcAddr.String(), policy.SrcRouterID))
-	fmt.Printf("    DstAddr: %s\n", srcDstDisplay(policy.DstAddr.String(), policy.DstRouterID))
-	fmt.Printf("    Color: %d\n", policy.Color)
-	fmt.Printf("    Preference: %d\n", policy.Preference)
-	fmt.Printf("    SegmentList: ")
-
-	if len(policy.SegmentList) == 0 {
-		fmt.Println("None")
-		return
-	}
-	for j, segment := range policy.SegmentList {
-		fmt.Print(segmentDisplayString(segment))
-		if j == len(policy.SegmentList)-1 {
-			fmt.Println()
-		} else {
-			fmt.Print(" -> ")
-		}
-	}
-}
-
-func sessionAddrFlag(cmd *cobra.Command) (netip.Addr, error) {
-	flag, err := cmd.Flags().GetString("session")
+func peerAddrFlag(cmd *cobra.Command) (netip.Addr, error) {
+	flag, err := cmd.Flags().GetString("peer")
 	if err != nil {
-		return netip.Addr{}, fmt.Errorf("failed to retrieve 'session' flag: %w", err)
+		return netip.Addr{}, fmt.Errorf("failed to retrieve 'peer' flag: %w", err)
 	}
 	if flag == "" {
 		return netip.Addr{}, nil
 	}
 	addr, err := netip.ParseAddr(flag)
 	if err != nil {
-		return netip.Addr{}, fmt.Errorf("invalid --session address %q: %w", flag, err)
+		return netip.Addr{}, fmt.Errorf("invalid --peer address %q: %w", flag, err)
 	}
 	return addr, nil
-}
-
-func srcDstDisplay(addr, routerID string) string {
-	if routerID == "" {
-		return addr
-	}
-	return fmt.Sprintf("%s (%s)", addr, routerID)
-}
-
-func segmentDisplayString(seg table.Segment) string {
-	var localAddr, remoteAddr string
-	switch v := seg.(type) {
-	case table.SegmentSRv6:
-		if v.LocalAddr.IsValid() {
-			localAddr = v.LocalAddr.String()
-		}
-		if v.RemoteAddr.IsValid() {
-			remoteAddr = v.RemoteAddr.String()
-		}
-	case table.SegmentSRMPLS:
-		if v.LocalAddr.IsValid() {
-			localAddr = v.LocalAddr.String()
-		}
-		if v.RemoteAddr.IsValid() {
-			remoteAddr = v.RemoteAddr.String()
-		}
-	}
-
-	switch {
-	case localAddr == "" && remoteAddr == "":
-		return seg.SidString()
-	case remoteAddr == "":
-		return fmt.Sprintf("%s (local=%s)", seg.SidString(), localAddr)
-	case localAddr == "":
-		return fmt.Sprintf("%s (remote=%s)", seg.SidString(), remoteAddr)
-	default:
-		return fmt.Sprintf("%s (local=%s, remote=%s)", seg.SidString(), localAddr, remoteAddr)
-	}
 }

--- a/cmd/pola/sr_policy_list.go
+++ b/cmd/pola/sr_policy_list.go
@@ -35,61 +35,75 @@ func showSRPolicyList(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-
 	sessions, err := grpc.GetSRPolicyList(client, sessionAddr)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve SR policy list: %w", err)
 	}
 
 	if jsonFlag {
-		// Output in JSON format
 		outputJSON, err := json.Marshal(sessions)
 		if err != nil {
 			return fmt.Errorf("failed to marshal SR policy list to JSON: %w", err)
 		}
 		fmt.Println(string(outputJSON))
-	} else {
-		// Output in user-friendly format
-		if len(sessions) == 0 {
-			fmt.Println("No SR Policies found.")
-		} else {
-			for _, session := range sessions {
-				fmt.Printf("Session: %s\n", session.Addr.String())
-				for _, policy := range session.SRPolicies {
-					fmt.Printf("  PolicyName: %s\n", policy.Name)
-					fmt.Printf("    PlspID: %d\n", policy.PlspID)
-					fmt.Printf("    LSPID: %d\n", policy.LSPID)
-					fmt.Printf("    State: %s\n", policy.State)
-					if policy.Type != "" {
-						fmt.Printf("    Type: %s\n", policy.Type)
-					}
-					if policy.Metric != table.UnspecifiedMetric {
-						fmt.Printf("    Metric: %s\n", policy.Metric.DisplayString())
-					}
-					fmt.Printf("    SrcAddr: %s\n", srcDstDisplay(policy.SrcAddr.String(), policy.SrcRouterID))
-					fmt.Printf("    DstAddr: %s\n", srcDstDisplay(policy.DstAddr.String(), policy.DstRouterID))
-					fmt.Printf("    Color: %d\n", policy.Color)
-					fmt.Printf("    Preference: %d\n", policy.Preference)
-					fmt.Printf("    SegmentList: ")
+		return nil
+	}
 
-					if len(policy.SegmentList) == 0 {
-						fmt.Println("None")
-					} else {
-						for j, segment := range policy.SegmentList {
-							fmt.Print(segmentDisplayString(segment))
-							if j == len(policy.SegmentList)-1 {
-								fmt.Println()
-							} else {
-								fmt.Print(" -> ")
-							}
-						}
-					}
-				}
-				fmt.Println()
-			}
-		}
+	if len(sessions) == 0 {
+		fmt.Println("No PCEP sessions connected.")
+		return nil
+	}
+	for _, session := range sessions {
+		printSRPolicySession(session)
 	}
 	return nil
+}
+
+func printSRPolicySession(session grpc.Session) {
+	fmt.Printf("Session: %s (State: %s, IsSynced: %t)\n",
+		session.Addr.String(), session.State, session.IsSynced)
+	if len(session.SRPolicies) == 0 {
+		if session.IsSynced {
+			fmt.Println("  No SR Policies.")
+		} else {
+			fmt.Println("  No SR Policies: session is still synchronizing.")
+		}
+	}
+	for _, policy := range session.SRPolicies {
+		printSRPolicy(policy)
+	}
+	fmt.Println()
+}
+
+func printSRPolicy(policy table.SRPolicy) {
+	fmt.Printf("  PolicyName: %s\n", policy.Name)
+	fmt.Printf("    PlspID: %d\n", policy.PlspID)
+	fmt.Printf("    LSPID: %d\n", policy.LSPID)
+	fmt.Printf("    State: %s\n", policy.State)
+	if policy.Type != "" {
+		fmt.Printf("    Type: %s\n", policy.Type)
+	}
+	if policy.Metric != table.UnspecifiedMetric {
+		fmt.Printf("    Metric: %s\n", policy.Metric.DisplayString())
+	}
+	fmt.Printf("    SrcAddr: %s\n", srcDstDisplay(policy.SrcAddr.String(), policy.SrcRouterID))
+	fmt.Printf("    DstAddr: %s\n", srcDstDisplay(policy.DstAddr.String(), policy.DstRouterID))
+	fmt.Printf("    Color: %d\n", policy.Color)
+	fmt.Printf("    Preference: %d\n", policy.Preference)
+	fmt.Printf("    SegmentList: ")
+
+	if len(policy.SegmentList) == 0 {
+		fmt.Println("None")
+		return
+	}
+	for j, segment := range policy.SegmentList {
+		fmt.Print(segmentDisplayString(segment))
+		if j == len(policy.SegmentList)-1 {
+			fmt.Println()
+		} else {
+			fmt.Print(" -> ")
+		}
+	}
 }
 
 func sessionAddrFlag(cmd *cobra.Command) (netip.Addr, error) {

--- a/cmd/pola/sr_policy_list_test.go
+++ b/cmd/pola/sr_policy_list_test.go
@@ -303,12 +303,13 @@ func TestShowSRPolicyList(t *testing.T) {
 		cmd := newSRPolicyListCmd()
 		require.NoError(t, cmd.Flags().Set("peer", "192.0.2.1"))
 
-		captureStdout(t, func() {
+		out := captureStdout(t, func() {
 			require.NoError(t, showSRPolicyList(cmd, []string{}))
 		})
 
 		require.NotNil(t, fake.srPolicyListReq)
 		assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), fake.srPolicyListReq.GetPeerAddr())
+		assert.Equal(t, "No PCEP session for 192.0.2.1.\n", out)
 	})
 
 	t.Run("grpc error propagates", func(t *testing.T) {

--- a/cmd/pola/sr_policy_list_test.go
+++ b/cmd/pola/sr_policy_list_test.go
@@ -147,13 +147,15 @@ func TestShowSRPolicyList(t *testing.T) {
 		out := captureStdout(t, func() {
 			require.NoError(t, showSRPolicyList(listCmdWithJSONFlag(), []string{}))
 		})
-		assert.Equal(t, "No SR Policies found.\n", out)
+		assert.Equal(t, "No PCEP sessions connected.\n", out)
 	})
 
 	t.Run("plain text output", func(t *testing.T) {
 		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
 			Sessions: []*pb.Session{{
-				Addr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+				Addr:     netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:    pb.SessionState_SESSION_STATE_UP,
+				IsSynced: true,
 				SrPolicies: []*pb.SRPolicy{
 					{
 						PolicyName:  "pol1",
@@ -183,7 +185,7 @@ func TestShowSRPolicyList(t *testing.T) {
 			require.NoError(t, showSRPolicyList(listCmdWithJSONFlag(), []string{}))
 		})
 
-		want := "Session: 192.0.2.1\n" +
+		want := "Session: 192.0.2.1 (State: UP, IsSynced: true)\n" +
 			"  PolicyName: pol1\n" +
 			"    PlspID: 1\n" +
 			"    LSPID: 2\n" +
@@ -205,6 +207,42 @@ func TestShowSRPolicyList(t *testing.T) {
 			"    Preference: 0\n" +
 			"    SegmentList: None\n" +
 			"\n"
+		assert.Equal(t, want, out)
+	})
+
+	t.Run("synced session with no policies", func(t *testing.T) {
+		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
+			Sessions: []*pb.Session{{
+				Addr:     netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:    pb.SessionState_SESSION_STATE_UP,
+				IsSynced: true,
+			}},
+		}}
+
+		out := captureStdout(t, func() {
+			require.NoError(t, showSRPolicyList(listCmdWithJSONFlag(), []string{}))
+		})
+
+		want := "Session: 192.0.2.1 (State: UP, IsSynced: true)\n" +
+			"  No SR Policies.\n\n"
+		assert.Equal(t, want, out)
+	})
+
+	t.Run("unsynced session is shown with an explanatory note", func(t *testing.T) {
+		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
+			Sessions: []*pb.Session{{
+				Addr:     netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:    pb.SessionState_SESSION_STATE_UP,
+				IsSynced: false,
+			}},
+		}}
+
+		out := captureStdout(t, func() {
+			require.NoError(t, showSRPolicyList(listCmdWithJSONFlag(), []string{}))
+		})
+
+		want := "Session: 192.0.2.1 (State: UP, IsSynced: false)\n" +
+			"  No SR Policies: session is still synchronizing.\n\n"
 		assert.Equal(t, want, out)
 	})
 
@@ -233,6 +271,20 @@ func TestShowSRPolicyList(t *testing.T) {
 		require.NoError(t, cmd.Flags().Set("session", "not-an-address"))
 		err := showSRPolicyList(cmd, []string{})
 		require.Error(t, err)
+	})
+
+	t.Run("session filter propagates to the request", func(t *testing.T) {
+		fake := &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{}}
+		client = fake
+		cmd := listCmdWithJSONFlag()
+		require.NoError(t, cmd.Flags().Set("session", "192.0.2.1"))
+
+		captureStdout(t, func() {
+			require.NoError(t, showSRPolicyList(cmd, []string{}))
+		})
+
+		require.NotNil(t, fake.srPolicyListReq)
+		assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), fake.srPolicyListReq.GetSessionAddr())
 	})
 
 	t.Run("grpc error propagates", func(t *testing.T) {

--- a/cmd/pola/sr_policy_list_test.go
+++ b/cmd/pola/sr_policy_list_test.go
@@ -17,37 +17,37 @@ import (
 	"github.com/nttcom/pola/pkg/table"
 )
 
-func TestSessionAddrFlag_Unset(t *testing.T) {
+func TestPeerAddrFlag_Unset(t *testing.T) {
 	cmd := newSRPolicyListCmd()
 
-	addr, err := sessionAddrFlag(cmd)
+	addr, err := peerAddrFlag(cmd)
 	require.NoError(t, err)
 	assert.False(t, addr.IsValid())
 }
 
-func TestSessionAddrFlag_Valid(t *testing.T) {
+func TestPeerAddrFlag_Valid(t *testing.T) {
 	cmd := newSRPolicyListCmd()
-	require.NoError(t, cmd.Flags().Set("session", "10.0.0.1"))
+	require.NoError(t, cmd.Flags().Set("peer", "10.0.0.1"))
 
-	addr, err := sessionAddrFlag(cmd)
+	addr, err := peerAddrFlag(cmd)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.1", addr.String())
 }
 
-func TestSessionAddrFlag_Invalid(t *testing.T) {
+func TestPeerAddrFlag_Invalid(t *testing.T) {
 	cmd := newSRPolicyListCmd()
-	require.NoError(t, cmd.Flags().Set("session", "not-an-address"))
+	require.NoError(t, cmd.Flags().Set("peer", "not-an-address"))
 
-	_, err := sessionAddrFlag(cmd)
+	_, err := peerAddrFlag(cmd)
 	require.Error(t, err)
 }
 
-func TestSessionAddrFlag_UnregisteredFlag(t *testing.T) {
-	_, err := sessionAddrFlag(&cobra.Command{})
+func TestPeerAddrFlag_UnregisteredFlag(t *testing.T) {
+	_, err := peerAddrFlag(&cobra.Command{})
 	require.Error(t, err)
 }
 
-func TestShowSRPolicyList_UnregisteredJSONFlag(t *testing.T) {
+func TestShowSRPolicyList_UnregisteredFlag(t *testing.T) {
 	err := showSRPolicyList(&cobra.Command{}, []string{})
 	require.Error(t, err)
 }
@@ -134,28 +134,33 @@ func TestSrcDstDisplay(t *testing.T) {
 	assert.Equal(t, "192.0.2.1 (0000.0aff.0001)", srcDstDisplay("192.0.2.1", "0000.0aff.0001"))
 }
 
-// listCmdWithJSONFlag adds the root command's persistent --json flag for tests.
-func listCmdWithJSONFlag() *cobra.Command {
-	cmd := newSRPolicyListCmd()
-	cmd.Flags().Bool("json", false, "")
-	return cmd
-}
-
 func TestShowSRPolicyList(t *testing.T) {
 	t.Run("no policies found", func(t *testing.T) {
+		jsonFmt = false
 		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{}}
 		out := captureStdout(t, func() {
-			require.NoError(t, showSRPolicyList(listCmdWithJSONFlag(), []string{}))
+			require.NoError(t, showSRPolicyList(newSRPolicyListCmd(), []string{}))
 		})
 		assert.Equal(t, "No PCEP sessions connected.\n", out)
 	})
 
+	t.Run("no policies found, json output", func(t *testing.T) {
+		jsonFmt = true
+		t.Cleanup(func() { jsonFmt = false })
+		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{}}
+		out := captureStdout(t, func() {
+			require.NoError(t, showSRPolicyList(newSRPolicyListCmd(), []string{}))
+		})
+		assert.Equal(t, "[]\n", out)
+	})
+
 	t.Run("plain text output", func(t *testing.T) {
+		jsonFmt = false
 		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
-			Sessions: []*pb.Session{{
-				Addr:     netip.MustParseAddr("192.0.2.1").AsSlice(),
-				State:    pb.SessionState_SESSION_STATE_UP,
-				IsSynced: true,
+			Sessions: []*pb.SRPolicySession{{
+				PeerAddr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:     pb.SessionState_SESSION_STATE_UP,
+				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 				SrPolicies: []*pb.SRPolicy{
 					{
 						PolicyName:  "pol1",
@@ -182,10 +187,10 @@ func TestShowSRPolicyList(t *testing.T) {
 		}}
 
 		out := captureStdout(t, func() {
-			require.NoError(t, showSRPolicyList(listCmdWithJSONFlag(), []string{}))
+			require.NoError(t, showSRPolicyList(newSRPolicyListCmd(), []string{}))
 		})
 
-		want := "Session: 192.0.2.1 (State: UP, IsSynced: true)\n" +
+		want := "Session: 192.0.2.1 (State: up, LSP-DB Sync: finished)\n" +
 			"  PolicyName: pol1\n" +
 			"    PlspID: 1\n" +
 			"    LSPID: 2\n" +
@@ -211,45 +216,51 @@ func TestShowSRPolicyList(t *testing.T) {
 	})
 
 	t.Run("synced session with no policies", func(t *testing.T) {
+		jsonFmt = false
 		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
-			Sessions: []*pb.Session{{
-				Addr:     netip.MustParseAddr("192.0.2.1").AsSlice(),
-				State:    pb.SessionState_SESSION_STATE_UP,
-				IsSynced: true,
+			Sessions: []*pb.SRPolicySession{{
+				PeerAddr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:     pb.SessionState_SESSION_STATE_UP,
+				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 			}},
 		}}
 
 		out := captureStdout(t, func() {
-			require.NoError(t, showSRPolicyList(listCmdWithJSONFlag(), []string{}))
+			require.NoError(t, showSRPolicyList(newSRPolicyListCmd(), []string{}))
 		})
 
-		want := "Session: 192.0.2.1 (State: UP, IsSynced: true)\n" +
+		want := "Session: 192.0.2.1 (State: up, LSP-DB Sync: finished)\n" +
 			"  No SR Policies.\n\n"
 		assert.Equal(t, want, out)
 	})
 
 	t.Run("unsynced session is shown with an explanatory note", func(t *testing.T) {
+		jsonFmt = false
 		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
-			Sessions: []*pb.Session{{
-				Addr:     netip.MustParseAddr("192.0.2.1").AsSlice(),
-				State:    pb.SessionState_SESSION_STATE_UP,
-				IsSynced: false,
+			Sessions: []*pb.SRPolicySession{{
+				PeerAddr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:     pb.SessionState_SESSION_STATE_UP,
+				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_PENDING,
 			}},
 		}}
 
 		out := captureStdout(t, func() {
-			require.NoError(t, showSRPolicyList(listCmdWithJSONFlag(), []string{}))
+			require.NoError(t, showSRPolicyList(newSRPolicyListCmd(), []string{}))
 		})
 
-		want := "Session: 192.0.2.1 (State: UP, IsSynced: false)\n" +
+		want := "Session: 192.0.2.1 (State: up, LSP-DB Sync: pending)\n" +
 			"  No SR Policies: session is still synchronizing.\n\n"
 		assert.Equal(t, want, out)
 	})
 
 	t.Run("json output", func(t *testing.T) {
+		jsonFmt = true
+		t.Cleanup(func() { jsonFmt = false })
 		client = &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
-			Sessions: []*pb.Session{{
-				Addr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+			Sessions: []*pb.SRPolicySession{{
+				PeerAddr:  netip.MustParseAddr("192.0.2.1").AsSlice(),
+				State:     pb.SessionState_SESSION_STATE_UP,
+				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 				SrPolicies: []*pb.SRPolicy{{
 					PolicyName: "pol1",
 					SrcAddr:    netip.MustParseAddr("192.0.2.1").AsSlice(),
@@ -258,38 +269,53 @@ func TestShowSRPolicyList(t *testing.T) {
 			}},
 		}}
 
-		cmd := listCmdWithJSONFlag()
-		require.NoError(t, cmd.Flags().Set("json", "true"))
+		cmd := newSRPolicyListCmd()
 		out := captureStdout(t, func() {
 			require.NoError(t, showSRPolicyList(cmd, []string{}))
 		})
-		assert.Contains(t, out, `"policyName":"pol1"`)
+		want := `[{
+			"peerAddress": "192.0.2.1",
+			"state": "up",
+			"lspDbSync": "finished",
+			"srPolicies": [{
+				"policyName": "pol1",
+				"segmentList": [],
+				"srcAddr": "192.0.2.1",
+				"dstAddr": "192.0.2.2",
+				"color": 0,
+				"preference": 0
+			}]
+		}]`
+		assert.JSONEq(t, want, out)
 	})
 
-	t.Run("invalid session filter is rejected", func(t *testing.T) {
-		cmd := listCmdWithJSONFlag()
-		require.NoError(t, cmd.Flags().Set("session", "not-an-address"))
+	t.Run("invalid peer filter is rejected", func(t *testing.T) {
+		jsonFmt = false
+		cmd := newSRPolicyListCmd()
+		require.NoError(t, cmd.Flags().Set("peer", "not-an-address"))
 		err := showSRPolicyList(cmd, []string{})
 		require.Error(t, err)
 	})
 
-	t.Run("session filter propagates to the request", func(t *testing.T) {
+	t.Run("peer filter propagates to the request", func(t *testing.T) {
+		jsonFmt = false
 		fake := &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{}}
 		client = fake
-		cmd := listCmdWithJSONFlag()
-		require.NoError(t, cmd.Flags().Set("session", "192.0.2.1"))
+		cmd := newSRPolicyListCmd()
+		require.NoError(t, cmd.Flags().Set("peer", "192.0.2.1"))
 
 		captureStdout(t, func() {
 			require.NoError(t, showSRPolicyList(cmd, []string{}))
 		})
 
 		require.NotNil(t, fake.srPolicyListReq)
-		assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), fake.srPolicyListReq.GetSessionAddr())
+		assert.Equal(t, netip.MustParseAddr("192.0.2.1").AsSlice(), fake.srPolicyListReq.GetPeerAddr())
 	})
 
 	t.Run("grpc error propagates", func(t *testing.T) {
+		jsonFmt = false
 		client = &fakePCEServiceClient{srPolicyListErr: assert.AnError}
-		err := showSRPolicyList(listCmdWithJSONFlag(), []string{})
+		err := showSRPolicyList(newSRPolicyListCmd(), []string{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to retrieve SR policy list")
 	})

--- a/cmd/pola/sr_policy_list_test.go
+++ b/cmd/pola/sr_policy_list_test.go
@@ -210,8 +210,7 @@ func TestShowSRPolicyList(t *testing.T) {
 			"    DstAddr: 192.0.2.4\n" +
 			"    Color: 0\n" +
 			"    Preference: 0\n" +
-			"    SegmentList: None\n" +
-			"\n"
+			"    SegmentList: None\n"
 		assert.Equal(t, want, out)
 	})
 
@@ -230,7 +229,7 @@ func TestShowSRPolicyList(t *testing.T) {
 		})
 
 		want := "Session: 192.0.2.1 (State: up, LSP-DB Sync: finished)\n" +
-			"  No SR Policies.\n\n"
+			"  No SR Policies.\n"
 		assert.Equal(t, want, out)
 	})
 
@@ -249,7 +248,7 @@ func TestShowSRPolicyList(t *testing.T) {
 		})
 
 		want := "Session: 192.0.2.1 (State: up, LSP-DB Sync: pending)\n" +
-			"  No SR Policies: session is still synchronizing.\n\n"
+			"  No SR Policies: session is still synchronizing.\n"
 		assert.Equal(t, want, out)
 	})
 

--- a/cmd/pola/sr_policy_text.go
+++ b/cmd/pola/sr_policy_text.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/nttcom/pola/pkg/table"
+)
+
+func writeSRPolicyText(w io.Writer, views []srPolicySessionView) error {
+	for i, v := range views {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if err := writeSRPolicySession(w, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeSRPolicySession(w io.Writer, v srPolicySessionView) error {
+	if _, err := fmt.Fprintf(w, "Session: %s (State: %s, LSP-DB Sync: %s)\n", v.PeerAddress, v.State, v.LSPDBSync); err != nil {
+		return err
+	}
+	if len(v.SRPolicies) == 0 {
+		if v.LSPDBSync == "finished" {
+			if _, err := fmt.Fprintln(w, "  No SR Policies."); err != nil {
+				return err
+			}
+		} else if _, err := fmt.Fprintln(w, "  No SR Policies: session is still synchronizing."); err != nil {
+			return err
+		}
+	}
+	for _, policy := range v.SRPolicies {
+		if err := writeSRPolicy(w, policy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// errWriter records the first write error and allows chained writes.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) printf(format string, a ...any) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, a...)
+}
+
+func writeSRPolicy(w io.Writer, policy table.SRPolicy) error {
+	ew := &errWriter{w: w}
+	ew.printf("  PolicyName: %s\n", policy.Name)
+	ew.printf("    PlspID: %d\n", policy.PlspID)
+	ew.printf("    LSPID: %d\n", policy.LSPID)
+	ew.printf("    State: %s\n", policy.State)
+	if policy.Type != "" {
+		ew.printf("    Type: %s\n", policy.Type)
+	}
+	if policy.Metric != table.UnspecifiedMetric {
+		ew.printf("    Metric: %s\n", policy.Metric.DisplayString())
+	}
+	ew.printf("    SrcAddr: %s\n", srcDstDisplay(policy.SrcAddr.String(), policy.SrcRouterID))
+	ew.printf("    DstAddr: %s\n", srcDstDisplay(policy.DstAddr.String(), policy.DstRouterID))
+	ew.printf("    Color: %d\n", policy.Color)
+	ew.printf("    Preference: %d\n", policy.Preference)
+	ew.printf("    SegmentList: %s\n", segmentListDisplayString(policy.SegmentList))
+	return ew.err
+}
+
+func segmentListDisplayString(segmentList []table.Segment) string {
+	if len(segmentList) == 0 {
+		return "None"
+	}
+	tokens := make([]string, len(segmentList))
+	for i, segment := range segmentList {
+		tokens[i] = segmentDisplayString(segment)
+	}
+	return strings.Join(tokens, " -> ")
+}
+
+func srcDstDisplay(addr, routerID string) string {
+	if routerID == "" {
+		return addr
+	}
+	return fmt.Sprintf("%s (%s)", addr, routerID)
+}
+
+func segmentDisplayString(seg table.Segment) string {
+	var localAddr, remoteAddr string
+	switch v := seg.(type) {
+	case table.SegmentSRv6:
+		if v.LocalAddr.IsValid() {
+			localAddr = v.LocalAddr.String()
+		}
+		if v.RemoteAddr.IsValid() {
+			remoteAddr = v.RemoteAddr.String()
+		}
+	case table.SegmentSRMPLS:
+		if v.LocalAddr.IsValid() {
+			localAddr = v.LocalAddr.String()
+		}
+		if v.RemoteAddr.IsValid() {
+			remoteAddr = v.RemoteAddr.String()
+		}
+	}
+
+	switch {
+	case localAddr == "" && remoteAddr == "":
+		return seg.SidString()
+	case remoteAddr == "":
+		return fmt.Sprintf("%s (local=%s)", seg.SidString(), localAddr)
+	case localAddr == "":
+		return fmt.Sprintf("%s (remote=%s)", seg.SidString(), remoteAddr)
+	default:
+		return fmt.Sprintf("%s (local=%s, remote=%s)", seg.SidString(), localAddr, remoteAddr)
+	}
+}

--- a/cmd/pola/sr_policy_text.go
+++ b/cmd/pola/sr_policy_text.go
@@ -32,12 +32,19 @@ func writeSRPolicySession(w io.Writer, v srPolicySessionView) error {
 		return err
 	}
 	if len(v.SRPolicies) == 0 {
-		if v.LSPDBSync == "finished" {
+		switch {
+		case v.LSPDBSync == "finished":
 			if _, err := fmt.Fprintln(w, "  No SR Policies."); err != nil {
 				return err
 			}
-		} else if _, err := fmt.Fprintln(w, "  No SR Policies: session is still synchronizing."); err != nil {
-			return err
+		case v.State != "up":
+			if _, err := fmt.Fprintln(w, "  No SR Policies: session is not established."); err != nil {
+				return err
+			}
+		default:
+			if _, err := fmt.Fprintln(w, "  No SR Policies: session is still synchronizing."); err != nil {
+				return err
+			}
 		}
 	}
 	for _, policy := range v.SRPolicies {

--- a/cmd/pola/sr_policy_text_test.go
+++ b/cmd/pola/sr_policy_text_test.go
@@ -58,6 +58,11 @@ func TestWriteSRPolicySession_EmptyPolicies_PropagatesWriteError(t *testing.T) {
 			v:    srPolicySessionView{PeerAddress: "192.0.2.1", State: "up", LSPDBSync: "pending"},
 			fail: exactFail("  No SR Policies: session is still synchronizing.\n"),
 		},
+		{
+			name: "not established",
+			v:    srPolicySessionView{PeerAddress: "192.0.2.1", State: "tcp-pending", LSPDBSync: "pending"},
+			fail: exactFail("  No SR Policies: session is not established.\n"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/pola/sr_policy_text_test.go
+++ b/cmd/pola/sr_policy_text_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nttcom/pola/pkg/table"
+)
+
+func TestWriteSRPolicyText_PropagatesWriteErrors(t *testing.T) {
+	views := []srPolicySessionView{
+		{
+			PeerAddress: "192.0.2.1",
+			State:       "up",
+			LSPDBSync:   "finished",
+			SRPolicies: []table.SRPolicy{
+				{Name: "policy1", PlspID: 1, LSPID: 2, State: "up"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		fail func(string) bool
+	}{
+		{"session header", containsFail("Session:")},
+		{"policy name", containsFail("PolicyName:")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &condFailWriter{fail: tt.fail}
+			err := writeSRPolicyText(w, views)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestWriteSRPolicySession_EmptyPolicies_PropagatesWriteError(t *testing.T) {
+	tests := []struct {
+		name string
+		v    srPolicySessionView
+		fail func(string) bool
+	}{
+		{
+			name: "finished",
+			v:    srPolicySessionView{PeerAddress: "192.0.2.1", State: "up", LSPDBSync: "finished"},
+			fail: exactFail("  No SR Policies.\n"),
+		},
+		{
+			name: "still synchronizing",
+			v:    srPolicySessionView{PeerAddress: "192.0.2.1", State: "up", LSPDBSync: "pending"},
+			fail: exactFail("  No SR Policies: session is still synchronizing.\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &condFailWriter{fail: tt.fail}
+			err := writeSRPolicySession(w, tt.v)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestWriteSRPolicyText_PropagatesSeparatorWriteError(t *testing.T) {
+	views := []srPolicySessionView{
+		{PeerAddress: "192.0.2.1", State: "up", LSPDBSync: "finished"},
+		{PeerAddress: "192.0.2.2", State: "up", LSPDBSync: "finished"},
+	}
+	w := &condFailWriter{fail: exactFail("\n")}
+	err := writeSRPolicyText(w, views)
+	require.Error(t, err)
+}
+
+func TestWriteSRPolicyText_SeparatesMultipleSessionsWithBlankLine(t *testing.T) {
+	views := []srPolicySessionView{
+		{PeerAddress: "192.0.2.1", State: "up", LSPDBSync: "finished"},
+		{PeerAddress: "192.0.2.2", State: "up", LSPDBSync: "finished"},
+	}
+	w := &condFailWriter{}
+	require.NoError(t, writeSRPolicyText(w, views))
+	require.False(t, strings.HasSuffix(w.buf.String(), "\n\n"), "output must not end with a blank line")
+	require.Contains(t, w.buf.String(), "\n\nSession: 192.0.2.2")
+}

--- a/cmd/pola/sr_policy_view.go
+++ b/cmd/pola/sr_policy_view.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"github.com/nttcom/pola/cmd/pola/grpc"
+	"github.com/nttcom/pola/pkg/table"
+)
+
+// srPolicySessionView groups SR policies by peer and preserves session state
+// needed to distinguish unsynchronized sessions from synced sessions with no policies.
+type srPolicySessionView struct {
+	PeerAddress string           `json:"peerAddress"`
+	State       string           `json:"state"`
+	LSPDBSync   string           `json:"lspDbSync"`
+	SRPolicies  []table.SRPolicy `json:"srPolicies"`
+}
+
+func newSRPolicySessionView(ss grpc.SRPolicySession) srPolicySessionView {
+	policies := ss.SRPolicies
+	if policies == nil {
+		policies = []table.SRPolicy{}
+	}
+	return srPolicySessionView{
+		PeerAddress: ss.PeerAddr.String(),
+		State:       ss.State,
+		LSPDBSync:   ss.SyncState,
+		SRPolicies:  policies,
+	}
+}

--- a/cmd/pola/sr_policy_view_test.go
+++ b/cmd/pola/sr_policy_view_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nttcom/pola/cmd/pola/grpc"
+	"github.com/nttcom/pola/pkg/table"
+)
+
+func TestNewSRPolicySessionView(t *testing.T) {
+	ss := grpc.SRPolicySession{
+		PeerAddr:  netip.MustParseAddr("192.0.2.1"),
+		State:     "up",
+		SyncState: "finished",
+		SRPolicies: []table.SRPolicy{
+			{Name: "pol1"},
+		},
+	}
+
+	v := newSRPolicySessionView(ss)
+	assert.Equal(t, "192.0.2.1", v.PeerAddress)
+	assert.Equal(t, "up", v.State)
+	assert.Equal(t, "finished", v.LSPDBSync)
+	assert.Equal(t, []table.SRPolicy{{Name: "pol1"}}, v.SRPolicies)
+}
+
+func TestNewSRPolicySessionView_NilSRPoliciesBecomesEmptySlice(t *testing.T) {
+	ss := grpc.SRPolicySession{PeerAddr: netip.MustParseAddr("192.0.2.1"), State: "up", SyncState: "pending"}
+
+	v := newSRPolicySessionView(ss)
+	require.NotNil(t, v.SRPolicies)
+	assert.Empty(t, v.SRPolicies)
+}

--- a/cmd/pola/ted.go
+++ b/cmd/pola/ted.go
@@ -6,126 +6,42 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
+	"errors"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
-	"github.com/nttcom/pola/pkg/table"
-	"github.com/spf13/cobra"
 )
 
 func newTEDCmd() *cobra.Command {
 	return &cobra.Command{
 		Use: "ted",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if err := printTED(jsonFmt); err != nil {
+			format, err := resolveOutputFormat(jsonFmt, false)
+			if err != nil {
 				return err
 			}
-			return nil
+			return showTED(os.Stdout, format)
 		},
 	}
 }
 
-func printTED(jsonFlag bool) error {
+func showTED(w io.Writer, format outputFormat) error {
 	ted, err := grpc.GetTED(client)
 	if err != nil {
 		return err
 	}
 
 	if ted == nil {
-		fmt.Println("TED is disabled by polad")
-		return nil
+		return errors.New("TED is disabled by polad")
 	}
 
-	if jsonFlag {
-		outputJSON, err := json.Marshal(tedToJSONMap(ted))
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(outputJSON))
-	} else {
-		ted.Print()
-	}
+	views := newTEDNodeViews(ted.Nodes)
 
-	return nil
-}
-
-// tedToJSONMap converts ted into the map shape marshalled by printTED.
-func tedToJSONMap(ted *table.LsTED) map[string]any {
-	nodes := []map[string]any{}
-	for _, node := range ted.Nodes {
-		nodes = append(nodes, tedNodeToJSONMap(node))
+	if format == outputJSON {
+		return writeJSON(w, views)
 	}
-
-	return map[string]any{
-		"ted": nodes,
-	}
-}
-
-func tedNodeToJSONMap(node *table.LsNode) map[string]any {
-	links := []map[string]any{}
-	for _, link := range node.Links {
-		links = append(links, tedLinkToJSONMap(link))
-	}
-
-	prefixes := []map[string]any{}
-	for _, prefix := range node.Prefixes {
-		prefixMap := map[string]any{
-			"prefix": prefix.Prefix.String(),
-		}
-		if prefix.HasPrefixSID() {
-			prefixMap["sidIndex"] = prefix.SidIndex
-		}
-		prefixes = append(prefixes, prefixMap)
-	}
-
-	srv6SIDs := []map[string]any{}
-	for _, srv6SID := range node.SRv6SIDs {
-		srv6SIDs = append(srv6SIDs, map[string]any{
-			"sids":             srv6SID.Sids,
-			"endpointBehavior": srv6SID.EndpointBehavior,
-			"multiTopoIDs":     srv6SID.MultiTopoIDs,
-		})
-	}
-
-	return map[string]any{ // TODO: Fix format according to readme
-		"asn":        node.ASN,
-		"routerID":   node.RouterID,
-		"isisAreaID": node.IsisAreaID,
-		"hostname":   node.Hostname,
-		"srgbBegin":  node.SrgbBegin,
-		"srgbEnd":    node.SrgbEnd,
-		"prefixes":   prefixes,
-		"links":      links,
-		"srv6SIDs":   srv6SIDs,
-	}
-}
-
-func tedLinkToJSONMap(link *table.LsLink) map[string]any {
-	metrics := []map[string]any{}
-	for _, metric := range link.Metrics {
-		metrics = append(metrics, map[string]any{
-			"type":  metric.Type.String(),
-			"value": metric.Value,
-		})
-	}
-
-	// Links whose BGP-LS descriptor carried no interface address report "None",
-	// matching table.LsTED.Print.
-	localIP := "None"
-	if link.LocalIP.IsValid() {
-		localIP = link.LocalIP.String()
-	}
-	remoteIP := "None"
-	if link.RemoteIP.IsValid() {
-		remoteIP = link.RemoteIP.String()
-	}
-
-	return map[string]any{
-		"localIP":    localIP,
-		"remoteIP":   remoteIP,
-		"remoteNode": link.RemoteNode.RouterID,
-		"metrics":    metrics,
-		"adjSid":     link.AdjSid,
-	}
+	return writeTEDText(w, views)
 }

--- a/cmd/pola/ted.go
+++ b/cmd/pola/ted.go
@@ -16,16 +16,13 @@ import (
 )
 
 func newTEDCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use: "ted",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			format, err := resolveOutputFormat(jsonFmt, false)
-			if err != nil {
-				return err
-			}
-			return showTED(os.Stdout, format)
+			return showTED(os.Stdout, resolveOutputFormat(jsonFmt))
 		},
 	}
+	return cmd
 }
 
 func showTED(w io.Writer, format outputFormat) error {

--- a/cmd/pola/ted_test.go
+++ b/cmd/pola/ted_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -20,8 +21,8 @@ func TestNewTEDCmd_RunE(t *testing.T) {
 	cmd := newTEDCmd()
 
 	client = &fakePCEServiceClient{tedResp: &pb.GetTEDResponse{
-		Enable:  true,
-		LsNodes: []*pb.LsNode{{RouterId: "0000.0aff.0001"}},
+		Enabled: true,
+		Nodes:   []*pb.LsNode{{RouterId: "0000.0aff.0001"}},
 	}}
 	captureStdout(t, func() {
 		require.NoError(t, cmd.RunE(cmd, []string{}))
@@ -32,30 +33,36 @@ func TestNewTEDCmd_RunE(t *testing.T) {
 	require.ErrorIs(t, err, assert.AnError)
 }
 
-func TestPrintTED(t *testing.T) {
+func TestShowTED(t *testing.T) {
 	t.Run("grpc error propagates", func(t *testing.T) {
 		client = &fakePCEServiceClient{tedErr: assert.AnError}
-		err := printTED(false)
+		var buf bytes.Buffer
+		err := showTED(&buf, outputText)
 		require.Error(t, err)
 	})
 
-	t.Run("disabled TED prints a dedicated message", func(t *testing.T) {
-		client = &fakePCEServiceClient{tedResp: &pb.GetTEDResponse{Enable: false}}
-		out := captureStdout(t, func() {
-			require.NoError(t, printTED(false))
-		})
-		assert.Contains(t, out, "TED is disabled by polad")
+	t.Run("disabled TED returns an error", func(t *testing.T) {
+		client = &fakePCEServiceClient{tedResp: &pb.GetTEDResponse{Enabled: false}}
+		var buf bytes.Buffer
+		err := showTED(&buf, outputText)
+		require.ErrorContains(t, err, "TED is disabled by polad")
 	})
 
-	t.Run("plain text output delegates to LsTED.Print", func(t *testing.T) {
+	t.Run("disabled TED returns an error even in JSON mode", func(t *testing.T) {
+		client = &fakePCEServiceClient{tedResp: &pb.GetTEDResponse{Enabled: false}}
+		var buf bytes.Buffer
+		err := showTED(&buf, outputJSON)
+		require.ErrorContains(t, err, "TED is disabled by polad")
+	})
+
+	t.Run("plain text output", func(t *testing.T) {
 		client = &fakePCEServiceClient{tedResp: &pb.GetTEDResponse{
-			Enable:  true,
-			LsNodes: []*pb.LsNode{{RouterId: "0000.0aff.0001"}},
+			Enabled: true,
+			Nodes:   []*pb.LsNode{{RouterId: "0000.0aff.0001"}},
 		}}
-		out := captureStdout(t, func() {
-			require.NoError(t, printTED(false))
-		})
-		assert.Contains(t, out, "0000.0aff.0001")
+		var buf bytes.Buffer
+		require.NoError(t, showTED(&buf, outputText))
+		assert.Contains(t, buf.String(), "0000.0aff.0001")
 	})
 
 	t.Run("json output", func(t *testing.T) {
@@ -63,7 +70,7 @@ func TestPrintTED(t *testing.T) {
 			Asn:      65000,
 			RouterId: "0000.0aff.0001",
 			Hostname: "routerA",
-			LsLinks: []*pb.LsLink{
+			Links: []*pb.LsLink{
 				{
 					LocalRouterId:  "0000.0aff.0001",
 					RemoteRouterId: "0000.0aff.0001",
@@ -78,27 +85,25 @@ func TestPrintTED(t *testing.T) {
 					AdjSid:         24002,
 				},
 			},
-			LsPrefixes: []*pb.LsPrefix{
+			Prefixes: []*pb.LsPrefix{
 				{Prefix: "10.0.0.1/32", SidIndex: proto.Uint32(1)},
 				{Prefix: "10.0.0.2/32"},
 			},
-			LsSrv6Sids: []*pb.LsSrv6SID{{
+			Srv6Sids: []*pb.LsSrv6SID{{
 				Sids:             []*pb.SID{{Sid: "2001:db8:1::"}},
 				EndpointBehavior: &pb.EndpointBehavior{Behavior: 1},
+				SidStructure:     &pb.SidStructure{},
 			}},
 		}
-		client = &fakePCEServiceClient{tedResp: &pb.GetTEDResponse{Enable: true, LsNodes: []*pb.LsNode{node}}}
+		client = &fakePCEServiceClient{tedResp: &pb.GetTEDResponse{Enabled: true, Nodes: []*pb.LsNode{node}}}
 
-		out := captureStdout(t, func() {
-			require.NoError(t, printTED(true))
-		})
+		var buf bytes.Buffer
+		require.NoError(t, showTED(&buf, outputJSON))
 
-		var decoded map[string]any
-		require.NoError(t, json.Unmarshal([]byte(out), &decoded))
-		nodes, ok := decoded["ted"].([]any)
-		require.True(t, ok)
+		var nodes []map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &nodes))
 		require.Len(t, nodes, 1)
-		nodeMap := nodes[0].(map[string]any)
+		nodeMap := nodes[0]
 		assert.Equal(t, "routerA", nodeMap["hostname"])
 		//nolint:testifylint // float-compare: JSON decodes numbers to float64, and these are exact small integers.
 		assert.Equal(t, float64(65000), nodeMap["asn"])
@@ -107,12 +112,14 @@ func TestPrintTED(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, links, 2)
 		linkMap := links[0].(map[string]any)
-		assert.Equal(t, "192.0.2.1", linkMap["localIP"])
-		assert.Equal(t, "None", linkMap["remoteIP"])
+		assert.Equal(t, "192.0.2.1", linkMap["localIp"])
+		_, hasRemoteIP := linkMap["remoteIp"]
+		assert.False(t, hasRemoteIP, "unset remoteIp must be omitted, not a \"None\" sentinel")
 
 		linkMap2 := links[1].(map[string]any)
-		assert.Equal(t, "None", linkMap2["localIP"])
-		assert.Equal(t, "192.0.2.2", linkMap2["remoteIP"])
+		_, hasLocalIP := linkMap2["localIp"]
+		assert.False(t, hasLocalIP)
+		assert.Equal(t, "192.0.2.2", linkMap2["remoteIp"])
 
 		prefixes, ok := nodeMap["prefixes"].([]any)
 		require.True(t, ok)
@@ -122,7 +129,7 @@ func TestPrintTED(t *testing.T) {
 		_, hasSidIndex := prefixes[1].(map[string]any)["sidIndex"]
 		assert.False(t, hasSidIndex)
 
-		srv6SIDs, ok := nodeMap["srv6SIDs"].([]any)
+		srv6SIDs, ok := nodeMap["srv6Sids"].([]any)
 		require.True(t, ok)
 		assert.Len(t, srv6SIDs, 1)
 	})

--- a/cmd/pola/ted_text.go
+++ b/cmd/pola/ted_text.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// writeTEDText expects nodes to be sorted by router ID for deterministic output.
+func writeTEDText(w io.Writer, nodes []tedNodeView) error {
+	if len(nodes) == 0 {
+		_, err := fmt.Fprintln(w, "TED is empty")
+		return err
+	}
+
+	for i, node := range nodes {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "Node #%d: %s\n", i, node.RouterID); err != nil {
+			return err
+		}
+		if err := writeTEDNodeBasic(w, node); err != nil {
+			return err
+		}
+		if err := writeTEDNodePrefixes(w, node); err != nil {
+			return err
+		}
+		if err := writeTEDNodeLinks(w, node); err != nil {
+			return err
+		}
+		if err := writeTEDNodeSrv6SIDs(w, node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTEDNodeBasic(w io.Writer, node tedNodeView) error {
+	if _, err := fmt.Fprintf(w, "  Hostname: %s\n", node.Hostname); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  ISIS Area ID: %s\n", node.IsisAreaID); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "  SRGB: %d - %d\n", node.Srgb.Begin, node.Srgb.End)
+	return err
+}
+
+func writeTEDNodePrefixes(w io.Writer, node tedNodeView) error {
+	if _, err := fmt.Fprintln(w, "  Prefixes:"); err != nil {
+		return err
+	}
+	for _, p := range node.Prefixes {
+		if _, err := fmt.Fprintf(w, "    %s\n", p.Prefix); err != nil {
+			return err
+		}
+		if p.SidIndex != nil {
+			if _, err := fmt.Fprintf(w, "      index: %d\n", *p.SidIndex); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeTEDNodeLinks(w io.Writer, node tedNodeView) error {
+	if _, err := fmt.Fprintln(w, "  Links:"); err != nil {
+		return err
+	}
+	for _, link := range node.Links {
+		if err := writeTEDLink(w, link); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "None"
+	}
+	return s
+}
+
+func writeTEDLink(w io.Writer, link tedLinkView) error {
+	if _, err := fmt.Fprintf(w, "    Local: %s Remote: %s\n", orNone(link.LocalIP), orNone(link.RemoteIP)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "      RemoteRouterID: %s\n", orNone(link.RemoteRouterID)); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(w, "      Metrics:"); err != nil {
+		return err
+	}
+	for _, m := range link.Metrics {
+		if _, err := fmt.Fprintf(w, "        %s: %d\n", m.Type, m.Value); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(w, "      Adj-SID: %d\n", link.AdjSid); err != nil {
+		return err
+	}
+
+	if link.Srv6EndXSID != nil {
+		if err := writeTEDSrv6EndXSID(w, *link.Srv6EndXSID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTEDSrv6EndXSID(w io.Writer, sid tedSrv6EndXSIDView) error {
+	if _, err := fmt.Fprintln(w, "      SRv6 End.X SID:"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "        EndpointBehavior: %s\n", sid.EndpointBehavior.Name); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "        SIDs: %v\n", sid.Sids); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "        SID Structure: Block: %d, Node: %d, Func: %d, Arg: %d\n",
+		sid.SidStructure.LocalBlock, sid.SidStructure.LocalNode, sid.SidStructure.LocalFunc, sid.SidStructure.LocalArg)
+	return err
+}
+
+func writeTEDNodeSrv6SIDs(w io.Writer, node tedNodeView) error {
+	if _, err := fmt.Fprintln(w, "  SRv6 SIDs:"); err != nil {
+		return err
+	}
+	for _, sid := range node.SRv6SIDs {
+		if err := writeTEDSrv6SID(w, sid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTEDSrv6SID(w io.Writer, sid tedSrv6SIDView) error {
+	if _, err := fmt.Fprintf(w, "    SIDs: %v\n", sid.Sids); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "    Block: %d, Node: %d, Func: %d, Arg: %d\n",
+		sid.SidStructure.LocalBlock, sid.SidStructure.LocalNode, sid.SidStructure.LocalFunc, sid.SidStructure.LocalArg); err != nil {
+		return err
+	}
+	var flags, algorithm uint8
+	if sid.EndpointBehavior.Flags != nil {
+		flags = *sid.EndpointBehavior.Flags
+	}
+	if sid.EndpointBehavior.Algorithm != nil {
+		algorithm = *sid.EndpointBehavior.Algorithm
+	}
+	if _, err := fmt.Fprintf(w, "    EndpointBehavior: %s, Flags: %d, Algorithm: %d\n",
+		sid.EndpointBehavior.Name, flags, algorithm); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "    MultiTopoIDs: %v\n", sid.MultiTopoIDs)
+	return err
+}

--- a/cmd/pola/ted_text_test.go
+++ b/cmd/pola/ted_text_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fullTEDNodeViewFixture exercises the rendering branches in ted_text.go.
+func fullTEDNodeViewFixture() tedNodeView {
+	sidIdx := uint32(7)
+	flags, algorithm := uint8(1), uint8(2)
+	return tedNodeView{
+		RouterID:   "0000.0aff.0001",
+		Hostname:   "router1",
+		IsisAreaID: "49.0001",
+		Srgb:       srgbView{Begin: 16000, End: 23999},
+		Prefixes: []tedPrefixView{
+			{Prefix: "10.0.0.1/32"},
+			{Prefix: "10.0.0.2/32", SidIndex: &sidIdx},
+		},
+		Links: []tedLinkView{
+			{
+				RemoteRouterID: "",
+				AdjSid:         100,
+			},
+			{
+				LocalIP:        "192.0.2.2",
+				RemoteIP:       "192.0.2.3",
+				RemoteRouterID: "0000.0aff.0002",
+				Metrics:        []tedMetricView{{Type: "igp", Value: 10}},
+				AdjSid:         200,
+				Srv6EndXSID: &tedSrv6EndXSIDView{
+					EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
+					Sids:             []string{"fc00:0:1:endx::"},
+					SidStructure:     sidStructureView{LocalBlock: 21, LocalNode: 22, LocalFunc: 23, LocalArg: 24},
+				},
+			},
+		},
+		SRv6SIDs: []tedSrv6SIDView{
+			{
+				Sids:             []string{"fc00:0:2:node1::"},
+				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-1"},
+				SidStructure:     sidStructureView{LocalBlock: 31, LocalNode: 32, LocalFunc: 33, LocalArg: 34},
+				MultiTopoIDs:     []uint32{1},
+			},
+			{
+				Sids:             []string{"fc00:0:2:node2::"},
+				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-2", Flags: &flags, Algorithm: &algorithm},
+				SidStructure:     sidStructureView{LocalBlock: 41, LocalNode: 42, LocalFunc: 43, LocalArg: 44},
+				MultiTopoIDs:     []uint32{2, 3},
+			},
+		},
+	}
+}
+
+func TestWriteTEDText_EmptyTED(t *testing.T) {
+	w := &condFailWriter{}
+	require.NoError(t, writeTEDText(w, nil))
+	require.Equal(t, "TED is empty\n", w.buf.String())
+}
+
+func TestWriteTEDText_FullRenderSucceeds(t *testing.T) {
+	w := &condFailWriter{}
+	require.NoError(t, writeTEDText(w, []tedNodeView{fullTEDNodeViewFixture()}))
+}
+
+func TestWriteTEDText_PropagatesWriteErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		fail func(string) bool
+	}{
+		{"node header", containsFail("Node #0: 0000.0aff.0001")},
+		{"hostname", containsFail("Hostname: router1")},
+		{"isis area id", containsFail("ISIS Area ID: 49.0001")},
+		{"prefixes header", containsFail("Prefixes:")},
+		{"prefix line", containsFail("10.0.0.1/32")},
+		{"prefix sid index", containsFail("index: 7")},
+		{"links header", containsFail("  Links:")},
+		{"link local/remote", containsFail("Local: None Remote: None")},
+		{"link remote router id", containsFail("RemoteRouterID: None")},
+		{"link metrics header", containsFail("      Metrics:")},
+		{"link metric line", containsFail("igp: 10")},
+		{"link adj-sid", containsFail("Adj-SID: 100")},
+		{"srv6 end.x sid header", containsFail("SRv6 End.X SID:")},
+		{"srv6 end.x endpoint behavior", containsFail("EndpointBehavior: END-X-BEHAVIOR")},
+		{"srv6 end.x sids", containsFail("fc00:0:1:endx::")},
+		{"node srv6 sids header", containsFail("SRv6 SIDs:")},
+		{"node srv6 sid sids", containsFail("fc00:0:2:node1::")},
+		{"node srv6 sid structure", containsFail("Block: 31")},
+		{"node srv6 sid endpoint behavior", containsFail("EndpointBehavior: NODE-SID-BEHAVIOR-1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &condFailWriter{fail: tt.fail}
+			err := writeTEDText(w, []tedNodeView{fullTEDNodeViewFixture()})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestWriteTEDText_PropagatesSeparatorWriteError(t *testing.T) {
+	w := &condFailWriter{fail: exactFail("\n")}
+	err := writeTEDText(w, []tedNodeView{fullTEDNodeViewFixture(), fullTEDNodeViewFixture()})
+	require.Error(t, err)
+}
+
+func TestWriteTEDText_SeparatesMultipleNodesWithBlankLine(t *testing.T) {
+	w := &condFailWriter{}
+	require.NoError(t, writeTEDText(w, []tedNodeView{fullTEDNodeViewFixture(), fullTEDNodeViewFixture()}))
+	require.False(t, strings.HasSuffix(w.buf.String(), "\n\n"), "output must not end with a blank line")
+	require.Contains(t, w.buf.String(), "\n\nNode #1:")
+}

--- a/cmd/pola/ted_view.go
+++ b/cmd/pola/ted_view.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"slices"
+
+	"github.com/nttcom/pola/pkg/table"
+)
+
+type tedNodeView struct {
+	ASN        uint32           `json:"asn"`
+	RouterID   string           `json:"routerId"`
+	Hostname   string           `json:"hostname"`
+	IsisAreaID string           `json:"isisAreaId"`
+	Srgb       srgbView         `json:"srgb"`
+	Prefixes   []tedPrefixView  `json:"prefixes"`
+	Links      []tedLinkView    `json:"links"`
+	SRv6SIDs   []tedSrv6SIDView `json:"srv6Sids"`
+}
+
+type srgbView struct {
+	Begin uint32 `json:"begin"`
+	End   uint32 `json:"end"`
+}
+
+type tedPrefixView struct {
+	Prefix   string  `json:"prefix"`
+	SidIndex *uint32 `json:"sidIndex,omitempty"`
+}
+
+type tedLinkView struct {
+	LocalIP        string              `json:"localIp,omitempty"`
+	RemoteIP       string              `json:"remoteIp,omitempty"`
+	RemoteRouterID string              `json:"remoteRouterId"`
+	Metrics        []tedMetricView     `json:"metrics"`
+	AdjSid         uint32              `json:"adjSid"`
+	Srv6EndXSID    *tedSrv6EndXSIDView `json:"srv6EndXSid,omitempty"`
+}
+
+type tedMetricView struct {
+	Type  string `json:"type"` // igp | te | delay | hopcount
+	Value uint32 `json:"value"`
+}
+
+type tedSrv6SIDView struct {
+	Sids             []string             `json:"sids"`
+	EndpointBehavior endpointBehaviorView `json:"endpointBehavior"`
+	SidStructure     sidStructureView     `json:"sidStructure"`
+	MultiTopoIDs     []uint32             `json:"multiTopoIds"`
+}
+
+type tedSrv6EndXSIDView struct {
+	EndpointBehavior endpointBehaviorView `json:"endpointBehavior"`
+	Sids             []string             `json:"sids"`
+	SidStructure     sidStructureView     `json:"sidStructure"`
+}
+
+// endpointBehaviorView omits Flags and Algorithm for End.X SIDs, which carry only the behavior.
+type endpointBehaviorView struct {
+	Behavior  uint16 `json:"behavior"`
+	Name      string `json:"name"` // table.BehaviorToString
+	Flags     *uint8 `json:"flags,omitempty"`
+	Algorithm *uint8 `json:"algorithm,omitempty"`
+}
+
+type sidStructureView struct {
+	LocalBlock uint8 `json:"localBlock"`
+	LocalNode  uint8 `json:"localNode"`
+	LocalFunc  uint8 `json:"localFunc"`
+	LocalArg   uint8 `json:"localArg"`
+}
+
+// newTEDNodeViews derives CLI/JSON views from a TED in router ID order
+// for deterministic output.
+func newTEDNodeViews(nodes map[string]*table.LsNode) []tedNodeView {
+	routerIDs := make([]string, 0, len(nodes))
+	for routerID := range nodes {
+		routerIDs = append(routerIDs, routerID)
+	}
+	slices.Sort(routerIDs)
+
+	views := make([]tedNodeView, 0, len(routerIDs))
+	for _, routerID := range routerIDs {
+		if node := nodes[routerID]; node != nil {
+			views = append(views, newTEDNodeView(node))
+		}
+	}
+	return views
+}
+
+func newTEDNodeView(node *table.LsNode) tedNodeView {
+	return tedNodeView{
+		ASN:        node.ASN,
+		RouterID:   node.RouterID,
+		Hostname:   node.Hostname,
+		IsisAreaID: node.IsisAreaID,
+		Srgb:       srgbView{Begin: node.SrgbBegin, End: node.SrgbEnd},
+		Prefixes:   newTEDPrefixViews(node.Prefixes),
+		Links:      newTEDLinkViews(node.Links),
+		SRv6SIDs:   newTEDSrv6SIDViews(node.SRv6SIDs),
+	}
+}
+
+func newTEDPrefixViews(prefixes []*table.LsPrefix) []tedPrefixView {
+	views := make([]tedPrefixView, 0, len(prefixes))
+	for _, p := range prefixes {
+		if p == nil {
+			continue
+		}
+		v := tedPrefixView{Prefix: p.Prefix.String()}
+		if p.HasPrefixSID() {
+			sidIndex := p.SidIndex
+			v.SidIndex = &sidIndex
+		}
+		views = append(views, v)
+	}
+	return views
+}
+
+func newTEDLinkViews(links []*table.LsLink) []tedLinkView {
+	views := make([]tedLinkView, 0, len(links))
+	for _, l := range links {
+		if l == nil {
+			continue
+		}
+		views = append(views, newTEDLinkView(l))
+	}
+	return views
+}
+
+func newTEDLinkView(l *table.LsLink) tedLinkView {
+	v := tedLinkView{
+		Metrics: newTEDMetricViews(l.Metrics),
+		AdjSid:  l.AdjSid,
+	}
+	if l.LocalIP.IsValid() {
+		v.LocalIP = l.LocalIP.String()
+	}
+	if l.RemoteIP.IsValid() {
+		v.RemoteIP = l.RemoteIP.String()
+	}
+	if l.RemoteNode != nil {
+		v.RemoteRouterID = l.RemoteNode.RouterID
+	}
+	if l.Srv6EndXSID != nil {
+		sid := newTEDSrv6EndXSIDView(l.Srv6EndXSID)
+		v.Srv6EndXSID = &sid
+	}
+	return v
+}
+
+func newTEDMetricViews(metrics []*table.Metric) []tedMetricView {
+	views := make([]tedMetricView, 0, len(metrics))
+	for _, m := range metrics {
+		if m == nil {
+			continue
+		}
+		views = append(views, tedMetricView{Type: m.Type.DisplayString(), Value: m.Value})
+	}
+	return views
+}
+
+func newTEDSrv6SIDViews(sids []*table.LsSrv6SID) []tedSrv6SIDView {
+	views := make([]tedSrv6SIDView, 0, len(sids))
+	for _, s := range sids {
+		if s == nil {
+			continue
+		}
+		views = append(views, tedSrv6SIDView{
+			Sids:             s.Sids,
+			EndpointBehavior: endpointBehaviorViewFrom(s.EndpointBehavior),
+			SidStructure:     sidStructureViewFrom(s.SIDStructure),
+			MultiTopoIDs:     s.MultiTopoIDs,
+		})
+	}
+	return views
+}
+
+func newTEDSrv6EndXSIDView(s *table.Srv6EndXSID) tedSrv6EndXSIDView {
+	return tedSrv6EndXSIDView{
+		EndpointBehavior: endpointBehaviorViewFromBehavior(s.EndpointBehavior),
+		Sids:             s.Sids,
+		SidStructure:     sidStructureViewFrom(s.Srv6SIDStructure),
+	}
+}
+
+func endpointBehaviorViewFrom(eb table.EndpointBehavior) endpointBehaviorView {
+	flags := eb.Flags
+	algorithm := eb.Algorithm
+	return endpointBehaviorView{
+		Behavior:  eb.Behavior,
+		Name:      table.BehaviorToString(eb.Behavior),
+		Flags:     &flags,
+		Algorithm: &algorithm,
+	}
+}
+
+func endpointBehaviorViewFromBehavior(behavior uint16) endpointBehaviorView {
+	return endpointBehaviorView{
+		Behavior: behavior,
+		Name:     table.BehaviorToString(behavior),
+	}
+}
+
+func sidStructureViewFrom(s table.SIDStructure) sidStructureView {
+	return sidStructureView{
+		LocalBlock: s.LocalBlock,
+		LocalNode:  s.LocalNode,
+		LocalFunc:  s.LocalFunc,
+		LocalArg:   s.LocalArg,
+	}
+}

--- a/cmd/pola/ted_view_test.go
+++ b/cmd/pola/ted_view_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package main
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nttcom/pola/pkg/table"
+)
+
+func TestNewTEDNodeViews_SortedByRouterID(t *testing.T) {
+	nodes := map[string]*table.LsNode{
+		"0000.0aff.0002": {ASN: 65000, RouterID: "0000.0aff.0002"},
+		"0000.0aff.0001": {ASN: 65000, RouterID: "0000.0aff.0001"},
+		"nil-entry":      nil,
+	}
+
+	views := newTEDNodeViews(nodes)
+	require.Len(t, views, 2)
+	assert.Equal(t, "0000.0aff.0001", views[0].RouterID)
+	assert.Equal(t, "0000.0aff.0002", views[1].RouterID)
+}
+
+func TestNewTEDLinkView_OmitsUnsetIPs(t *testing.T) {
+	link := &table.LsLink{RemoteNode: &table.LsNode{RouterID: "0000.0aff.0002"}}
+	v := newTEDLinkView(link)
+	assert.Empty(t, v.LocalIP)
+	assert.Empty(t, v.RemoteIP)
+	assert.Equal(t, "0000.0aff.0002", v.RemoteRouterID)
+}
+
+func TestEndpointBehaviorViewFrom_IncludesFlagsAndAlgorithm(t *testing.T) {
+	v := endpointBehaviorViewFrom(table.EndpointBehavior{Behavior: table.BehaviorEND, Flags: 1, Algorithm: 2})
+	assert.Equal(t, table.BehaviorEND, v.Behavior)
+	require.NotNil(t, v.Flags)
+	assert.Equal(t, uint8(1), *v.Flags)
+	require.NotNil(t, v.Algorithm)
+	assert.Equal(t, uint8(2), *v.Algorithm)
+}
+
+func TestEndpointBehaviorViewFromBehavior_OmitsFlagsAndAlgorithm(t *testing.T) {
+	v := endpointBehaviorViewFromBehavior(table.BehaviorENDX)
+	assert.Equal(t, table.BehaviorENDX, v.Behavior)
+	assert.Nil(t, v.Flags)
+	assert.Nil(t, v.Algorithm)
+}
+
+func TestNewTEDPrefixViews_SkipsNilEntries(t *testing.T) {
+	p := &table.LsPrefix{Prefix: netip.MustParsePrefix("10.0.0.0/24")}
+	views := newTEDPrefixViews([]*table.LsPrefix{nil, p})
+	require.Len(t, views, 1)
+	assert.Equal(t, "10.0.0.0/24", views[0].Prefix)
+}
+
+func TestNewTEDLinkViews_SkipsNilEntries(t *testing.T) {
+	l := &table.LsLink{RemoteNode: &table.LsNode{RouterID: "0000.0aff.0002"}}
+	views := newTEDLinkViews([]*table.LsLink{nil, l})
+	require.Len(t, views, 1)
+	assert.Equal(t, "0000.0aff.0002", views[0].RemoteRouterID)
+}
+
+func TestNewTEDLinkView_IncludesSrv6EndXSID(t *testing.T) {
+	link := &table.LsLink{
+		Srv6EndXSID: &table.Srv6EndXSID{
+			EndpointBehavior: table.BehaviorENDX,
+			Sids:             []string{"fc00:0:1:endx::"},
+			Srv6SIDStructure: table.SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
+		},
+	}
+
+	v := newTEDLinkView(link)
+	require.NotNil(t, v.Srv6EndXSID)
+	assert.Equal(t, []string{"fc00:0:1:endx::"}, v.Srv6EndXSID.Sids)
+	assert.Equal(t, table.BehaviorENDX, v.Srv6EndXSID.EndpointBehavior.Behavior)
+	assert.Equal(t, uint8(1), v.Srv6EndXSID.SidStructure.LocalBlock)
+}
+
+func TestNewTEDMetricViews_SkipsNilEntries(t *testing.T) {
+	m := table.NewMetric(table.IGPMetric, 10)
+	views := newTEDMetricViews([]*table.Metric{nil, m})
+	require.Len(t, views, 1)
+	assert.Equal(t, "igp", views[0].Type)
+	assert.Equal(t, uint32(10), views[0].Value)
+}
+
+func TestNewTEDSrv6SIDViews_SkipsNilEntries(t *testing.T) {
+	s := &table.LsSrv6SID{Sids: []string{"fc00:0:1::"}}
+	views := newTEDSrv6SIDViews([]*table.LsSrv6SID{nil, s})
+	require.Len(t, views, 1)
+	assert.Equal(t, []string{"fc00:0:1::"}, views[0].Sids)
+}

--- a/cmd/pola/testutil_test.go
+++ b/cmd/pola/testutil_test.go
@@ -9,12 +9,13 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// captureStdout captures output written directly to os.Stdout while f runs.
 func captureStdout(t *testing.T, f func()) string {
 	t.Helper()
 
@@ -33,7 +34,6 @@ func captureStdout(t *testing.T, f func()) string {
 	return buf.String()
 }
 
-// captureStderr captures output written directly to os.Stderr while f runs.
 func captureStderr(t *testing.T, f func()) string {
 	t.Helper()
 
@@ -50,4 +50,25 @@ func captureStderr(t *testing.T, f func()) string {
 	_, err = io.Copy(&buf, r)
 	require.NoError(t, err)
 	return buf.String()
+}
+
+// condFailWriter injects a write error when the content matches its predicate.
+type condFailWriter struct {
+	fail func(string) bool
+	buf  bytes.Buffer
+}
+
+func (w *condFailWriter) Write(p []byte) (int, error) {
+	if w.fail != nil && w.fail(string(p)) {
+		return 0, assert.AnError
+	}
+	return w.buf.Write(p)
+}
+
+func containsFail(sub string) func(string) bool {
+	return func(s string) bool { return strings.Contains(s, sub) }
+}
+
+func exactFail(s string) func(string) bool {
+	return func(p string) bool { return p == s }
 }

--- a/cmd/polad/main.go
+++ b/cmd/polad/main.go
@@ -103,13 +103,18 @@ func run(args []string, deps runDeps) error {
 	}
 
 	o := &server.PCEOptions{
-		PCEPAddr:  c.Global.PCEP.Address,
-		PCEPPort:  c.Global.PCEP.Port,
-		GRPCAddr:  c.Global.GRPCServer.Address,
-		GRPCPort:  c.Global.GRPCServer.Port,
-		TEDEnable: c.Global.TED.Enable,
-		USidMode:  c.Global.USidMode,
-		ASN:       c.Global.TED.ASN,
+		PCEPAddr:         c.Global.PCEP.Address,
+		PCEPPort:         c.Global.PCEP.Port,
+		GRPCAddr:         c.Global.GRPCServer.Address,
+		GRPCPort:         c.Global.GRPCServer.Port,
+		TEDEnable:        c.Global.TED.Enable,
+		USidMode:         c.Global.USidMode,
+		ASN:              c.Global.TED.ASN,
+		Keepalive:        c.Global.PCEP.Keepalive,
+		DeadTimer:        c.Global.PCEP.DeadTimer,
+		MinKeepalive:     c.Global.PCEP.MinKeepalive,
+		MaxKeepalive:     c.Global.PCEP.MaxKeepalive,
+		AllowNegotiation: c.Global.PCEP.AllowNegotiation,
 	}
 	if serverErr := deps.newPCE(ctx, o, logger, tedElemsChan); serverErr.Error != nil {
 		return fmt.Errorf("server %q failed: %w", serverErr.Server, serverErr.Error)

--- a/docs/schemas/server/polad_config.json
+++ b/docs/schemas/server/polad_config.json
@@ -21,6 +21,29 @@
                         },
                         "port": {
                             "type": "integer"
+                        },
+                        "keepalive": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 255
+                        },
+                        "deadTimer": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 255
+                        },
+                        "minKeepalive": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 255
+                        },
+                        "maxKeepalive": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 255
+                        },
+                        "allowNegotiation": {
+                            "type": "boolean"
                         }
                     },
                     "required": [

--- a/docs/sources/getting-started.md
+++ b/docs/sources/getting-started.md
@@ -75,9 +75,6 @@ global:
     deadTimer: 120
 ```
 
-These timers apply to Pola's side of the session. Pola uses the DeadTimer
-advertised by the PCC to detect a peer failure.
-
 #### Validating peer timers
 
 `global.pcep.minKeepalive` and `global.pcep.maxKeepalive` limit the Keepalive

--- a/docs/sources/getting-started.md
+++ b/docs/sources/getting-started.md
@@ -2,7 +2,7 @@
 
 This page explains how to use Pola PCE.
 
-## Instllation
+## Installation
 
 ### From Go Package
 
@@ -38,9 +38,9 @@ Specify the IP address and port number for each PCEP and gRPC.
 `address` must be a literal IPv4 or IPv6 address; hostnames are not resolved.
 See [JSON schema](../schemas/server/polad_config.json) for config details.
 
-### case: TED disable
+### TED disable
 
-To manage SR Policy without using TED.
+To manage SR Policy without using TED, disable TED as follows.
 
 ```yaml
 global:
@@ -58,15 +58,62 @@ global:
   usidMode: false
 ```
 
-### case: TED enable
+### PCEP session timers
 
-To manage SR Policy using TED.
-Enabling TED allows dynamic path calculation.
+#### Advertising Pola's timers
+
+`global.pcep.keepalive` and `global.pcep.deadTimer` configure the values Pola
+advertises in its Open message (RFC 5440 §7.3). If omitted, they default to a
+30-second Keepalive and a DeadTimer of four times the Keepalive.
+
+`keepalive` is the maximum interval between PCEP messages sent by Pola.
+`deadTimer` is the silence after which the PCC may declare Pola down. If
+`keepalive` is `0`, `deadTimer` must also be `0`.
+
+```yaml
+global:
+  pcep:
+    address: "192.0.2.254"
+    port: 4189
+    keepalive: 30
+    deadTimer: 120
+```
+
+Note that these values apply to Pola's own transmissions only. The interval Pola
+waits before declaring a PCC down comes from the DeadTimer that PCC advertised.
+
+#### Validating peer timers
+
+`global.pcep.minKeepalive` and `global.pcep.maxKeepalive` limit the Keepalive
+value that Pola accepts from a peer's Open message (RFC 7420). Both are
+optional; omitting them disables validation.
+
+If both are set, `minKeepalive` must be less than or equal to `maxKeepalive`.
+
+`global.pcep.allowNegotiation` controls behavior when a peer's Keepalive is
+outside the configured range. It defaults to `true`, allowing Pola to negotiate
+the value; when `false`, the session is rejected.
+
+```yaml
+global:
+  pcep:
+    address: "192.0.2.254"
+    port: 4189
+    keepalive: 30
+    deadTimer: 120
+    minKeepalive: 10
+    maxKeepalive: 60
+```
+
+### TED enable
+
+To manage SR Policy using TED, enable TED as follows.
+This also enables dynamic path calculation.
 
 A specific tool for updating TED is required to use this feature.
 Currently, only GoBGP is supported.
 
-**Not currently available for IPv6 underlay(IPv6 SR-MPLS / SRv6).**
+**Not currently available for IPv6 underlay (IPv6 SR-MPLS / SRv6).**
 
 ```yaml
 global:
@@ -119,4 +166,4 @@ $ sudo polad -f polad.yaml
 ```
 
 After Polad is running, use [pola cmd](../../cmd/pola/README.md) or the
-[gRCP client](../../api/grpc/) for daemon operations
+[gRPC client](../../api/grpc/) for daemon operations

--- a/docs/sources/getting-started.md
+++ b/docs/sources/getting-started.md
@@ -62,13 +62,9 @@ global:
 
 #### Advertising Pola's timers
 
-`global.pcep.keepalive` and `global.pcep.deadTimer` configure the values Pola
-advertises in its Open message (RFC 5440 §7.3). If omitted, they default to a
-30-second Keepalive and a DeadTimer of four times the Keepalive.
-
-`keepalive` is the maximum interval between PCEP messages sent by Pola.
-`deadTimer` is the silence after which the PCC may declare Pola down. If
-`keepalive` is `0`, `deadTimer` must also be `0`.
+`global.pcep.keepalive` and `global.pcep.deadTimer` configure the timers Pola
+advertises in its Open message (RFC 5440 §7.3). They default to 30 and 120
+seconds. If `keepalive` is `0`, `deadTimer` must also be `0`.
 
 ```yaml
 global:
@@ -79,8 +75,8 @@ global:
     deadTimer: 120
 ```
 
-Note that these values apply to Pola's own transmissions only. The interval Pola
-waits before declaring a PCC down comes from the DeadTimer that PCC advertised.
+These timers apply to Pola's side of the session. Pola uses the DeadTimer
+advertised by the PCC to detect a peer failure.
 
 #### Validating peer timers
 

--- a/examples/containerlab/sr-mpls-explicit-path-l3vpn/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path-l3vpn/README.md
@@ -40,7 +40,7 @@ Session #0: 10.0.255.1
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:02:46
+  Up Time:           00:12:24
   Session ID:        Local=0, Peer=0
   Transport:         tcp, auth=none
   Timers:
@@ -50,22 +50,24 @@ Session #0: 10.0.255.1
   Capabilities:
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
-      SR-PCE-CAPABILITY [RFC8664]: SR, Unlimited-SID-Depth
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
       SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=1
     Peer only:
-      -
+      SR-PCE-CAPABILITY [RFC8664]: MSD=4
 
 Session #1: 10.0.255.2
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:02:46
+  Up Time:           00:12:24
   Session ID:        Local=0, Peer=0
   Transport:         tcp, auth=none
   Timers:
@@ -75,16 +77,18 @@ Session #1: 10.0.255.2
   Capabilities:
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
-      SR-PCE-CAPABILITY [RFC8664]: SR, Unlimited-SID-Depth
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
       SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=1
     Peer only:
-      -
+      SR-PCE-CAPABILITY [RFC8664]: MSD=4
 root@pola:/pola# pola sr-policy list
 Session: 10.0.255.1 (State: up, LSP-DB Sync: finished)
   No SR Policies.
@@ -151,13 +155,13 @@ PCE POLA
  PCE SR Version draft16 and RFC8408
  Next PcReq ID 1
  Next PLSP  ID 2
- Connected for 250 seconds, since 2026-08-25 06:03:57 UTC
+ Connected for 802 seconds, since 2026-08-27 01:19:10 UTC
  PCC Capabilities: [PCC and PCE Initiated LSPs] [Stateful PCE] [SR TE PST]
  PCE Capabilities: [Stateful PCE] [SR TE PST]
  PCEP Message Statistics
                         Sent   Rcvd
          Message Open:     1      1
-    Message KeepAlive:     8      9
+    Message KeepAlive:    26     27
         Message PcReq:     0      0
         Message PcRep:     0      0
        Message Notify:     0      0
@@ -168,7 +172,7 @@ PCE POLA
      Message Initiate:     0      1
      Message StartTls:     0      0
     Message Erroneous:     0      0
-                Total:    13     11
+                Total:    31     29
 PCEP Sessions => Configured 1 ; Connected 1
 pe01# show sr-te policy detail
 
@@ -221,12 +225,12 @@ tcpdump inside the container's network namespace with `nsenter`:
 $ sudo nsenter -t $(docker inspect -f '{{.State.Pid}}' clab-sr-mpls-explicit-path-l3vpn-p01) -n tcpdump -nni eth1
 tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
 listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-15:11:09.335148 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 1, length 64
-15:11:09.335223 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 1, length 64
-15:11:10.363953 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 2, length 64
-15:11:10.363998 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 2, length 64
-15:11:11.387951 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 3, length 64
-15:11:11.387993 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 3, length 64
+10:32:33.335148 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 1, length 64
+10:32:33.335223 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 1, length 64
+10:32:33.363953 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 2, length 64
+10:32:33.363998 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 2, length 64
+10:32:33.387951 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 3, length 64
+10:32:33.387993 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 3, length 64
 ```
 
 Also, you can analyze with Wireshark on your Local PC

--- a/examples/containerlab/sr-mpls-explicit-path-l3vpn/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path-l3vpn/README.md
@@ -52,7 +52,12 @@ Session #0: 10.0.255.1
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
     Local only:
-      color
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: SR, Unlimited-SID-Depth
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        6 SR Policy Association
     Peer only:
       -
 
@@ -72,7 +77,12 @@ Session #1: 10.0.255.2
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
     Local only:
-      color
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: SR, Unlimited-SID-Depth
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        6 SR Policy Association
     Peer only:
       -
 root@pola:/pola# pola sr-policy list

--- a/examples/containerlab/sr-mpls-explicit-path-l3vpn/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path-l3vpn/README.md
@@ -36,23 +36,58 @@ Connect to PCEP container, check PCEP session and SR policy
 $ docker exec -it clab-sr-mpls-explicit-path-l3vpn-pola bash
 
 root@pola:/pola# pola session
-sessionAddr(0): 10.0.255.1
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SR-TE]
-  IsSynced: true
-sessionAddr(1): 10.0.255.2
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SR-TE]
-  IsSynced: true
+Session #0: 10.0.255.1
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:02:46
+  Session ID:        Local=0, Peer=0
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
+    Local only:
+      color
+    Peer only:
+      -
+
+Session #1: 10.0.255.2
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:02:46
+  Session ID:        Local=0, Peer=0
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
+    Local only:
+      color
+    Peer only:
+      -
 root@pola:/pola# pola sr-policy list
-No SR Policies found.
+Session: 10.0.255.1 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
+
+Session: 10.0.255.2 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
 ```
 
 Both PE nodes establish a PCEP session, but this example only applies an SR Policy to pe01.
 
-Apply and check SR Policy
+### Applying SR Policies
 
-`pe01-policy1.yaml` is mounted in the Pola container. It steers traffic from pe01 to
+The Pola container includes `pe01-policy1.yaml`. It steers traffic from pe01 to
 pe02 (10.255.0.3) along the explicit path p01 -> p02 -> pe02, using the
 Prefix-SID labels 16002 (p01), 16004 (p02) and 16003 (pe02).
 
@@ -61,13 +96,20 @@ root@pola:/pola# pola sr-policy add -f pe01-policy1.yaml --no-sid-validate
 warning: skipping SID validation (--no-sid-validate)
 success!
 root@pola:/pola# pola sr-policy list
-Session: 10.0.255.1
+Session: 10.0.255.1 (State: up, LSP-DB Sync: finished)
   PolicyName: pe01-policy1
+    PlspID: 1
+    LSPID: 0
+    State: active
+    Type: explicit
     SrcAddr: 10.0.255.1
     DstAddr: 10.255.0.3
     Color: 0
     Preference: 0
-    SegmentList: 16002 -> 16004 -> 16003
+    SegmentList: 16002 (local=10.255.0.2) -> 16004 (local=10.255.0.4) -> 16003 (local=10.255.0.3)
+
+Session: 10.0.255.2 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
 ```
 
 FRRouting does not report the color, the preference and the source address of an SR Policy back
@@ -80,6 +122,7 @@ Enter container pe01 and check SR Policy
 root@pola:/pola# exit
 
 $ docker exec -it clab-sr-mpls-explicit-path-l3vpn-pe01 vtysh
+
 pe01# show sr-te pcep session
 
 PCE POLA
@@ -98,13 +141,13 @@ PCE POLA
  PCE SR Version draft16 and RFC8408
  Next PcReq ID 1
  Next PLSP  ID 2
- Connected for 144 seconds, since 2026-07-30 09:51:31 UTC
+ Connected for 250 seconds, since 2026-08-25 06:03:57 UTC
  PCC Capabilities: [PCC and PCE Initiated LSPs] [Stateful PCE] [SR TE PST]
  PCE Capabilities: [Stateful PCE] [SR TE PST]
  PCEP Message Statistics
                         Sent   Rcvd
          Message Open:     1      1
-    Message KeepAlive:     5      5
+    Message KeepAlive:     8      9
         Message PcReq:     0      0
         Message PcRep:     0      0
        Message Notify:     0      0
@@ -115,9 +158,8 @@ PCE POLA
      Message Initiate:     0      1
      Message StartTls:     0      0
     Message Erroneous:     0      0
-                Total:    10      7
+                Total:    13     11
 PCEP Sessions => Configured 1 ; Connected 1
-
 pe01# show sr-te policy detail
 
 Endpoint: 10.255.0.3  Color: 1  Name: pe01-policy1  BSID: -  Status: Active
@@ -129,7 +171,6 @@ Add Color setting
 ```bash
 $ docker exec -it clab-sr-mpls-explicit-path-l3vpn-pe01 bash
 bash-5.1# vtysh -c 'conf t' -c 'router bgp 65000' -c 'address-family ipv4 vpn' -c 'neighbor 10.255.0.3 route-map color1 in'
-
 bash-5.1# exit
 ```
 
@@ -141,7 +182,7 @@ $ docker exec -it clab-sr-mpls-explicit-path-l3vpn-pe01 vtysh
 pe01# show ip route vrf cust-a 192.168.1.0/24
 Routing entry for 192.168.1.0/24
   Known via "bgp", distance 20, metric 0, vrf cust-a, best
-  Last update 00:00:20 ago
+  Last update 00:00:16 ago
     10.255.0.3(vrf default) (recursive), label 17, weight 1
   *   10.0.0.2, via eth1(vrf default), label 16004/16003/17, weight 1
 ```
@@ -170,11 +211,12 @@ tcpdump inside the container's network namespace with `nsenter`:
 $ sudo nsenter -t $(docker inspect -f '{{.State.Pid}}' clab-sr-mpls-explicit-path-l3vpn-p01) -n tcpdump -nni eth1
 tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
 listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-18:55:44.909823 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 2218, seq 1, length 64
-18:55:45.915956 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 2218, seq 2, length 64
-18:55:45.916001 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 2218, seq 2, length 64
-18:55:46.939959 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 2218, seq 3, length 64
-18:55:46.940001 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 2218, seq 3, length 64
+15:11:09.335148 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 1, length 64
+15:11:09.335223 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 1, length 64
+15:11:10.363953 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 2, length 64
+15:11:10.363998 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 2, length 64
+15:11:11.387951 MPLS (label 16004, exp 0, ttl 63) (label 16003, exp 0, ttl 63) (label 17, exp 0, [S], ttl 63) IP 192.168.0.2 > 192.168.1.2: ICMP echo request, id 3515, seq 3, length 64
+15:11:11.387993 MPLS (label 17, exp 0, [S], ttl 63) IP 192.168.1.2 > 192.168.0.2: ICMP echo reply, id 3515, seq 3, length 64
 ```
 
 Also, you can analyze with Wireshark on your Local PC

--- a/examples/containerlab/sr-mpls-explicit-path/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path/README.md
@@ -24,7 +24,6 @@ prepare these images.
 Start Containerlab network
 
 ```bash
-git clone https://github.com/nttcom/pola
 cd pola/examples/containerlab/sr-mpls-explicit-path
 sudo containerlab deploy
 ```
@@ -34,7 +33,7 @@ Wait for vJunos-router startup after `sudo containerlab deploy` (it takes severa
 ```bash
 $ docker logs clab-sr-mpls-explicit-path-pe02 -f
 <snip.>
-2026-07-30 09:58:26,934: launch      INFO Startup complete in: 0:01:44.162598
+2026-08-25 05:58:19,052: launch     INFO Startup complete in: 0:01:44.709074
 ```
 
 ### Apply SR Policy
@@ -45,26 +44,95 @@ Connect to PCEP container, check PCEP session and SR policy
 $ docker exec -it clab-sr-mpls-explicit-path-pola bash
 
 root@pola:/pola# pola session
-sessionAddr(0): 10.0.255.3
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SR-TE]
-  IsSynced: true
-sessionAddr(1): 10.0.255.1
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SRv6 SR-TE SRv6-TE SR-P2MP-POLICY-CAPABILITY]
-  IsSynced: true
-sessionAddr(2): 10.0.255.2
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SR-TE Multipath Vendor-Info(Juniper)]
-  IsSynced: true
+Session #0: 10.0.255.1
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:02:13
+  Session ID:        Local=0, Peer=1
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        2 Disjoint Association
+        3 Policy Association
+        5 Double Sided Bidirectional LSP Association
+        6 SR Policy Association
+        9 P2MP SR Policy Association (draft)
+      Unrecognized TLVs:
+        type=73: SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11)
+    Local only:
+      color
+    Peer only:
+      -
 
+Session #1: 10.0.255.2
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:00:12
+  Session ID:        Local=0, Peer=1
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+        6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+    Local only:
+      color
+    Peer only:
+      -
+
+Session #2: 10.0.255.3
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:02:38
+  Session ID:        Local=0, Peer=2
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
+    Local only:
+      color
+    Peer only:
+      -
 root@pola:/pola# pola sr-policy list
-No SR Policies found.
+Session: 10.0.255.1 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
+
+Session: 10.0.255.2 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
+
+Session: 10.0.255.3 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
 ```
 
-Apply and check SR Policy
+### Applying SR Policies
 
-One explicit-path policy per PCC is mounted in the Pola container.
+The Pola container includes one explicit-path policy for each PCC.
 
 | File | PCC | Endpoint | Segment List |
 | --- | --- | --- | --- |
@@ -84,31 +152,42 @@ success!
 root@pola:/pola# pola sr-policy add -f pe03-policy1.yaml --no-sid-validate
 warning: skipping SID validation (--no-sid-validate)
 success!
-
 root@pola:/pola# pola sr-policy list
-Session: 10.0.255.1
+Session: 10.0.255.1 (State: up, LSP-DB Sync: finished)
   PolicyName: pe01-policy1
+    PlspID: 1
+    LSPID: 2
+    State: active
+    Type: explicit
     SrcAddr: 10.255.0.1
     DstAddr: 10.255.0.2
     Color: 1
     Preference: 100
-    SegmentList: 16002 -> 16003
+    SegmentList: 16002 (local=10.255.0.2) -> 16003 (local=10.255.0.3)
 
-Session: 10.0.255.2
+Session: 10.0.255.2 (State: up, LSP-DB Sync: finished)
   PolicyName: pe02-policy1
+    PlspID: 1
+    LSPID: 0
+    State: active
+    Type: explicit
     SrcAddr: 10.255.0.2
     DstAddr: 10.255.0.1
     Color: 1
     Preference: 100
-    SegmentList: 16001 -> 16003
+    SegmentList: 16001 (local=10.255.0.1) -> 16003 (local=10.255.0.3)
 
-Session: 10.0.255.3
+Session: 10.0.255.3 (State: up, LSP-DB Sync: finished)
   PolicyName: pe03-policy1
+    PlspID: 1
+    LSPID: 0
+    State: active
+    Type: explicit
     SrcAddr: 10.0.255.3
     DstAddr: 10.255.0.1
     Color: 0
     Preference: 0
-    SegmentList: 16001 -> 16002
+    SegmentList: 16001 (local=10.255.0.1) -> 16002 (local=10.255.0.2)
 ```
 
 FRRouting does not report the color, the preference and the source address of an SR Policy back to
@@ -124,8 +203,9 @@ Enter each PCC and check the installed SR Policy
 root@pola:/pola# exit
 
 $ ssh clab-sr-mpls-explicit-path-pe01 -l admin
-RP/0/RP0/CPU0:pe01# show segment-routing traffic-eng policy
-Thu Jul 30 10:00:36.288 UTC
+
+RP/0/RP0/CPU0:pe01#show segment-routing traffic-eng policy
+Tue Aug 25 06:01:32.210 UTC
 
 SR-TE policy database
 ---------------------
@@ -133,7 +213,7 @@ SR-TE policy database
 Color: 1, End-point: 10.255.0.2
   Name: srte_c_1_ep_10.255.0.2
   Status:
-    Admin: up  Operational: up for 00:00:36 (since Jul 30 09:59:59.913)
+    Admin: up  Operational: up for 00:01:07 (since Aug 25 06:00:24.733)
   Candidate-paths:
     Preference: 100 (PCEP) (active)
       Name: pe01-policy1
@@ -146,8 +226,8 @@ Color: 1, End-point: 10.255.0.2
         Maximum SID Depth: 10
       Dynamic (pce 10.0.255.254) (valid)
         Metric Type: TE,   Path Accumulated Metric: 0
-          SID[0]: 16002
-          SID[1]: 16003
+          SID[0]: 16002 [Prefix-SID, 10.255.0.2]
+          SID[1]: 16003 [Prefix-SID, 10.255.0.3]
   Attributes:
     Binding SID: 24003
     Forward Class: Not Configured
@@ -161,6 +241,7 @@ Color: 1, End-point: 10.255.0.2
 
 ```bash
 $ ssh clab-sr-mpls-explicit-path-pe02 -l admin
+
 admin@pe02> show spring-traffic-engineering lsp detail
 E = Entropy-label Capability
 
@@ -195,6 +276,7 @@ Total displayed LSPs: 1 (Up: 1, Down: 0, Initializing: 0)
 
 ```bash
 $ docker exec -it clab-sr-mpls-explicit-path-pe03 vtysh
+
 pe03# show sr-te policy detail
 
 Endpoint: 10.255.0.1  Color: 1  Name: pe03-policy1  BSID: -  Status: Active

--- a/examples/containerlab/sr-mpls-explicit-path/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path/README.md
@@ -34,7 +34,7 @@ Wait for vJunos-router startup after `sudo containerlab deploy` (it takes severa
 ```bash
 $ docker logs clab-sr-mpls-explicit-path-pe02 -f
 <snip.>
-2026-08-25 05:58:19,052: launch     INFO Startup complete in: 0:01:44.709074
+2026-08-27 01:07:57,095: launch     INFO Startup complete in: 0:01:44.709074
 ```
 
 ### Apply SR Policy
@@ -49,7 +49,7 @@ Session #0: 10.0.255.1
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:02:13
+  Up Time:           00:10:18
   Session ID:        Local=0, Peer=1
   Transport:         tcp, auth=none
   Timers:
@@ -67,8 +67,9 @@ Session #0: 10.0.255.1
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
       SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=1
     Peer only:
-      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: MSD=10
       ASSOC-TYPE-LIST [RFC8697]:
         2 Disjoint Association
         3 Policy Association
@@ -81,7 +82,7 @@ Session #1: 10.0.255.2
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:00:12
+  Up Time:           00:00:21
   Session ID:        Local=0, Peer=1
   Transport:         tcp, auth=none
   Timers:
@@ -95,24 +96,26 @@ Session #1: 10.0.255.2
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
       SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
       SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SRv6-TE
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=1
     Peer only:
       VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
-      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: MSD=5
       ASSOC-TYPE-LIST [RFC8697]:
         1 Path Protection Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=128, Weighted
 
 Session #2: 10.0.255.3
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:02:38
-  Session ID:        Local=0, Peer=2
+  Up Time:           00:10:53
+  Session ID:        Local=0, Peer=1
   Transport:         tcp, auth=none
   Timers:
                Local  Peer  Effective
@@ -121,16 +124,18 @@ Session #2: 10.0.255.3
   Capabilities:
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
-      SR-PCE-CAPABILITY [RFC8664]: SR, Unlimited-SID-Depth
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
       SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=1
     Peer only:
-      -
+      SR-PCE-CAPABILITY [RFC8664]: MSD=4
 root@pola:/pola# pola sr-policy list
 Session: 10.0.255.1 (State: up, LSP-DB Sync: finished)
   No SR Policies.
@@ -217,7 +222,7 @@ root@pola:/pola# exit
 $ ssh clab-sr-mpls-explicit-path-pe01 -l admin
 
 RP/0/RP0/CPU0:pe01#show segment-routing traffic-eng policy
-Tue Aug 25 06:01:32.210 UTC
+Thu Aug 27 01:12:33.948 UTC
 
 SR-TE policy database
 ---------------------
@@ -225,7 +230,7 @@ SR-TE policy database
 Color: 1, End-point: 10.255.0.2
   Name: srte_c_1_ep_10.255.0.2
   Status:
-    Admin: up  Operational: up for 00:01:07 (since Aug 25 06:00:24.733)
+    Admin: up  Operational: up for 00:00:52 (since Aug 27 01:11:41.192)
   Candidate-paths:
     Preference: 100 (PCEP) (active)
       Name: pe01-policy1

--- a/examples/containerlab/sr-mpls-explicit-path/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path/README.md
@@ -59,21 +59,23 @@ Session #0: 10.0.255.1
   Capabilities:
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
-      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: SR
       SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        6 SR Policy Association
+    Local only:
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
+    Peer only:
+      SR-PCE-CAPABILITY [RFC8664]: MSD=0
       ASSOC-TYPE-LIST [RFC8697]:
         2 Disjoint Association
         3 Policy Association
         5 Double Sided Bidirectional LSP Association
-        6 SR Policy Association
         9 P2MP SR Policy Association (draft)
       Unrecognized TLVs:
         type=73: SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11)
-    Local only:
-      color
-    Peer only:
-      -
 
 Session #1: 10.0.255.2
   State:             up
@@ -88,18 +90,22 @@ Session #1: 10.0.255.2
     DeadTimer  120    120   120
   Capabilities:
     Common:
-      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
-      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: SR
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
       ASSOC-TYPE-LIST [RFC8697]:
-        1 Path Protection Association
         6 SR Policy Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
     Local only:
-      color
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SRv6-TE
     Peer only:
-      -
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
 
 Session #2: 10.0.255.3
   State:             up
@@ -117,7 +123,12 @@ Session #2: 10.0.255.3
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE
     Local only:
-      color
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: SR, Unlimited-SID-Depth
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        6 SR Policy Association
     Peer only:
       -
 root@pola:/pola# pola sr-policy list

--- a/examples/containerlab/sr-mpls-explicit-path/README.md
+++ b/examples/containerlab/sr-mpls-explicit-path/README.md
@@ -24,6 +24,7 @@ prepare these images.
 Start Containerlab network
 
 ```bash
+git clone https://github.com/nttcom/pola
 cd pola/examples/containerlab/sr-mpls-explicit-path
 sudo containerlab deploy
 ```

--- a/examples/containerlab/srv6-explicit-path-l3vpn/README.md
+++ b/examples/containerlab/srv6-explicit-path-l3vpn/README.md
@@ -30,7 +30,7 @@ Wait for vJunos-router startup after `sudo containerlab deploy` (it takes severa
 ```bash
 $ docker logs clab-srv6-explicit-path-l3vpn-p01 -f
 <snip.>
-2026-08-25 06:14:21,560: launch     INFO Startup complete in: 0:01:52.248573
+2026-08-27 02:50:06,324: launch     INFO Startup complete in: 0:08:27.376646
 ```
 
 ### Apply SR Policy
@@ -45,8 +45,8 @@ Session #0: fd00::1
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:01:50
-  Session ID:        Local=0, Peer=1
+  Up Time:           00:01:31
+  Session ID:        Local=0, Peer=2
   Transport:         tcp, auth=none
   Timers:
                Local  Peer  Effective
@@ -56,25 +56,27 @@ Session #0: fd00::1
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       SR-PCE-CAPABILITY [RFC8664]: SR
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
       SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
-      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=1
     Peer only:
       VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
-      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: MSD=5
       ASSOC-TYPE-LIST [RFC8697]:
         1 Path Protection Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=128, Weighted
 
 Session #1: fd00::2
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:01:54
+  Up Time:           00:01:56
   Session ID:        Local=0, Peer=1
   Transport:         tcp, auth=none
   Timers:
@@ -85,19 +87,21 @@ Session #1: fd00::2
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       SR-PCE-CAPABILITY [RFC8664]: SR
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
       SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
-      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=1
     Peer only:
       VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
-      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: MSD=5
       ASSOC-TYPE-LIST [RFC8697]:
         1 Path Protection Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=128, Weighted
 root@pola:/pola# pola sr-policy list
 Session: fd00::1 (State: up, LSP-DB Sync: finished)
   No SR Policies.
@@ -206,18 +210,18 @@ admin@pe01> show route table CUST-A.inet.0 192.168.2.0/24
 CUST-A.inet.0: 3 destinations, 3 routes (3 active, 0 holddown, 0 hidden)
 + = Active Route, - = Last Active, * = Both
 
-192.168.2.0/24     *[BGP/170] 00:01:28, localpref 100, from fd00:ffff::2
+192.168.2.0/24     *[BGP/170] 00:01:15, localpref 100, from fd00:ffff::2
                       AS path: I, validation-state: unverified
-                    >  to fe80::aac1:abff:fea2:1e02 via ge-0/0/0.0, SRv6 SID: fd00:ffff:2:0:4:a::, SRV6-Tunnel, Dest: fd00:ffff:2:0:1::-1<c6>
+                    >  to fe80::e00:91ff:fe5a:7301 via ge-0/0/0.0, SRv6 SID: fd00:ffff:2:0:4:a::, SRV6-Tunnel, Dest: fd00:ffff:2:0:1::-1<c6>
 
 admin@pe01> show route table CUST-A.inet6.0 fd00:a2::/64
 
 CUST-A.inet6.0: 5 destinations, 5 routes (5 active, 0 holddown, 0 hidden)
 + = Active Route, - = Last Active, * = Both
 
-fd00:a2::/64       *[BGP/170] 00:01:49, localpref 100, from fd00:ffff::2
+fd00:a2::/64       *[BGP/170] 00:01:30, localpref 100, from fd00:ffff::2
                       AS path: I, validation-state: unverified
-                    >  to fe80::aac1:abff:fea2:1e02 via ge-0/0/0.0, SRv6 SID: fd00:ffff:2:0:6:a::, SRV6-Tunnel, Dest: fd00:ffff:2:0:1::-1<c6>
+                    >  to fe80::e00:91ff:fe5a:7301 via ge-0/0/0.0, SRv6 SID: fd00:ffff:2:0:6:a::, SRV6-Tunnel, Dest: fd00:ffff:2:0:1::-1<c6>
 ```
 
 Enter container host01 and check SRv6-TE
@@ -231,15 +235,16 @@ $ docker exec -it clab-srv6-explicit-path-l3vpn-host01 /bin/bash
 
 host01:/# ping -c 3 192.168.2.1
 PING 192.168.2.1 (192.168.2.1) 56(84) bytes of data.
-64 bytes from 192.168.2.1: icmp_seq=1 ttl=62 time=34.3 ms
-64 bytes from 192.168.2.1: icmp_seq=2 ttl=62 time=8.22 ms
-64 bytes from 192.168.2.1: icmp_seq=3 ttl=62 time=3.43 ms
+64 bytes from 192.168.2.1: icmp_seq=1 ttl=62 time=40.2 ms
+64 bytes from 192.168.2.1: icmp_seq=2 ttl=62 time=6.79 ms
+64 bytes from 192.168.2.1: icmp_seq=3 ttl=62 time=7.09 ms
 
 host01:/# ping -c 3 fd00:a2::1
-PING fd00:a2::1 (fd00:a2::1) 56 data bytes
-64 bytes from fd00:a2::1: icmp_seq=1 ttl=62 time=949 ms
-64 bytes from fd00:a2::1: icmp_seq=2 ttl=62 time=2.67 ms
-64 bytes from fd00:a2::1: icmp_seq=3 ttl=62 time=2.57 ms
+PING fd00:a2::1(fd00:a2::1) 56 data bytes
+64 bytes from fd00:a2::1: icmp_seq=1 ttl=62 time=180 ms
+64 bytes from fd00:a2::1: icmp_seq=2 ttl=62 time=6.97 ms
+64 bytes from fd00:a2::1: icmp_seq=3 ttl=62 time=7.46 ms
+
 ```
 
 * Capture on containerlab host
@@ -249,20 +254,21 @@ network namespace with `nsenter`:
 
 ```bash
 $ sudo nsenter -t $(docker inspect -f '{{.State.Pid}}' clab-srv6-explicit-path-l3vpn-pe01) -n tcpdump -nni eth1
+libibverbs: Warning: couldn't open config directory '/etc/libibverbs.d'.
 tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
 listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-15:21:09.103707 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 3516, seq 1, length 64
-15:21:09.128823 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 3516, seq 1, length 64
-15:21:10.096342 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 3516, seq 2, length 64
-15:21:10.103683 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 3516, seq 2, length 64
-15:21:11.097217 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 3516, seq 3, length 64
-15:21:11.099480 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 3516, seq 3, length 64
-15:21:12.933163 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 3517, seq 1, length 64
-15:21:13.880423 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 3517, seq 1, length 64
-15:21:13.931239 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 3517, seq 2, length 64
-15:21:13.933253 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 3517, seq 2, length 64
-15:21:14.932395 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 3517, seq 3, length 64
-15:21:14.934276 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 3517, seq 3, length 64
+02:56:55.290437 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 10694, seq 1, length 64
+02:56:55.323726 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 10694, seq 1, length 64
+02:56:56.287226 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 10694, seq 2, length 64
+02:56:56.292142 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 10694, seq 2, length 64
+02:56:57.288186 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 10694, seq 3, length 64
+02:56:57.292767 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 10694, seq 3, length 64
+02:56:57.973543 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 10695, seq 1, length 64
+02:56:58.145589 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 10695, seq 1, length 64
+02:56:58.968607 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 10695, seq 2, length 64
+02:56:58.973750 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 10695, seq 2, length 64
+02:56:59.969785 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 10695, seq 3, length 64
+02:56:59.975658 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 10695, seq 3, length 64
 ```
 
 Also, you can analyze with Wireshark on your Local PC

--- a/examples/containerlab/srv6-explicit-path-l3vpn/README.md
+++ b/examples/containerlab/srv6-explicit-path-l3vpn/README.md
@@ -54,18 +54,21 @@ Session #0: fd00::1
     DeadTimer  120    120   120
   Capabilities:
     Common:
-      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
-      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: SR
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
-        1 Path Protection Association
         6 SR Policy Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
     Local only:
-      color
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
     Peer only:
-      -
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
 
 Session #1: fd00::2
   State:             up
@@ -80,18 +83,21 @@ Session #1: fd00::2
     DeadTimer  120    120   120
   Capabilities:
     Common:
-      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
-      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: SR
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
-        1 Path Protection Association
         6 SR Policy Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
     Local only:
-      color
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
     Peer only:
-      -
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
 root@pola:/pola# pola sr-policy list
 Session: fd00::1 (State: up, LSP-DB Sync: finished)
   No SR Policies.

--- a/examples/containerlab/srv6-explicit-path-l3vpn/README.md
+++ b/examples/containerlab/srv6-explicit-path-l3vpn/README.md
@@ -21,9 +21,7 @@ prepare these images.
 Start Containerlab network
 
 ```bash
-git clone https://github.com/nttcom/pola
 cd pola/examples/containerlab/srv6-explicit-path-l3vpn
-
 sudo containerlab deploy
 ```
 
@@ -32,7 +30,7 @@ Wait for vJunos-router startup after `sudo containerlab deploy` (it takes severa
 ```bash
 $ docker logs clab-srv6-explicit-path-l3vpn-p01 -f
 <snip.>
-2026-07-29 10:04:52,616: launch      INFO Startup complete in: 0:02:02.424893
+2026-08-25 06:14:21,560: launch     INFO Startup complete in: 0:01:52.248573
 ```
 
 ### Apply SR Policy
@@ -43,22 +41,68 @@ Connect to PCEP container, check PCEP session and SR policy
 $ docker exec -it clab-srv6-explicit-path-l3vpn-pola bash
 
 root@pola:/pola# pola session
-sessionAddr(0): fd00::2
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SR-TE SRv6-TE Multipath Vendor-Info(Juniper)]
-  IsSynced: true
-sessionAddr(1): fd00::1
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SR-TE SRv6-TE Multipath Vendor-Info(Juniper)]
-  IsSynced: true
+Session #0: fd00::1
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:01:50
+  Session ID:        Local=0, Peer=1
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+        6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+    Local only:
+      color
+    Peer only:
+      -
 
+Session #1: fd00::2
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:01:54
+  Session ID:        Local=0, Peer=1
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+        6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+    Local only:
+      color
+    Peer only:
+      -
 root@pola:/pola# pola sr-policy list
-No SR Policies found.
+Session: fd00::1 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
+
+Session: fd00::2 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
 ```
 
-Apply and check SR Policy
+### Applying SR Policies
 
-One explicit-path policy per PCC is mounted in the Pola container.
+The Pola container includes one explicit-path policy for each PCC.
 
 | File | PCC | Endpoint | Segment List |
 | --- | --- | --- | --- |
@@ -76,21 +120,29 @@ root@pola:/pola# pola sr-policy add -f pe02-policy1.yaml --no-sid-validate
 warning: skipping SID validation (--no-sid-validate)
 success!
 root@pola:/pola# pola sr-policy list
-Session: fd00::2
-  PolicyName: pe02-policy1
-    SrcAddr: fd00:ffff::2
-    DstAddr: fd00:ffff:1:0:1::
-    Color: 1
-    Preference: 100
-    SegmentList: fd00:ffff:4:0:1:: -> fd00:ffff:3:0:1:: -> fd00:ffff:1:0:1::
-
-Session: fd00::1
+Session: fd00::1 (State: up, LSP-DB Sync: finished)
   PolicyName: pe01-policy1
+    PlspID: 1
+    LSPID: 0
+    State: active
+    Type: explicit
     SrcAddr: fd00:ffff::1
     DstAddr: fd00:ffff:2:0:1::
     Color: 1
     Preference: 100
-    SegmentList: fd00:ffff:3:0:1:: -> fd00:ffff:4:0:1:: -> fd00:ffff:2:0:1::
+    SegmentList: fd00:ffff:3:0:1:: (local=fd00:ffff::3) -> fd00:ffff:4:0:1:: (local=fd00:ffff::4) -> fd00:ffff:2:0:1:: (local=fd00:ffff::2)
+
+Session: fd00::2 (State: up, LSP-DB Sync: finished)
+  PolicyName: pe02-policy1
+    PlspID: 1
+    LSPID: 0
+    State: active
+    Type: explicit
+    SrcAddr: fd00:ffff::2
+    DstAddr: fd00:ffff:1:0:1::
+    Color: 1
+    Preference: 100
+    SegmentList: fd00:ffff:4:0:1:: (local=fd00:ffff::4) -> fd00:ffff:3:0:1:: (local=fd00:ffff::3) -> fd00:ffff:1:0:1:: (local=fd00:ffff::1)
 ```
 
 Enter container pe01 and check SR Policy
@@ -148,18 +200,18 @@ admin@pe01> show route table CUST-A.inet.0 192.168.2.0/24
 CUST-A.inet.0: 3 destinations, 3 routes (3 active, 0 holddown, 0 hidden)
 + = Active Route, - = Last Active, * = Both
 
-192.168.2.0/24     *[BGP/170] 00:01:40, localpref 100, from fd00:ffff::2
+192.168.2.0/24     *[BGP/170] 00:01:28, localpref 100, from fd00:ffff::2
                       AS path: I, validation-state: unverified
-                    >  to fe80::aac1:abff:fea9:267e via ge-0/0/0.0, SRv6 SID: fd00:ffff:2:0:4:a::, SRV6-Tunnel, Dest: fd00:ffff:2:0:1::-1<c6>
+                    >  to fe80::aac1:abff:fea2:1e02 via ge-0/0/0.0, SRv6 SID: fd00:ffff:2:0:4:a::, SRV6-Tunnel, Dest: fd00:ffff:2:0:1::-1<c6>
 
 admin@pe01> show route table CUST-A.inet6.0 fd00:a2::/64
 
 CUST-A.inet6.0: 5 destinations, 5 routes (5 active, 0 holddown, 0 hidden)
 + = Active Route, - = Last Active, * = Both
 
-fd00:a2::/64       *[BGP/170] 00:02:07, localpref 100, from fd00:ffff::2
+fd00:a2::/64       *[BGP/170] 00:01:49, localpref 100, from fd00:ffff::2
                       AS path: I, validation-state: unverified
-                    >  to fe80::aac1:abff:fea9:267e via ge-0/0/0.0, SRv6 SID: fd00:ffff:2:0:6:a::, SRV6-Tunnel, Dest: fd00:ffff:2:0:1::-1<c6>
+                    >  to fe80::aac1:abff:fea2:1e02 via ge-0/0/0.0, SRv6 SID: fd00:ffff:2:0:6:a::, SRV6-Tunnel, Dest: fd00:ffff:2:0:1::-1<c6>
 ```
 
 Enter container host01 and check SRv6-TE
@@ -173,15 +225,15 @@ $ docker exec -it clab-srv6-explicit-path-l3vpn-host01 /bin/bash
 
 host01:/# ping -c 3 192.168.2.1
 PING 192.168.2.1 (192.168.2.1) 56(84) bytes of data.
-64 bytes from 192.168.2.1: icmp_seq=1 ttl=62 time=32.9 ms
-64 bytes from 192.168.2.1: icmp_seq=2 ttl=62 time=3.05 ms
-64 bytes from 192.168.2.1: icmp_seq=3 ttl=62 time=3.31 ms
+64 bytes from 192.168.2.1: icmp_seq=1 ttl=62 time=34.3 ms
+64 bytes from 192.168.2.1: icmp_seq=2 ttl=62 time=8.22 ms
+64 bytes from 192.168.2.1: icmp_seq=3 ttl=62 time=3.43 ms
 
 host01:/# ping -c 3 fd00:a2::1
 PING fd00:a2::1 (fd00:a2::1) 56 data bytes
-64 bytes from fd00:a2::1: icmp_seq=1 ttl=62 time=895 ms
-64 bytes from fd00:a2::1: icmp_seq=2 ttl=62 time=2.88 ms
-64 bytes from fd00:a2::1: icmp_seq=3 ttl=62 time=2.68 ms
+64 bytes from fd00:a2::1: icmp_seq=1 ttl=62 time=949 ms
+64 bytes from fd00:a2::1: icmp_seq=2 ttl=62 time=2.67 ms
+64 bytes from fd00:a2::1: icmp_seq=3 ttl=62 time=2.57 ms
 ```
 
 * Capture on containerlab host
@@ -193,18 +245,18 @@ network namespace with `nsenter`:
 $ sudo nsenter -t $(docker inspect -f '{{.State.Pid}}' clab-srv6-explicit-path-l3vpn-pe01) -n tcpdump -nni eth1
 tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
 listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-10:06:29.445984 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 2207, seq 1, length 64
-10:06:29.471892 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 2207, seq 1, length 64
-10:06:30.440747 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 2207, seq 2, length 64
-10:06:30.442996 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 2207, seq 2, length 64
-10:06:31.441810 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 2207, seq 3, length 64
-10:06:31.444281 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 2207, seq 3, length 64
-10:06:35.382665 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 2208, seq 1, length 64
-10:06:36.275209 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 2208, seq 1, length 64
-10:06:36.380178 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 2208, seq 2, length 64
-10:06:36.382145 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 2208, seq 2, length 64
-10:06:37.380982 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 2208, seq 3, length 64
-10:06:37.383046 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 2208, seq 3, length 64
+15:21:09.103707 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 3516, seq 1, length 64
+15:21:09.128823 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 3516, seq 1, length 64
+15:21:10.096342 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 3516, seq 2, length 64
+15:21:10.103683 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 3516, seq 2, length 64
+15:21:11.097217 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:4:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP 192.168.1.1 > 192.168.2.1: ICMP echo request, id 3516, seq 3, length 64
+15:21:11.099480 IP6 fd00:ffff::2 > fd00:ffff:1:0:4:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:4:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP 192.168.2.1 > 192.168.1.1: ICMP echo reply, id 3516, seq 3, length 64
+15:21:12.933163 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 3517, seq 1, length 64
+15:21:13.880423 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 3517, seq 1, length 64
+15:21:13.931239 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 3517, seq 2, length 64
+15:21:13.933253 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 3517, seq 2, length 64
+15:21:14.932395 IP6 fd00:ffff::1 > fd00:ffff:3:0:1::: RT6 (len=6, type=4, segleft=2, last-entry=2, tag=0, [0]fd00:ffff:2:0:6:a::, [1]fd00:ffff:4:0:1::, [2]fd00:ffff:3:0:1::) IP6 fd00:a1::1 > fd00:a2::1: ICMP6, echo request, id 3517, seq 3, length 64
+15:21:14.934276 IP6 fd00:ffff::2 > fd00:ffff:1:0:6:a::: RT6 (len=6, type=4, segleft=0, last-entry=2, tag=0, [0]fd00:ffff:1:0:6:a::, [1]fd00:ffff:3:0:1::, [2]fd00:ffff:4:0:1::) IP6 fd00:a2::1 > fd00:a1::1: ICMP6, echo reply, id 3517, seq 3, length 64
 ```
 
 Also, you can analyze with Wireshark on your Local PC

--- a/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
@@ -23,6 +23,7 @@ prepare these images.
 Copy the GoBGP binaries to `bin`:
 
 ```bash
+cd pola/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc
 make -C ../../.. fetch-gobgp
 cp ../../../test/bin/gobgpd bin/gobgpd
 cp ../../../test/bin/gobgp bin/gobgp
@@ -33,9 +34,6 @@ Pola and GoBGP start automatically when the lab is deployed.
 Start Containerlab network
 
 ```bash
-git clone https://github.com/nttcom/pola
-cd pola/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc
-
 sudo containerlab deploy
 ```
 
@@ -44,7 +42,7 @@ Wait for vJunos-router startup after `sudo containerlab deploy` (it takes severa
 ```bash
 $ docker logs clab-srv6-usid-dynamic-path-loose-source-routing-sfc-pe02 -f
 <snip.>
-2026-07-30 10:42:32,108: launch     INFO Startup complete in: 0:01:50.155859
+2026-08-25 06:32:12,048: launch     INFO Startup complete in: 0:01:48.144289
 ```
 
 ### Show TED
@@ -53,31 +51,39 @@ $ docker logs clab-srv6-usid-dynamic-path-loose-source-routing-sfc-pe02 -f
 $ docker exec -it clab-srv6-usid-dynamic-path-loose-source-routing-sfc-pola bash
 
 root@pola:/pola# pola ted -p 50052
-Node: 1
-  0000.0001.0002
-  Hostname: pe02
+Node #0: 0000.0001.0001
+  Hostname: pe01
   ISIS Area ID: 49.0000
   SRGB: 0 - 0
   Prefixes:
-    fd00:ffff::2/128
-    fcbb:bb00:1002::/48
+    fcbb:bb00:1001::/48
+    fd00:ffff::1/128
   Links:
     Local: None Remote: None
-      RemoteNode: 0000.0001.0004
+      RemoteRouterID: 0000.0001.0003
       Metrics:
-        METRIC_TYPE_IGP: 10
+        igp: 1
       Adj-SID: 0
       SRv6 End.X SID:
         EndpointBehavior: UA
-        SIDs: [fcbb:bb00:1002:e000::]
+        SIDs: [fcbb:bb00:1001:e000::]
+        SID Structure: Block: 32, Node: 16, Func: 16, Arg: 64
+    Local: None Remote: None
+      RemoteRouterID: 0000.0001.0004
+      Metrics:
+        igp: 1
+      Adj-SID: 0
+      SRv6 End.X SID:
+        EndpointBehavior: UA
+        SIDs: [fcbb:bb00:1001:e001::]
         SID Structure: Block: 32, Node: 16, Func: 16, Arg: 64
   SRv6 SIDs:
-    SIDs: [fcbb:bb00:1002::]
+    SIDs: [fcbb:bb00:1001::]
     Block: 32, Node: 16, Func: 0, Arg: 80
     EndpointBehavior: UN, Flags: 0, Algorithm: 0
     MultiTopoIDs: [2]
 
-Node: 2
+Node #1: 0000.0001.0002
 <snip.>
 ```
 
@@ -87,18 +93,39 @@ Connect to PCEP container, check PCEP session and SR policy
 
 ```bash
 root@pola:/pola# pola session -p 50052
-sessionAddr(0): fd00::2
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SR-TE SRv6-TE Multipath Vendor-Info(Juniper)]
-  IsSynced: true
-
+Session #0: fd00::2
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:00:49
+  Session ID:        Local=0, Peer=2
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+        6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+    Local only:
+      color
+    Peer only:
+      -
 root@pola:/pola# pola sr-policy list -p 50052
-No SR Policies found.
+Session: fd00::2 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
 ```
 
-Apply and check SR Policy
+### Applying SR Policies
 
-`pe02-policy1.yaml` is mounted in the Pola container. It requests a dynamic path from pe02 to
+The Pola container includes `pe02-policy1.yaml`. It requests a dynamic path from pe02 to
 pe01 (`fd00:ffff::1`) with color 100 and lists p01, p02 and p01 again as waypoints. End SIDs are
 `fcbb:bb00:1001::` (pe01), `fcbb:bb00:1003::` (p01) and `fcbb:bb00:1004::` (p02), so p01 is
 visited twice in the segment list below.
@@ -106,15 +133,19 @@ visited twice in the segment list below.
 ```bash
 root@pola:/pola# pola sr-policy add -f pe02-policy1.yaml -p 50052
 success!
-
 root@pola:/pola# pola sr-policy list -p 50052
-Session: fd00::2
+Session: fd00::2 (State: up, LSP-DB Sync: finished)
   PolicyName: DYNAMIC-POLICY
-    SrcAddr: fd00:ffff::2
-    DstAddr: fd00:ffff::1
+    PlspID: 1
+    LSPID: 0
+    State: active
+    Type: dynamic
+    Metric: igp
+    SrcAddr: fd00:ffff::2 (0000.0001.0002)
+    DstAddr: fd00:ffff::1 (0000.0001.0001)
     Color: 100
     Preference: 100
-    SegmentList: fcbb:bb00:1003:: -> fcbb:bb00:1004:: -> fcbb:bb00:1003:: -> fcbb:bb00:1001::
+    SegmentList: fcbb:bb00:1003:: (local=fcbb:bb00:1003::) -> fcbb:bb00:1004:: (local=fcbb:bb00:1004::) -> fcbb:bb00:1003:: (local=fcbb:bb00:1003::) -> fcbb:bb00:1001:: (local=fcbb:bb00:1001::)
 ```
 
 Enter container pe02 and check SR Policy

--- a/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
@@ -107,18 +107,21 @@ Session #0: fd00::2
     DeadTimer  120    120   120
   Capabilities:
     Common:
-      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
-      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: SR
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
-        1 Path Protection Association
         6 SR Policy Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
     Local only:
-      color
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
     Peer only:
-      -
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
 root@pola:/pola# pola sr-policy list -p 50052
 Session: fd00::2 (State: up, LSP-DB Sync: finished)
   No SR Policies.

--- a/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
@@ -23,6 +23,7 @@ prepare these images.
 Copy the GoBGP binaries to `bin`:
 
 ```bash
+git clone https://github.com/nttcom/pola
 cd pola/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc
 make -C ../../.. fetch-gobgp
 cp ../../../test/bin/gobgpd bin/gobgpd

--- a/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
@@ -43,7 +43,7 @@ Wait for vJunos-router startup after `sudo containerlab deploy` (it takes severa
 ```bash
 $ docker logs clab-srv6-usid-dynamic-path-loose-source-routing-sfc-pe02 -f
 <snip.>
-2026-08-25 06:32:12,048: launch     INFO Startup complete in: 0:01:48.144289
+2026-08-27 03:57:17,431: launch     INFO Startup complete in: 0:07:27.973851
 ```
 
 ### Show TED
@@ -98,7 +98,7 @@ Session #0: fd00::2
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:00:49
+  Up Time:           00:01:22
   Session ID:        Local=0, Peer=2
   Transport:         tcp, auth=none
   Timers:
@@ -109,19 +109,21 @@ Session #0: fd00::2
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       SR-PCE-CAPABILITY [RFC8664]: SR
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
       SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
-      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=1
     Peer only:
       VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
-      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: MSD=5
       ASSOC-TYPE-LIST [RFC8697]:
         1 Path Protection Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=128, Weighted
 root@pola:/pola# pola sr-policy list -p 50052
 Session: fd00::2 (State: up, LSP-DB Sync: finished)
   No SR Policies.

--- a/examples/containerlab/srv6-usid-dynamic-path/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path/README.md
@@ -107,18 +107,21 @@ Session #0: fd00::2
     DeadTimer  120    120   120
   Capabilities:
     Common:
-      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
-      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: SR
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
-        1 Path Protection Association
         6 SR Policy Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
     Local only:
-      color
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
+      SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
     Peer only:
-      -
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
 root@pola:/pola# pola sr-policy list -p 50052
 Session: fd00::2 (State: up, LSP-DB Sync: finished)
   No SR Policies.

--- a/examples/containerlab/srv6-usid-dynamic-path/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path/README.md
@@ -43,7 +43,7 @@ Wait for vJunos-router startup after `sudo containerlab deploy` (it takes severa
 ```bash
 $ docker logs clab-srv6-usid-dynamic-path-pe02 -f
 <snip.>
-2026-08-25 06:26:03,619: launch     INFO Startup complete in: 0:01:46.155728
+2026-08-27 04:16:29,763: launch     INFO Startup complete in: 0:07:40.825956
 ```
 
 ### Show TED
@@ -98,7 +98,7 @@ Session #0: fd00::2
   State:             up
   LSP-DB Sync:       finished
   Role:              active-stateful-pce
-  Up Time:           00:00:24
+  Up Time:           00:00:06
   Session ID:        Local=0, Peer=2
   Transport:         tcp, auth=none
   Timers:
@@ -109,19 +109,21 @@ Session #0: fd00::2
     Common:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       SR-PCE-CAPABILITY [RFC8664]: SR
+      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
       PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
       ASSOC-TYPE-LIST [RFC8697]:
         6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath
     Local only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
       SR-PCE-CAPABILITY [RFC8664]: Unlimited-SID-Depth
-      SRv6-PCE-CAPABILITY [RFC9603]: SRv6
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=1
     Peer only:
       VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
-      SR-PCE-CAPABILITY [RFC8664]: MSD=0
+      SR-PCE-CAPABILITY [RFC8664]: MSD=5
       ASSOC-TYPE-LIST [RFC8697]:
         1 Path Protection Association
-      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: MaxMultipaths=128, Weighted
 root@pola:/pola# pola sr-policy list -p 50052
 Session: fd00::2 (State: up, LSP-DB Sync: finished)
   No SR Policies.

--- a/examples/containerlab/srv6-usid-dynamic-path/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path/README.md
@@ -23,6 +23,7 @@ prepare these images.
 Copy the GoBGP binaries to `bin`:
 
 ```bash
+git clone https://github.com/nttcom/pola
 cd pola/examples/containerlab/srv6-usid-dynamic-path
 make -C ../../.. fetch-gobgp
 cp ../../../test/bin/gobgpd bin/gobgpd

--- a/examples/containerlab/srv6-usid-dynamic-path/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path/README.md
@@ -23,6 +23,7 @@ prepare these images.
 Copy the GoBGP binaries to `bin`:
 
 ```bash
+cd pola/examples/containerlab/srv6-usid-dynamic-path
 make -C ../../.. fetch-gobgp
 cp ../../../test/bin/gobgpd bin/gobgpd
 cp ../../../test/bin/gobgp bin/gobgp
@@ -33,9 +34,6 @@ Pola and GoBGP start automatically when the lab is deployed.
 Start Containerlab network
 
 ```bash
-git clone https://github.com/nttcom/pola
-cd pola/examples/containerlab/srv6-usid-dynamic-path
-
 sudo containerlab deploy
 ```
 
@@ -44,7 +42,7 @@ Wait for vJunos-router startup after `sudo containerlab deploy` (it takes severa
 ```bash
 $ docker logs clab-srv6-usid-dynamic-path-pe02 -f
 <snip.>
-2026-07-30 10:32:50,476: launch      INFO Startup complete in: 0:01:41.309132
+2026-08-25 06:26:03,619: launch     INFO Startup complete in: 0:01:46.155728
 ```
 
 ### Show TED
@@ -53,8 +51,7 @@ $ docker logs clab-srv6-usid-dynamic-path-pe02 -f
 $ docker exec -it clab-srv6-usid-dynamic-path-pola bash
 
 root@pola:/pola# pola ted -p 50052
-Node: 1
-  0000.0001.0001
+Node #0: 0000.0001.0001
   Hostname: pe01
   ISIS Area ID: 49.0000
   SRGB: 0 - 0
@@ -63,18 +60,18 @@ Node: 1
     fd00:ffff::1/128
   Links:
     Local: None Remote: None
-      RemoteNode: 0000.0001.0003
+      RemoteRouterID: 0000.0001.0003
       Metrics:
-        METRIC_TYPE_IGP: 10
+        igp: 10
       Adj-SID: 0
       SRv6 End.X SID:
         EndpointBehavior: UA
         SIDs: [fcbb:bb00:1001:e000::]
         SID Structure: Block: 32, Node: 16, Func: 16, Arg: 64
     Local: None Remote: None
-      RemoteNode: 0000.0001.0004
+      RemoteRouterID: 0000.0001.0004
       Metrics:
-        METRIC_TYPE_IGP: 100
+        igp: 100
       Adj-SID: 0
       SRv6 End.X SID:
         EndpointBehavior: UA
@@ -86,7 +83,7 @@ Node: 1
     EndpointBehavior: UN, Flags: 0, Algorithm: 0
     MultiTopoIDs: [2]
 
-Node: 2
+Node #1: 0000.0001.0003
 <snip.>
 ```
 
@@ -96,18 +93,39 @@ Connect to PCEP container, check PCEP session and SR policy
 
 ```bash
 root@pola:/pola# pola session -p 50052
-sessionAddr(0): fd00::2
-  State: SESSION_STATE_UP
-  Capabilities: [Stateful Update Instantiation Color SR-TE SRv6-TE Multipath Vendor-Info(Juniper)]
-  IsSynced: true
-
+Session #0: fd00::2
+  State:             up
+  LSP-DB Sync:       finished
+  Role:              active-stateful-pce
+  Up Time:           00:00:24
+  Session ID:        Local=0, Peer=2
+  Transport:         tcp, auth=none
+  Timers:
+               Local  Peer  Effective
+    Keepalive  30     30    30
+    DeadTimer  120    120   120
+  Capabilities:
+    Common:
+      VENDOR-INFORMATION [RFC7470]: 2636 (Juniper Networks, Inc.)
+      STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
+      SR-PCE-CAPABILITY [RFC8664]: SR, MSD=0
+      PATH-SETUP-TYPE-CAPABILITY [RFC8408]: SR-TE, SRv6-TE
+      ASSOC-TYPE-LIST [RFC8697]:
+        1 Path Protection Association
+        6 SR Policy Association
+      MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath, MaxMultipaths=128, Weighted
+    Local only:
+      color
+    Peer only:
+      -
 root@pola:/pola# pola sr-policy list -p 50052
-No SR Policies found.
+Session: fd00::2 (State: up, LSP-DB Sync: finished)
+  No SR Policies.
 ```
 
-Apply and check SR Policy
+### Applying SR Policies
 
-`pe02-policy1.yaml` is mounted in the Pola container. It requests a dynamic path from pe02 to
+The Pola container includes `pe02-policy1.yaml`. It requests a dynamic path from pe02 to
 pe01 (`fd00:ffff::1`) with color 100. End SIDs are `fcbb:bb00:1001::` (pe01),
 `fcbb:bb00:1003::` (p01) and `fcbb:bb00:1004::` (p02), so the computed segment list below is the
 path p02 -> p01 -> pe01.
@@ -116,13 +134,18 @@ path p02 -> p01 -> pe01.
 root@pola:/pola# pola sr-policy add -f pe02-policy1.yaml -p 50052
 success!
 root@pola:/pola# pola sr-policy list -p 50052
-Session: fd00::2
+Session: fd00::2 (State: up, LSP-DB Sync: finished)
   PolicyName: DYNAMIC-POLICY
-    SrcAddr: fd00:ffff::2
-    DstAddr: fd00:ffff::1
+    PlspID: 1
+    LSPID: 0
+    State: active
+    Type: dynamic
+    Metric: igp
+    SrcAddr: fd00:ffff::2 (0000.0001.0002)
+    DstAddr: fd00:ffff::1 (0000.0001.0001)
     Color: 100
     Preference: 100
-    SegmentList: fcbb:bb00:1004:: -> fcbb:bb00:1003:: -> fcbb:bb00:1001::
+    SegmentList: fcbb:bb00:1004:: (local=fcbb:bb00:1004::) -> fcbb:bb00:1003:: (local=fcbb:bb00:1003::) -> fcbb:bb00:1001:: (local=fcbb:bb00:1001::)
 ```
 
 Enter container pe02 and check SR Policy

--- a/examples/grpc/go/examples_test.go
+++ b/examples/grpc/go/examples_test.go
@@ -35,7 +35,7 @@ type fakeServer struct {
 	fail bool
 
 	sessions         []*pb.Session
-	srPolicySessions []*pb.Session
+	srPolicySessions []*pb.SRPolicySession
 	ted              *pb.GetTEDResponse
 
 	mu         sync.Mutex
@@ -51,7 +51,7 @@ func (f *fakeServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyReq
 	if f.fail {
 		return nil, errFake
 	}
-	return &pb.CreateSRPolicyResponse{IsSuccess: true}, nil
+	return &pb.CreateSRPolicyResponse{}, nil
 }
 
 func (f *fakeServer) DeleteSRPolicy(_ context.Context, req *pb.DeleteSRPolicyRequest) (*pb.DeleteSRPolicyResponse, error) {
@@ -61,7 +61,7 @@ func (f *fakeServer) DeleteSRPolicy(_ context.Context, req *pb.DeleteSRPolicyReq
 	if f.fail {
 		return nil, errFake
 	}
-	return &pb.DeleteSRPolicyResponse{IsSuccess: true}, nil
+	return &pb.DeleteSRPolicyResponse{}, nil
 }
 
 func (f *fakeServer) DeleteSession(_ context.Context, req *pb.DeleteSessionRequest) (*pb.DeleteSessionResponse, error) {
@@ -71,7 +71,7 @@ func (f *fakeServer) DeleteSession(_ context.Context, req *pb.DeleteSessionReque
 	if f.fail {
 		return nil, errFake
 	}
-	return &pb.DeleteSessionResponse{IsSuccess: true}, nil
+	return &pb.DeleteSessionResponse{}, nil
 }
 
 func (f *fakeServer) GetSessionList(_ context.Context, _ *pb.GetSessionListRequest) (*pb.GetSessionListResponse, error) {
@@ -292,7 +292,7 @@ func TestSRPolicyCreateDynamic(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeServer{}
 		out, code := run(t, "sr-policy-create-dynamic", serve(t, f))
-		wantOutput(t, out, code, "success: isSuccess=true")
+		wantOutput(t, out, code, "success")
 
 		req := f.createReq
 		require.NotNil(t, req, "server received no request")
@@ -316,7 +316,7 @@ func TestSRPolicyCreateExplicit(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeServer{}
 		out, code := run(t, "sr-policy-create-explicit", serve(t, f))
-		wantOutput(t, out, code, "success: isSuccess=true")
+		wantOutput(t, out, code, "success")
 
 		req := f.createReq
 		require.NotNil(t, req, "server received no request")
@@ -336,7 +336,7 @@ func TestSRPolicyCreateNoSIDValidate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeServer{}
 		out, code := run(t, "sr-policy-create-no-sid-validate", serve(t, f))
-		wantOutput(t, out, code, "success: isSuccess=true")
+		wantOutput(t, out, code, "success")
 
 		req := f.createReq
 		require.NotNil(t, req, "server received no request")
@@ -358,7 +358,7 @@ func TestSRPolicyCreateSRv6(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeServer{}
 		out, code := run(t, "sr-policy-create-srv6", serve(t, f))
-		wantOutput(t, out, code, "success: isSuccess=true")
+		wantOutput(t, out, code, "success")
 
 		req := f.createReq
 		require.NotNil(t, req, "server received no request")
@@ -380,12 +380,12 @@ func TestSRPolicyDelete(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeServer{}
 		out, code := run(t, "sr-policy-delete", serve(t, f))
-		wantOutput(t, out, code, "success: isSuccess=true")
+		wantOutput(t, out, code, "success")
 
 		req := f.deleteReq
 		require.NotNil(t, req, "server received no request")
 		// polad identifies the policy by these four fields, so all must be set.
-		assert.NotEmpty(t, req.GetSrPolicy().GetPcepSessionAddr())
+		assert.NotEmpty(t, req.GetSrPolicy().GetPeerAddr())
 		assert.NotEmpty(t, req.GetSrPolicy().GetDstAddr())
 		assert.NotZero(t, req.GetSrPolicy().GetColor())
 		assert.NotEmpty(t, req.GetSrPolicy().GetPolicyName())
@@ -401,10 +401,10 @@ func TestSessionDelete(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeServer{}
 		out, code := run(t, "session-delete", serve(t, f))
-		wantOutput(t, out, code, "success: isSuccess=true")
+		wantOutput(t, out, code, "success")
 
 		require.NotNil(t, f.sessionReq, "server received no request")
-		assert.Equal(t, addrBytes(t, "192.0.2.1"), f.sessionReq.GetAddr())
+		assert.Equal(t, addrBytes(t, "192.0.2.1"), f.sessionReq.GetPeerAddr())
 	})
 
 	t.Run("rpc error", func(t *testing.T) {
@@ -417,26 +417,26 @@ func TestSessionList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeServer{sessions: []*pb.Session{
 			{
-				Addr:  addrBytes(t, "192.0.2.1"),
-				State: pb.SessionState_SESSION_STATE_UP,
-				Capabilities: []*pb.Capability{
+				PeerAddr: addrBytes(t, "192.0.2.1"),
+				State:    pb.SessionState_SESSION_STATE_UP,
+				LocalCapabilities: []*pb.Capability{
 					{Type: pb.CapabilityType_CAPABILITY_TYPE_STATEFUL},
 					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
 				},
-				IsSynced: true,
+				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 			},
-			// Invalid session address: the example should warn and skip the session.
-			{Addr: []byte{1, 2, 3}},
+			// Invalid peer address: the example should warn and skip the session.
+			{PeerAddr: []byte{1, 2, 3}},
 		}}
 		out, code := run(t, "session-list", serve(t, f))
 		wantOutput(t, out, code,
-			"sessionAddr(0): 192.0.2.1",
+			"peerAddr(0): 192.0.2.1",
 			"state: SESSION_STATE_UP",
 			"capabilities (Pola): STATEFUL, SR(msd=10, unlimitedMsd=false, naiSupported=false)",
-			"isSynced: true",
+			"syncState: FINISHED",
 			"invalid address for session 1",
 		)
-		assert.NotContains(t, out, "sessionAddr(1)", "the invalid session was printed anyway")
+		assert.NotContains(t, out, "peerAddr(1)", "the invalid session was printed anyway")
 	})
 
 	t.Run("rpc error", func(t *testing.T) {
@@ -447,9 +447,9 @@ func TestSessionList(t *testing.T) {
 
 func TestSRPolicyList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		f := &fakeServer{srPolicySessions: []*pb.Session{
+		f := &fakeServer{srPolicySessions: []*pb.SRPolicySession{
 			{
-				Addr: addrBytes(t, "192.0.2.1"),
+				PeerAddr: addrBytes(t, "192.0.2.1"),
 				SrPolicies: []*pb.SRPolicy{{
 					SrcAddr:     addrBytes(t, "192.0.2.1"),
 					DstAddr:     addrBytes(t, "192.0.2.2"),
@@ -460,7 +460,7 @@ func TestSRPolicyList(t *testing.T) {
 				}},
 			},
 			{
-				Addr: []byte{1, 2, 3},
+				PeerAddr: []byte{1, 2, 3},
 				SrPolicies: []*pb.SRPolicy{{
 					PolicyName: "no-segments",
 				}},
@@ -476,7 +476,7 @@ func TestSRPolicyList(t *testing.T) {
 			"preference: 200",
 			"path: 16002 -> 16003",
 			"srPolicy(1):",
-			"sessionAddr: invalid",
+			"peerAddr: invalid",
 			"path: None",
 		)
 	})
@@ -490,13 +490,13 @@ func TestSRPolicyList(t *testing.T) {
 func TestTEDGet(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		f := &fakeServer{ted: &pb.GetTEDResponse{
-			Enable: true,
-			LsNodes: []*pb.LsNode{{
-				Asn:        65000,
-				RouterId:   "0000.0aff.0001",
-				Hostname:   "node1",
-				LsPrefixes: []*pb.LsPrefix{{Prefix: "10.0.0.1/32"}},
-				LsLinks:    []*pb.LsLink{{LocalRouterId: "0000.0aff.0001"}},
+			Enabled: true,
+			Nodes: []*pb.LsNode{{
+				Asn:      65000,
+				RouterId: "0000.0aff.0001",
+				Hostname: "node1",
+				Prefixes: []*pb.LsPrefix{{Prefix: "10.0.0.1/32"}},
+				Links:    []*pb.LsLink{{LocalRouterId: "0000.0aff.0001"}},
 			}},
 		}}
 		out, code := run(t, "ted-get", serve(t, f))
@@ -505,7 +505,7 @@ func TestTEDGet(t *testing.T) {
 	})
 
 	t.Run("disabled", func(t *testing.T) {
-		f := &fakeServer{ted: &pb.GetTEDResponse{Enable: false}}
+		f := &fakeServer{ted: &pb.GetTEDResponse{Enabled: false}}
 		out, code := run(t, "ted-get", serve(t, f))
 		wantOutput(t, out, code, "TED is disabled")
 	})

--- a/examples/grpc/go/examples_test.go
+++ b/examples/grpc/go/examples_test.go
@@ -432,7 +432,7 @@ func TestSessionList(t *testing.T) {
 		wantOutput(t, out, code,
 			"sessionAddr(0): 192.0.2.1",
 			"state: SESSION_STATE_UP",
-			"capabilities: STATEFUL, SR(msd=10, unlimitedMsd=false, naiSupported=false)",
+			"capabilities (Pola): STATEFUL, SR(msd=10, unlimitedMsd=false, naiSupported=false)",
 			"isSynced: true",
 			"invalid address for session 1",
 		)

--- a/examples/grpc/go/examples_test.go
+++ b/examples/grpc/go/examples_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 )
@@ -210,9 +211,7 @@ func buildExamples() error {
 		errs []error
 	)
 	for _, dir := range exampleDirs {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			pkg := modulePath + "/" + dir
 			out, err := exec.Command("go", "build",
 				"-cover", "-coverpkg="+pkg,
@@ -222,7 +221,7 @@ func buildExamples() error {
 				errs = append(errs, fmt.Errorf("build %s: %w\n%s", dir, err, out))
 				mu.Unlock()
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -421,7 +420,7 @@ func TestSessionList(t *testing.T) {
 				State:    pb.SessionState_SESSION_STATE_UP,
 				LocalCapabilities: []*pb.Capability{
 					{Type: pb.CapabilityType_CAPABILITY_TYPE_STATEFUL},
-					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: 10}}},
+					{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{Msd: proto.Uint32(10)}}},
 				},
 				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 			},

--- a/examples/grpc/go/session-delete/main.go
+++ b/examples/grpc/go/session-delete/main.go
@@ -39,12 +39,12 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 
-	r, err := c.DeleteSession(ctx, &pb.DeleteSessionRequest{
-		Addr: netip.MustParseAddr("192.0.2.1").AsSlice(),
+	_, err = c.DeleteSession(ctx, &pb.DeleteSessionRequest{
+		PeerAddr: netip.MustParseAddr("192.0.2.1").AsSlice(),
 	})
 	if err != nil {
 		log.Fatalf("c.DeleteSession error: %v", err)
 	}
 
-	log.Printf("success: isSuccess=%t", r.GetIsSuccess())
+	log.Print("success")
 }

--- a/examples/grpc/go/session-list/main.go
+++ b/examples/grpc/go/session-list/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"net/netip"
+	"strconv"
 	"strings"
 	"time"
 
@@ -53,10 +54,32 @@ func main() {
 			continue
 		}
 		fmt.Printf("sessionAddr(%d): %v\n", i, addr)
+		fmt.Printf("  sessionID (Pola): %s, sessionID (PCC): %s\n",
+			optionalUint32(ss.LocalSessionId), optionalUint32(ss.PccSessionId))
 		fmt.Printf("  state: %s\n", ss.GetState())
-		fmt.Printf("  capabilities: %s\n", strings.Join(capStrings(ss.GetCapabilities()), ", "))
+		fmt.Printf("  advertised (Pola): %s\n", timersString(ss.GetLocalTimers()))
+		fmt.Printf("  advertised (PCC): %s\n", timersString(ss.GetPccTimers()))
+		fmt.Printf("  effective: keepalive: %d, deadTimer: %d\n",
+			ss.GetEffectiveTimers().GetKeepalive(), ss.GetEffectiveTimers().GetDeadTimer())
+		fmt.Printf("  pccType: %s\n", strings.TrimPrefix(ss.GetPccType().String(), "PCC_TYPE_"))
+		fmt.Printf("  capabilities (Pola): %s\n", strings.Join(capStrings(ss.GetCapabilities()), ", "))
+		fmt.Printf("  capabilities (PCC): %s\n", strings.Join(capStrings(ss.GetPccCapabilities()), ", "))
 		fmt.Printf("  isSynced: %t\n", ss.GetIsSynced())
 	}
+}
+
+func optionalUint32(v *uint32) string {
+	if v == nil {
+		return "-"
+	}
+	return strconv.FormatUint(uint64(*v), 10)
+}
+
+func timersString(timers *pb.SessionTimers) string {
+	if timers == nil {
+		return "-"
+	}
+	return fmt.Sprintf("keepalive: %d, deadTimer: %d", timers.GetKeepalive(), timers.GetDeadTimer())
 }
 
 func capStrings(capabilities []*pb.Capability) []string {

--- a/examples/grpc/go/session-list/main.go
+++ b/examples/grpc/go/session-list/main.go
@@ -42,30 +42,42 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 
-	ret, err := c.GetSessionList(ctx, &pb.GetSessionListRequest{})
+	ret, err := c.GetSessionList(ctx, &pb.GetSessionListRequest{IncludeStats: true})
 	if err != nil {
 		log.Fatalf("unable to get session list from server: %v", err)
 	}
 
 	for i, ss := range ret.GetSessions() {
-		addr, ok := netip.AddrFromSlice(ss.GetAddr())
+		addr, ok := netip.AddrFromSlice(ss.GetPeerAddr())
 		if !ok {
-			log.Printf("invalid address for session %d: %v", i, ss.GetAddr())
+			log.Printf("invalid address for session %d: %v", i, ss.GetPeerAddr())
 			continue
 		}
-		fmt.Printf("sessionAddr(%d): %v\n", i, addr)
-		fmt.Printf("  sessionID (Pola): %s, sessionID (PCC): %s\n",
-			optionalUint32(ss.LocalSessionId), optionalUint32(ss.PccSessionId))
+		fmt.Printf("peerAddr(%d): %v\n", i, addr)
+		fmt.Printf("  sessionID (Pola): %s, sessionID (peer): %s\n",
+			optionalUint32(ss.LocalSessionId), optionalUint32(ss.PeerSessionId))
 		fmt.Printf("  state: %s\n", ss.GetState())
 		fmt.Printf("  advertised (Pola): %s\n", timersString(ss.GetLocalTimers()))
-		fmt.Printf("  advertised (PCC): %s\n", timersString(ss.GetPccTimers()))
-		fmt.Printf("  effective: keepalive: %d, deadTimer: %d\n",
-			ss.GetEffectiveTimers().GetKeepalive(), ss.GetEffectiveTimers().GetDeadTimer())
+		fmt.Printf("  advertised (peer): %s\n", timersString(ss.GetPeerTimers()))
+		fmt.Printf("  effective: keepalive: %s, deadTimer: %s\n",
+			effectiveTimerString(pb.EffectiveKeepalive(ss.GetState(), ss.GetEffectiveTimers())),
+			effectiveTimerString(pb.EffectiveDeadTimer(ss.GetState(), ss.GetEffectiveTimers())))
 		fmt.Printf("  pccType: %s\n", strings.TrimPrefix(ss.GetPccType().String(), "PCC_TYPE_"))
-		fmt.Printf("  capabilities (Pola): %s\n", strings.Join(capStrings(ss.GetCapabilities()), ", "))
-		fmt.Printf("  capabilities (PCC): %s\n", strings.Join(capStrings(ss.GetPccCapabilities()), ", "))
-		fmt.Printf("  isSynced: %t\n", ss.GetIsSynced())
+		fmt.Printf("  capabilities (Pola): %s\n", strings.Join(capStrings(ss.GetLocalCapabilities()), ", "))
+		fmt.Printf("  capabilities (peer): %s\n", strings.Join(capStrings(ss.GetPeerCapabilities()), ", "))
+		fmt.Printf("  initiator: %s\n", strings.TrimPrefix(ss.GetInitiator().String(), "SESSION_INITIATOR_"))
+		fmt.Printf("  syncState: %s\n", strings.TrimPrefix(ss.GetSyncState().String(), "LSP_DB_SYNC_STATE_"))
+		fmt.Printf("  createdAt: %s\n", unixNanoString(ss.GetCreatedAtUnixNano()))
+		fmt.Printf("  establishedAt: %s\n", unixNanoString(ss.GetEstablishedAtUnixNano()))
+		fmt.Printf("  stats: %s\n", ss.GetStats())
 	}
+}
+
+func unixNanoString(n int64) string {
+	if n == 0 {
+		return "-"
+	}
+	return time.Unix(0, n).UTC().Format(time.RFC3339)
 }
 
 func optionalUint32(v *uint32) string {
@@ -73,6 +85,13 @@ func optionalUint32(v *uint32) string {
 		return "-"
 	}
 	return strconv.FormatUint(uint64(*v), 10)
+}
+
+func effectiveTimerString(v uint32, ok bool) string {
+	if !ok {
+		return "-"
+	}
+	return strconv.FormatUint(uint64(v), 10)
 }
 
 func timersString(timers *pb.SessionTimers) string {

--- a/examples/grpc/go/sr-policy-create-dynamic/main.go
+++ b/examples/grpc/go/sr-policy-create-dynamic/main.go
@@ -42,16 +42,16 @@ func main() {
 
 	ssAddr := netip.MustParseAddr("192.0.2.1")
 
-	r, err := c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
+	_, err = c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
 		Asn: 65000,
 		SrPolicy: &pb.SRPolicy{
-			PcepSessionAddr: ssAddr.AsSlice(),
-			SrcRouterId:     "0000.0aff.0001",
-			DstRouterId:     "0000.0aff.0004",
-			Color:           100,
-			PolicyName:      "sample-name",
-			Type:            pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-			Metric:          pb.MetricType_METRIC_TYPE_TE,
+			PeerAddr:    ssAddr.AsSlice(),
+			SrcRouterId: "0000.0aff.0001",
+			DstRouterId: "0000.0aff.0004",
+			Color:       100,
+			PolicyName:  "sample-name",
+			Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
+			Metric:      pb.MetricType_METRIC_TYPE_TE,
 			// Optional: constrain the computed path through these routers.
 			Waypoints: []*pb.Waypoint{
 				{RouterId: "0000.0aff.0002"},
@@ -63,5 +63,5 @@ func main() {
 		log.Fatalf("c.CreateSRPolicy error: %v", err)
 	}
 
-	log.Printf("success: isSuccess=%t", r.GetIsSuccess())
+	log.Print("success")
 }

--- a/examples/grpc/go/sr-policy-create-explicit/main.go
+++ b/examples/grpc/go/sr-policy-create-explicit/main.go
@@ -41,15 +41,15 @@ func main() {
 
 	ssAddr := netip.MustParseAddr("192.0.2.1")
 
-	r, err := c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
+	_, err = c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
 		Asn: 65000,
 		SrPolicy: &pb.SRPolicy{
-			PcepSessionAddr: ssAddr.AsSlice(),
-			SrcRouterId:     "0000.0aff.0001",
-			DstRouterId:     "0000.0aff.0004",
-			Color:           100,
-			PolicyName:      "sample-name",
-			Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+			PeerAddr:    ssAddr.AsSlice(),
+			SrcRouterId: "0000.0aff.0001",
+			DstRouterId: "0000.0aff.0004",
+			Color:       100,
+			PolicyName:  "sample-name",
+			Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 			SegmentList: []*pb.Segment{
 				{Sid: "16002"},
 				{Sid: "16003"},
@@ -62,5 +62,5 @@ func main() {
 		log.Fatalf("c.CreateSRPolicy error: %v", err)
 	}
 
-	log.Printf("success: isSuccess=%t", r.GetIsSuccess())
+	log.Print("success")
 }

--- a/examples/grpc/go/sr-policy-create-no-sid-validate/main.go
+++ b/examples/grpc/go/sr-policy-create-no-sid-validate/main.go
@@ -44,14 +44,14 @@ func main() {
 	srcAddr := netip.MustParseAddr("192.0.2.1")
 	dstAddr := netip.MustParseAddr("192.0.2.2")
 
-	r, err := c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
+	_, err = c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
-			PcepSessionAddr: ssAddr.AsSlice(),
-			SrcAddr:         srcAddr.AsSlice(),
-			DstAddr:         dstAddr.AsSlice(),
-			Color:           100,
-			PolicyName:      "sample-name",
-			Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+			PeerAddr:   ssAddr.AsSlice(),
+			SrcAddr:    srcAddr.AsSlice(),
+			DstAddr:    dstAddr.AsSlice(),
+			Color:      100,
+			PolicyName: "sample-name",
+			Type:       pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 			SegmentList: []*pb.Segment{
 				{Sid: "16002"},
 				{Sid: "16003"},
@@ -65,5 +65,5 @@ func main() {
 		log.Fatalf("c.CreateSRPolicy error: %v", err)
 	}
 
-	log.Printf("success: isSuccess=%t", r.GetIsSuccess())
+	log.Print("success")
 }

--- a/examples/grpc/go/sr-policy-create-srv6/main.go
+++ b/examples/grpc/go/sr-policy-create-srv6/main.go
@@ -44,14 +44,14 @@ func main() {
 	srcAddr := netip.MustParseAddr("2001:db8::1")
 	dstAddr := netip.MustParseAddr("2001:db8::2")
 
-	r, err := c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
+	_, err = c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
-			PcepSessionAddr: ssAddr.AsSlice(),
-			SrcAddr:         srcAddr.AsSlice(),
-			DstAddr:         dstAddr.AsSlice(),
-			Color:           100,
-			PolicyName:      "sample-srv6",
-			Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+			PeerAddr:   ssAddr.AsSlice(),
+			SrcAddr:    srcAddr.AsSlice(),
+			DstAddr:    dstAddr.AsSlice(),
+			Color:      100,
+			PolicyName: "sample-srv6",
+			Type:       pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 			SegmentList: []*pb.Segment{
 				{
 					Sid:          "2001:db8:1005::",
@@ -72,5 +72,5 @@ func main() {
 		log.Fatalf("c.CreateSRPolicy error: %v", err)
 	}
 
-	log.Printf("success: isSuccess=%t", r.GetIsSuccess())
+	log.Print("success")
 }

--- a/examples/grpc/go/sr-policy-delete/main.go
+++ b/examples/grpc/go/sr-policy-delete/main.go
@@ -4,7 +4,7 @@
 // see https://github.com/nttcom/pola/blob/main/LICENSE
 
 // Command sr-policy-delete deletes an SR Policy.
-// The policy is identified by PcepSessionAddr, Color, DstAddr and PolicyName.
+// The policy is identified by PeerAddr, Color, DstAddr and PolicyName.
 package main
 
 import (
@@ -43,17 +43,17 @@ func main() {
 	ssAddr := netip.MustParseAddr("192.0.2.1")
 	dstAddr := netip.MustParseAddr("192.0.2.2")
 
-	r, err := c.DeleteSRPolicy(ctx, &pb.DeleteSRPolicyRequest{
+	_, err = c.DeleteSRPolicy(ctx, &pb.DeleteSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
-			PcepSessionAddr: ssAddr.AsSlice(),
-			DstAddr:         dstAddr.AsSlice(),
-			Color:           100,
-			PolicyName:      "sample-name",
+			PeerAddr:   ssAddr.AsSlice(),
+			DstAddr:    dstAddr.AsSlice(),
+			Color:      100,
+			PolicyName: "sample-name",
 		},
 	})
 	if err != nil {
 		log.Fatalf("c.DeleteSRPolicy error: %v", err)
 	}
 
-	log.Printf("success: isSuccess=%t", r.GetIsSuccess())
+	log.Print("success")
 }

--- a/examples/grpc/go/sr-policy-list/main.go
+++ b/examples/grpc/go/sr-policy-list/main.go
@@ -49,6 +49,7 @@ func main() {
 	i := 0
 	for _, session := range ret.GetSessions() {
 		sessionAddr := formatAddr(session.GetAddr())
+		fmt.Printf("session: %s (state: %s, isSynced: %t)\n", sessionAddr, session.GetState(), session.GetIsSynced())
 		for _, srPolicy := range session.GetSrPolicies() {
 			fmt.Printf("srPolicy(%d):\n", i)
 			i++
@@ -79,7 +80,21 @@ func formatSegmentList(segmentList []*pb.Segment) string {
 
 	sids := make([]string, 0, len(segmentList))
 	for _, segment := range segmentList {
-		sids = append(sids, segment.GetSid())
+		sids = append(sids, formatSegment(segment))
 	}
 	return strings.Join(sids, " -> ")
+}
+
+func formatSegment(segment *pb.Segment) string {
+	local, remote := segment.GetLocalAddr(), segment.GetRemoteAddr()
+	switch {
+	case local == "" && remote == "":
+		return segment.GetSid()
+	case remote == "":
+		return fmt.Sprintf("%s (local=%s)", segment.GetSid(), local)
+	case local == "":
+		return fmt.Sprintf("%s (remote=%s)", segment.GetSid(), remote)
+	default:
+		return fmt.Sprintf("%s (local=%s, remote=%s)", segment.GetSid(), local, remote)
+	}
 }

--- a/examples/grpc/go/sr-policy-list/main.go
+++ b/examples/grpc/go/sr-policy-list/main.go
@@ -48,12 +48,12 @@ func main() {
 
 	i := 0
 	for _, session := range ret.GetSessions() {
-		sessionAddr := formatAddr(session.GetAddr())
-		fmt.Printf("session: %s (state: %s, isSynced: %t)\n", sessionAddr, session.GetState(), session.GetIsSynced())
+		peerAddr := formatAddr(session.GetPeerAddr())
+		fmt.Printf("session: %s (state: %s, syncState: %s)\n", peerAddr, session.GetState(), session.GetSyncState())
 		for _, srPolicy := range session.GetSrPolicies() {
 			fmt.Printf("srPolicy(%d):\n", i)
 			i++
-			fmt.Printf("  sessionAddr: %s\n", sessionAddr)
+			fmt.Printf("  peerAddr: %s\n", peerAddr)
 			fmt.Printf("  policyName: %s\n", srPolicy.GetPolicyName())
 			fmt.Printf("  srcAddr: %s\n", formatAddr(srPolicy.GetSrcAddr()))
 			fmt.Printf("  dstAddr: %s\n", formatAddr(srPolicy.GetDstAddr()))

--- a/examples/grpc/go/ted-get/main.go
+++ b/examples/grpc/go/ted-get/main.go
@@ -47,13 +47,13 @@ func main() {
 	}
 
 	// A disabled TED returns an empty node list instead of an error.
-	if !ret.GetEnable() {
+	if !ret.GetEnabled() {
 		fmt.Println("TED is disabled on this polad instance")
 		return
 	}
 
 	marshaler := protojson.MarshalOptions{Multiline: true, Indent: "  "}
-	for _, node := range ret.GetLsNodes() {
+	for _, node := range ret.GetNodes() {
 		fmt.Println(marshaler.Format(node))
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/nttcom/pola/pkg/packet/pcep"
 )
 
 // PCEP holds the configuration for PCEP protocol settings.
@@ -105,17 +107,12 @@ func (p PCEP) validate() []error {
 	if p.Port == "" {
 		errs = append(errs, errors.New("global.pcep.port is required"))
 	}
-	if p.DeadTimer != nil && *p.DeadTimer != 0 {
-		keepalive := defaultKeepalive
-		if p.Keepalive != nil {
-			keepalive = *p.Keepalive
-		}
-		switch {
-		case keepalive == 0:
-			errs = append(errs, errors.New("global.pcep.deadTimer must be 0 when global.pcep.keepalive is 0"))
-		case *p.DeadTimer < keepalive:
-			errs = append(errs, errors.New("global.pcep.deadTimer must be >= global.pcep.keepalive when both are nonzero"))
-		}
+	keepalive := defaultKeepalive
+	if p.Keepalive != nil {
+		keepalive = *p.Keepalive
+	}
+	if err := pcep.ValidateTimers(keepalive, p.DeadTimer); err != nil {
+		errs = append(errs, fmt.Errorf("global.pcep.%w", err))
 	}
 	if p.MinKeepalive != nil && p.MaxKeepalive != nil && *p.MinKeepalive > *p.MaxKeepalive {
 		errs = append(errs, errors.New("global.pcep.minKeepalive must be <= global.pcep.maxKeepalive"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,8 +15,13 @@ import (
 
 // PCEP holds the configuration for PCEP protocol settings.
 type PCEP struct {
-	Address string `yaml:"address"`
-	Port    string `yaml:"port"`
+	Address          string `yaml:"address"`
+	Port             string `yaml:"port"`
+	Keepalive        *uint8 `yaml:"keepalive"`
+	DeadTimer        *uint8 `yaml:"deadTimer"`
+	MinKeepalive     *uint8 `yaml:"minKeepalive"`
+	MaxKeepalive     *uint8 `yaml:"maxKeepalive"`
+	AllowNegotiation *bool  `yaml:"allowNegotiation"`
 }
 
 // GRPCServer holds the configuration for the gRPC server.
@@ -88,16 +93,29 @@ func ReadConfigFile(configFile string) (Config, error) {
 	return *c, nil
 }
 
-// Validate checks required configuration fields.
-func (c *Config) Validate() error {
+func (p PCEP) validate() []error {
 	var errs []error
 
-	if c.Global.PCEP.Address == "" {
+	if p.Address == "" {
 		errs = append(errs, errors.New("global.pcep.address is required"))
 	}
-	if c.Global.PCEP.Port == "" {
+	if p.Port == "" {
 		errs = append(errs, errors.New("global.pcep.port is required"))
 	}
+	if p.Keepalive != nil && *p.Keepalive == 0 && p.DeadTimer != nil && *p.DeadTimer != 0 {
+		errs = append(errs, errors.New("global.pcep.deadTimer must be 0 when global.pcep.keepalive is 0"))
+	}
+	if p.MinKeepalive != nil && p.MaxKeepalive != nil && *p.MinKeepalive > *p.MaxKeepalive {
+		errs = append(errs, errors.New("global.pcep.minKeepalive must be <= global.pcep.maxKeepalive"))
+	}
+
+	return errs
+}
+
+// Validate checks the configuration.
+func (c *Config) Validate() error {
+	errs := c.Global.PCEP.validate()
+
 	if c.Global.GRPCServer.Address == "" {
 		errs = append(errs, errors.New("global.grpcServer.address is required"))
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,6 +93,9 @@ func ReadConfigFile(configFile string) (Config, error) {
 	return *c, nil
 }
 
+// RFC 5440 §7.3 default Keepalive.
+const defaultKeepalive uint8 = 30
+
 func (p PCEP) validate() []error {
 	var errs []error
 
@@ -102,8 +105,17 @@ func (p PCEP) validate() []error {
 	if p.Port == "" {
 		errs = append(errs, errors.New("global.pcep.port is required"))
 	}
-	if p.Keepalive != nil && *p.Keepalive == 0 && p.DeadTimer != nil && *p.DeadTimer != 0 {
-		errs = append(errs, errors.New("global.pcep.deadTimer must be 0 when global.pcep.keepalive is 0"))
+	if p.DeadTimer != nil && *p.DeadTimer != 0 {
+		keepalive := defaultKeepalive
+		if p.Keepalive != nil {
+			keepalive = *p.Keepalive
+		}
+		switch {
+		case keepalive == 0:
+			errs = append(errs, errors.New("global.pcep.deadTimer must be 0 when global.pcep.keepalive is 0"))
+		case *p.DeadTimer < keepalive:
+			errs = append(errs, errors.New("global.pcep.deadTimer must be >= global.pcep.keepalive when both are nonzero"))
+		}
 	}
 	if p.MinKeepalive != nil && p.MaxKeepalive != nil && *p.MinKeepalive > *p.MaxKeepalive {
 		errs = append(errs, errors.New("global.pcep.minKeepalive must be <= global.pcep.maxKeepalive"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -382,6 +382,51 @@ global:
 	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be 0")
 }
 
+func TestValidate_RejectsDeadTimerLessThanKeepalive(t *testing.T) {
+	path := writeConfig(t, `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+    keepalive: 30
+    deadTimer: 10
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be >= global.pcep.keepalive")
+}
+
+func TestValidate_RejectsDeadTimerLessThanDefaultKeepaliveWhenKeepaliveUnset(t *testing.T) {
+	path := writeConfig(t, `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+    deadTimer: 10
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be >= global.pcep.keepalive")
+}
+
 func TestPCEPKeepaliveRange_ReadsConfiguredValues(t *testing.T) {
 	path := writeConfig(t, `
 global:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -321,3 +321,129 @@ func TestReadConfigFile_UnquotedIntegerPort(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "50052", c.Global.GRPCServer.Port)
 }
+
+func TestPCEPTimers_AreOptionalAndDistinguishZeroFromUnset(t *testing.T) {
+	path := writeConfig(t, `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+    keepalive: 0
+    deadTimer: 0
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Validate())
+	require.NotNil(t, c.Global.PCEP.Keepalive)
+	assert.Zero(t, *c.Global.PCEP.Keepalive)
+	require.NotNil(t, c.Global.PCEP.DeadTimer)
+	assert.Zero(t, *c.Global.PCEP.DeadTimer)
+}
+
+func TestPCEPTimers_UnsetLeavesTimersNil(t *testing.T) {
+	path := writeConfig(t, validConfig)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+
+	assert.Nil(t, c.Global.PCEP.Keepalive)
+	assert.Nil(t, c.Global.PCEP.DeadTimer)
+}
+
+func TestValidate_RejectsNonZeroDeadTimerWithZeroKeepalive(t *testing.T) {
+	path := writeConfig(t, `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+    keepalive: 0
+    deadTimer: 120
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be 0")
+}
+
+func TestPCEPKeepaliveRange_ReadsConfiguredValues(t *testing.T) {
+	path := writeConfig(t, `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+    minKeepalive: 10
+    maxKeepalive: 60
+    allowNegotiation: false
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Validate())
+
+	require.NotNil(t, c.Global.PCEP.MinKeepalive)
+	assert.Equal(t, uint8(10), *c.Global.PCEP.MinKeepalive)
+	require.NotNil(t, c.Global.PCEP.MaxKeepalive)
+	assert.Equal(t, uint8(60), *c.Global.PCEP.MaxKeepalive)
+	require.NotNil(t, c.Global.PCEP.AllowNegotiation)
+	assert.False(t, *c.Global.PCEP.AllowNegotiation)
+}
+
+func TestPCEPKeepaliveRange_UnsetLeavesFieldsNil(t *testing.T) {
+	path := writeConfig(t, validConfig)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+
+	assert.Nil(t, c.Global.PCEP.MinKeepalive)
+	assert.Nil(t, c.Global.PCEP.MaxKeepalive)
+	assert.Nil(t, c.Global.PCEP.AllowNegotiation)
+}
+
+func TestValidate_RejectsMinKeepaliveGreaterThanMaxKeepalive(t *testing.T) {
+	path := writeConfig(t, `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+    minKeepalive: 60
+    maxKeepalive: 10
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+
+	require.ErrorContains(t, c.Validate(), "global.pcep.minKeepalive must be <= global.pcep.maxKeepalive")
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -402,7 +402,7 @@ global:
 
 	c, err := ReadConfigFile(path)
 	require.NoError(t, err)
-	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be >= global.pcep.keepalive")
+	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be greater than keepalive")
 }
 
 func TestValidate_RejectsDeadTimerLessThanDefaultKeepaliveWhenKeepaliveUnset(t *testing.T) {
@@ -424,7 +424,52 @@ global:
 
 	c, err := ReadConfigFile(path)
 	require.NoError(t, err)
-	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be >= global.pcep.keepalive")
+	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be greater than keepalive")
+}
+
+func TestValidate_RejectsDeadTimerEqualToKeepalive(t *testing.T) {
+	path := writeConfig(t, `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+    keepalive: 30
+    deadTimer: 30
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be greater than keepalive")
+}
+
+func TestValidate_RejectsKeepalive255WithDefaultedDeadTimer(t *testing.T) {
+	path := writeConfig(t, `
+global:
+  pcep:
+    address: "127.0.0.1"
+    port: 4189
+    keepalive: 255
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: false
+`)
+
+	c, err := ReadConfigFile(path)
+	require.NoError(t, err)
+	require.ErrorContains(t, c.Validate(), "global.pcep.deadTimer must be greater than keepalive")
 }
 
 func TestPCEPKeepaliveRange_ReadsConfiguredValues(t *testing.T) {

--- a/pkg/packet/pcep/capability.go
+++ b/pkg/packet/pcep/capability.go
@@ -11,30 +11,39 @@ type CapabilityInterface interface {
 	CapStrings() []string
 }
 
+// polaStatefulCapability returns Pola's Stateful PCE Capability.
+func polaStatefulCapability() *StatefulPCECapability {
+	return &StatefulPCECapability{
+		LSPUpdateCapability:            true,
+		IncludeDBVersion:               false,
+		LSPInstantiationCapability:     true,
+		TriggeredResync:                false,
+		DeltaLSPSyncCapability:         false,
+		TriggeredInitialSync:           false,
+		P2mpCapability:                 false,
+		P2mpLSPUpdateCapability:        false,
+		P2mpLSPInstantiationCapability: false,
+		LSPSchedulingCapability:        false,
+		PdLSPCapability:                false,
+		ColorCapability:                true,
+		PathRecomputationCapability:    false,
+		StrictPathCapability:           false,
+		Relax:                          false,
+	}
+}
+
+// DefaultCapabilities returns Pola's default advertised capabilities.
+func DefaultCapabilities() []CapabilityInterface {
+	return []CapabilityInterface{polaStatefulCapability()}
+}
+
 // PolaCapability converts received capabilities to those advertised by Pola.
 func PolaCapability(caps []CapabilityInterface) []CapabilityInterface {
 	polaCaps := []CapabilityInterface{}
 	for _, cap := range caps {
 		switch tlv := cap.(type) {
 		case *StatefulPCECapability:
-			tlv = &StatefulPCECapability{
-				LSPUpdateCapability:            true,
-				IncludeDBVersion:               false,
-				LSPInstantiationCapability:     true,
-				TriggeredResync:                false,
-				DeltaLSPSyncCapability:         false,
-				TriggeredInitialSync:           false,
-				P2mpCapability:                 false,
-				P2mpLSPUpdateCapability:        false,
-				P2mpLSPInstantiationCapability: false,
-				LSPSchedulingCapability:        false,
-				PdLSPCapability:                false,
-				ColorCapability:                true,
-				PathRecomputationCapability:    false,
-				StrictPathCapability:           false,
-				Relax:                          false,
-			}
-			polaCaps = append(polaCaps, tlv)
+			polaCaps = append(polaCaps, polaStatefulCapability())
 		case *LSPDBVersion:
 			continue
 		default:

--- a/pkg/packet/pcep/capability.go
+++ b/pkg/packet/pcep/capability.go
@@ -33,7 +33,7 @@ func polaStatefulCapability() *StatefulPCECapability {
 }
 
 // polaPathSetupTypeCapability returns Pola's supported path setup types
-// and their corresponding SR capability sub-TLVs.
+// and their SR capability sub-TLVs.
 func polaPathSetupTypeCapability() *PathSetupTypeCapability {
 	return &PathSetupTypeCapability{
 		PathSetupTypes: Psts{PathSetupTypeSRTE, PathSetupTypeSRv6TE},
@@ -44,15 +44,19 @@ func polaPathSetupTypeCapability() *PathSetupTypeCapability {
 	}
 }
 
-// polaAssocTypeList returns Pola's ASSOC-TYPE-LIST TLV.
-//
-// Only the IANA-assigned SR Policy Association type is advertised.
-// Legacy Cisco (0x14) and Juniper (0xffe1) values are peer-specific
-// interop quirks and are handled after the peer's OPEN is received.
+// polaAssocTypeList returns the IANA-assigned SR Policy Association type.
+// Legacy Cisco (0x14) and Juniper (0xffe1) values are handled separately
+// after the peer's OPEN is received.
 func polaAssocTypeList() *AssocTypeList {
 	return &AssocTypeList{
 		AssocTypes: []AssocType{AssocTypeSRPolicyAssociation},
 	}
+}
+
+// polaMultipathCapability returns Pola's MULTIPATH-CAP TLV.
+// Pola currently computes a single path per request.
+func polaMultipathCapability() *MultipathCapability {
+	return NewMultipathCapability(1, false, false, false, false)
 }
 
 // FlattenCapabilities appends PATH-SETUP-TYPE-CAPABILITY sub-capabilities
@@ -77,5 +81,6 @@ func DefaultCapabilities() []CapabilityInterface {
 		polaStatefulCapability(),
 		polaPathSetupTypeCapability(),
 		polaAssocTypeList(),
+		polaMultipathCapability(),
 	}
 }

--- a/pkg/packet/pcep/capability.go
+++ b/pkg/packet/pcep/capability.go
@@ -45,10 +45,30 @@ func polaPathSetupTypeCapability() *PathSetupTypeCapability {
 }
 
 // polaAssocTypeList returns Pola's ASSOC-TYPE-LIST TLV.
+//
+// Only the IANA-assigned SR Policy Association type is advertised.
+// Legacy Cisco (0x14) and Juniper (0xffe1) values are peer-specific
+// interop quirks and are handled after the peer's OPEN is received.
 func polaAssocTypeList() *AssocTypeList {
 	return &AssocTypeList{
 		AssocTypes: []AssocType{AssocTypeSRPolicyAssociation},
 	}
+}
+
+// FlattenCapabilities appends PATH-SETUP-TYPE-CAPABILITY sub-capabilities
+// to the top-level list. This normalizes the two nesting forms allowed by
+// RFC 8664 Appendix A. Only one level of nesting is expanded.
+func FlattenCapabilities(caps []CapabilityInterface) []CapabilityInterface {
+	ret := make([]CapabilityInterface, 0, len(caps))
+	ret = append(ret, caps...)
+
+	for _, c := range caps {
+		if pstCap, ok := c.(*PathSetupTypeCapability); ok {
+			ret = append(ret, pstCap.SubCapabilities()...)
+		}
+	}
+
+	return ret
 }
 
 // DefaultCapabilities returns the capabilities Pola advertises in its OPEN.

--- a/pkg/packet/pcep/capability.go
+++ b/pkg/packet/pcep/capability.go
@@ -11,7 +11,7 @@ type CapabilityInterface interface {
 	CapStrings() []string
 }
 
-// polaStatefulCapability returns Pola's Stateful PCE Capability.
+// polaStatefulCapability returns Pola's Stateful PCE Capability (RFC 8231).
 func polaStatefulCapability() *StatefulPCECapability {
 	return &StatefulPCECapability{
 		LSPUpdateCapability:            true,
@@ -32,23 +32,30 @@ func polaStatefulCapability() *StatefulPCECapability {
 	}
 }
 
-// DefaultCapabilities returns Pola's default advertised capabilities.
-func DefaultCapabilities() []CapabilityInterface {
-	return []CapabilityInterface{polaStatefulCapability()}
+// polaPathSetupTypeCapability returns Pola's supported path setup types
+// and their corresponding SR capability sub-TLVs.
+func polaPathSetupTypeCapability() *PathSetupTypeCapability {
+	return &PathSetupTypeCapability{
+		PathSetupTypes: Psts{PathSetupTypeSRTE, PathSetupTypeSRv6TE},
+		SubTLVs: []TLVInterface{
+			&SRPCECapability{HasUnlimitedMaxSIDDepth: true},
+			&SRv6PCECapability{},
+		},
+	}
 }
 
-// PolaCapability converts received capabilities to those advertised by Pola.
-func PolaCapability(caps []CapabilityInterface) []CapabilityInterface {
-	polaCaps := []CapabilityInterface{}
-	for _, cap := range caps {
-		switch tlv := cap.(type) {
-		case *StatefulPCECapability:
-			polaCaps = append(polaCaps, polaStatefulCapability())
-		case *LSPDBVersion:
-			continue
-		default:
-			polaCaps = append(polaCaps, tlv)
-		}
+// polaAssocTypeList returns Pola's ASSOC-TYPE-LIST TLV.
+func polaAssocTypeList() *AssocTypeList {
+	return &AssocTypeList{
+		AssocTypes: []AssocType{AssocTypeSRPolicyAssociation},
 	}
-	return polaCaps
+}
+
+// DefaultCapabilities returns the capabilities Pola advertises in its OPEN.
+func DefaultCapabilities() []CapabilityInterface {
+	return []CapabilityInterface{
+		polaStatefulCapability(),
+		polaPathSetupTypeCapability(),
+		polaAssocTypeList(),
+	}
 }

--- a/pkg/packet/pcep/capability_test.go
+++ b/pkg/packet/pcep/capability_test.go
@@ -12,117 +12,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPolaCapability(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []CapabilityInterface
-		expected []CapabilityInterface
-	}{
-		{
-			name: "Basic Capability Test",
-			input: []CapabilityInterface{
-				&StatefulPCECapability{
-					LSPUpdateCapability:        false,
-					IncludeDBVersion:           true,
-					LSPInstantiationCapability: false,
-					TriggeredResync:            true,
-					DeltaLSPSyncCapability:     true,
-					TriggeredInitialSync:       true,
-				},
-				&PathSetupTypeCapability{
-					PathSetupTypes: Psts{PathSetupTypeRSVPTE, PathSetupTypeSRTE, PathSetupTypeSRv6TE},
-					SubTLVs: []TLVInterface{
-						&SRPCECapability{
-							HasUnlimitedMaxSIDDepth: false,
-							IsNAISupported:          false,
-							MaximumSidDepth:         16,
-						},
-					},
-				},
-				&SRPCECapability{
-					HasUnlimitedMaxSIDDepth: false,
-					IsNAISupported:          false,
-					MaximumSidDepth:         16,
-				},
-				&AssocTypeList{
-					AssocTypes: []AssocType{AssocTypePathProtectionAssociation, AssocTypeSRPolicyAssociation},
-				},
-			},
-			expected: []CapabilityInterface{
-				&StatefulPCECapability{
-					LSPUpdateCapability:            true,
-					IncludeDBVersion:               false,
-					LSPInstantiationCapability:     true,
-					TriggeredResync:                false,
-					DeltaLSPSyncCapability:         false,
-					TriggeredInitialSync:           false,
-					P2mpCapability:                 false,
-					P2mpLSPUpdateCapability:        false,
-					P2mpLSPInstantiationCapability: false,
-					LSPSchedulingCapability:        false,
-					PdLSPCapability:                false,
-					ColorCapability:                true,
-					PathRecomputationCapability:    false,
-					StrictPathCapability:           false,
-					Relax:                          false,
-				},
-				&PathSetupTypeCapability{
-					PathSetupTypes: Psts{PathSetupTypeRSVPTE, PathSetupTypeSRTE, PathSetupTypeSRv6TE},
-					SubTLVs: []TLVInterface{
-						&SRPCECapability{
-							HasUnlimitedMaxSIDDepth: false,
-							IsNAISupported:          false,
-							MaximumSidDepth:         16,
-						},
-					},
-				},
-				&SRPCECapability{
-					HasUnlimitedMaxSIDDepth: false,
-					IsNAISupported:          false,
-					MaximumSidDepth:         16,
-				},
-				&AssocTypeList{
-					AssocTypes: []AssocType{AssocTypePathProtectionAssociation, AssocTypeSRPolicyAssociation},
-				},
-			},
-		},
-		{
-			name: "Includes LSPDBVersion (should be skipped)",
-			input: []CapabilityInterface{
-				&LSPDBVersion{},
-			},
-			expected: []CapabilityInterface{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, PolaCapability(tt.input))
-		})
-	}
-}
-
 func TestDefaultCapabilities(t *testing.T) {
 	caps := DefaultCapabilities()
-	require.Len(t, caps, 1)
+	require.Len(t, caps, 3)
+
 	statefulCap, ok := caps[0].(*StatefulPCECapability)
-	require.True(t, ok, "expected DefaultCapabilities to return a StatefulPCECapability")
+	require.True(t, ok, "expected DefaultCapabilities[0] to be a StatefulPCECapability")
 	assert.True(t, statefulCap.LSPUpdateCapability)
 	assert.True(t, statefulCap.LSPInstantiationCapability)
 	assert.True(t, statefulCap.ColorCapability)
+
+	pstCap, ok := caps[1].(*PathSetupTypeCapability)
+	require.True(t, ok, "expected DefaultCapabilities[1] to be a PathSetupTypeCapability")
+	assert.Equal(t, Psts{PathSetupTypeSRTE, PathSetupTypeSRv6TE}, pstCap.PathSetupTypes)
+	require.Len(t, pstCap.SubTLVs, 2)
+
+	srCap, ok := pstCap.SubTLVs[0].(*SRPCECapability)
+	require.True(t, ok, "expected the first PST-CAPABILITY sub-TLV to be SR-PCE-CAPABILITY")
+	// RFC 8664 §5.1: a PCE MUST set N-Flag=0, X-Flag=1, and MSD=0.
+	assert.False(t, srCap.IsNAISupported)
+	assert.True(t, srCap.HasUnlimitedMaxSIDDepth)
+	assert.Equal(t, uint8(0), srCap.MaximumSidDepth)
+
+	srv6Cap, ok := pstCap.SubTLVs[1].(*SRv6PCECapability)
+	require.True(t, ok, "expected the second PST-CAPABILITY sub-TLV to be SRv6-PCE-CAPABILITY")
+	// RFC 9603 §5.1: a PCE MUST set the N flag to zero and omit the MSD.
+	assert.False(t, srv6Cap.IsNAISupported)
+
+	assocCap, ok := caps[2].(*AssocTypeList)
+	require.True(t, ok, "expected DefaultCapabilities[2] to be an AssocTypeList")
+	// RFC 9862 §5.2: a PCEP speaker MUST advertise the SRPA type before using it.
+	assert.Equal(t, []AssocType{AssocTypeSRPolicyAssociation}, assocCap.AssocTypes)
 }
 
-func TestPolaCapability_OutputAlwaysSerializes(t *testing.T) {
-	caps := []CapabilityInterface{
-		&StatefulPCECapability{LSPUpdateCapability: true},
-		&SRPCECapability{MaximumSidDepth: 16},
-		&PathSetupTypeCapability{PathSetupTypes: Psts{PathSetupTypeSRTE}},
-		&AssocTypeList{AssocTypes: []AssocType{AssocTypeSRPolicyAssociation}},
-		&LSPDBVersion{VersionNumber: 1},
-	}
+func TestDefaultCapabilities_WireRoundTrip(t *testing.T) {
+	for _, cap := range DefaultCapabilities() {
+		b, err := cap.Serialize()
+		require.NoError(t, err, "%T must serialize", cap)
 
-	for _, cap := range PolaCapability(caps) {
-		_, err := cap.Serialize()
-		assert.NoError(t, err, "PolaCapability output must always serialize: %T", cap)
+		decodedTLVs, err := DecodeTLVs(b)
+		require.NoError(t, err, "%T must decode its own serialized bytes", cap)
+		require.Len(t, decodedTLVs, 1)
+		assert.Equal(t, cap, decodedTLVs[0], "%T round-trip mismatch", cap)
 	}
 }

--- a/pkg/packet/pcep/capability_test.go
+++ b/pkg/packet/pcep/capability_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPolaCapability(t *testing.T) {
@@ -34,14 +35,14 @@ func TestPolaCapability(t *testing.T) {
 						&SRPCECapability{
 							HasUnlimitedMaxSIDDepth: false,
 							IsNAISupported:          false,
-							MaximumSidDepth:         msdPtr(16),
+							MaximumSidDepth:         16,
 						},
 					},
 				},
 				&SRPCECapability{
 					HasUnlimitedMaxSIDDepth: false,
 					IsNAISupported:          false,
-					MaximumSidDepth:         msdPtr(16),
+					MaximumSidDepth:         16,
 				},
 				&AssocTypeList{
 					AssocTypes: []AssocType{AssocTypePathProtectionAssociation, AssocTypeSRPolicyAssociation},
@@ -71,14 +72,14 @@ func TestPolaCapability(t *testing.T) {
 						&SRPCECapability{
 							HasUnlimitedMaxSIDDepth: false,
 							IsNAISupported:          false,
-							MaximumSidDepth:         msdPtr(16),
+							MaximumSidDepth:         16,
 						},
 					},
 				},
 				&SRPCECapability{
 					HasUnlimitedMaxSIDDepth: false,
 					IsNAISupported:          false,
-					MaximumSidDepth:         msdPtr(16),
+					MaximumSidDepth:         16,
 				},
 				&AssocTypeList{
 					AssocTypes: []AssocType{AssocTypePathProtectionAssociation, AssocTypeSRPolicyAssociation},
@@ -101,10 +102,20 @@ func TestPolaCapability(t *testing.T) {
 	}
 }
 
+func TestDefaultCapabilities(t *testing.T) {
+	caps := DefaultCapabilities()
+	require.Len(t, caps, 1)
+	statefulCap, ok := caps[0].(*StatefulPCECapability)
+	require.True(t, ok, "expected DefaultCapabilities to return a StatefulPCECapability")
+	assert.True(t, statefulCap.LSPUpdateCapability)
+	assert.True(t, statefulCap.LSPInstantiationCapability)
+	assert.True(t, statefulCap.ColorCapability)
+}
+
 func TestPolaCapability_OutputAlwaysSerializes(t *testing.T) {
 	caps := []CapabilityInterface{
 		&StatefulPCECapability{LSPUpdateCapability: true},
-		&SRPCECapability{MaximumSidDepth: msdPtr(16)},
+		&SRPCECapability{MaximumSidDepth: 16},
 		&PathSetupTypeCapability{PathSetupTypes: Psts{PathSetupTypeSRTE}},
 		&AssocTypeList{AssocTypes: []AssocType{AssocTypeSRPolicyAssociation}},
 		&LSPDBVersion{VersionNumber: 1},

--- a/pkg/packet/pcep/capability_test.go
+++ b/pkg/packet/pcep/capability_test.go
@@ -43,6 +43,42 @@ func TestDefaultCapabilities(t *testing.T) {
 	require.True(t, ok, "expected DefaultCapabilities[2] to be an AssocTypeList")
 	// RFC 9862 §5.2: a PCEP speaker MUST advertise the SRPA type before using it.
 	assert.Equal(t, []AssocType{AssocTypeSRPolicyAssociation}, assocCap.AssocTypes)
+	assert.NotContains(t, assocCap.AssocTypes, AssocTypeSRPolicyAssociationCisco)
+	assert.NotContains(t, assocCap.AssocTypes, AssocTypeSRPolicyAssociationJuniper)
+}
+
+func TestFlattenCapabilities(t *testing.T) {
+	t.Parallel()
+
+	statefulCap := &StatefulPCECapability{LSPUpdateCapability: true}
+	srCap := &SRPCECapability{HasUnlimitedMaxSIDDepth: true}
+	srv6Cap := &SRv6PCECapability{IsNAISupported: true}
+	pstCap := &PathSetupTypeCapability{
+		PathSetupTypes: Psts{PathSetupTypeSRTE, PathSetupTypeSRv6TE},
+		SubTLVs:        []TLVInterface{srCap, srv6Cap},
+	}
+
+	cases := map[string]struct {
+		input    []CapabilityInterface
+		expected []CapabilityInterface
+	}{
+		"Nil": {nil, []CapabilityInterface{}},
+		"TopLevelOnly": {
+			[]CapabilityInterface{statefulCap},
+			[]CapabilityInterface{statefulCap},
+		},
+		"PSTCapAppendsSubCapabilitiesAfterTopLevel": {
+			[]CapabilityInterface{statefulCap, pstCap},
+			[]CapabilityInterface{statefulCap, pstCap, srCap, srv6Cap},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.expected, FlattenCapabilities(c.input))
+		})
+	}
 }
 
 func TestDefaultCapabilities_WireRoundTrip(t *testing.T) {

--- a/pkg/packet/pcep/capability_test.go
+++ b/pkg/packet/pcep/capability_test.go
@@ -34,14 +34,14 @@ func TestPolaCapability(t *testing.T) {
 						&SRPCECapability{
 							HasUnlimitedMaxSIDDepth: false,
 							IsNAISupported:          false,
-							MaximumSidDepth:         uint8(16),
+							MaximumSidDepth:         msdPtr(16),
 						},
 					},
 				},
 				&SRPCECapability{
 					HasUnlimitedMaxSIDDepth: false,
 					IsNAISupported:          false,
-					MaximumSidDepth:         uint8(16),
+					MaximumSidDepth:         msdPtr(16),
 				},
 				&AssocTypeList{
 					AssocTypes: []AssocType{AssocTypePathProtectionAssociation, AssocTypeSRPolicyAssociation},
@@ -71,14 +71,14 @@ func TestPolaCapability(t *testing.T) {
 						&SRPCECapability{
 							HasUnlimitedMaxSIDDepth: false,
 							IsNAISupported:          false,
-							MaximumSidDepth:         uint8(16),
+							MaximumSidDepth:         msdPtr(16),
 						},
 					},
 				},
 				&SRPCECapability{
 					HasUnlimitedMaxSIDDepth: false,
 					IsNAISupported:          false,
-					MaximumSidDepth:         uint8(16),
+					MaximumSidDepth:         msdPtr(16),
 				},
 				&AssocTypeList{
 					AssocTypes: []AssocType{AssocTypePathProtectionAssociation, AssocTypeSRPolicyAssociation},
@@ -104,7 +104,7 @@ func TestPolaCapability(t *testing.T) {
 func TestPolaCapability_OutputAlwaysSerializes(t *testing.T) {
 	caps := []CapabilityInterface{
 		&StatefulPCECapability{LSPUpdateCapability: true},
-		&SRPCECapability{MaximumSidDepth: 16},
+		&SRPCECapability{MaximumSidDepth: msdPtr(16)},
 		&PathSetupTypeCapability{PathSetupTypes: Psts{PathSetupTypeSRTE}},
 		&AssocTypeList{AssocTypes: []AssocType{AssocTypeSRPolicyAssociation}},
 		&LSPDBVersion{VersionNumber: 1},

--- a/pkg/packet/pcep/capability_test.go
+++ b/pkg/packet/pcep/capability_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestDefaultCapabilities(t *testing.T) {
 	caps := DefaultCapabilities()
-	require.Len(t, caps, 3)
+	require.Len(t, caps, 4)
 
 	statefulCap, ok := caps[0].(*StatefulPCECapability)
 	require.True(t, ok, "expected DefaultCapabilities[0] to be a StatefulPCECapability")
@@ -45,6 +45,14 @@ func TestDefaultCapabilities(t *testing.T) {
 	assert.Equal(t, []AssocType{AssocTypeSRPolicyAssociation}, assocCap.AssocTypes)
 	assert.NotContains(t, assocCap.AssocTypes, AssocTypeSRPolicyAssociationCisco)
 	assert.NotContains(t, assocCap.AssocTypes, AssocTypeSRPolicyAssociationJuniper)
+
+	multipathCap, ok := caps[3].(*MultipathCapability)
+	require.True(t, ok, "expected DefaultCapabilities[3] to be a MultipathCapability")
+	assert.Equal(t, uint16(1), multipathCap.MaxMultipaths)
+	assert.False(t, multipathCap.IsWeightedSupported)
+	assert.False(t, multipathCap.IsOppositeDirSupported)
+	assert.False(t, multipathCap.IsForwardClassSupported)
+	assert.False(t, multipathCap.IsCompositePathSupported)
 }
 
 func TestFlattenCapabilities(t *testing.T) {

--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -276,6 +276,9 @@ func (m *PCErrMessage) DecodeFromBytes(messageBody []uint8) error {
 			}
 			m.SRPs = append(m.SRPs, srp)
 		case ObjectClassOpen:
+			if commonObjectHeader.ObjectType != ObjectTypeOpenOpen {
+				return fmt.Errorf("PCErr: unsupported OPEN ObjectType: %d", commonObjectHeader.ObjectType)
+			}
 			openObj := &OpenObject{}
 			if err := openObj.DecodeFromBytes(commonObjectHeader.ObjectType, body); err != nil {
 				return err

--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -216,9 +216,9 @@ func (m *OpenMessage) Serialize() ([]uint8, error) {
 }
 
 // NewOpenMessage creates a new OpenMessage.
-func NewOpenMessage(sessionID uint8, keepalive uint8, capabilities []CapabilityInterface) *OpenMessage {
+func NewOpenMessage(sessionID uint8, keepalive uint8, deadTimer uint8, capabilities []CapabilityInterface) *OpenMessage {
 	return &OpenMessage{
-		OpenObject: NewOpenObject(sessionID, keepalive, capabilities),
+		OpenObject: NewOpenObject(sessionID, keepalive, deadTimer, capabilities),
 	}
 }
 
@@ -244,6 +244,7 @@ func NewKeepaliveMessage() *KeepaliveMessage {
 type PCErrMessage struct {
 	Errors []*ErrorObject
 	SRPs   []*SrpObject
+	Open   *OpenObject
 }
 
 // DecodeFromBytes decodes the given bytes into the PCErrMessage.
@@ -274,6 +275,12 @@ func (m *PCErrMessage) DecodeFromBytes(messageBody []uint8) error {
 				return err
 			}
 			m.SRPs = append(m.SRPs, srp)
+		case ObjectClassOpen:
+			openObj := &OpenObject{}
+			if err := openObj.DecodeFromBytes(commonObjectHeader.ObjectType, body); err != nil {
+				return err
+			}
+			m.Open = openObj
 		}
 		offset += int(commonObjectHeader.ObjectLength)
 	}
@@ -286,7 +293,7 @@ func (m *PCErrMessage) DecodeFromBytes(messageBody []uint8) error {
 
 // Serialize encodes the PCErrMessage into bytes.
 func (m *PCErrMessage) Serialize() ([]uint8, error) {
-	objects := make([][]uint8, 0, len(m.SRPs)+len(m.Errors))
+	objects := make([][]uint8, 0, len(m.SRPs)+len(m.Errors)+1)
 	for _, srp := range m.SRPs {
 		b, err := srp.Serialize()
 		if err != nil {
@@ -296,6 +303,13 @@ func (m *PCErrMessage) Serialize() ([]uint8, error) {
 	}
 	for _, errObj := range m.Errors {
 		b, err := errObj.Serialize()
+		if err != nil {
+			return nil, err
+		}
+		objects = append(objects, b)
+	}
+	if m.Open != nil {
+		b, err := m.Open.Serialize()
 		if err != nil {
 			return nil, err
 		}
@@ -327,6 +341,14 @@ func (m *PCErrMessage) SRPIDs() []uint32 {
 func NewPCErrMessage(errorType uint8, errorValue uint8, tlvs []TLVInterface) *PCErrMessage {
 	return &PCErrMessage{
 		Errors: []*ErrorObject{NewErrorObject(errorType, errorValue, tlvs)},
+	}
+}
+
+// NewPCErrMessageWithOpen creates a PCErrMessage with an attached OPEN object.
+func NewPCErrMessageWithOpen(errorType uint8, errorValue uint8, openObject *OpenObject) *PCErrMessage {
+	return &PCErrMessage{
+		Errors: []*ErrorObject{NewErrorObject(errorType, errorValue, nil)},
+		Open:   openObject,
 	}
 }
 

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -270,7 +270,7 @@ func TestOpenMessage_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	want := NewOpenMessage(7, 30, 120, []CapabilityInterface{
-		&SRPCECapability{MaximumSidDepth: 10},
+		NewSRPCECapability(false, false, 10),
 	})
 
 	raw, err := want.Serialize()

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -887,6 +887,11 @@ func TestPCErrMessage_DecodeFromBytes_Errors(t *testing.T) {
 			NewCommonObjectHeader(ObjectClassOpen, ObjectTypeOpenOpen, commonObjectHeaderLength+4).Serialize(),
 			[]uint8{0x40, 0x00, 0x00, 0x00}, // unsupported PCEP version (2) in the OPEN object
 		),
+		"UnsupportedOpenObjectType": AppendByteSlices(
+			validError,
+			NewCommonObjectHeader(ObjectClassOpen, ObjectType(2), commonObjectHeaderLength+4).Serialize(),
+			[]uint8{0x20, 0x00, 0x00, 0x00},
+		),
 	}
 
 	for name, body := range cases {

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -38,6 +38,12 @@ func TestPCErrMessage_RoundTrip(t *testing.T) {
 				{ObjectType: ObjectTypeErrorError, ErrorType: 24, ErrorValue: 1},
 			},
 		},
+		"SingleErrorWithOpen": {
+			Errors: []*ErrorObject{
+				{ObjectType: ObjectTypeErrorError, ErrorType: 1, ErrorValue: 4},
+			},
+			Open: &OpenObject{ObjectType: ObjectTypeOpenOpen, Version: 1, Keepalive: 10, Deadtime: 40},
+		},
 		"MultipleSRPsAndErrors": {
 			SRPs: []*SrpObject{
 				{ObjectType: ObjectTypeSRPSRP, SrpID: 1},
@@ -98,6 +104,17 @@ func TestPCErrMessage_Serialize_Errors(t *testing.T) {
 		m := PCErrMessage{Errors: []*ErrorObject{{Tlvs: []TLVInterface{&UnknownTLV{Value: make([]byte, 65520)}}}}}
 		_, err := m.Serialize()
 		assert.ErrorContains(t, err, "exceeds")
+	})
+
+	t.Run("OpenSerializeError", func(t *testing.T) {
+		t.Parallel()
+
+		m := PCErrMessage{
+			Errors: []*ErrorObject{{ObjectType: ObjectTypeErrorError, ErrorType: 1, ErrorValue: 4}},
+			Open:   &OpenObject{Caps: []CapabilityInterface{&UnknownTLV{Value: make([]byte, 65536)}}},
+		}
+		_, err := m.Serialize()
+		assert.Error(t, err)
 	})
 }
 
@@ -252,7 +269,7 @@ func TestMessageType_StringWithReference(t *testing.T) {
 func TestOpenMessage_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	want := NewOpenMessage(7, 30, []CapabilityInterface{
+	want := NewOpenMessage(7, 30, 120, []CapabilityInterface{
 		&SRPCECapability{MaximumSidDepth: 10},
 	})
 
@@ -440,6 +457,19 @@ func TestNewPCErrMessage(t *testing.T) {
 
 	want := &PCErrMessage{
 		Errors: []*ErrorObject{{ObjectType: ObjectTypeErrorError, ErrorType: 6, ErrorValue: 1, Tlvs: tlvs}},
+	}
+	assert.Equal(t, want, m)
+}
+
+func TestNewPCErrMessageWithOpen(t *testing.T) {
+	t.Parallel()
+
+	openObject := NewOpenObject(0, 10, 40, nil)
+	m := NewPCErrMessageWithOpen(1, 4, openObject)
+
+	want := &PCErrMessage{
+		Errors: []*ErrorObject{{ObjectType: ObjectTypeErrorError, ErrorType: 1, ErrorValue: 4}},
+		Open:   openObject,
 	}
 	assert.Equal(t, want, m)
 }
@@ -834,6 +864,8 @@ func TestPCErrMessage_DecodeFromBytes_Errors(t *testing.T) {
 
 	validSRP, err := (&SrpObject{ObjectType: ObjectTypeSRPSRP, SrpID: 1}).Serialize()
 	require.NoError(t, err)
+	validError, err := (&ErrorObject{ObjectType: ObjectTypeErrorError, ErrorType: 6, ErrorValue: 1}).Serialize()
+	require.NoError(t, err)
 
 	cases := map[string][]uint8{
 		"TruncatedObjectHeader":        {0x01, 0x02},
@@ -850,6 +882,11 @@ func TestPCErrMessage_DecodeFromBytes_Errors(t *testing.T) {
 		),
 		// RFC 5440 §6.7 requires at least one PCEP-ERROR object.
 		"NoErrorObjectPresent": validSRP,
+		"MalformedOpenBody": AppendByteSlices(
+			validError,
+			NewCommonObjectHeader(ObjectClassOpen, ObjectTypeOpenOpen, commonObjectHeaderLength+4).Serialize(),
+			[]uint8{0x40, 0x00, 0x00, 0x00}, // unsupported PCEP version (2) in the OPEN object
+		),
 	}
 
 	for name, body := range cases {

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -186,7 +186,7 @@ func TestNewPCInitiateMessage_VendorObjectSelection(t *testing.T) {
 		"JuniperLegacy": {
 			pccType:         JuniperLegacy,
 			wantAssociation: true,
-			wantAssocType:   AssociationTypeSRPolicyAssociationJuniper,
+			wantAssocType:   AssocTypeSRPolicyAssociationJuniper,
 		},
 		"CiscoLegacy": {
 			pccType:        CiscoLegacy,
@@ -195,7 +195,7 @@ func TestNewPCInitiateMessage_VendorObjectSelection(t *testing.T) {
 		"RFCCompliant": {
 			pccType:         RFCCompliant,
 			wantAssociation: true,
-			wantAssocType:   AssociationTypeSRPolicyAssociation,
+			wantAssocType:   AssocTypeSRPolicyAssociation,
 			wantVendorInfo:  true,
 		},
 	}
@@ -572,7 +572,7 @@ func TestPCRptMessage_DecodeFromBytes(t *testing.T) {
 		metric2 := &MetricObject{ObjectType: ObjectType(1), BFlag: true, MetricType: 1}
 		lspa := &LSPAObject{ObjectType: ObjectType(1), SetupPriority: 7, HoldingPriority: 7, LFlag: true}
 		assoc := &AssociationObject{
-			ObjectType: ObjectTypeAssociationIPv4, AssocType: AssociationTypeSRPolicyAssociation,
+			ObjectType: ObjectTypeAssociationIPv4, AssocType: AssocTypeSRPolicyAssociation,
 			AssocID: 1, AssocSrc: netip.MustParseAddr("192.0.2.1"),
 		}
 		vendorInfo := &VendorInformationObject{ObjectType: ObjectTypeVendorSpecificConstraints, EnterpriseNumber: EnterpriseNumberCisco}

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1832,13 +1832,6 @@ const (
 	ObjectTypeAssociationIPv6 ObjectType = 0x02
 )
 
-// Association types for SR Policy associations, including legacy PCC values.
-const (
-	AssociationTypeSRPolicyAssociation        AssocType = 0x06   // standard
-	AssociationTypeSRPolicyAssociationCisco   AssocType = 0x14   // Cisco-specific
-	AssociationTypeSRPolicyAssociationJuniper AssocType = 0xffe1 // Juniper-specific (deprecated)
-)
-
 // PccType values, selecting how SR Policy attributes are encoded towards a PCC.
 const (
 	// CiscoLegacy encodes color and preference in a Cisco VENDOR-INFORMATION object.
@@ -1855,9 +1848,9 @@ func DeterminePccType(caps []CapabilityInterface) (pccType PccType) {
 	for _, cap := range caps {
 		if t, ok := cap.(*AssocTypeList); ok {
 			for _, v := range t.AssocTypes {
-				if v == AssociationTypeSRPolicyAssociationCisco {
+				if v == AssocTypeSRPolicyAssociationCisco {
 					pccType = CiscoLegacy
-				} else if v == AssociationTypeSRPolicyAssociationJuniper {
+				} else if v == AssocTypeSRPolicyAssociationJuniper {
 					pccType = JuniperLegacy
 					break
 				}
@@ -2006,7 +1999,7 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 			return nil, fmt.Errorf("invalid endpoint address for JuniperLegacy (NewAssociationObject): only IPv4 is supported, got dst=%v", dstAddr)
 		}
 		o.AssocID = 0
-		o.AssocType = AssociationTypeSRPolicyAssociationJuniper
+		o.AssocType = AssocTypeSRPolicyAssociationJuniper
 		associationObjectTLVs := []TLVInterface{
 			&ExtendedAssociationIDIPv4Juniper{
 				ExtendedAssociationID: ExtendedAssociationID{
@@ -2031,8 +2024,8 @@ func NewAssociationObject(srcAddr netip.Addr, dstAddr netip.Addr, color uint32, 
 		}
 		o.TLVs = append(o.TLVs, associationObjectTLVs...)
 	} else {
-		o.AssocID = 1                                    // (I.D. pce-segment-routing-policy-cp-07 5.1)
-		o.AssocType = AssociationTypeSRPolicyAssociation // (I.D. pce-segment-routing-policy-cp-07 5.1)
+		o.AssocID = 1                              // (I.D. pce-segment-routing-policy-cp-07 5.1)
+		o.AssocType = AssocTypeSRPolicyAssociation // (I.D. pce-segment-routing-policy-cp-07 5.1)
 		associationObjectTLVs := []TLVInterface{
 			&ExtendedAssociationID{
 				Color:    color,

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -302,13 +302,13 @@ func (o *OpenObject) Len() int {
 }
 
 // NewOpenObject creates a new OpenObject.
-func NewOpenObject(sessionID uint8, keepalive uint8, capabilities []CapabilityInterface) *OpenObject {
+func NewOpenObject(sessionID uint8, keepalive uint8, deadTimer uint8, capabilities []CapabilityInterface) *OpenObject {
 	return &OpenObject{
 		ObjectType: ObjectTypeOpenOpen,
 		Version:    uint8(1), // PCEP version. Current version is 1
 		Flag:       uint8(0),
 		Keepalive:  keepalive,
-		Deadtime:   DeadTimerFor(keepalive),
+		Deadtime:   deadTimer,
 		Sid:        sessionID,
 		Caps:       capabilities,
 	}

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -325,6 +325,22 @@ func DeadTimerFor(keepalive uint8) uint8 {
 	return uint8(d)
 }
 
+// ValidateTimers validates keepalive/deadTimer according to RFC 5440 §7.3.
+// A nil deadTimer uses the RFC-recommended default, DeadTimerFor(keepalive).
+func ValidateTimers(keepalive uint8, deadTimer *uint8) error {
+	resolved := DeadTimerFor(keepalive)
+	if deadTimer != nil {
+		resolved = *deadTimer
+	}
+	switch {
+	case keepalive == 0 && resolved != 0:
+		return errors.New("deadTimer must be 0 when keepalive is 0")
+	case keepalive != 0 && resolved != 0 && resolved <= keepalive:
+		return fmt.Errorf("deadTimer must be greater than keepalive (got deadTimer=%d, keepalive=%d)", resolved, keepalive)
+	}
+	return nil
+}
+
 // BandwidthObject is a PCEP Bandwidth object (RFC 5440 §7.7).
 type BandwidthObject struct {
 	ObjectType ObjectType

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -1197,20 +1197,20 @@ func TestAssociationObject_RoundTrip(t *testing.T) {
 	cases := map[string]AssociationObject{
 		"IPv4_NoTLVs": {
 			ObjectType: ObjectTypeAssociationIPv4,
-			AssocType:  AssociationTypeSRPolicyAssociation,
+			AssocType:  AssocTypeSRPolicyAssociation,
 			AssocID:    1,
 			AssocSrc:   v4,
 		},
 		"IPv4_RFlag": {
 			ObjectType: ObjectTypeAssociationIPv4,
 			RFlag:      true,
-			AssocType:  AssociationTypeSRPolicyAssociation,
+			AssocType:  AssocTypeSRPolicyAssociation,
 			AssocID:    1,
 			AssocSrc:   v4,
 		},
 		"IPv4_WithSRPolicyTLVs": {
 			ObjectType: ObjectTypeAssociationIPv4,
-			AssocType:  AssociationTypeSRPolicyAssociation,
+			AssocType:  AssocTypeSRPolicyAssociation,
 			AssocID:    1,
 			AssocSrc:   v4,
 			TLVs: []TLVInterface{
@@ -1231,13 +1231,13 @@ func TestAssociationObject_RoundTrip(t *testing.T) {
 		},
 		"IPv6_NoTLVs": {
 			ObjectType: ObjectTypeAssociationIPv6,
-			AssocType:  AssociationTypeSRPolicyAssociation,
+			AssocType:  AssocTypeSRPolicyAssociation,
 			AssocID:    1,
 			AssocSrc:   v6,
 		},
 		"IPv6_WithExtendedAssociationID": {
 			ObjectType: ObjectTypeAssociationIPv6,
-			AssocType:  AssociationTypeSRPolicyAssociation,
+			AssocType:  AssocTypeSRPolicyAssociation,
 			AssocID:    1,
 			AssocSrc:   v6,
 			TLVs: []TLVInterface{
@@ -2444,16 +2444,16 @@ func TestDeterminePccType(t *testing.T) {
 		"NoCaps":          {nil, RFCCompliant},
 		"NoAssocTypeList": {[]CapabilityInterface{&SRPCECapability{}}, RFCCompliant},
 		"CiscoAssocType": {
-			[]CapabilityInterface{&AssocTypeList{AssocTypes: []AssocType{AssociationTypeSRPolicyAssociationCisco}}},
+			[]CapabilityInterface{&AssocTypeList{AssocTypes: []AssocType{AssocTypeSRPolicyAssociationCisco}}},
 			CiscoLegacy,
 		},
 		"JuniperAssocType": {
-			[]CapabilityInterface{&AssocTypeList{AssocTypes: []AssocType{AssociationTypeSRPolicyAssociationJuniper}}},
+			[]CapabilityInterface{&AssocTypeList{AssocTypes: []AssocType{AssocTypeSRPolicyAssociationJuniper}}},
 			JuniperLegacy,
 		},
 		"JuniperWinsOverCisco": {
 			[]CapabilityInterface{&AssocTypeList{AssocTypes: []AssocType{
-				AssociationTypeSRPolicyAssociationCisco, AssociationTypeSRPolicyAssociationJuniper,
+				AssocTypeSRPolicyAssociationCisco, AssocTypeSRPolicyAssociationJuniper,
 			}}},
 			JuniperLegacy,
 		},
@@ -2473,7 +2473,7 @@ func TestAssociationObject_DecodeFromBytes_Errors(t *testing.T) {
 	v4Body := []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0xc0, 0x00, 0x02, 0x01}
 	v6Body := AppendByteSlices(
 		make([]uint8, 4),
-		Uint16ToByteSlice(uint16(AssociationTypeSRPolicyAssociation)),
+		Uint16ToByteSlice(uint16(AssocTypeSRPolicyAssociation)),
 		Uint16ToByteSlice(uint16(1)),
 		netip.MustParseAddr("2001:db8::1").AsSlice(),
 	)

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -667,7 +667,7 @@ func TestOpenObject_RoundTrip(t *testing.T) {
 				&SRPCECapability{
 					HasUnlimitedMaxSIDDepth: true,
 					IsNAISupported:          true,
-					MaximumSidDepth:         10,
+					MaximumSidDepth:         msdPtr(10),
 				},
 			},
 		},
@@ -681,7 +681,7 @@ func TestOpenObject_RoundTrip(t *testing.T) {
 				&SRPCECapability{
 					HasUnlimitedMaxSIDDepth: false,
 					IsNAISupported:          false,
-					MaximumSidDepth:         16,
+					MaximumSidDepth:         msdPtr(16),
 				},
 				&SRv6PCECapability{
 					IsNAISupported: true,
@@ -1771,7 +1771,7 @@ func TestCommonObjectHeader_DecodeFromBytes_TooShort(t *testing.T) {
 func TestNewOpenObject(t *testing.T) {
 	t.Parallel()
 
-	caps := []CapabilityInterface{&SRPCECapability{MaximumSidDepth: 10}}
+	caps := []CapabilityInterface{&SRPCECapability{MaximumSidDepth: msdPtr(10)}}
 	o := NewOpenObject(7, 30, DeadTimerFor(30), caps)
 
 	want := &OpenObject{

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -667,7 +667,7 @@ func TestOpenObject_RoundTrip(t *testing.T) {
 				&SRPCECapability{
 					HasUnlimitedMaxSIDDepth: true,
 					IsNAISupported:          true,
-					MaximumSidDepth:         msdPtr(10),
+					MaximumSidDepth:         10,
 				},
 			},
 		},
@@ -681,7 +681,7 @@ func TestOpenObject_RoundTrip(t *testing.T) {
 				&SRPCECapability{
 					HasUnlimitedMaxSIDDepth: false,
 					IsNAISupported:          false,
-					MaximumSidDepth:         msdPtr(16),
+					MaximumSidDepth:         16,
 				},
 				&SRv6PCECapability{
 					IsNAISupported: true,
@@ -752,6 +752,39 @@ func TestOpenObject_Serialize_ObjectLengthBoundary(t *testing.T) {
 	o := OpenObject{Caps: []CapabilityInterface{&UnknownTLV{Value: make([]byte, 65531)}}}
 	_, err := o.Serialize()
 	assert.ErrorContains(t, err, "exceeds")
+}
+
+func TestValidateTimers(t *testing.T) {
+	t.Parallel()
+
+	uint8Ptr := func(v uint8) *uint8 { return &v }
+
+	cases := map[string]struct {
+		keepalive uint8
+		deadTimer *uint8
+		wantErr   bool
+	}{
+		"NilDeadTimer_KeepaliveZero":       {keepalive: 0, deadTimer: nil, wantErr: false},
+		"NilDeadTimer_KeepaliveNonzero":    {keepalive: 30, deadTimer: nil, wantErr: false},
+		"ExplicitZero_KeepaliveZero":       {keepalive: 0, deadTimer: uint8Ptr(0), wantErr: false},
+		"ExplicitNonzero_KeepaliveZero":    {keepalive: 0, deadTimer: uint8Ptr(1), wantErr: true},
+		"ExplicitGreater_KeepaliveNonzero": {keepalive: 30, deadTimer: uint8Ptr(60), wantErr: false},
+		"ExplicitEqual_KeepaliveNonzero":   {keepalive: 30, deadTimer: uint8Ptr(30), wantErr: true},
+		"ExplicitLess_KeepaliveNonzero":    {keepalive: 30, deadTimer: uint8Ptr(10), wantErr: true},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateTimers(tt.keepalive, tt.deadTimer)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestLSPAObject_RoundTrip(t *testing.T) {
@@ -1771,7 +1804,7 @@ func TestCommonObjectHeader_DecodeFromBytes_TooShort(t *testing.T) {
 func TestNewOpenObject(t *testing.T) {
 	t.Parallel()
 
-	caps := []CapabilityInterface{&SRPCECapability{MaximumSidDepth: msdPtr(10)}}
+	caps := []CapabilityInterface{&SRPCECapability{MaximumSidDepth: 10}}
 	o := NewOpenObject(7, 30, DeadTimerFor(30), caps)
 
 	want := &OpenObject{

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -1772,7 +1772,7 @@ func TestNewOpenObject(t *testing.T) {
 	t.Parallel()
 
 	caps := []CapabilityInterface{&SRPCECapability{MaximumSidDepth: 10}}
-	o := NewOpenObject(7, 30, caps)
+	o := NewOpenObject(7, 30, DeadTimerFor(30), caps)
 
 	want := &OpenObject{
 		ObjectType: ObjectTypeOpenOpen,
@@ -1785,11 +1785,11 @@ func TestNewOpenObject(t *testing.T) {
 	assert.Equal(t, want, o)
 }
 
-func TestNewOpenObject_DeadtimeClampsInsteadOfWrapping(t *testing.T) {
+func TestNewOpenObject_UsesGivenDeadtime(t *testing.T) {
 	t.Parallel()
 
-	o := NewOpenObject(7, 65, nil)
-	assert.Equal(t, uint8(math.MaxUint8), o.Deadtime)
+	o := NewOpenObject(7, 30, 0, nil)
+	assert.Zero(t, o.Deadtime)
 }
 
 func TestDeadTimerFor(t *testing.T) {

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -898,19 +898,17 @@ func NewLSPDBVersion(version uint64) *LSPDBVersion {
 
 // SRPCECapability represents the SR-PCE-CAPABILITY TLV, advertising the
 // maximum SID depth (MSD) for SR-MPLS paths and NAI support (RFC 8664).
+// The MSD octet is always present on the wire and is 0 when unlimited.
 type SRPCECapability struct {
 	HasUnlimitedMaxSIDDepth bool
 	IsNAISupported          bool
-	MaximumSidDepth         *uint8
+	MaximumSidDepth         uint8
 }
 
-// Flag bits of the SR-PCE-CAPABILITY TLV, as masks against its Flags byte.
+// Flag bits of the SR-PCE-CAPABILITY TLV.
 const (
-	// UnlimitedMaximumSIDDepthFlag means the speaker imposes no MSD limit, so
-	// the Maximum SID Depth field must be ignored.
 	UnlimitedMaximumSIDDepthFlag byte = 0x01
-	// NAISupportedFlag means the speaker can resolve a NAI in an SR-ERO subobject.
-	NAISupportedFlag byte = 0x02
+	NAISupportedFlag             byte = 0x02
 )
 
 // Byte offsets of the fields within the SR-PCE-CAPABILITY TLV value.
@@ -935,8 +933,7 @@ func (tlv *SRPCECapability) DecodeFromBytes(data []byte) error {
 	flags := val[SRPCECapabilityFlagsOffset]
 	tlv.HasUnlimitedMaxSIDDepth = IsBitSet(flags, UnlimitedMaximumSIDDepthFlag)
 	tlv.IsNAISupported = IsBitSet(flags, NAISupportedFlag)
-	msd := val[SRPCECapabilityMSDOffset]
-	tlv.MaximumSidDepth = &msd
+	tlv.MaximumSidDepth = val[SRPCECapabilityMSDOffset]
 
 	return nil
 }
@@ -947,9 +944,7 @@ func (tlv *SRPCECapability) Serialize() ([]byte, error) {
 
 	value[SRPCECapabilityFlagsOffset] = SetBit(value[SRPCECapabilityFlagsOffset], UnlimitedMaximumSIDDepthFlag, tlv.HasUnlimitedMaxSIDDepth)
 	value[SRPCECapabilityFlagsOffset] = SetBit(value[SRPCECapabilityFlagsOffset], NAISupportedFlag, tlv.IsNAISupported)
-	if tlv.MaximumSidDepth != nil {
-		value[SRPCECapabilityMSDOffset] = *tlv.MaximumSidDepth
-	}
+	value[SRPCECapabilityMSDOffset] = tlv.MaximumSidDepth
 
 	return AppendByteSlices(
 		Uint16ToByteSlice(tlv.Type()),
@@ -966,9 +961,7 @@ func (tlv *SRPCECapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 	enc.AddBool("unlimited_max_sid_depth", tlv.HasUnlimitedMaxSIDDepth)
 	enc.AddBool("nai_is_supported", tlv.IsNAISupported)
-	if tlv.MaximumSidDepth != nil {
-		enc.AddUint8("maximum_sid_depth", *tlv.MaximumSidDepth)
-	}
+	enc.AddUint8("maximum_sid_depth", tlv.MaximumSidDepth)
 	return nil
 }
 
@@ -985,11 +978,10 @@ func (tlv *SRPCECapability) Len() int {
 // CapStrings returns capability strings for the receiver.
 func (tlv *SRPCECapability) CapStrings() []string {
 	ret := []string{"SR"}
-	switch {
-	case tlv.HasUnlimitedMaxSIDDepth:
+	if tlv.HasUnlimitedMaxSIDDepth {
 		ret = append(ret, "Unlimited-SID-Depth")
-	case tlv.MaximumSidDepth != nil:
-		ret = append(ret, fmt.Sprintf("MSD=%d", *tlv.MaximumSidDepth))
+	} else {
+		ret = append(ret, fmt.Sprintf("MSD=%d", tlv.MaximumSidDepth))
 	}
 	if tlv.IsNAISupported {
 		ret = append(ret, "SR-NAI-Supported")
@@ -997,12 +989,18 @@ func (tlv *SRPCECapability) CapStrings() []string {
 	return ret
 }
 
+// HasInvalidZeroMSD reports the invalid RFC 8664 §5.1 combination of
+// X=0 and MSD=0.
+func (tlv *SRPCECapability) HasInvalidZeroMSD() bool {
+	return !tlv.HasUnlimitedMaxSIDDepth && tlv.MaximumSidDepth == 0
+}
+
 // NewSRPCECapability creates and returns a new SRPCECapability.
 func NewSRPCECapability(hasUnlimitedMaxSIDDepth bool, isNAISupported bool, maximumSidDepth uint8) *SRPCECapability {
 	return &SRPCECapability{
 		HasUnlimitedMaxSIDDepth: hasUnlimitedMaxSIDDepth,
 		IsNAISupported:          isNAISupported,
-		MaximumSidDepth:         &maximumSidDepth,
+		MaximumSidDepth:         maximumSidDepth,
 	}
 }
 

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1696,6 +1696,12 @@ const (
 	AssocTypeP2MPSRPolicyAssociation                AssocType = 0x09
 )
 
+// Vendor-specific Association Type values used for legacy PCC interoperability.
+const (
+	AssocTypeSRPolicyAssociationCisco   AssocType = 0x14   // Cisco-specific
+	AssocTypeSRPolicyAssociationJuniper AssocType = 0xffe1 // Juniper-specific (deprecated)
+)
+
 var assocTypeDescriptions = map[AssocType]struct {
 	Description string
 	Reference   string
@@ -1709,6 +1715,8 @@ var assocTypeDescriptions = map[AssocType]struct {
 	AssocTypeVnAssociationType:                      {"VN Association Type", "RFC9358"},
 	AssocTypeBidirectionalSRLSPAssociation:          {"Bidirectional SR LSP Association", "draft-ietf-pce-sr-bidir-path-25"},
 	AssocTypeP2MPSRPolicyAssociation:                {"P2MP SR Policy Association", "draft-ietf-pce-sr-p2mp-policy-11"},
+	AssocTypeSRPolicyAssociationCisco:               {"SR Policy Association (Cisco-specific)", "not IANA-assigned"},
+	AssocTypeSRPolicyAssociationJuniper:             {"SR Policy Association (Juniper-specific, deprecated)", "not IANA-assigned"},
 }
 
 // String returns the display name of the association type, suffixing

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -911,10 +911,12 @@ const (
 	NAISupportedFlag             byte = 0x02
 )
 
-// Byte offsets of the fields within the SR-PCE-CAPABILITY TLV value.
+// Field offsets in the SR-PCE-CAPABILITY TLV value (RFC 8664 §5.1.1):
+// Reserved (2 octets), Flags (1 octet), MSD (1 octet).
+// Reserved octets MUST be zero when sent and MUST be ignored when received.
 const (
-	SRPCECapabilityFlagsOffset = 0
-	SRPCECapabilityMSDOffset   = 1
+	SRPCECapabilityFlagsOffset = 2
+	SRPCECapabilityMSDOffset   = 3
 )
 
 // DecodeFromBytes decodes the given bytes into the receiver.

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -1679,6 +1679,23 @@ func (tlv *PathSetupTypeCapability) CapStrings() []string {
 	return ret
 }
 
+// SubCapabilities returns the receiver's sub-TLVs that implement
+// CapabilityInterface.
+func (tlv *PathSetupTypeCapability) SubCapabilities() []CapabilityInterface {
+	ret := make([]CapabilityInterface, 0, len(tlv.SubTLVs))
+	for _, subTLV := range tlv.SubTLVs {
+		if c, ok := subTLV.(CapabilityInterface); ok {
+			ret = append(ret, c)
+		}
+	}
+	return ret
+}
+
+// HasPathSetupType reports whether the receiver advertises the given PST.
+func (tlv *PathSetupTypeCapability) HasPathSetupType(pst Pst) bool {
+	return slices.Contains(tlv.PathSetupTypes[:tlv.pstCount()], pst)
+}
+
 // AssocType is the association type of an ASSOCIATION object, identifying
 // what the associated LSPs have in common (RFC 8697).
 type AssocType uint16

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -14,6 +14,7 @@ import (
 	"net/netip"
 	"slices"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 
 	"go.uber.org/zap/zapcore"
@@ -186,6 +187,22 @@ func (t TLVType) String() string {
 		return fmt.Sprintf("%s (%s)", desc.Description, desc.Reference)
 	}
 	return fmt.Sprintf("Unknown TLV (0x%04x)", uint16(t))
+}
+
+// Name returns the registered name of the TLV type, or "" if unregistered.
+func (t TLVType) Name() string {
+	if desc, ok := tlvDescriptions[t]; ok {
+		return desc.Description
+	}
+	return ""
+}
+
+// Reference returns the defining document of the TLV type, or "" if unregistered.
+func (t TLVType) Reference() string {
+	if desc, ok := tlvDescriptions[t]; ok {
+		return desc.Reference
+	}
+	return ""
 }
 
 // IPv4AddrLen is the byte length of an IPv4 address.
@@ -884,7 +901,7 @@ func NewLSPDBVersion(version uint64) *LSPDBVersion {
 type SRPCECapability struct {
 	HasUnlimitedMaxSIDDepth bool
 	IsNAISupported          bool
-	MaximumSidDepth         uint8
+	MaximumSidDepth         *uint8
 }
 
 // Flag bits of the SR-PCE-CAPABILITY TLV, as masks against its Flags byte.
@@ -918,7 +935,8 @@ func (tlv *SRPCECapability) DecodeFromBytes(data []byte) error {
 	flags := val[SRPCECapabilityFlagsOffset]
 	tlv.HasUnlimitedMaxSIDDepth = IsBitSet(flags, UnlimitedMaximumSIDDepthFlag)
 	tlv.IsNAISupported = IsBitSet(flags, NAISupportedFlag)
-	tlv.MaximumSidDepth = val[SRPCECapabilityMSDOffset]
+	msd := val[SRPCECapabilityMSDOffset]
+	tlv.MaximumSidDepth = &msd
 
 	return nil
 }
@@ -929,7 +947,9 @@ func (tlv *SRPCECapability) Serialize() ([]byte, error) {
 
 	value[SRPCECapabilityFlagsOffset] = SetBit(value[SRPCECapabilityFlagsOffset], UnlimitedMaximumSIDDepthFlag, tlv.HasUnlimitedMaxSIDDepth)
 	value[SRPCECapabilityFlagsOffset] = SetBit(value[SRPCECapabilityFlagsOffset], NAISupportedFlag, tlv.IsNAISupported)
-	value[SRPCECapabilityMSDOffset] = tlv.MaximumSidDepth
+	if tlv.MaximumSidDepth != nil {
+		value[SRPCECapabilityMSDOffset] = *tlv.MaximumSidDepth
+	}
 
 	return AppendByteSlices(
 		Uint16ToByteSlice(tlv.Type()),
@@ -946,7 +966,9 @@ func (tlv *SRPCECapability) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 	enc.AddBool("unlimited_max_sid_depth", tlv.HasUnlimitedMaxSIDDepth)
 	enc.AddBool("nai_is_supported", tlv.IsNAISupported)
-	enc.AddUint8("maximum_sid_depth", tlv.MaximumSidDepth)
+	if tlv.MaximumSidDepth != nil {
+		enc.AddUint8("maximum_sid_depth", *tlv.MaximumSidDepth)
+	}
 	return nil
 }
 
@@ -963,10 +985,11 @@ func (tlv *SRPCECapability) Len() int {
 // CapStrings returns capability strings for the receiver.
 func (tlv *SRPCECapability) CapStrings() []string {
 	ret := []string{"SR"}
-	if tlv.HasUnlimitedMaxSIDDepth {
+	switch {
+	case tlv.HasUnlimitedMaxSIDDepth:
 		ret = append(ret, "Unlimited-SID-Depth")
-	} else {
-		ret = append(ret, fmt.Sprintf("MSD=%d", tlv.MaximumSidDepth))
+	case tlv.MaximumSidDepth != nil:
+		ret = append(ret, fmt.Sprintf("MSD=%d", *tlv.MaximumSidDepth))
 	}
 	if tlv.IsNAISupported {
 		ret = append(ret, "SR-NAI-Supported")
@@ -979,7 +1002,7 @@ func NewSRPCECapability(hasUnlimitedMaxSIDDepth bool, isNAISupported bool, maxim
 	return &SRPCECapability{
 		HasUnlimitedMaxSIDDepth: hasUnlimitedMaxSIDDepth,
 		IsNAISupported:          isNAISupported,
-		MaximumSidDepth:         maximumSidDepth,
+		MaximumSidDepth:         &maximumSidDepth,
 	}
 }
 
@@ -1662,7 +1685,7 @@ func (tlv *PathSetupTypeCapability) CapStrings() []string {
 // what the associated LSPs have in common (RFC 8697).
 type AssocType uint16
 
-// IANA-assigned association types. assocTypeNames holds their names.
+// IANA-assigned association types (see the IANA PCEP "Association Type Field" registry).
 const (
 	AssocTypePathProtectionAssociation              AssocType = 0x01
 	AssocTypeDisjointAssociation                    AssocType = 0x02
@@ -1671,24 +1694,36 @@ const (
 	AssocTypeDoubleSidedBidirectionalLSPAssociation AssocType = 0x05
 	AssocTypeSRPolicyAssociation                    AssocType = 0x06
 	AssocTypeVnAssociationType                      AssocType = 0x07
+	AssocTypeBidirectionalSRLSPAssociation          AssocType = 0x08
+	AssocTypeP2MPSRPolicyAssociation                AssocType = 0x09
 )
 
-//nolint:gosec // G101: these are RFC 8697 association-type display names, not credentials.
-var assocTypeNames = map[AssocType]string{
-	AssocTypePathProtectionAssociation:              "Path Protection Association",
-	AssocTypeDisjointAssociation:                    "Disjoint Association",
-	AssocTypePolicyAssociation:                      "Policy Association",
-	AssocTypeSingleSidedBidirectionalLSPAssociation: "Single Sided Bidirectional LSP Association",
-	AssocTypeDoubleSidedBidirectionalLSPAssociation: "Double Sided Bidirectional LSP Association",
-	AssocTypeSRPolicyAssociation:                    "SR Policy Association",
-	AssocTypeVnAssociationType:                      "VN Association Type",
+var assocTypeDescriptions = map[AssocType]struct {
+	Description string
+	Reference   string
+}{
+	AssocTypePathProtectionAssociation:              {"Path Protection Association", "RFC8745"},
+	AssocTypeDisjointAssociation:                    {"Disjoint Association", "RFC8800"},
+	AssocTypePolicyAssociation:                      {"Policy Association", "RFC9005"},
+	AssocTypeSingleSidedBidirectionalLSPAssociation: {"Single Sided Bidirectional LSP Association", "RFC9059"},
+	AssocTypeDoubleSidedBidirectionalLSPAssociation: {"Double Sided Bidirectional LSP Association", "RFC9059"},
+	AssocTypeSRPolicyAssociation:                    {"SR Policy Association", "RFC9862"},
+	AssocTypeVnAssociationType:                      {"VN Association Type", "RFC9358"},
+	AssocTypeBidirectionalSRLSPAssociation:          {"Bidirectional SR LSP Association", "draft-ietf-pce-sr-bidir-path-25"},
+	AssocTypeP2MPSRPolicyAssociation:                {"P2MP SR Policy Association", "draft-ietf-pce-sr-p2mp-policy-11"},
 }
 
+// String returns the display name of the association type, suffixing
+// draft-defined types with " (draft)".
 func (at AssocType) String() string {
-	if name, ok := assocTypeNames[at]; ok {
-		return name
+	desc, ok := assocTypeDescriptions[at]
+	if !ok {
+		return fmt.Sprintf("Unknown AssocType (0x%04x)", uint16(at))
 	}
-	return fmt.Sprintf("Unknown AssocType (0x%04x)", uint16(at))
+	if strings.HasPrefix(desc.Reference, "draft-") {
+		return desc.Description + " (draft)"
+	}
+	return desc.Description
 }
 
 // AssocTypeList represents the ASSOC-TYPE-LIST TLV, advertising the

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1316,6 +1316,63 @@ func TestPathSetupTypeCapability_CapStrings(t *testing.T) {
 	runCapStringsTests(t, cases)
 }
 
+func TestPathSetupTypeCapability_SubCapabilities(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		input    *PathSetupTypeCapability
+		expected []CapabilityInterface
+	}{
+		"NoSubTLVs": {
+			&PathSetupTypeCapability{},
+			[]CapabilityInterface{},
+		},
+		"SRAndSRv6": {
+			&PathSetupTypeCapability{SubTLVs: []TLVInterface{
+				&SRPCECapability{HasUnlimitedMaxSIDDepth: true},
+				&SRv6PCECapability{IsNAISupported: true},
+			}},
+			[]CapabilityInterface{
+				&SRPCECapability{HasUnlimitedMaxSIDDepth: true},
+				&SRv6PCECapability{IsNAISupported: true},
+			},
+		},
+		"KeepsUnknownTLV": {
+			&PathSetupTypeCapability{SubTLVs: []TLVInterface{
+				&UnknownTLV{Typ: TLVType(0x1234), Value: []byte{0x01}},
+			}},
+			[]CapabilityInterface{
+				&UnknownTLV{Typ: TLVType(0x1234), Value: []byte{0x01}},
+			},
+		},
+		"DropsNonCapabilityTLV": {
+			&PathSetupTypeCapability{SubTLVs: []TLVInterface{
+				&PathSetupType{PathSetupType: PathSetupTypeSRTE},
+				&SRPCECapability{HasUnlimitedMaxSIDDepth: true},
+			}},
+			[]CapabilityInterface{
+				&SRPCECapability{HasUnlimitedMaxSIDDepth: true},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.expected, c.input.SubCapabilities())
+		})
+	}
+}
+
+func TestPathSetupTypeCapability_HasPathSetupType(t *testing.T) {
+	t.Parallel()
+
+	tlv := &PathSetupTypeCapability{PathSetupTypes: Psts{PathSetupTypeSRTE}}
+
+	assert.True(t, tlv.HasPathSetupType(PathSetupTypeSRTE))
+	assert.False(t, tlv.HasPathSetupType(PathSetupTypeSRv6TE))
+}
+
 func TestAssocType_String(t *testing.T) {
 	cases := map[string]struct {
 		input    AssocType

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -805,11 +805,12 @@ func TestLSPDBVersion_CapStrings(t *testing.T) {
 
 // Test data for SRPCECapability.
 var (
-	testSRPCECapability                      = NewSRPCECapability(true, true, 10)
-	testSRPCECapabilityBytes                 = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x0a, 0x00, 0x00)
+	testSRPCECapability = NewSRPCECapability(true, true, 10)
+	// RFC 8664 §5.1.1: Reserved (2), Flags (1), MSD (1).
+	testSRPCECapabilityBytes                 = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x00, 0x03, 0x0a)
 	testSRPCECapabilityTruncated             = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x02)
-	testSRPCECapabilityExtra                 = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
-	testSRPCECapabilityInvalidLength         = append(tlvHeader(TLVSRPCECapability, 8), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
+	testSRPCECapabilityExtra                 = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x00, 0x03, 0x05, 0xde, 0xad, 0xbe, 0xef)
+	testSRPCECapabilityInvalidLength         = append(tlvHeader(TLVSRPCECapability, 8), 0x00, 0x00, 0x03, 0x05, 0xde, 0xad, 0xbe, 0xef)
 	testSRPCECapabilityZeroMSDBytes          = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x00, 0x00, 0x00)
 	testSRPCECapabilityAllEnabled            = &SRPCECapability{HasUnlimitedMaxSIDDepth: true, IsNAISupported: true}
 	testSRPCECapabilityUnlimitedOnly         = &SRPCECapability{HasUnlimitedMaxSIDDepth: true}
@@ -844,6 +845,88 @@ func TestSRPCECapability_Serialize(t *testing.T) {
 		"ValidSRPCECapability": {testSRPCECapability, testSRPCECapabilityBytes},
 	}
 	runTLVSerializeTests(t, cases)
+}
+
+func TestSRPCECapability_Serialize_WireFormat(t *testing.T) {
+	cases := map[string]struct {
+		input         *SRPCECapability
+		expectedFlags uint8
+		expectedMSD   uint8
+	}{
+		"NoFlagsMSD5":         {&SRPCECapability{MaximumSidDepth: 5}, 0x00, 5},
+		"NoFlagsMSD10":        {&SRPCECapability{MaximumSidDepth: 10}, 0x00, 10},
+		"UnlimitedMSDOnly":    {&SRPCECapability{HasUnlimitedMaxSIDDepth: true}, 0x01, 0},
+		"NAIOnlyWithMSD":      {&SRPCECapability{IsNAISupported: true, MaximumSidDepth: 8}, 0x02, 8},
+		"BothFlagsWithMSD255": {NewSRPCECapability(true, true, 255), 0x03, 255},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := tt.input.Serialize()
+			require.NoError(t, err, "Serialize failed for '%s'", name)
+			require.Len(t, got, int(TLVValueOffset+TLVSRPCECapabilityValueLength))
+
+			value := got[TLVValueOffset:]
+			assert.Equal(t, []uint8{0x00, 0x00}, value[0:2], "Reserved octets must be zero")
+			assert.Equal(t, tt.expectedFlags, value[SRPCECapabilityFlagsOffset], "Flags in wrong byte position")
+			assert.Equal(t, tt.expectedMSD, value[SRPCECapabilityMSDOffset], "MSD in wrong byte position")
+		})
+	}
+}
+
+func TestSRPCECapability_DecodeFromBytes_WireFormat(t *testing.T) {
+	cases := map[string]struct {
+		value    []uint8
+		expected *SRPCECapability
+	}{
+		// Junos: MSD=5; Cisco IOS-XR: MSD=10; no flags.
+		"MSD5":  {[]uint8{0x00, 0x00, 0x00, 0x05}, &SRPCECapability{MaximumSidDepth: 5}},
+		"MSD10": {[]uint8{0x00, 0x00, 0x00, 0x0a}, &SRPCECapability{MaximumSidDepth: 10}},
+		"XFlag": {[]uint8{0x00, 0x00, 0x01, 0x00}, &SRPCECapability{HasUnlimitedMaxSIDDepth: true}},
+		"NFlagWithMSD": {
+			[]uint8{0x00, 0x00, 0x02, 0x04},
+			&SRPCECapability{IsNAISupported: true, MaximumSidDepth: 4},
+		},
+		"BothFlags": {
+			[]uint8{0x00, 0x00, 0x03, 0x0a},
+			&SRPCECapability{HasUnlimitedMaxSIDDepth: true, IsNAISupported: true, MaximumSidDepth: 10},
+		},
+		"NonZeroReservedIsIgnored": {
+			[]uint8{0xde, 0xad, 0x00, 0x05},
+			&SRPCECapability{MaximumSidDepth: 5},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			var tlv SRPCECapability
+			err := tlv.DecodeFromBytes(append(tlvHeader(TLVSRPCECapability, 4), tt.value...))
+			require.NoError(t, err, "DecodeFromBytes failed for '%s'", name)
+			assert.Equal(t, tt.expected, &tlv, "unexpected decode result for '%s'", name)
+		})
+	}
+}
+
+func TestSRPCECapability_RoundTrip(t *testing.T) {
+	cases := map[string]*SRPCECapability{
+		"Empty":        {},
+		"MSD5":         {MaximumSidDepth: 5},
+		"MSD10":        {MaximumSidDepth: 10},
+		"UnlimitedMSD": {HasUnlimitedMaxSIDDepth: true},
+		"NAIWithMSD":   {IsNAISupported: true, MaximumSidDepth: 8},
+		"AllFields":    NewSRPCECapability(true, true, 10),
+	}
+
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			raw, err := want.Serialize()
+			require.NoError(t, err, "Serialize failed for '%s'", name)
+
+			var got SRPCECapability
+			require.NoError(t, got.DecodeFromBytes(raw), "DecodeFromBytes failed for '%s'", name)
+			assert.Equal(t, want, &got, "round-trip mismatch for '%s'", name)
+		})
+	}
 }
 
 func TestSRPCECapability_MarshalLogObject(t *testing.T) {
@@ -1128,7 +1211,7 @@ var (
 		0x00, 0x22, 0x00, 0x10,
 		0x00, 0x00, 0x00, 0x01,
 		0x01, 0x00, 0x00, 0x00,
-		0x00, 0x1a, 0x00, 0x04, 0x03, 0x0a, 0x00, 0x00,
+		0x00, 0x1a, 0x00, 0x04, 0x00, 0x00, 0x03, 0x0a,
 	}
 
 	// Invalid / error test cases

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1330,6 +1330,8 @@ func TestAssocType_String(t *testing.T) {
 		"VnAssociation":    {AssocTypeVnAssociationType, "VN Association Type"},
 		"BidirSRLSP":       {AssocTypeBidirectionalSRLSPAssociation, "Bidirectional SR LSP Association (draft)"},
 		"P2MPSRPolicy":     {AssocTypeP2MPSRPolicyAssociation, "P2MP SR Policy Association (draft)"},
+		"SRPolicyCisco":    {AssocTypeSRPolicyAssociationCisco, "SR Policy Association (Cisco-specific)"},
+		"SRPolicyJuniper":  {AssocTypeSRPolicyAssociationJuniper, "SR Policy Association (Juniper-specific, deprecated)"},
 		"Unknown":          {AssocType(0xffff), "Unknown AssocType (0xffff)"},
 	}
 

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -8,6 +8,7 @@ package pcep
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"net/netip"
 	"slices"
 	"strings"
@@ -802,8 +803,6 @@ func TestLSPDBVersion_CapStrings(t *testing.T) {
 	assert.Equal(t, testLSPDBVersionCapStrings, actual, "CapStrings() did not return expected value")
 }
 
-func msdPtr(v uint8) *uint8 { return &v }
-
 // Test data for SRPCECapability.
 var (
 	testSRPCECapability                      = NewSRPCECapability(true, true, 10)
@@ -818,11 +817,11 @@ var (
 	testSRPCECapabilityNoneEnabled           = &SRPCECapability{}
 	testSRPCECapabilityAllEnabledStrs        = []string{"SR", "Unlimited-SID-Depth", "SR-NAI-Supported"}
 	testSRPCECapabilityUnlimitedStrs         = []string{"SR", "Unlimited-SID-Depth"}
-	testSRPCECapabilityNAIStrs               = []string{"SR", "SR-NAI-Supported"}
-	testSRPCECapabilityMSDOnly               = &SRPCECapability{MaximumSidDepth: msdPtr(10)}
+	testSRPCECapabilityNAIStrs               = []string{"SR", "MSD=0", "SR-NAI-Supported"}
+	testSRPCECapabilityMSDOnly               = &SRPCECapability{MaximumSidDepth: 10}
 	testSRPCECapabilityMSDOnlyStrs           = []string{"SR", "MSD=10"}
-	testSRPCECapabilityNoneStrs              = []string{"SR"}
-	testSRPCECapabilityMSDZeroAdvertised     = &SRPCECapability{MaximumSidDepth: msdPtr(0)}
+	testSRPCECapabilityNoneStrs              = []string{"SR", "MSD=0"}
+	testSRPCECapabilityMSDZeroAdvertised     = &SRPCECapability{MaximumSidDepth: 0}
 	testSRPCECapabilityMSDZeroAdvertisedStrs = []string{"SR", "MSD=0"}
 )
 
@@ -858,6 +857,7 @@ func TestSRPCECapability_MarshalLogObject(t *testing.T) {
 			map[string]any{
 				"unlimited_max_sid_depth": false,
 				"nai_is_supported":        false,
+				"maximum_sid_depth":       uint8(0),
 			},
 		},
 		"FullTLV": {
@@ -873,6 +873,7 @@ func TestSRPCECapability_MarshalLogObject(t *testing.T) {
 			map[string]any{
 				"unlimited_max_sid_depth": true,
 				"nai_is_supported":        false,
+				"maximum_sid_depth":       uint8(0),
 			},
 		},
 		"OnlyNAI": {
@@ -880,6 +881,7 @@ func TestSRPCECapability_MarshalLogObject(t *testing.T) {
 			map[string]any{
 				"unlimited_max_sid_depth": false,
 				"nai_is_supported":        true,
+				"maximum_sid_depth":       uint8(0),
 			},
 		},
 	}
@@ -917,6 +919,54 @@ func TestSRPCECapability_CapStrings(t *testing.T) {
 		"MSDAdvertisedAsZero":             {testSRPCECapabilityMSDZeroAdvertised, testSRPCECapabilityMSDZeroAdvertisedStrs},
 	}
 	runCapStringsTests(t, cases)
+}
+
+func TestSRPCECapability_DecodeSerializeRoundTrip(t *testing.T) {
+	cases := map[string]*SRPCECapability{
+		"MSDNonZero":       {MaximumSidDepth: 200},
+		"MSDMax":           {MaximumSidDepth: math.MaxUint8},
+		"UnlimitedZeroMSD": {HasUnlimitedMaxSIDDepth: true},
+		"UnlimitedWithNAIZeroMSD": {
+			HasUnlimitedMaxSIDDepth: true,
+			IsNAISupported:          true,
+		},
+	}
+
+	for name, original := range cases {
+		t.Run(name, func(t *testing.T) {
+			b, err := original.Serialize()
+			require.NoError(t, err)
+
+			var decoded SRPCECapability
+			require.NoError(t, decoded.DecodeFromBytes(b))
+			assert.Equal(t, original, &decoded, "first decode must match the original")
+
+			b2, err := decoded.Serialize()
+			require.NoError(t, err)
+			assert.Equal(t, b, b2, "re-serializing a decoded value must produce identical bytes")
+
+			var decodedAgain SRPCECapability
+			require.NoError(t, decodedAgain.DecodeFromBytes(b2))
+			assert.Equal(t, decoded, decodedAgain, "second decode must match the first")
+		})
+	}
+}
+
+func TestSRPCECapability_HasInvalidZeroMSD(t *testing.T) {
+	cases := map[string]struct {
+		input    *SRPCECapability
+		expected bool
+	}{
+		"XZeroMSDZero":        {&SRPCECapability{}, true},
+		"XZeroMSDNonZero":     {&SRPCECapability{MaximumSidDepth: 10}, false},
+		"XOneMSDZero":         {&SRPCECapability{HasUnlimitedMaxSIDDepth: true}, false},
+		"XZeroNAIOnlyMSDZero": {&SRPCECapability{IsNAISupported: true}, true},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.input.HasInvalidZeroMSD())
+		})
+	}
 }
 
 func TestPst_String(t *testing.T) {

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -36,6 +36,25 @@ func TestTLVType_String(t *testing.T) {
 	}
 }
 
+func TestTLVType_NameAndReference(t *testing.T) {
+	cases := map[string]struct {
+		tlvType      TLVType
+		expectedName string
+		expectedRef  string
+	}{
+		"StatefulPCECapability": {TLVStatefulPCECapability, "STATEFUL-PCE-CAPABILITY", "RFC8231"},
+		"MultipathCap":          {TLVMultipathCap, "MULTIPATH-CAP", "draft-ietf-pce-multipath-07"},
+		"UnknownType":           {TLVType(0xdead), "", ""},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedName, tt.tlvType.Name(), "unexpected TLVType.Name() result")
+			assert.Equal(t, tt.expectedRef, tt.tlvType.Reference(), "unexpected TLVType.Reference() result")
+		})
+	}
+}
+
 func TestTLVMap(t *testing.T) {
 	cases := map[string]struct {
 		tlvType  TLVType
@@ -783,23 +802,28 @@ func TestLSPDBVersion_CapStrings(t *testing.T) {
 	assert.Equal(t, testLSPDBVersionCapStrings, actual, "CapStrings() did not return expected value")
 }
 
+func msdPtr(v uint8) *uint8 { return &v }
+
 // Test data for SRPCECapability.
 var (
-	testSRPCECapability               = NewSRPCECapability(true, true, 10)
-	testSRPCECapabilityBytes          = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x0a, 0x00, 0x00)
-	testSRPCECapabilityTruncated      = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x02)
-	testSRPCECapabilityExtra          = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
-	testSRPCECapabilityInvalidLength  = append(tlvHeader(TLVSRPCECapability, 8), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
-	testSRPCECapabilityAllEnabled     = &SRPCECapability{HasUnlimitedMaxSIDDepth: true, IsNAISupported: true}
-	testSRPCECapabilityUnlimitedOnly  = &SRPCECapability{HasUnlimitedMaxSIDDepth: true}
-	testSRPCECapabilityNAIOnly        = &SRPCECapability{IsNAISupported: true}
-	testSRPCECapabilityNoneEnabled    = &SRPCECapability{}
-	testSRPCECapabilityAllEnabledStrs = []string{"SR", "Unlimited-SID-Depth", "SR-NAI-Supported"}
-	testSRPCECapabilityUnlimitedStrs  = []string{"SR", "Unlimited-SID-Depth"}
-	testSRPCECapabilityNAIStrs        = []string{"SR", "MSD=0", "SR-NAI-Supported"}
-	testSRPCECapabilityMSDOnly        = &SRPCECapability{MaximumSidDepth: 10}
-	testSRPCECapabilityMSDOnlyStrs    = []string{"SR", "MSD=10"}
-	testSRPCECapabilityNoneStrs       = []string{"SR", "MSD=0"}
+	testSRPCECapability                      = NewSRPCECapability(true, true, 10)
+	testSRPCECapabilityBytes                 = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x0a, 0x00, 0x00)
+	testSRPCECapabilityTruncated             = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x02)
+	testSRPCECapabilityExtra                 = append(tlvHeader(TLVSRPCECapability, 4), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
+	testSRPCECapabilityInvalidLength         = append(tlvHeader(TLVSRPCECapability, 8), 0x03, 0x05, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef)
+	testSRPCECapabilityZeroMSDBytes          = append(tlvHeader(TLVSRPCECapability, 4), 0x00, 0x00, 0x00, 0x00)
+	testSRPCECapabilityAllEnabled            = &SRPCECapability{HasUnlimitedMaxSIDDepth: true, IsNAISupported: true}
+	testSRPCECapabilityUnlimitedOnly         = &SRPCECapability{HasUnlimitedMaxSIDDepth: true}
+	testSRPCECapabilityNAIOnly               = &SRPCECapability{IsNAISupported: true}
+	testSRPCECapabilityNoneEnabled           = &SRPCECapability{}
+	testSRPCECapabilityAllEnabledStrs        = []string{"SR", "Unlimited-SID-Depth", "SR-NAI-Supported"}
+	testSRPCECapabilityUnlimitedStrs         = []string{"SR", "Unlimited-SID-Depth"}
+	testSRPCECapabilityNAIStrs               = []string{"SR", "SR-NAI-Supported"}
+	testSRPCECapabilityMSDOnly               = &SRPCECapability{MaximumSidDepth: msdPtr(10)}
+	testSRPCECapabilityMSDOnlyStrs           = []string{"SR", "MSD=10"}
+	testSRPCECapabilityNoneStrs              = []string{"SR"}
+	testSRPCECapabilityMSDZeroAdvertised     = &SRPCECapability{MaximumSidDepth: msdPtr(0)}
+	testSRPCECapabilityMSDZeroAdvertisedStrs = []string{"SR", "MSD=0"}
 )
 
 func TestSRPCECapability_DecodeFromBytes(t *testing.T) {
@@ -808,6 +832,7 @@ func TestSRPCECapability_DecodeFromBytes(t *testing.T) {
 		"TruncatedSRPCECapability":     {testSRPCECapabilityTruncated, nil, true},
 		"ExtraBytesInSRPCECapability":  {testSRPCECapabilityExtra, nil, true},
 		"InvalidLengthSRPCECapability": {testSRPCECapabilityInvalidLength, nil, true},
+		"ZeroMSDIsStillAdvertised":     {testSRPCECapabilityZeroMSDBytes, testSRPCECapabilityMSDZeroAdvertised, false},
 	}
 	runTLVDecodeTests(t, cases, func() TLVInterface { return &SRPCECapability{} })
 }
@@ -833,7 +858,6 @@ func TestSRPCECapability_MarshalLogObject(t *testing.T) {
 			map[string]any{
 				"unlimited_max_sid_depth": false,
 				"nai_is_supported":        false,
-				"maximum_sid_depth":       uint8(0),
 			},
 		},
 		"FullTLV": {
@@ -849,7 +873,6 @@ func TestSRPCECapability_MarshalLogObject(t *testing.T) {
 			map[string]any{
 				"unlimited_max_sid_depth": true,
 				"nai_is_supported":        false,
-				"maximum_sid_depth":       uint8(0),
 			},
 		},
 		"OnlyNAI": {
@@ -857,7 +880,6 @@ func TestSRPCECapability_MarshalLogObject(t *testing.T) {
 			map[string]any{
 				"unlimited_max_sid_depth": false,
 				"nai_is_supported":        true,
-				"maximum_sid_depth":       uint8(0),
 			},
 		},
 	}
@@ -892,6 +914,7 @@ func TestSRPCECapability_CapStrings(t *testing.T) {
 		"OnlyNAISupportedEnabled":         {testSRPCECapabilityNAIOnly, testSRPCECapabilityNAIStrs},
 		"NoCapabilitiesEnabled":           {testSRPCECapabilityNoneEnabled, testSRPCECapabilityNoneStrs},
 		"WithNonZeroMSD":                  {testSRPCECapabilityMSDOnly, testSRPCECapabilityMSDOnlyStrs},
+		"MSDAdvertisedAsZero":             {testSRPCECapabilityMSDZeroAdvertised, testSRPCECapabilityMSDZeroAdvertisedStrs},
 	}
 	runCapStringsTests(t, cases)
 }
@@ -1255,6 +1278,8 @@ func TestAssocType_String(t *testing.T) {
 		"DoubleSidedBidir": {AssocTypeDoubleSidedBidirectionalLSPAssociation, "Double Sided Bidirectional LSP Association"},
 		"SRPolicy":         {AssocTypeSRPolicyAssociation, "SR Policy Association"},
 		"VnAssociation":    {AssocTypeVnAssociationType, "VN Association Type"},
+		"BidirSRLSP":       {AssocTypeBidirectionalSRLSPAssociation, "Bidirectional SR LSP Association (draft)"},
+		"P2MPSRPolicy":     {AssocTypeP2MPSRPolicyAssociation, "P2MP SR Policy Association (draft)"},
 		"Unknown":          {AssocType(0xffff), "Unknown AssocType (0xffff)"},
 	}
 

--- a/pkg/packet/pcep/vendor.go
+++ b/pkg/packet/pcep/vendor.go
@@ -49,3 +49,18 @@ func (en EnterpriseNumber) capLabel() string {
 	}
 	return "EN-" + strconv.FormatUint(uint64(en), 10)
 }
+
+var enterpriseNumberFullNames = map[EnterpriseNumber]string{
+	EnterpriseNumberCisco:   "Cisco Systems, Inc.",
+	EnterpriseNumberHuawei:  "Huawei Technologies Co., Ltd.",
+	EnterpriseNumberJuniper: "Juniper Networks, Inc.",
+}
+
+// DisplayLabel returns the enterprise number and vendor name.
+func (en EnterpriseNumber) DisplayLabel() string {
+	name, ok := enterpriseNumberFullNames[en]
+	if !ok {
+		name = "Unknown"
+	}
+	return fmt.Sprintf("%d (%s)", uint32(en), name)
+}

--- a/pkg/packet/pcep/vendor_test.go
+++ b/pkg/packet/pcep/vendor_test.go
@@ -51,3 +51,21 @@ func TestEnterpriseNumber_capLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestEnterpriseNumber_DisplayLabel(t *testing.T) {
+	cases := map[string]struct {
+		enterpriseNumber EnterpriseNumber
+		expected         string
+	}{
+		"Cisco":     {EnterpriseNumberCisco, "9 (Cisco Systems, Inc.)"},
+		"Huawei":    {EnterpriseNumberHuawei, "2011 (Huawei Technologies Co., Ltd.)"},
+		"Juniper":   {EnterpriseNumberJuniper, "2636 (Juniper Networks, Inc.)"},
+		"UnknownEN": {99999, "99999 (Unknown)"},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.enterpriseNumber.DisplayLabel())
+		})
+	}
+}

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/nttcom/pola/pkg/table"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/proto"
 )
 
 func dedupCapabilities(logger *zap.Logger, kind string, caps []pcep.CapabilityInterface) []*pb.Capability {
@@ -123,14 +122,11 @@ func buildCapability(cap pcep.CapabilityInterface) *pb.Capability {
 			Color:                tlv.ColorCapability,
 		}}
 	case *pcep.SRPCECapability:
-		sr := &pb.SrCapability{
+		c.Detail = &pb.Capability_Sr{Sr: &pb.SrCapability{
 			UnlimitedMsd: tlv.HasUnlimitedMaxSIDDepth,
 			NaiSupported: tlv.IsNAISupported,
-		}
-		if tlv.MaximumSidDepth != nil {
-			sr.Msd = proto.Uint32(uint32(*tlv.MaximumSidDepth))
-		}
-		c.Detail = &pb.Capability_Sr{Sr: sr}
+			Msd:          new(uint32(tlv.MaximumSidDepth)),
+		}}
 	case *pcep.SRv6PCECapability:
 		c.Detail = &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
 			NaiSupported: tlv.IsNAISupported,
@@ -201,49 +197,49 @@ func capabilityType(t pcep.TLVType) pb.CapabilityType {
 // buildPBSession converts a Session to its protobuf representation.
 // Stats is included only when requested.
 func (s *APIServer) buildPBSession(pcepSession *Session, includeStats bool) *pb.Session {
-	pccOpen, hasPccOpen := pcepSession.PccOpen()
+	snap := pcepSession.snapshot()
+
 	pbPccType := pb.PccType_PCC_TYPE_UNSPECIFIED
-	if hasPccOpen {
-		pbPccType = toPBPccType(pcepSession.PccType())
+	if snap.pccOpen != nil {
+		pbPccType = toPBPccType(snap.pccType)
 	}
 
 	pbSession := &pb.Session{
 		PeerAddr:          pcepSession.peerAddr.AsSlice(),
-		State:             toPBSessionState(pcepSession.State()),
+		State:             toPBSessionState(snap.state),
 		PccType:           pbPccType,
-		LocalCapabilities: dedupCapabilities(s.logger, "advertised", pcepSession.AdvertisedCapabilities()),
-		PeerCapabilities:  dedupCapabilities(s.logger, "received", pcepSession.ReceivedCapabilities()),
-		Initiator:         toPBInitiator(pcepSession.Initiator()),
-		SyncState:         toPBSyncState(pcepSession.SyncState()),
+		LocalCapabilities: dedupCapabilities(s.logger, "advertised", snap.advertisedCapabilities),
+		PeerCapabilities:  dedupCapabilities(s.logger, "received", snap.receivedPccCapabilities),
+		Initiator:         toPBInitiator(snap.initiator),
+		SyncState:         toPBSyncState(snap.syncState),
 	}
 
-	localOpen, hasLocalOpen := pcepSession.LocalOpen()
-	if hasLocalOpen {
-		pbSession.LocalSessionId = new(uint32(localOpen.SessionID))
+	if snap.localOpen != nil {
+		pbSession.LocalSessionId = new(uint32(snap.localOpen.SessionID))
 		pbSession.LocalTimers = &pb.SessionTimers{
-			Keepalive: uint32(localOpen.Keepalive),
-			DeadTimer: uint32(localOpen.DeadTimer),
+			Keepalive: uint32(snap.localOpen.Keepalive),
+			DeadTimer: uint32(snap.localOpen.DeadTimer),
 		}
 	}
-	if hasPccOpen {
-		pbSession.PeerSessionId = new(uint32(pccOpen.SessionID))
+	if snap.pccOpen != nil {
+		pbSession.PeerSessionId = new(uint32(snap.pccOpen.SessionID))
 		pbSession.PeerTimers = &pb.SessionTimers{
-			Keepalive: uint32(pccOpen.Keepalive),
-			DeadTimer: uint32(pccOpen.DeadTimer),
+			Keepalive: uint32(snap.pccOpen.Keepalive),
+			DeadTimer: uint32(snap.pccOpen.DeadTimer),
 		}
 	}
-	// Use Up() rather than Open flags: they become true before negotiation completes.
-	if pcepSession.Up() {
+	if snap.state == sessionStateUp {
 		pbSession.EffectiveTimers = &pb.EffectiveTimers{
-			Keepalive: uint32(pcepSession.keepaliveInterval()),
-			DeadTimer: uint32(pcepSession.readDeadline() / time.Second),
+			Keepalive: uint32(snap.keepaliveInterval()),
+			DeadTimer: uint32(snap.readDeadline() / time.Second),
 		}
 	}
-	if t := pcepSession.CreatedAt(); !t.IsZero() {
-		pbSession.CreatedAtUnixNano = t.UnixNano()
+	if !snap.createdAt.IsZero() {
+		pbSession.CreatedAtUnixNano = snap.createdAt.UnixNano()
 	}
-	if t := pcepSession.EstablishedAt(); !t.IsZero() {
-		pbSession.EstablishedAtUnixNano = t.UnixNano()
+	if !snap.establishedAt.IsZero() {
+		pbSession.EstablishedAtUnixNano = snap.establishedAt.UnixNano()
+		pbSession.UptimeNanos = time.Since(snap.establishedAt).Nanoseconds()
 	}
 	if includeStats {
 		setupOK, setupFail := s.pce.PeerSetupStats(pcepSession.peerAddr)
@@ -282,10 +278,11 @@ func (s *APIServer) buildPBSRPolicy(pcepSession *Session, policy *table.SRPolicy
 // buildPBSRPolicySession converts a Session and its SR Policies into the
 // lightweight SRPolicySession representation returned by GetSRPolicyList.
 func buildPBSRPolicySession(pcepSession *Session, policies []*pb.SRPolicy) *pb.SRPolicySession {
+	snap := pcepSession.snapshot()
 	return &pb.SRPolicySession{
 		PeerAddr:   pcepSession.peerAddr.AsSlice(),
-		State:      toPBSessionState(pcepSession.State()),
-		SyncState:  toPBSyncState(pcepSession.SyncState()),
+		State:      toPBSessionState(snap.state),
+		SyncState:  toPBSyncState(snap.syncState),
 		SrPolicies: policies,
 	}
 }

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -8,6 +8,7 @@ package server
 import (
 	"fmt"
 	"net/netip"
+	"time"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/packet/pcep"
@@ -15,6 +16,54 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 )
+
+// dedupCapabilities converts capabilities to protobuf, dropping duplicates.
+func dedupCapabilities(logger *zap.Logger, kind string, caps []pcep.CapabilityInterface) []*pb.Capability {
+	var pbCaps []*pb.Capability
+	seen := make(map[string]struct{})
+	for _, cap := range caps {
+		b, err := cap.Serialize()
+		if err != nil {
+			logger.Warn(fmt.Sprintf("failed to serialize %s capability", kind), zap.Error(err))
+			continue
+		}
+		key := fmt.Sprintf("%d:%s", cap.Type(), b)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		pbCaps = append(pbCaps, buildCapability(cap))
+	}
+	return pbCaps
+}
+
+func toPBSessionState(state sessionState) pb.SessionState {
+	switch state {
+	case sessionStateTCPPending:
+		return pb.SessionState_SESSION_STATE_TCP_PENDING
+	case sessionStateOpenWait:
+		return pb.SessionState_SESSION_STATE_OPEN_WAIT
+	case sessionStateKeepWait:
+		return pb.SessionState_SESSION_STATE_KEEP_WAIT
+	case sessionStateUp:
+		return pb.SessionState_SESSION_STATE_UP
+	default:
+		return pb.SessionState_SESSION_STATE_UNSPECIFIED
+	}
+}
+
+func toPBPccType(pccType pcep.PccType) pb.PccType {
+	switch pccType {
+	case pcep.CiscoLegacy:
+		return pb.PccType_PCC_TYPE_CISCO_LEGACY
+	case pcep.JuniperLegacy:
+		return pb.PccType_PCC_TYPE_JUNIPER_LEGACY
+	case pcep.RFCCompliant:
+		return pb.PccType_PCC_TYPE_RFC_COMPLIANT
+	default:
+		return pb.PccType_PCC_TYPE_UNSPECIFIED
+	}
+}
 
 func buildCapability(cap pcep.CapabilityInterface) *pb.Capability {
 	c := &pb.Capability{Type: capabilityType(cap.Type())}
@@ -102,9 +151,43 @@ func capabilityType(t pcep.TLVType) pb.CapabilityType {
 	}
 }
 
-func (s *APIServer) buildPBSRPolicy(peerAddr netip.Addr, policy *table.SRPolicy, routerIDIndex map[netip.Addr]string) *pb.SRPolicy {
+// buildPBSession converts a Session to its protobuf representation.
+// Session IDs and advertised timers are nil until the Open message is received.
+func (s *APIServer) buildPBSession(pcepSession *Session) *pb.Session {
+	pbSession := &pb.Session{
+		Addr:            pcepSession.peerAddr.AsSlice(),
+		State:           toPBSessionState(pcepSession.State()),
+		IsSynced:        pcepSession.IsSynced(),
+		PccType:         toPBPccType(pcepSession.PccType()),
+		Capabilities:    dedupCapabilities(s.logger, "advertised", pcepSession.AdvertisedCapabilities()),
+		PccCapabilities: dedupCapabilities(s.logger, "received", pcepSession.ReceivedCapabilities()),
+		EffectiveTimers: &pb.EffectiveTimers{
+			Keepalive: uint32(pcepSession.keepaliveInterval()),
+			DeadTimer: uint32(pcepSession.readDeadline() / time.Second),
+		},
+	}
+
+	if localOpen, ok := pcepSession.LocalOpen(); ok {
+		pbSession.LocalSessionId = proto.Uint32(uint32(localOpen.SessionID))
+		pbSession.LocalTimers = &pb.SessionTimers{
+			Keepalive: uint32(localOpen.Keepalive),
+			DeadTimer: uint32(localOpen.DeadTimer),
+		}
+	}
+	if pccOpen, ok := pcepSession.PccOpen(); ok {
+		pbSession.PccSessionId = proto.Uint32(uint32(pccOpen.SessionID))
+		pbSession.PccTimers = &pb.SessionTimers{
+			Keepalive: uint32(pccOpen.Keepalive),
+			DeadTimer: uint32(pccOpen.DeadTimer),
+		}
+	}
+
+	return pbSession
+}
+
+func (s *APIServer) buildPBSRPolicy(pcepSession *Session, policy *table.SRPolicy, routerIDIndex map[netip.Addr]string) *pb.SRPolicy {
 	srPolicy := &pb.SRPolicy{
-		PcepSessionAddr: peerAddr.AsSlice(),
+		PcepSessionAddr: pcepSession.peerAddr.AsSlice(),
 		SegmentList:     make([]*pb.Segment, 0, len(policy.SegmentList)),
 		Color:           policy.Color,
 		Preference:      policy.Preference,

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// dedupCapabilities converts capabilities to protobuf, dropping duplicates.
 func dedupCapabilities(logger *zap.Logger, kind string, caps []pcep.CapabilityInterface) []*pb.Capability {
 	var pbCaps []*pb.Capability
 	seen := make(map[string]struct{})
@@ -52,6 +51,51 @@ func toPBSessionState(state sessionState) pb.SessionState {
 	}
 }
 
+func toPBInitiator(initiator sessionInitiator) pb.SessionInitiator {
+	switch initiator {
+	case sessionInitiatorLocal:
+		return pb.SessionInitiator_SESSION_INITIATOR_LOCAL
+	case sessionInitiatorRemote:
+		return pb.SessionInitiator_SESSION_INITIATOR_REMOTE
+	default:
+		return pb.SessionInitiator_SESSION_INITIATOR_UNSPECIFIED
+	}
+}
+
+func toPBSyncState(state lspDBSyncState) pb.LspDbSyncState {
+	switch state {
+	case lspDBSyncPending:
+		return pb.LspDbSyncState_LSP_DB_SYNC_STATE_PENDING
+	case lspDBSyncOngoing:
+		return pb.LspDbSyncState_LSP_DB_SYNC_STATE_ONGOING
+	case lspDBSyncFinished:
+		return pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED
+	default:
+		return pb.LspDbSyncState_LSP_DB_SYNC_STATE_UNSPECIFIED
+	}
+}
+
+// toPBSessionStats converts session counters and setup counters to protobuf.
+// Counters not applicable to Pola's PCE role are reported as 0.
+func toPBSessionStats(stats sessionStatsSnapshot, setupOK, setupFail uint64) *pb.SessionStats {
+	return &pb.SessionStats{
+		Open:             &pb.MessageCounter{Sent: stats.OpenSent, Rcvd: stats.OpenRcvd},
+		Keepalive:        &pb.MessageCounter{Sent: stats.KeepaliveSent, Rcvd: stats.KeepaliveRcvd},
+		Close:            &pb.MessageCounter{Sent: stats.CloseSent, Rcvd: stats.CloseRcvd},
+		Pcerr:            &pb.MessageCounter{Sent: stats.PCErrSent, Rcvd: stats.PCErrRcvd},
+		Pcntf:            &pb.MessageCounter{Sent: 0, Rcvd: stats.PCNtfRcvd},
+		Pcreq:            &pb.MessageCounter{Sent: 0, Rcvd: stats.PCReqRcvd},
+		Pcrep:            &pb.MessageCounter{Sent: 0, Rcvd: stats.PCRepRcvd},
+		Report:           &pb.MessageCounter{Sent: 0, Rcvd: stats.RptRcvd},
+		Update:           &pb.MessageCounter{Sent: stats.UpdSent, Rcvd: 0},
+		Initiate:         &pb.MessageCounter{Sent: stats.PCInitiateSent, Rcvd: 0},
+		UnrecognizedRcvd: stats.UnknownRcvd,
+		CorruptRcvd:      stats.CorruptRcvd,
+		SessSetupOk:      setupOK,
+		SessSetupFail:    setupFail,
+	}
+}
+
 func toPBPccType(pccType pcep.PccType) pb.PccType {
 	switch pccType {
 	case pcep.CiscoLegacy:
@@ -79,11 +123,14 @@ func buildCapability(cap pcep.CapabilityInterface) *pb.Capability {
 			Color:                tlv.ColorCapability,
 		}}
 	case *pcep.SRPCECapability:
-		c.Detail = &pb.Capability_Sr{Sr: &pb.SrCapability{
+		sr := &pb.SrCapability{
 			UnlimitedMsd: tlv.HasUnlimitedMaxSIDDepth,
 			NaiSupported: tlv.IsNAISupported,
-			Msd:          uint32(tlv.MaximumSidDepth),
-		}}
+		}
+		if tlv.MaximumSidDepth != nil {
+			sr.Msd = proto.Uint32(uint32(*tlv.MaximumSidDepth))
+		}
+		c.Detail = &pb.Capability_Sr{Sr: sr}
 	case *pcep.SRv6PCECapability:
 		c.Detail = &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
 			NaiSupported: tlv.IsNAISupported,
@@ -152,34 +199,55 @@ func capabilityType(t pcep.TLVType) pb.CapabilityType {
 }
 
 // buildPBSession converts a Session to its protobuf representation.
-// Session IDs and advertised timers are nil until the Open message is received.
-func (s *APIServer) buildPBSession(pcepSession *Session) *pb.Session {
-	pbSession := &pb.Session{
-		Addr:            pcepSession.peerAddr.AsSlice(),
-		State:           toPBSessionState(pcepSession.State()),
-		IsSynced:        pcepSession.IsSynced(),
-		PccType:         toPBPccType(pcepSession.PccType()),
-		Capabilities:    dedupCapabilities(s.logger, "advertised", pcepSession.AdvertisedCapabilities()),
-		PccCapabilities: dedupCapabilities(s.logger, "received", pcepSession.ReceivedCapabilities()),
-		EffectiveTimers: &pb.EffectiveTimers{
-			Keepalive: uint32(pcepSession.keepaliveInterval()),
-			DeadTimer: uint32(pcepSession.readDeadline() / time.Second),
-		},
+// Stats is included only when requested.
+func (s *APIServer) buildPBSession(pcepSession *Session, includeStats bool) *pb.Session {
+	pccOpen, hasPccOpen := pcepSession.PccOpen()
+	pbPccType := pb.PccType_PCC_TYPE_UNSPECIFIED
+	if hasPccOpen {
+		pbPccType = toPBPccType(pcepSession.PccType())
 	}
 
-	if localOpen, ok := pcepSession.LocalOpen(); ok {
-		pbSession.LocalSessionId = proto.Uint32(uint32(localOpen.SessionID))
+	pbSession := &pb.Session{
+		PeerAddr:          pcepSession.peerAddr.AsSlice(),
+		State:             toPBSessionState(pcepSession.State()),
+		PccType:           pbPccType,
+		LocalCapabilities: dedupCapabilities(s.logger, "advertised", pcepSession.AdvertisedCapabilities()),
+		PeerCapabilities:  dedupCapabilities(s.logger, "received", pcepSession.ReceivedCapabilities()),
+		Initiator:         toPBInitiator(pcepSession.Initiator()),
+		SyncState:         toPBSyncState(pcepSession.SyncState()),
+	}
+
+	localOpen, hasLocalOpen := pcepSession.LocalOpen()
+	if hasLocalOpen {
+		pbSession.LocalSessionId = new(uint32(localOpen.SessionID))
 		pbSession.LocalTimers = &pb.SessionTimers{
 			Keepalive: uint32(localOpen.Keepalive),
 			DeadTimer: uint32(localOpen.DeadTimer),
 		}
 	}
-	if pccOpen, ok := pcepSession.PccOpen(); ok {
-		pbSession.PccSessionId = proto.Uint32(uint32(pccOpen.SessionID))
-		pbSession.PccTimers = &pb.SessionTimers{
+	if hasPccOpen {
+		pbSession.PeerSessionId = new(uint32(pccOpen.SessionID))
+		pbSession.PeerTimers = &pb.SessionTimers{
 			Keepalive: uint32(pccOpen.Keepalive),
 			DeadTimer: uint32(pccOpen.DeadTimer),
 		}
+	}
+	// Use Up() rather than Open flags: they become true before negotiation completes.
+	if pcepSession.Up() {
+		pbSession.EffectiveTimers = &pb.EffectiveTimers{
+			Keepalive: uint32(pcepSession.keepaliveInterval()),
+			DeadTimer: uint32(pcepSession.readDeadline() / time.Second),
+		}
+	}
+	if t := pcepSession.CreatedAt(); !t.IsZero() {
+		pbSession.CreatedAtUnixNano = t.UnixNano()
+	}
+	if t := pcepSession.EstablishedAt(); !t.IsZero() {
+		pbSession.EstablishedAtUnixNano = t.UnixNano()
+	}
+	if includeStats {
+		setupOK, setupFail := s.pce.PeerSetupStats(pcepSession.peerAddr)
+		pbSession.Stats = toPBSessionStats(pcepSession.Stats(), setupOK, setupFail)
 	}
 
 	return pbSession
@@ -187,18 +255,18 @@ func (s *APIServer) buildPBSession(pcepSession *Session) *pb.Session {
 
 func (s *APIServer) buildPBSRPolicy(pcepSession *Session, policy *table.SRPolicy, routerIDIndex map[netip.Addr]string) *pb.SRPolicy {
 	srPolicy := &pb.SRPolicy{
-		PcepSessionAddr: pcepSession.peerAddr.AsSlice(),
-		SegmentList:     make([]*pb.Segment, 0, len(policy.SegmentList)),
-		Color:           policy.Color,
-		Preference:      policy.Preference,
-		PolicyName:      policy.Name,
-		SrcAddr:         policy.SrcAddr.AsSlice(),
-		DstAddr:         policy.DstAddr.AsSlice(),
-		PlspId:          policy.PlspID,
-		LspId:           uint32(policy.LSPID),
-		State:           toPBPolicyState(policy.State),
-		Type:            toPBPolicyType(policy.Type),
-		Metric:          toPBMetricType(policy.Metric),
+		PeerAddr:    pcepSession.peerAddr.AsSlice(),
+		SegmentList: make([]*pb.Segment, 0, len(policy.SegmentList)),
+		Color:       policy.Color,
+		Preference:  policy.Preference,
+		PolicyName:  policy.Name,
+		SrcAddr:     policy.SrcAddr.AsSlice(),
+		DstAddr:     policy.DstAddr.AsSlice(),
+		PlspId:      policy.PlspID,
+		LspId:       uint32(policy.LSPID),
+		State:       toPBPolicyState(policy.State),
+		Type:        toPBPolicyType(policy.Type),
+		Metric:      toPBMetricType(policy.Metric),
 	}
 
 	srPolicy.SrcRouterId = routerIDIndex[policy.SrcAddr]
@@ -209,6 +277,17 @@ func (s *APIServer) buildPBSRPolicy(pcepSession *Session, policy *table.SRPolicy
 	}
 
 	return srPolicy
+}
+
+// buildPBSRPolicySession converts a Session and its SR Policies into the
+// lightweight SRPolicySession representation returned by GetSRPolicyList.
+func buildPBSRPolicySession(pcepSession *Session, policies []*pb.SRPolicy) *pb.SRPolicySession {
+	return &pb.SRPolicySession{
+		PeerAddr:   pcepSession.peerAddr.AsSlice(),
+		State:      toPBSessionState(pcepSession.State()),
+		SyncState:  toPBSyncState(pcepSession.SyncState()),
+		SrPolicies: policies,
+	}
 }
 
 func toPBPolicyType(polType table.PolicyType) pb.SRPolicyType {
@@ -290,9 +369,9 @@ func convertLsNode(lsNode *table.LsNode, logger *zap.Logger) *pb.LsNode {
 		Hostname:   lsNode.Hostname,
 		SrgbBegin:  lsNode.SrgbBegin,
 		SrgbEnd:    lsNode.SrgbEnd,
-		LsLinks:    convertLsLinks(lsNode.Links, logger),
-		LsPrefixes: convertLsPrefixes(lsNode.Prefixes),
-		LsSrv6Sids: convertLsSrv6SIDs(lsNode.SRv6SIDs),
+		Links:      convertLsLinks(lsNode.Links, logger),
+		Prefixes:   convertLsPrefixes(lsNode.Prefixes),
+		Srv6Sids:   convertLsSrv6SIDs(lsNode.SRv6SIDs),
 	}
 }
 
@@ -361,7 +440,7 @@ func convertLsPrefixes(prefixes []*table.LsPrefix) []*pb.LsPrefix {
 			pbPrefix := &pb.LsPrefix{Prefix: p.Prefix.String()}
 			// Preserve Prefix-SID presence, including index 0.
 			if p.HasPrefixSID() {
-				pbPrefix.SidIndex = proto.Uint32(p.SidIndex)
+				pbPrefix.SidIndex = new(p.SidIndex)
 			}
 			result = append(result, pbPrefix)
 		}

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -122,11 +122,14 @@ func buildCapability(cap pcep.CapabilityInterface) *pb.Capability {
 			Color:                tlv.ColorCapability,
 		}}
 	case *pcep.SRPCECapability:
-		c.Detail = &pb.Capability_Sr{Sr: &pb.SrCapability{
+		sr := &pb.SrCapability{
 			UnlimitedMsd: tlv.HasUnlimitedMaxSIDDepth,
 			NaiSupported: tlv.IsNAISupported,
-			Msd:          new(uint32(tlv.MaximumSidDepth)),
-		}}
+		}
+		if !tlv.HasUnlimitedMaxSIDDepth {
+			sr.Msd = new(uint32(tlv.MaximumSidDepth))
+		}
+		c.Detail = &pb.Capability_Sr{Sr: sr}
 	case *pcep.SRv6PCECapability:
 		c.Detail = &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
 			NaiSupported: tlv.IsNAISupported,
@@ -136,9 +139,11 @@ func buildCapability(cap pcep.CapabilityInterface) *pb.Capability {
 		for i, pst := range tlv.PathSetupTypes {
 			psts[i] = uint32(pst)
 		}
-		c.Detail = &pb.Capability_PathSetupType{PathSetupType: &pb.PathSetupTypeCapability{
-			PathSetupTypes: psts,
-		}}
+		pstCap := &pb.PathSetupTypeCapability{PathSetupTypes: psts}
+		for _, subCap := range tlv.SubCapabilities() {
+			pstCap.SubCapabilities = append(pstCap.SubCapabilities, buildCapability(subCap))
+		}
+		c.Detail = &pb.Capability_PathSetupType{PathSetupType: pstCap}
 	case *pcep.AssocTypeList:
 		assocTypes := make([]uint32, len(tlv.AssocTypes))
 		for i, at := range tlv.AssocTypes {

--- a/pkg/server/grpc_convert_test.go
+++ b/pkg/server/grpc_convert_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package server
+
+import (
+	"testing"
+
+	pb "github.com/nttcom/pola/api/pola/v1"
+	"github.com/nttcom/pola/pkg/packet/pcep"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToPBSessionState(t *testing.T) {
+	tests := []struct {
+		name string
+		in   sessionState
+		want pb.SessionState
+	}{
+		{"TCPPending", sessionStateTCPPending, pb.SessionState_SESSION_STATE_TCP_PENDING},
+		{"OpenWait", sessionStateOpenWait, pb.SessionState_SESSION_STATE_OPEN_WAIT},
+		{"KeepWait", sessionStateKeepWait, pb.SessionState_SESSION_STATE_KEEP_WAIT},
+		{"Up", sessionStateUp, pb.SessionState_SESSION_STATE_UP},
+		{"unrecognized value maps to unspecified", sessionState(99), pb.SessionState_SESSION_STATE_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, toPBSessionState(tt.in))
+		})
+	}
+}
+
+func TestToPBPccType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   pcep.PccType
+		want pb.PccType
+	}{
+		{"CiscoLegacy", pcep.CiscoLegacy, pb.PccType_PCC_TYPE_CISCO_LEGACY},
+		{"JuniperLegacy", pcep.JuniperLegacy, pb.PccType_PCC_TYPE_JUNIPER_LEGACY},
+		{"RFCCompliant", pcep.RFCCompliant, pb.PccType_PCC_TYPE_RFC_COMPLIANT},
+		{"unrecognized value maps to unspecified", pcep.PccType(99), pb.PccType_PCC_TYPE_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, toPBPccType(tt.in))
+		})
+	}
+}

--- a/pkg/server/grpc_convert_test.go
+++ b/pkg/server/grpc_convert_test.go
@@ -6,11 +6,14 @@
 package server
 
 import (
+	"net/netip"
 	"testing"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestToPBSessionState(t *testing.T) {
@@ -48,4 +51,121 @@ func TestToPBPccType(t *testing.T) {
 			assert.Equal(t, tt.want, toPBPccType(tt.in))
 		})
 	}
+}
+
+func TestToPBInitiator(t *testing.T) {
+	tests := []struct {
+		name string
+		in   sessionInitiator
+		want pb.SessionInitiator
+	}{
+		{"Remote", sessionInitiatorRemote, pb.SessionInitiator_SESSION_INITIATOR_REMOTE},
+		{"Local", sessionInitiatorLocal, pb.SessionInitiator_SESSION_INITIATOR_LOCAL},
+		{"unrecognized value maps to unspecified", sessionInitiator(99), pb.SessionInitiator_SESSION_INITIATOR_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, toPBInitiator(tt.in))
+		})
+	}
+}
+
+func TestToPBSyncState(t *testing.T) {
+	tests := []struct {
+		name string
+		in   lspDBSyncState
+		want pb.LspDbSyncState
+	}{
+		{"Pending", lspDBSyncPending, pb.LspDbSyncState_LSP_DB_SYNC_STATE_PENDING},
+		{"Ongoing", lspDBSyncOngoing, pb.LspDbSyncState_LSP_DB_SYNC_STATE_ONGOING},
+		{"Finished", lspDBSyncFinished, pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED},
+		{"unrecognized value maps to unspecified", lspDBSyncState(99), pb.LspDbSyncState_LSP_DB_SYNC_STATE_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, toPBSyncState(tt.in))
+		})
+	}
+}
+
+func TestToPBSessionStats_AlwaysZeroCountersForRolesPolaNeverPlays(t *testing.T) {
+	stats := sessionStatsSnapshot{
+		OpenSent: 20, OpenRcvd: 21,
+		KeepaliveSent: 1, KeepaliveRcvd: 2,
+		CloseSent: 22, CloseRcvd: 23,
+		PCErrSent: 3, PCErrRcvd: 4,
+		PCNtfRcvd: 5,
+		PCReqRcvd: 24, PCRepRcvd: 25,
+		RptRcvd: 6, UpdSent: 7, PCInitiateSent: 8,
+		UnknownRcvd: 9, CorruptRcvd: 10,
+	}
+
+	got := toPBSessionStats(stats, 11, 12)
+
+	assert.Equal(t, uint64(20), got.GetOpen().GetSent())
+	assert.Equal(t, uint64(21), got.GetOpen().GetRcvd())
+	assert.Equal(t, uint64(1), got.GetKeepalive().GetSent())
+	assert.Equal(t, uint64(2), got.GetKeepalive().GetRcvd())
+	assert.Equal(t, uint64(22), got.GetClose().GetSent())
+	assert.Equal(t, uint64(23), got.GetClose().GetRcvd())
+	assert.Equal(t, uint64(3), got.GetPcerr().GetSent())
+	assert.Equal(t, uint64(4), got.GetPcerr().GetRcvd())
+	assert.Equal(t, uint64(0), got.GetPcntf().GetSent(), "Pola never sends PCNtf")
+	assert.Equal(t, uint64(5), got.GetPcntf().GetRcvd())
+	assert.Equal(t, uint64(0), got.GetPcreq().GetSent(), "Pola never sends PCReq")
+	assert.Equal(t, uint64(24), got.GetPcreq().GetRcvd())
+	assert.Equal(t, uint64(0), got.GetPcrep().GetSent(), "Pola never sends PCRep")
+	assert.Equal(t, uint64(25), got.GetPcrep().GetRcvd())
+	assert.Equal(t, uint64(0), got.GetReport().GetSent(), "Pola never sends PCRpt")
+	assert.Equal(t, uint64(6), got.GetReport().GetRcvd())
+	assert.Equal(t, uint64(7), got.GetUpdate().GetSent())
+	assert.Equal(t, uint64(0), got.GetUpdate().GetRcvd(), "Pola never receives PCUpd")
+	assert.Equal(t, uint64(8), got.GetInitiate().GetSent())
+	assert.Equal(t, uint64(0), got.GetInitiate().GetRcvd(), "Pola never receives PCInitiate")
+	assert.Equal(t, uint64(9), got.GetUnrecognizedRcvd())
+	assert.Equal(t, uint64(10), got.GetCorruptRcvd())
+	assert.Equal(t, uint64(11), got.GetSessSetupOk())
+	assert.Equal(t, uint64(12), got.GetSessSetupFail())
+}
+
+func TestBuildPBSession_StatsOmittedUnlessRequested(t *testing.T) {
+	server := &Server{logger: zap.NewNop()}
+	apiServer := &APIServer{pce: server, logger: zap.NewNop()}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+
+	without := apiServer.buildPBSession(ss, false)
+	assert.Nil(t, without.GetStats(), "Stats must be nil unless includeStats is set")
+
+	with := apiServer.buildPBSession(ss, true)
+	require.NotNil(t, with.GetStats(), "Stats must be populated when includeStats is set")
+}
+
+func TestBuildPBSession_TimestampsAndInitiatorAndSyncState(t *testing.T) {
+	apiServer := &APIServer{pce: &Server{logger: zap.NewNop()}, logger: zap.NewNop()}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+
+	pbSession := apiServer.buildPBSession(ss, false)
+	assert.NotZero(t, pbSession.GetCreatedAtUnixNano())
+	assert.Zero(t, pbSession.GetEstablishedAtUnixNano(), "session has not reached Up yet")
+	assert.Equal(t, pb.SessionInitiator_SESSION_INITIATOR_REMOTE, pbSession.GetInitiator())
+	assert.Equal(t, pb.LspDbSyncState_LSP_DB_SYNC_STATE_PENDING, pbSession.GetSyncState())
+
+	ss.setState(sessionStateUp)
+	pbSession = apiServer.buildPBSession(ss, false)
+	assert.NotZero(t, pbSession.GetEstablishedAtUnixNano())
+}
+
+func TestSessionListFilter(t *testing.T) {
+	addr := netip.MustParseAddr("10.0.255.1")
+
+	got, err := sessionListFilter(&pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	assert.False(t, got.IsValid(), "no filter address means no filter")
+
+	got, err = sessionListFilter(&pb.GetSessionListRequest{PeerAddr: addr.AsSlice()})
+	require.NoError(t, err)
+	assert.Equal(t, addr, got)
+
+	_, err = sessionListFilter(&pb.GetSessionListRequest{PeerAddr: []byte{0x01, 0x02, 0x03}})
+	assert.Error(t, err, "an address that is neither 4 nor 16 bytes must be rejected")
 }

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -232,8 +232,7 @@ func newEnrichedSegment(segment *pb.Segment, usidMode bool) (table.Segment, erro
 	}
 }
 
-// resolvedPath is the path of the requested SR Policy: its endpoints, its
-// segment list, and the metric it was optimized for.
+// resolvedPath contains the resolved SR Policy path.
 type resolvedPath struct {
 	SegmentList []table.Segment
 	SrcAddr     netip.Addr
@@ -241,9 +240,7 @@ type resolvedPath struct {
 	Metric      table.MetricType
 }
 
-// resolvePath resolves the SR Policy path either by computing it over the TED,
-// or, when path computation is disabled, by taking the request values verbatim.
-// Metric is table.UnspecifiedMetric in the latter case, since nothing was optimized.
+// resolvePath resolves the SR Policy path using the TED or request values.
 func resolvePath(s *APIServer, input *pb.CreateSRPolicyRequest, disablePathCompute bool) (resolvedPath, error) {
 	var srcAddr, dstAddr netip.Addr
 	var segmentList []table.Segment
@@ -262,7 +259,7 @@ func resolvePath(s *APIServer, input *pb.CreateSRPolicyRequest, disablePathCompu
 			return resolvedPath{}, newStatus(codes.FailedPrecondition, ReasonTEDNotSynced, "no node in TED")
 		}
 
-		// Check the ASN against the first TED node; all nodes are expected to share the same ASN.
+		// All TED nodes are expected to share the same ASN.
 		for _, node := range ted.Nodes {
 			if node == nil {
 				continue
@@ -320,8 +317,7 @@ func resolvePath(s *APIServer, input *pb.CreateSRPolicyRequest, disablePathCompu
 // resolveSRPolicyIntent resolves the candidate-path type and metric per RFC 9256 §2.4.2.
 func resolveSRPolicyIntent(inputSRPolicy *pb.SRPolicy, disablePathCompute bool, metricType table.MetricType) (table.PolicyType, table.MetricType, error) {
 	if disablePathCompute {
-		// disable_path_compute uses the given SegmentList as an explicit candidate path,
-		// regardless of the requested policy type.
+		// disable_path_compute treats the given SegmentList as an explicit path.
 		return table.PolicyTypeExplicit, table.UnspecifiedMetric, nil
 	}
 
@@ -532,36 +528,43 @@ func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRe
 	return &pb.DeleteSRPolicyResponse{IsSuccess: true}, nil
 }
 
-// GetSRPolicyList returns a list of SR Policies registered with PCEP sessions.
-func (s *APIServer) GetSRPolicyList(_ context.Context, req *pb.GetSRPolicyListRequest) (*pb.GetSRPolicyListResponse, error) {
-	s.logger.Info("Received GetSRPolicyList API request")
-
+// srPolicyListFilter validates and parses the session filter.
+func srPolicyListFilter(req *pb.GetSRPolicyListRequest) (netip.Addr, error) {
 	var filterAddr netip.Addr
 	if raw := req.GetSessionAddr(); len(raw) > 0 {
 		var ok bool
 		filterAddr, ok = netip.AddrFromSlice(raw)
 		if !ok {
-			return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid session filter address %v", raw)
+			return netip.Addr{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid session filter address %v", raw)
 		}
+	}
+	return filterAddr, nil
+}
+
+// GetSRPolicyList returns SR Policies grouped by PCEP session.
+func (s *APIServer) GetSRPolicyList(_ context.Context, req *pb.GetSRPolicyListRequest) (*pb.GetSRPolicyListResponse, error) {
+	s.logger.Info("Received GetSRPolicyList API request")
+
+	filterAddr, err := srPolicyListFilter(req)
+	if err != nil {
+		return nil, err
 	}
 
-	policiesByPeer := s.pce.SRPolicies()
-	peerAddrs := make([]netip.Addr, 0, len(policiesByPeer))
-	for peerAddr := range policiesByPeer {
-		if filterAddr.IsValid() && peerAddr != filterAddr {
-			continue
-		}
-		peerAddrs = append(peerAddrs, peerAddr)
-	}
-	slices.SortFunc(peerAddrs, func(a, b netip.Addr) int { return a.Compare(b) })
+	pcepSessions := s.pce.Sessions()
+	sortSessionsByAddr(pcepSessions)
 
 	routerIDIndex := s.pce.TED().RouterIDIndex()
 
-	sessions := make([]*pb.Session, 0, len(peerAddrs))
-	for _, peerAddr := range peerAddrs {
-		pbPolicies := make([]*pb.SRPolicy, 0, len(policiesByPeer[peerAddr]))
-		for _, policy := range policiesByPeer[peerAddr] {
-			pbPolicies = append(pbPolicies, s.buildPBSRPolicy(peerAddr, policy, routerIDIndex))
+	sessions := make([]*pb.Session, 0, len(pcepSessions))
+	for _, pcepSession := range pcepSessions {
+		if filterAddr.IsValid() && pcepSession.peerAddr != filterAddr {
+			continue
+		}
+
+		policies := pcepSession.SRPolicies()
+		pbPolicies := make([]*pb.SRPolicy, 0, len(policies))
+		for _, policy := range policies {
+			pbPolicies = append(pbPolicies, s.buildPBSRPolicy(pcepSession, policy, routerIDIndex))
 		}
 		slices.SortFunc(pbPolicies, func(a, b *pb.SRPolicy) int {
 			if a.GetColor() < b.GetColor() {
@@ -579,10 +582,9 @@ func (s *APIServer) GetSRPolicyList(_ context.Context, req *pb.GetSRPolicyListRe
 			return strings.Compare(a.GetPolicyName(), b.GetPolicyName())
 		})
 
-		sessions = append(sessions, &pb.Session{
-			Addr:       peerAddr.AsSlice(),
-			SrPolicies: pbPolicies,
-		})
+		pbSession := s.buildPBSession(pcepSession)
+		pbSession.SrPolicies = pbPolicies
+		sessions = append(sessions, pbSession)
 	}
 
 	s.logger.Debug("Send SRPolicyList API reply")
@@ -674,17 +676,36 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 	},
 }
 
-func getSyncedPCEPSession(pce *Server, addr []byte) (*Session, error) {
-	pcepSessionAddr, ok := netip.AddrFromSlice(addr)
+// sortSessionsByAddr orders sessions by peer address.
+func sortSessionsByAddr(sessions []*Session) {
+	slices.SortFunc(sessions, func(a, b *Session) int {
+		return a.peerAddr.Compare(b.peerAddr)
+	})
+}
+
+// resolveSession resolves the PCEP session a request targets.
+// RFC 5440 §7.15 allows at most one session per peer.
+func resolveSession(pce *Server, addr []byte, requireSynced bool) (*Session, error) {
+	peerAddr, ok := netip.AddrFromSlice(addr)
 	if !ok {
 		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid PCEP session address: %v", addr)
 	}
 
-	pcepSession := pce.SearchSession(pcepSessionAddr, true)
+	pcepSession := pce.SearchSession(peerAddr)
 	if pcepSession == nil {
-		return nil, newStatus(codes.FailedPrecondition, ReasonPCEPSessionNotSynced, "no synced session with %s", pcepSessionAddr)
+		return nil, newStatus(codes.NotFound, ReasonPCEPSessionNotFound,
+			"no session with address %s found", peerAddr)
+	}
+	if requireSynced && !pcepSession.IsSynced() {
+		return nil, newStatus(codes.FailedPrecondition, ReasonPCEPSessionNotSynced,
+			"no synced session with %s", peerAddr)
 	}
 	return pcepSession, nil
+}
+
+// getSyncedPCEPSession resolves the synced PCEP session a write request targets.
+func getSyncedPCEPSession(pce *Server, addr []byte) (*Session, error) {
+	return resolveSession(pce, addr, true)
 }
 
 // tedNode returns the non-nil node for routerID.
@@ -793,30 +814,11 @@ func (s *APIServer) GetSessionList(_ context.Context, _ *pb.GetSessionListReques
 	s.logger.Info("Received GetSessionList API request")
 
 	pcepSessions := s.pce.Sessions()
-	slices.SortFunc(pcepSessions, func(a, b *Session) int { return a.peerAddr.Compare(b.peerAddr) })
+	sortSessionsByAddr(pcepSessions)
 
-	var sessions []*pb.Session
+	sessions := make([]*pb.Session, 0, len(pcepSessions))
 	for _, pcepSession := range pcepSessions {
-		ss := &pb.Session{
-			Addr:     pcepSession.peerAddr.AsSlice(),
-			State:    pb.SessionState_SESSION_STATE_UP, // Only the UP state in the current specification
-			IsSynced: pcepSession.IsSynced(),
-		}
-		seenCapabilities := make(map[string]struct{})
-		for _, cap := range pcepSession.AdvertisedCapabilities() {
-			b, err := cap.Serialize()
-			if err != nil {
-				s.logger.Warn("failed to serialize advertised capability", zap.Error(err))
-				continue
-			}
-			capabilityKey := fmt.Sprintf("%d:%s", cap.Type(), b)
-			if _, ok := seenCapabilities[capabilityKey]; ok {
-				continue
-			}
-			seenCapabilities[capabilityKey] = struct{}{}
-			ss.Capabilities = append(ss.Capabilities, buildCapability(cap))
-		}
-		sessions = append(sessions, ss)
+		sessions = append(sessions, s.buildPBSession(pcepSession))
 	}
 
 	s.logger.Debug("Send GetSessionList API reply")
@@ -827,15 +829,11 @@ func (s *APIServer) GetSessionList(_ context.Context, _ *pb.GetSessionListReques
 
 // DeleteSession deletes a PCEP session.
 func (s *APIServer) DeleteSession(_ context.Context, req *pb.DeleteSessionRequest) (*pb.DeleteSessionResponse, error) {
-	ssAddr, ok := netip.AddrFromSlice(req.GetAddr())
-	if !ok {
-		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid address: %v", req.GetAddr())
-	}
-
 	pce := s.pce
-	ss := pce.SearchSession(ssAddr, false)
-	if ss == nil {
-		return nil, newStatus(codes.NotFound, ReasonPCEPSessionNotFound, "no session with address %s found", ssAddr)
+	// A session being torn down need not be synced.
+	ss, err := resolveSession(pce, req.GetAddr(), false)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := ss.SendClose(pcep.CloseReasonNoExplanationProvided); err != nil {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -334,7 +334,7 @@ func resolveSRPolicyIntent(inputSRPolicy *pb.SRPolicy, disablePathCompute bool, 
 func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, path resolvedPath, disablePathCompute bool) error {
 	inputSRPolicy := input.GetSrPolicy()
 
-	pcepSession, err := getSyncedPCEPSession(s.pce, inputSRPolicy.GetPcepSessionAddr())
+	pcepSession, err := getSyncedPCEPSession(s.pce, inputSRPolicy.GetPeerAddr())
 	if err != nil {
 		return wrapStatusError(err, "failed to get synchronized PCEP session")
 	}
@@ -391,7 +391,7 @@ func (s *APIServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyRequ
 		return nil, wrapStatusError(err, "failed to send SR policy request")
 	}
 
-	return &pb.CreateSRPolicyResponse{IsSuccess: true}, nil
+	return &pb.CreateSRPolicyResponse{}, nil
 }
 
 func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []table.Segment) error {
@@ -465,7 +465,7 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []ta
 func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRequest) (*pb.DeleteSRPolicyResponse, error) {
 	err := validate(input.GetSrPolicy(), input.GetAsn(), ValidationDelete)
 	if err != nil {
-		return &pb.DeleteSRPolicyResponse{IsSuccess: false}, err
+		return nil, err
 	}
 
 	inputSRPolicy := input.GetSrPolicy()
@@ -476,23 +476,19 @@ func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRe
 		var ok bool
 		srcAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
 		if !ok {
-			return &pb.DeleteSRPolicyResponse{
-				IsSuccess: false,
-			}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid source address")
+			return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid source address")
 		}
 	}
 
 	dstAddr, ok := netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
 	if !ok {
-		return &pb.DeleteSRPolicyResponse{
-			IsSuccess: false,
-		}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid destination address")
+		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid destination address")
 	}
 
 	for _, segment := range inputSRPolicy.GetSegmentList() {
 		seg, err := newEnrichedSegment(segment, s.usidMode)
 		if err != nil {
-			return &pb.DeleteSRPolicyResponse{IsSuccess: false}, err
+			return nil, err
 		}
 		segmentList = append(segmentList, seg)
 	}
@@ -500,9 +496,9 @@ func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRe
 	s.logger.Info("Received DeleteSRPolicy API request")
 	s.logger.Debug("Received parameter", zap.Any("input", input))
 
-	pcepSession, err := getSyncedPCEPSession(s.pce, inputSRPolicy.GetPcepSessionAddr())
+	pcepSession, err := getSyncedPCEPSession(s.pce, inputSRPolicy.GetPeerAddr())
 	if err != nil {
-		return &pb.DeleteSRPolicyResponse{IsSuccess: false}, err
+		return nil, err
 	}
 
 	srPolicy := table.SRPolicy{
@@ -519,19 +515,19 @@ func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRe
 		srPolicy.PlspID = id
 
 		if err := pcepSession.RequestSRPolicyDeleted(srPolicy); err != nil {
-			return &pb.DeleteSRPolicyResponse{IsSuccess: false}, newStatus(codes.Internal, ReasonPCEPRequestFailed, "failed to send PC delete: %v", err)
+			return nil, newStatus(codes.Internal, ReasonPCEPRequestFailed, "failed to send PC delete: %v", err)
 		}
 	} else {
-		return &pb.DeleteSRPolicyResponse{IsSuccess: false}, newStatus(codes.NotFound, ReasonSRPolicyNotFound, "requested SR Policy not found")
+		return nil, newStatus(codes.NotFound, ReasonSRPolicyNotFound, "requested SR Policy not found")
 	}
 
-	return &pb.DeleteSRPolicyResponse{IsSuccess: true}, nil
+	return &pb.DeleteSRPolicyResponse{}, nil
 }
 
 // srPolicyListFilter validates and parses the session filter.
 func srPolicyListFilter(req *pb.GetSRPolicyListRequest) (netip.Addr, error) {
 	var filterAddr netip.Addr
-	if raw := req.GetSessionAddr(); len(raw) > 0 {
+	if raw := req.GetPeerAddr(); len(raw) > 0 {
 		var ok bool
 		filterAddr, ok = netip.AddrFromSlice(raw)
 		if !ok {
@@ -555,7 +551,7 @@ func (s *APIServer) GetSRPolicyList(_ context.Context, req *pb.GetSRPolicyListRe
 
 	routerIDIndex := s.pce.TED().RouterIDIndex()
 
-	sessions := make([]*pb.Session, 0, len(pcepSessions))
+	sessions := make([]*pb.SRPolicySession, 0, len(pcepSessions))
 	for _, pcepSession := range pcepSessions {
 		if filterAddr.IsValid() && pcepSession.peerAddr != filterAddr {
 			continue
@@ -582,9 +578,7 @@ func (s *APIServer) GetSRPolicyList(_ context.Context, req *pb.GetSRPolicyListRe
 			return strings.Compare(a.GetPolicyName(), b.GetPolicyName())
 		})
 
-		pbSession := s.buildPBSession(pcepSession)
-		pbSession.SrPolicies = pbPolicies
-		sessions = append(sessions, pbSession)
+		sessions = append(sessions, buildPBSRPolicySession(pcepSession, pbPolicies))
 	}
 
 	s.logger.Debug("Send SRPolicyList API reply")
@@ -625,8 +619,8 @@ const (
 
 var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 	ValidationAdd: func(policy *pb.SRPolicy, _ uint32) error {
-		if policy.PcepSessionAddr == nil {
-			return errors.New("policy.PCEP session address must not be nil")
+		if policy.PeerAddr == nil {
+			return errors.New("policy.PeerAddr must not be nil")
 		}
 		if policy.Color == 0 {
 			return errors.New("policy.Color must not be zero")
@@ -641,8 +635,8 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 	},
 
 	ValidationAddDisablePathCompute: func(policy *pb.SRPolicy, _ uint32) error {
-		if policy.PcepSessionAddr == nil {
-			return errors.New("policy.PCEP session address must not be nil")
+		if policy.PeerAddr == nil {
+			return errors.New("policy.PeerAddr must not be nil")
 		}
 		if policy.Color == 0 {
 			return errors.New("policy.Color must not be zero")
@@ -660,8 +654,8 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 	},
 
 	ValidationDelete: func(policy *pb.SRPolicy, _ uint32) error {
-		if policy.PcepSessionAddr == nil {
-			return errors.New("policy.PCEP session address must not be nil")
+		if policy.PeerAddr == nil {
+			return errors.New("policy.PeerAddr must not be nil")
 		}
 		if policy.Color == 0 {
 			return errors.New("policy.Color must not be zero")
@@ -809,16 +803,37 @@ func getMetricType(metricType pb.MetricType) (table.MetricType, error) {
 	}
 }
 
+// sessionListFilter validates and parses the peer address filter.
+func sessionListFilter(req *pb.GetSessionListRequest) (netip.Addr, error) {
+	var filterAddr netip.Addr
+	if raw := req.GetPeerAddr(); len(raw) > 0 {
+		var ok bool
+		filterAddr, ok = netip.AddrFromSlice(raw)
+		if !ok {
+			return netip.Addr{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid session filter address %v", raw)
+		}
+	}
+	return filterAddr, nil
+}
+
 // GetSessionList returns a list of PCEP sessions.
-func (s *APIServer) GetSessionList(_ context.Context, _ *pb.GetSessionListRequest) (*pb.GetSessionListResponse, error) {
+func (s *APIServer) GetSessionList(_ context.Context, req *pb.GetSessionListRequest) (*pb.GetSessionListResponse, error) {
 	s.logger.Info("Received GetSessionList API request")
+
+	filterAddr, err := sessionListFilter(req)
+	if err != nil {
+		return nil, err
+	}
 
 	pcepSessions := s.pce.Sessions()
 	sortSessionsByAddr(pcepSessions)
 
 	sessions := make([]*pb.Session, 0, len(pcepSessions))
 	for _, pcepSession := range pcepSessions {
-		sessions = append(sessions, s.buildPBSession(pcepSession))
+		if filterAddr.IsValid() && pcepSession.peerAddr != filterAddr {
+			continue
+		}
+		sessions = append(sessions, s.buildPBSession(pcepSession, req.GetIncludeStats()))
 	}
 
 	s.logger.Debug("Send GetSessionList API reply")
@@ -831,40 +846,40 @@ func (s *APIServer) GetSessionList(_ context.Context, _ *pb.GetSessionListReques
 func (s *APIServer) DeleteSession(_ context.Context, req *pb.DeleteSessionRequest) (*pb.DeleteSessionResponse, error) {
 	pce := s.pce
 	// A session being torn down need not be synced.
-	ss, err := resolveSession(pce, req.GetAddr(), false)
+	ss, err := resolveSession(pce, req.GetPeerAddr(), false)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := ss.SendClose(pcep.CloseReasonNoExplanationProvided); err != nil {
-		return &pb.DeleteSessionResponse{IsSuccess: false}, newStatus(codes.Internal, ReasonPCEPRequestFailed, "failed to send close message: %v", err)
+		return nil, newStatus(codes.Internal, ReasonPCEPRequestFailed, "failed to send close message: %v", err)
 	}
 
 	// A PCEP Close only notifies the peer; the TCP connection and the server-side
 	// session state have to be torn down here as well.
 	pce.closeSession(ss)
 
-	return &pb.DeleteSessionResponse{IsSuccess: true}, nil
+	return &pb.DeleteSessionResponse{}, nil
 }
 
 // GetTED returns the TED information in a structured way.
 func (s *APIServer) GetTED(_ context.Context, _ *pb.GetTEDRequest) (*pb.GetTEDResponse, error) {
 	s.logger.Info("Received GetTED API request")
 
-	ret := &pb.GetTEDResponse{Enable: true}
+	ret := &pb.GetTEDResponse{Enabled: true}
 	if s.pce == nil {
-		ret.Enable = false
+		ret.Enabled = false
 		return ret, nil
 	}
 	ted := s.pce.TED()
 	if ted == nil {
-		ret.Enable = false
+		ret.Enabled = false
 		return ret, nil
 	}
 
 	for _, node := range ted.Nodes {
 		if n := convertLsNode(node, s.logger); n != nil {
-			ret.LsNodes = append(ret.LsNodes, n)
+			ret.Nodes = append(ret.Nodes, n)
 		}
 	}
 

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -33,6 +33,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func testMSDPtr(v uint8) *uint8 { return &v }
+
 func TestStatusFromCSPFError(t *testing.T) {
 	reasonOf := func(t *testing.T, err error) (codes.Code, string) {
 		t.Helper()
@@ -128,7 +130,6 @@ func TestNewEnrichedSegmentSRMPLS(t *testing.T) {
 	}
 }
 
-// TestNewEnrichedSegmentSRv6 verifies that SRv6 segment attributes are preserved.
 func TestNewEnrichedSegmentSRv6(t *testing.T) {
 	segment := &pb.Segment{
 		Sid:          "2001:db8:1005::",
@@ -163,8 +164,6 @@ func addrString(addr netip.Addr) string {
 	return addr.String()
 }
 
-// TestCreateEroFromSegmentListWithNAI verifies that a localAddr is encoded as
-// the SR-ERO node NAI.
 func TestCreateEroFromSegmentListWithNAI(t *testing.T) {
 	seg := table.NewSegmentSRMPLS(16002)
 	seg.LocalAddr = netip.MustParseAddr("10.255.0.2")
@@ -473,7 +472,7 @@ func TestServe_ListenFailure(t *testing.T) {
 
 func TestServe_ReturnsNilWhenAlreadyStoppedBeforeServing(t *testing.T) {
 	grpcServer := grpc.NewServer()
-	grpcServer.GracefulStop() // simulate ctx cancellation winning the startup race against Serve
+	grpcServer.GracefulStop() // simulate cancellation winning the startup race
 
 	s := &APIServer{grpcServer: grpcServer, logger: zap.NewNop()}
 	assert.NoError(t, s.Serve("127.0.0.1", "0"), "grpc.ErrServerStopped from the startup race should not be reported as a failure")
@@ -540,8 +539,8 @@ func TestConvertLsPrefixes_SidIndexPresence(t *testing.T) {
 
 func TestGetSessionList_DeduplicatesNonAdjacentCapabilities(t *testing.T) {
 	session := &Session{
-		peerAddr: netip.MustParseAddr("10.0.0.1"),
-		isSynced: true,
+		peerAddr:  netip.MustParseAddr("10.0.0.1"),
+		syncState: lspDBSyncFinished,
 		advertisedCapabilities: []pcep.CapabilityInterface{
 			&pcep.SRPCECapability{IsNAISupported: true},
 			&pcep.SRv6PCECapability{IsNAISupported: true},
@@ -556,23 +555,23 @@ func TestGetSessionList_DeduplicatesNonAdjacentCapabilities(t *testing.T) {
 	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 1)
-	require.Len(t, resp.Sessions[0].Capabilities, 2)
+	require.Len(t, resp.Sessions[0].LocalCapabilities, 2)
 
-	sr := resp.Sessions[0].Capabilities[0]
+	sr := resp.Sessions[0].LocalCapabilities[0]
 	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_SR, sr.GetType())
 	assert.True(t, sr.GetSr().GetNaiSupported())
 
-	srv6 := resp.Sessions[0].Capabilities[1]
+	srv6 := resp.Sessions[0].LocalCapabilities[1]
 	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_SRV6, srv6.GetType())
 	assert.True(t, srv6.GetSrv6().GetNaiSupported())
 }
 
 func TestGetSessionList_BuildsStructuredCapabilities(t *testing.T) {
 	session := &Session{
-		peerAddr: netip.MustParseAddr("10.0.0.1"),
-		isSynced: true,
+		peerAddr:  netip.MustParseAddr("10.0.0.1"),
+		syncState: lspDBSyncFinished,
 		advertisedCapabilities: []pcep.CapabilityInterface{
-			&pcep.SRPCECapability{IsNAISupported: true, MaximumSidDepth: 10},
+			&pcep.SRPCECapability{IsNAISupported: true, MaximumSidDepth: testMSDPtr(10)},
 			&pcep.LSPDBVersion{VersionNumber: 42},
 		},
 	}
@@ -584,14 +583,14 @@ func TestGetSessionList_BuildsStructuredCapabilities(t *testing.T) {
 	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 1)
-	require.Len(t, resp.Sessions[0].Capabilities, 2)
+	require.Len(t, resp.Sessions[0].LocalCapabilities, 2)
 
-	sr := resp.Sessions[0].Capabilities[0]
+	sr := resp.Sessions[0].LocalCapabilities[0]
 	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_SR, sr.GetType())
 	assert.Equal(t, uint32(10), sr.GetSr().GetMsd())
 	assert.True(t, sr.GetSr().GetNaiSupported())
 
-	dbVersion := resp.Sessions[0].Capabilities[1]
+	dbVersion := resp.Sessions[0].LocalCapabilities[1]
 	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_LSP_DB_VERSION, dbVersion.GetType())
 	assert.Equal(t, uint64(42), dbVersion.GetLspDbVersion().GetVersionNumber())
 }
@@ -607,8 +606,8 @@ func (c *failingCapability) Serialize() ([]byte, error) {
 func TestGetSessionList_SkipsCapabilityOnSerializeError(t *testing.T) {
 	core, logs := observer.New(zap.WarnLevel)
 	session := &Session{
-		peerAddr: netip.MustParseAddr("10.0.0.1"),
-		isSynced: true,
+		peerAddr:  netip.MustParseAddr("10.0.0.1"),
+		syncState: lspDBSyncFinished,
 		advertisedCapabilities: []pcep.CapabilityInterface{
 			&failingCapability{},
 			&pcep.SRv6PCECapability{IsNAISupported: true},
@@ -622,17 +621,17 @@ func TestGetSessionList_SkipsCapabilityOnSerializeError(t *testing.T) {
 	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 1)
-	require.Len(t, resp.Sessions[0].Capabilities, 1, "the failing capability must be skipped")
+	require.Len(t, resp.Sessions[0].LocalCapabilities, 1, "the failing capability must be skipped")
 
-	srv6 := resp.Sessions[0].Capabilities[0]
+	srv6 := resp.Sessions[0].LocalCapabilities[0]
 	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_SRV6, srv6.GetType())
 	assert.Len(t, logs.FilterMessage("failed to serialize advertised capability").All(), 1)
 }
 
 func TestGetSessionList_MultipathCapabilityDoesNotSetMsd(t *testing.T) {
 	session := &Session{
-		peerAddr: netip.MustParseAddr("10.0.0.1"),
-		isSynced: true,
+		peerAddr:  netip.MustParseAddr("10.0.0.1"),
+		syncState: lspDBSyncFinished,
 		advertisedCapabilities: []pcep.CapabilityInterface{
 			pcep.NewMultipathCapability(8, true, true, true, true),
 		},
@@ -645,9 +644,9 @@ func TestGetSessionList_MultipathCapabilityDoesNotSetMsd(t *testing.T) {
 	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 1)
-	require.Len(t, resp.Sessions[0].Capabilities, 1)
+	require.Len(t, resp.Sessions[0].LocalCapabilities, 1)
 
-	multipath := resp.Sessions[0].Capabilities[0]
+	multipath := resp.Sessions[0].LocalCapabilities[0]
 	assert.Equal(t, pb.CapabilityType_CAPABILITY_TYPE_MULTIPATH, multipath.GetType())
 	assert.Nil(t, multipath.GetSr(), "MaxMultipaths must not be reported via the SR capability's Msd (Maximum SID Depth)")
 	assert.Equal(t, uint32(8), multipath.GetMultipath().GetMaxMultipaths())
@@ -656,7 +655,7 @@ func TestGetSessionList_MultipathCapabilityDoesNotSetMsd(t *testing.T) {
 func TestGetSessionList_ReportsLocalAndPccTimersAndSessionID(t *testing.T) {
 	session := &Session{
 		peerAddr:  netip.MustParseAddr("10.0.0.1"),
-		isSynced:  true,
+		syncState: lspDBSyncFinished,
 		state:     sessionStateUp,
 		localOpen: &OpenParams{SessionID: 3, Keepalive: 30, DeadTimer: 120},
 		pccOpen:   &OpenParams{SessionID: 7, Keepalive: 10, DeadTimer: 40},
@@ -673,11 +672,11 @@ func TestGetSessionList_ReportsLocalAndPccTimersAndSessionID(t *testing.T) {
 	got := resp.Sessions[0]
 	assert.Equal(t, pb.SessionState_SESSION_STATE_UP, got.GetState())
 	assert.Equal(t, uint32(3), got.GetLocalSessionId())
-	assert.Equal(t, uint32(7), got.GetPccSessionId())
+	assert.Equal(t, uint32(7), got.GetPeerSessionId())
 	assert.Equal(t, uint32(30), got.GetLocalTimers().GetKeepalive())
 	assert.Equal(t, uint32(120), got.GetLocalTimers().GetDeadTimer())
-	assert.Equal(t, uint32(10), got.GetPccTimers().GetKeepalive())
-	assert.Equal(t, uint32(40), got.GetPccTimers().GetDeadTimer())
+	assert.Equal(t, uint32(10), got.GetPeerTimers().GetKeepalive())
+	assert.Equal(t, uint32(40), got.GetPeerTimers().GetDeadTimer())
 	assert.Equal(t, uint32(30), got.GetEffectiveTimers().GetKeepalive())
 	assert.Equal(t, uint32(40), got.GetEffectiveTimers().GetDeadTimer())
 }
@@ -697,9 +696,9 @@ func TestGetSessionList_LeavesAdvertisedValuesUnsetBeforeTheOpenExchange(t *test
 	got := resp.Sessions[0]
 	assert.Equal(t, pb.SessionState_SESSION_STATE_OPEN_WAIT, got.GetState())
 	assert.Nil(t, got.LocalSessionId, "a SID of 0 must be distinguishable from an unsent Open message")
-	assert.Nil(t, got.PccSessionId, "a SID of 0 must be distinguishable from an unreceived Open message")
+	assert.Nil(t, got.PeerSessionId, "a SID of 0 must be distinguishable from an unreceived Open message")
 	assert.Nil(t, got.GetLocalTimers())
-	assert.Nil(t, got.GetPccTimers())
+	assert.Nil(t, got.GetPeerTimers())
 }
 
 func TestGetSessionList_ReportsZeroPccSessionIDAsAdvertised(t *testing.T) {
@@ -720,8 +719,8 @@ func TestGetSessionList_ReportsZeroPccSessionIDAsAdvertised(t *testing.T) {
 	got := resp.Sessions[0]
 	require.NotNil(t, got.LocalSessionId, "SID 0 is valid on the wire and must be reported")
 	assert.Zero(t, got.GetLocalSessionId())
-	require.NotNil(t, got.PccSessionId)
-	assert.Zero(t, got.GetPccSessionId())
+	require.NotNil(t, got.PeerSessionId)
+	assert.Zero(t, got.GetPeerSessionId())
 	assert.Zero(t, got.GetEffectiveTimers().GetDeadTimer())
 }
 
@@ -738,10 +737,56 @@ func TestGetSessionList_SortsSessionsByAddr(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 2)
 
-	addr0, _ := netip.AddrFromSlice(resp.Sessions[0].GetAddr())
-	addr1, _ := netip.AddrFromSlice(resp.Sessions[1].GetAddr())
+	addr0, _ := netip.AddrFromSlice(resp.Sessions[0].GetPeerAddr())
+	addr1, _ := netip.AddrFromSlice(resp.Sessions[1].GetPeerAddr())
 	assert.Equal(t, "10.0.0.1", addr0.String())
 	assert.Equal(t, "10.0.0.2", addr1.String())
+}
+
+func TestGetSessionList_FiltersBySessionAddr(t *testing.T) {
+	s := &APIServer{
+		pce: &Server{sessionList: []*Session{
+			{peerAddr: netip.MustParseAddr("10.0.0.1")},
+			{peerAddr: netip.MustParseAddr("10.0.0.2")},
+		}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{PeerAddr: netip.MustParseAddr("10.0.0.2").AsSlice()})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	addr, _ := netip.AddrFromSlice(resp.Sessions[0].GetPeerAddr())
+	assert.Equal(t, "10.0.0.2", addr.String())
+}
+
+func TestGetSessionList_RejectsInvalidSessionFilter(t *testing.T) {
+	s := &APIServer{
+		pce:    &Server{},
+		logger: zap.NewNop(),
+	}
+
+	_, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{PeerAddr: []byte{1, 2, 3}})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestGetSessionList_IncludeStatsControlsStatsPresence(t *testing.T) {
+	s := &APIServer{
+		pce: &Server{sessionList: []*Session{
+			{peerAddr: netip.MustParseAddr("10.0.0.1")},
+		}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	assert.Nil(t, resp.Sessions[0].GetStats(), "Stats must be nil unless include_stats is set")
+
+	resp, err = s.GetSessionList(context.Background(), &pb.GetSessionListRequest{IncludeStats: true})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	assert.NotNil(t, resp.Sessions[0].GetStats(), "Stats must be populated when include_stats is set")
 }
 
 func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing.T) {
@@ -756,8 +801,8 @@ func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing
 	ted.Nodes[srcNode.RouterID] = srcNode
 
 	session2 := &Session{
-		peerAddr: netip.MustParseAddr("10.0.0.2"),
-		isSynced: true,
+		peerAddr:  netip.MustParseAddr("10.0.0.2"),
+		syncState: lspDBSyncFinished,
 		srPolicies: []*table.SRPolicy{
 			table.NewSRPolicy(1, "policy-b", []table.Segment{seg},
 				netip.MustParseAddr("192.0.2.10"), netip.MustParseAddr("192.0.2.20"),
@@ -765,8 +810,8 @@ func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing
 		},
 	}
 	session1 := &Session{
-		peerAddr: netip.MustParseAddr("10.0.0.1"),
-		isSynced: true,
+		peerAddr:  netip.MustParseAddr("10.0.0.1"),
+		syncState: lspDBSyncFinished,
 		srPolicies: []*table.SRPolicy{
 			table.NewSRPolicy(2, "policy-a", []table.Segment{seg},
 				netip.MustParseAddr("192.0.2.10"), netip.MustParseAddr("192.0.2.20"),
@@ -783,8 +828,8 @@ func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 2)
 
-	// Sessions are ordered by peer address, not insertion order.
-	addr0, _ := netip.AddrFromSlice(resp.Sessions[0].GetAddr())
+	// Verify ordering is independent of insertion order.
+	addr0, _ := netip.AddrFromSlice(resp.Sessions[0].GetPeerAddr())
 	assert.Equal(t, "10.0.0.1", addr0.String())
 	require.Len(t, resp.Sessions[0].GetSrPolicies(), 1)
 
@@ -799,7 +844,7 @@ func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing
 func TestGetSRPolicyList_IncludesUnsyncedSessions(t *testing.T) {
 	s := &APIServer{
 		pce: &Server{sessionList: []*Session{
-			{peerAddr: netip.MustParseAddr("10.0.0.1"), isSynced: false},
+			{peerAddr: netip.MustParseAddr("10.0.0.1"), syncState: lspDBSyncPending},
 		}},
 		logger: zap.NewNop(),
 	}
@@ -807,7 +852,7 @@ func TestGetSRPolicyList_IncludesUnsyncedSessions(t *testing.T) {
 	resp, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 1, "unsynced sessions must still be reported so callers can see why policies are missing")
-	assert.False(t, resp.Sessions[0].GetIsSynced())
+	assert.Equal(t, pb.LspDbSyncState_LSP_DB_SYNC_STATE_PENDING, resp.Sessions[0].GetSyncState())
 	assert.Empty(t, resp.Sessions[0].GetSrPolicies())
 }
 
@@ -818,15 +863,15 @@ func TestGetSRPolicyList_FiltersBySessionAddr(t *testing.T) {
 	s := &APIServer{
 		pce: &Server{sessionList: []*Session{
 			{
-				peerAddr: netip.MustParseAddr("10.0.0.1"),
-				isSynced: true,
+				peerAddr:  netip.MustParseAddr("10.0.0.1"),
+				syncState: lspDBSyncFinished,
 				srPolicies: []*table.SRPolicy{
 					table.NewSRPolicy(1, "policy-a", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 100, 100, 0, table.PolicyUp),
 				},
 			},
 			{
-				peerAddr: netip.MustParseAddr("10.0.0.2"),
-				isSynced: true,
+				peerAddr:  netip.MustParseAddr("10.0.0.2"),
+				syncState: lspDBSyncFinished,
 				srPolicies: []*table.SRPolicy{
 					table.NewSRPolicy(2, "policy-b", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 200, 100, 0, table.PolicyUp),
 				},
@@ -835,10 +880,10 @@ func TestGetSRPolicyList_FiltersBySessionAddr(t *testing.T) {
 		logger: zap.NewNop(),
 	}
 
-	resp, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{SessionAddr: netip.MustParseAddr("10.0.0.2").AsSlice()})
+	resp, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{PeerAddr: netip.MustParseAddr("10.0.0.2").AsSlice()})
 	require.NoError(t, err)
 	require.Len(t, resp.Sessions, 1)
-	addr, _ := netip.AddrFromSlice(resp.Sessions[0].GetAddr())
+	addr, _ := netip.AddrFromSlice(resp.Sessions[0].GetPeerAddr())
 	assert.Equal(t, "10.0.0.2", addr.String())
 }
 
@@ -848,7 +893,7 @@ func TestGetSRPolicyList_RejectsInvalidSessionFilter(t *testing.T) {
 		logger: zap.NewNop(),
 	}
 
-	_, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{SessionAddr: []byte{1, 2, 3}})
+	_, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{PeerAddr: []byte{1, 2, 3}})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
@@ -920,7 +965,7 @@ func TestGetSRPolicyList_RoundTripsTypeAndMetric(t *testing.T) {
 		pce: &Server{sessionList: []*Session{
 			{
 				peerAddr:   netip.MustParseAddr("10.0.0.1"),
-				isSynced:   true,
+				syncState:  lspDBSyncFinished,
 				srPolicies: []*table.SRPolicy{knownPolicy, unknownPolicy},
 			},
 		}},
@@ -1042,7 +1087,7 @@ func TestSessionList_ConcurrentAccess(_ *testing.T) {
 	go func() {
 		defer close(done)
 		for i := range 100 {
-			ss := &Session{localSessionID: uint8(i), peerAddr: addr, isSynced: true}
+			ss := &Session{localSessionID: uint8(i), peerAddr: addr, syncState: lspDBSyncFinished}
 
 			s.sessionMu.Lock()
 			s.sessionList = append(s.sessionList, ss)
@@ -1079,7 +1124,7 @@ func TestDeleteSRPolicy_SrcAddrOmitted(t *testing.T) {
 	dstAddr := netip.MustParseAddr("10.255.0.2")
 
 	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-	ss.isSynced = true
+	ss.syncState = lspDBSyncFinished
 	ss.srPolicies = []*table.SRPolicy{
 		{
 			PlspID:     1,
@@ -1095,16 +1140,15 @@ func TestDeleteSRPolicy_SrcAddrOmitted(t *testing.T) {
 
 	req := &pb.DeleteSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
-			PcepSessionAddr: peerAddr.AsSlice(),
-			DstAddr:         dstAddr.AsSlice(),
-			Color:           100,
-			PolicyName:      "test-policy",
+			PeerAddr:   peerAddr.AsSlice(),
+			DstAddr:    dstAddr.AsSlice(),
+			Color:      100,
+			PolicyName: "test-policy",
 		},
 	}
 
-	resp, err := apiServer.DeleteSRPolicy(context.Background(), req)
+	_, err := apiServer.DeleteSRPolicy(context.Background(), req)
 	require.NoError(t, err)
-	assert.True(t, resp.GetIsSuccess())
 }
 
 func TestGetSegmentList_DynamicHopcountPrefersFewerHops(t *testing.T) {
@@ -1332,8 +1376,8 @@ func TestGetSRPolicyList_SortsBySameColorThenPlspIdThenName(t *testing.T) {
 	s := &APIServer{
 		pce: &Server{sessionList: []*Session{
 			{
-				peerAddr: netip.MustParseAddr("10.0.0.1"),
-				isSynced: true,
+				peerAddr:  netip.MustParseAddr("10.0.0.1"),
+				syncState: lspDBSyncFinished,
 				srPolicies: []*table.SRPolicy{
 					mk(200, 1, "z"),
 					mk(100, 1, "z"),
@@ -1384,10 +1428,10 @@ func TestValidateCreateSRPolicy(t *testing.T) {
 			req: &pb.CreateSRPolicyRequest{
 				Asn: 65000,
 				SrPolicy: &pb.SRPolicy{
-					PcepSessionAddr: netip.MustParseAddr("10.0.0.1").AsSlice(),
-					Color:           100,
-					SrcRouterId:     "r1",
-					DstRouterId:     "r2",
+					PeerAddr:    netip.MustParseAddr("10.0.0.1").AsSlice(),
+					Color:       100,
+					SrcRouterId: "r1",
+					DstRouterId: "r2",
 				},
 			},
 		},
@@ -1395,7 +1439,7 @@ func TestValidateCreateSRPolicy(t *testing.T) {
 			name: "path-compute request missing router IDs",
 			req: &pb.CreateSRPolicyRequest{
 				Asn:      65000,
-				SrPolicy: &pb.SRPolicy{PcepSessionAddr: netip.MustParseAddr("10.0.0.1").AsSlice(), Color: 100},
+				SrPolicy: &pb.SRPolicy{PeerAddr: netip.MustParseAddr("10.0.0.1").AsSlice(), Color: 100},
 			},
 			wantErr: true,
 		},
@@ -1403,11 +1447,11 @@ func TestValidateCreateSRPolicy(t *testing.T) {
 			name: "disable_path_compute request valid",
 			req: &pb.CreateSRPolicyRequest{
 				SrPolicy: &pb.SRPolicy{
-					PcepSessionAddr: netip.MustParseAddr("10.0.0.1").AsSlice(),
-					Color:           100,
-					SrcAddr:         netip.MustParseAddr("10.0.0.1").AsSlice(),
-					DstAddr:         netip.MustParseAddr("10.0.0.2").AsSlice(),
-					SegmentList:     []*pb.Segment{{Sid: "16003"}},
+					PeerAddr:    netip.MustParseAddr("10.0.0.1").AsSlice(),
+					Color:       100,
+					SrcAddr:     netip.MustParseAddr("10.0.0.1").AsSlice(),
+					DstAddr:     netip.MustParseAddr("10.0.0.2").AsSlice(),
+					SegmentList: []*pb.Segment{{Sid: "16003"}},
 				},
 				DisablePathCompute: true,
 			},
@@ -1417,10 +1461,10 @@ func TestValidateCreateSRPolicy(t *testing.T) {
 			name: "disable_path_compute request missing segment list",
 			req: &pb.CreateSRPolicyRequest{
 				SrPolicy: &pb.SRPolicy{
-					PcepSessionAddr: netip.MustParseAddr("10.0.0.1").AsSlice(),
-					Color:           100,
-					SrcAddr:         netip.MustParseAddr("10.0.0.1").AsSlice(),
-					DstAddr:         netip.MustParseAddr("10.0.0.2").AsSlice(),
+					PeerAddr: netip.MustParseAddr("10.0.0.1").AsSlice(),
+					Color:    100,
+					SrcAddr:  netip.MustParseAddr("10.0.0.1").AsSlice(),
+					DstAddr:  netip.MustParseAddr("10.0.0.2").AsSlice(),
 				},
 				DisablePathCompute: true,
 			},
@@ -1471,7 +1515,7 @@ func TestGetLoopbackAddr(t *testing.T) {
 
 func TestGetSyncedPCEPSession(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	ss := &Session{peerAddr: peerAddr, isSynced: true}
+	ss := &Session{peerAddr: peerAddr, syncState: lspDBSyncFinished}
 	pce := &Server{sessionList: []*Session{ss}}
 
 	got, err := getSyncedPCEPSession(pce, peerAddr.AsSlice())
@@ -1489,7 +1533,7 @@ func TestResolveSession(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 
 	t.Run("the peer address identifies the session", func(t *testing.T) {
-		ss := &Session{peerAddr: peerAddr, isSynced: true}
+		ss := &Session{peerAddr: peerAddr, syncState: lspDBSyncFinished}
 		pce := &Server{sessionList: []*Session{ss}}
 
 		got, err := resolveSession(pce, peerAddr.AsSlice(), true)
@@ -1507,7 +1551,7 @@ func TestResolveSession(t *testing.T) {
 	})
 
 	t.Run("an unsynced session reports not synced", func(t *testing.T) {
-		ss := &Session{peerAddr: peerAddr, isSynced: false}
+		ss := &Session{peerAddr: peerAddr, syncState: lspDBSyncPending}
 		pce := &Server{sessionList: []*Session{ss}}
 
 		_, err := resolveSession(pce, peerAddr.AsSlice(), true)
@@ -1517,7 +1561,7 @@ func TestResolveSession(t *testing.T) {
 	})
 
 	t.Run("requireSynced false accepts an unsynced session", func(t *testing.T) {
-		ss := &Session{peerAddr: peerAddr, isSynced: false}
+		ss := &Session{peerAddr: peerAddr, syncState: lspDBSyncPending}
 		pce := &Server{sessionList: []*Session{ss}}
 
 		got, err := resolveSession(pce, peerAddr.AsSlice(), false)
@@ -1765,13 +1809,13 @@ func TestCreateSRPolicy(t *testing.T) {
 		return &pb.CreateSRPolicyRequest{
 			Asn: 65000,
 			SrPolicy: &pb.SRPolicy{
-				Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-				PolicyName:      "test",
-				Color:           100,
-				PcepSessionAddr: netip.MustParseAddr("10.0.255.1").AsSlice(),
-				SrcRouterId:     "r1",
-				DstRouterId:     "r2",
-				SegmentList:     []*pb.Segment{{Sid: "16003"}},
+				Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+				PolicyName:  "test",
+				Color:       100,
+				PeerAddr:    netip.MustParseAddr("10.0.255.1").AsSlice(),
+				SrcRouterId: "r1",
+				DstRouterId: "r2",
+				SegmentList: []*pb.Segment{{Sid: "16003"}},
 			},
 			NoSidValidate: true,
 		}
@@ -1816,13 +1860,12 @@ func TestCreateSRPolicy(t *testing.T) {
 
 		peerAddr := netip.MustParseAddr("10.0.255.1")
 		ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-		ss.isSynced = true
+		ss.syncState = lspDBSyncFinished
 
 		s := &APIServer{pce: &Server{ted: ted, sessionList: []*Session{ss}}, logger: zap.NewNop()}
 
-		resp, err := s.CreateSRPolicy(context.Background(), baseReq())
+		_, err := s.CreateSRPolicy(context.Background(), baseReq())
 		require.NoError(t, err)
-		assert.True(t, resp.GetIsSuccess())
 	})
 }
 
@@ -1864,26 +1907,25 @@ func TestCreateSRPolicy_SRv6WithoutLocalAddr(t *testing.T) {
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-	ss.isSynced = true
+	ss.syncState = lspDBSyncFinished
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
 
 	req := &pb.CreateSRPolicyRequest{
 		DisablePathCompute: true,
 		SrPolicy: &pb.SRPolicy{
-			PolicyName:      "test",
-			Color:           100,
-			PcepSessionAddr: netip.MustParseAddr("10.0.255.1").AsSlice(),
-			SrcAddr:         netip.MustParseAddr("10.0.0.1").AsSlice(),
-			DstAddr:         netip.MustParseAddr("10.0.0.2").AsSlice(),
-			SegmentList:     []*pb.Segment{{Sid: "2001:db8::1"}},
+			PolicyName:  "test",
+			Color:       100,
+			PeerAddr:    netip.MustParseAddr("10.0.255.1").AsSlice(),
+			SrcAddr:     netip.MustParseAddr("10.0.0.1").AsSlice(),
+			DstAddr:     netip.MustParseAddr("10.0.0.2").AsSlice(),
+			SegmentList: []*pb.Segment{{Sid: "2001:db8::1"}},
 		},
 		NoSidValidate: true,
 	}
 
-	resp, err := s.CreateSRPolicy(context.Background(), req)
+	_, err := s.CreateSRPolicy(context.Background(), req)
 	require.NoError(t, err)
-	assert.True(t, resp.GetIsSuccess())
 
 	assert.Equal(t, table.BehaviorOpaque, readEROBehavior(t, client))
 }
@@ -1913,8 +1955,8 @@ func TestCreateSRPolicy_StatusCodes(t *testing.T) {
 			Asn: 65000,
 			SrPolicy: &pb.SRPolicy{
 				Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, PolicyName: "test", Color: 100,
-				PcepSessionAddr: netip.MustParseAddr("10.0.255.1").AsSlice(),
-				SrcRouterId:     "r1", DstRouterId: "r2",
+				PeerAddr:    netip.MustParseAddr("10.0.255.1").AsSlice(),
+				SrcRouterId: "r1", DstRouterId: "r2",
 				SegmentList: []*pb.Segment{{Sid: "16002"}},
 			},
 			NoSidValidate: true,
@@ -1940,8 +1982,8 @@ func TestCreateSRPolicy_StatusCodes(t *testing.T) {
 			codes.InvalidArgument, "INVALID_REQUEST", "ASN must not be zero"},
 		{"color is zero", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); r.SrPolicy.Color = 0; return r },
 			codes.InvalidArgument, "INVALID_REQUEST", "Color must not be zero"},
-		{"PCEP session address is absent", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); r.SrPolicy.PcepSessionAddr = nil; return r },
-			codes.InvalidArgument, "INVALID_REQUEST", "PCEP session address must not be nil"},
+		{"PCEP session address is absent", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); r.SrPolicy.PeerAddr = nil; return r },
+			codes.InvalidArgument, "INVALID_REQUEST", "policy.PeerAddr must not be nil"},
 		{"request ASN does not match the TED", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); r.Asn = 65001; return r },
 			codes.InvalidArgument, "INVALID_REQUEST", "does not match ted ASN"},
 		{"source router ID is not in the TED", true, func() *pb.CreateSRPolicyRequest { r := dynamicReq(); r.SrPolicy.SrcRouterId = "r9"; return r },
@@ -2031,10 +2073,10 @@ func TestDeleteSRPolicy(t *testing.T) {
 
 	validPolicy := func() *pb.SRPolicy {
 		return &pb.SRPolicy{
-			PcepSessionAddr: peerAddr.AsSlice(),
-			DstAddr:         dstAddr.AsSlice(),
-			Color:           100,
-			PolicyName:      "test-policy",
+			PeerAddr:   peerAddr.AsSlice(),
+			DstAddr:    dstAddr.AsSlice(),
+			Color:      100,
+			PolicyName: "test-policy",
 		}
 	}
 
@@ -2042,7 +2084,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 		s := &APIServer{logger: zap.NewNop()}
 		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: &pb.SRPolicy{}})
 		require.Error(t, err)
-		assert.False(t, resp.GetIsSuccess())
+		assert.Nil(t, resp)
 	})
 
 	t.Run("malformed source address", func(t *testing.T) {
@@ -2051,7 +2093,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 		policy.SrcAddr = []byte{1, 2, 3}
 		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: policy})
 		require.ErrorContains(t, err, "invalid source address")
-		assert.False(t, resp.GetIsSuccess())
+		assert.Nil(t, resp)
 	})
 
 	t.Run("malformed destination address", func(t *testing.T) {
@@ -2060,7 +2102,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 		policy.DstAddr = []byte{1, 2, 3}
 		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: policy})
 		require.ErrorContains(t, err, "invalid destination address")
-		assert.False(t, resp.GetIsSuccess())
+		assert.Nil(t, resp)
 	})
 
 	t.Run("malformed segment SID", func(t *testing.T) {
@@ -2069,22 +2111,22 @@ func TestDeleteSRPolicy(t *testing.T) {
 		policy.SegmentList = []*pb.Segment{{Sid: "not-a-sid"}}
 		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: policy})
 		require.Error(t, err)
-		assert.False(t, resp.GetIsSuccess())
+		assert.Nil(t, resp)
 	})
 
 	t.Run("no synced session", func(t *testing.T) {
 		s := &APIServer{pce: &Server{}, logger: zap.NewNop()}
 		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: validPolicy()})
 		require.Error(t, err)
-		assert.False(t, resp.GetIsSuccess())
+		assert.Nil(t, resp)
 	})
 
 	t.Run("SR Policy not found", func(t *testing.T) {
-		ss := &Session{peerAddr: peerAddr, isSynced: true}
+		ss := &Session{peerAddr: peerAddr, syncState: lspDBSyncFinished}
 		s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
 		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: validPolicy()})
 		require.ErrorContains(t, err, "requested SR Policy not found")
-		assert.False(t, resp.GetIsSuccess())
+		assert.Nil(t, resp)
 
 		st, ok := status.FromError(err)
 		require.True(t, ok)
@@ -2105,14 +2147,14 @@ func TestDeleteSRPolicy(t *testing.T) {
 		})
 
 		ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-		ss.isSynced = true
+		ss.syncState = lspDBSyncFinished
 		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: "test-policy", DstAddr: dstAddr, Color: 100, Preference: 100}}
 		require.NoError(t, server.Close(), "failed to close server connection")
 
 		s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
 		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: validPolicy()})
 		require.Error(t, err)
-		assert.False(t, resp.GetIsSuccess())
+		assert.Nil(t, resp)
 		assert.Equal(t, ReasonPCEPRequestFailed, errInfoReason(t, err))
 	})
 
@@ -2123,15 +2165,14 @@ func TestDeleteSRPolicy(t *testing.T) {
 		})
 
 		ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-		ss.isSynced = true
+		ss.syncState = lspDBSyncFinished
 		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: "test-policy", DstAddr: dstAddr, Color: 100, Preference: 100}}
 
 		s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
 		policy := validPolicy()
 		policy.SegmentList = []*pb.Segment{{Sid: "16003"}}
-		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: policy})
+		_, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: policy})
 		require.NoError(t, err)
-		assert.True(t, resp.GetIsSuccess())
 	})
 }
 
@@ -2140,18 +2181,18 @@ func TestValidate_NilPolicy(t *testing.T) {
 }
 
 func TestValidate_AddRequiresNonZeroASN(t *testing.T) {
-	policy := &pb.SRPolicy{PcepSessionAddr: []byte{10, 0, 0, 1}, Color: 100, SrcRouterId: "r1", DstRouterId: "r2"}
+	policy := &pb.SRPolicy{PeerAddr: []byte{10, 0, 0, 1}, Color: 100, SrcRouterId: "r1", DstRouterId: "r2"}
 	assert.ErrorContains(t, validate(policy, 0, ValidationAdd), "ASN must not be zero")
 }
 
 func TestValidate_UnknownKind(t *testing.T) {
-	policy := &pb.SRPolicy{PcepSessionAddr: []byte{10, 0, 0, 1}, Color: 100}
+	policy := &pb.SRPolicy{PeerAddr: []byte{10, 0, 0, 1}, Color: 100}
 	assert.ErrorContains(t, validate(policy, 100, ValidationKind("bogus")), "unknown validation kind")
 }
 
 func TestValidate_Add(t *testing.T) {
 	full := func() *pb.SRPolicy {
-		return &pb.SRPolicy{PcepSessionAddr: []byte{10, 0, 0, 1}, Color: 100, SrcRouterId: "r1", DstRouterId: "r2"}
+		return &pb.SRPolicy{PeerAddr: []byte{10, 0, 0, 1}, Color: 100, SrcRouterId: "r1", DstRouterId: "r2"}
 	}
 
 	tests := []struct {
@@ -2160,7 +2201,7 @@ func TestValidate_Add(t *testing.T) {
 		wantErr string
 	}{
 		{name: "valid"},
-		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PcepSessionAddr = nil }, wantErr: "PCEP session address must not be nil"},
+		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PeerAddr = nil }, wantErr: "policy.PeerAddr must not be nil"},
 		{name: "zero color", mutate: func(p *pb.SRPolicy) { p.Color = 0 }, wantErr: "Color must not be zero"},
 		{name: "missing source router ID", mutate: func(p *pb.SRPolicy) { p.SrcRouterId = "" }, wantErr: "SrcRouterId must not be empty"},
 		{name: "missing destination router ID", mutate: func(p *pb.SRPolicy) { p.DstRouterId = "" }, wantErr: "DstRouterId must not be empty"},
@@ -2185,11 +2226,11 @@ func TestValidate_Add(t *testing.T) {
 func TestValidate_AddDisablePathCompute(t *testing.T) {
 	full := func() *pb.SRPolicy {
 		return &pb.SRPolicy{
-			PcepSessionAddr: []byte{10, 0, 0, 1},
-			Color:           100,
-			SrcAddr:         []byte{10, 0, 0, 1},
-			DstAddr:         []byte{10, 0, 0, 2},
-			SegmentList:     []*pb.Segment{{Sid: "16003"}},
+			PeerAddr:    []byte{10, 0, 0, 1},
+			Color:       100,
+			SrcAddr:     []byte{10, 0, 0, 1},
+			DstAddr:     []byte{10, 0, 0, 2},
+			SegmentList: []*pb.Segment{{Sid: "16003"}},
 		}
 	}
 
@@ -2199,7 +2240,7 @@ func TestValidate_AddDisablePathCompute(t *testing.T) {
 		wantErr string
 	}{
 		{name: "valid"},
-		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PcepSessionAddr = nil }, wantErr: "PCEP session address must not be nil"},
+		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PeerAddr = nil }, wantErr: "policy.PeerAddr must not be nil"},
 		{name: "zero color", mutate: func(p *pb.SRPolicy) { p.Color = 0 }, wantErr: "Color must not be zero"},
 		{name: "missing source address", mutate: func(p *pb.SRPolicy) { p.SrcAddr = nil }, wantErr: "SrcAddr must not be empty"},
 		{name: "missing destination address", mutate: func(p *pb.SRPolicy) { p.DstAddr = nil }, wantErr: "DstAddr must not be empty"},
@@ -2225,10 +2266,10 @@ func TestValidate_AddDisablePathCompute(t *testing.T) {
 func TestValidate_Delete(t *testing.T) {
 	full := func() *pb.SRPolicy {
 		return &pb.SRPolicy{
-			PcepSessionAddr: []byte{10, 0, 0, 1},
-			Color:           100,
-			DstAddr:         []byte{10, 0, 0, 2},
-			PolicyName:      "test",
+			PeerAddr:   []byte{10, 0, 0, 1},
+			Color:      100,
+			DstAddr:    []byte{10, 0, 0, 2},
+			PolicyName: "test",
 		}
 	}
 
@@ -2238,7 +2279,7 @@ func TestValidate_Delete(t *testing.T) {
 		wantErr string
 	}{
 		{name: "valid"},
-		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PcepSessionAddr = nil }, wantErr: "PCEP session address must not be nil"},
+		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PeerAddr = nil }, wantErr: "policy.PeerAddr must not be nil"},
 		{name: "zero color", mutate: func(p *pb.SRPolicy) { p.Color = 0 }, wantErr: "Color must not be zero"},
 		{name: "missing destination address", mutate: func(p *pb.SRPolicy) { p.DstAddr = nil }, wantErr: "DstAddr must not be empty"},
 		{name: "missing policy name", mutate: func(p *pb.SRPolicy) { p.PolicyName = "" }, wantErr: "PolicyName must not be empty"},
@@ -2262,7 +2303,7 @@ func TestValidate_Delete(t *testing.T) {
 
 func TestSendSRPolicyRequest_GetSyncedPCEPSessionError(t *testing.T) {
 	s := &APIServer{pce: &Server{}, logger: zap.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: netip.MustParseAddr("10.0.255.1").AsSlice()}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: netip.MustParseAddr("10.0.255.1").AsSlice()}}
 
 	err := sendSRPolicyRequest(s, req, resolvedPath{}, false)
 	assert.ErrorContains(t, err, "failed to get synchronized PCEP session")
@@ -2270,9 +2311,9 @@ func TestSendSRPolicyRequest_GetSyncedPCEPSessionError(t *testing.T) {
 
 func TestSendSRPolicyRequest_ResolveIntentError(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	ss := &Session{peerAddr: peerAddr, isSynced: true}
+	ss := &Session{peerAddr: peerAddr, syncState: lspDBSyncFinished}
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Type: pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Type: pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED}}
 
 	err := sendSRPolicyRequest(s, req, resolvedPath{}, false)
 	assert.ErrorContains(t, err, "failed to resolve SR policy type")
@@ -2287,10 +2328,10 @@ func TestSendSRPolicyRequest_CreatesNewPolicy(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-	ss.isSynced = true
+	ss.syncState = lspDBSyncFinished
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
 	require.NoError(t, sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false))
@@ -2306,11 +2347,11 @@ func TestSendSRPolicyRequest_UpdatesExistingPolicy(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-	ss.isSynced = true
+	ss.syncState = lspDBSyncFinished
 	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, DstAddr: dstAddr}}
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
 	require.NoError(t, sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false))
@@ -2326,12 +2367,12 @@ func TestSendSRPolicyRequest_UpdateSendFailure(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-	ss.isSynced = true
+	ss.syncState = lspDBSyncFinished
 	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, DstAddr: dstAddr}}
 	require.NoError(t, server.Close(), "failed to close server connection")
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
 	err := sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false)
@@ -2348,11 +2389,11 @@ func TestSendSRPolicyRequest_CreateSendFailure(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
-	ss.isSynced = true
+	ss.syncState = lspDBSyncFinished
 	require.NoError(t, server.Close(), "failed to close server connection")
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PcepSessionAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
 	err := sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false)
@@ -2362,7 +2403,7 @@ func TestSendSRPolicyRequest_CreateSendFailure(t *testing.T) {
 
 func TestGetSRPolicyList_InvalidFilterAddrReason(t *testing.T) {
 	s := &APIServer{logger: zap.NewNop()}
-	_, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{SessionAddr: []byte{1, 2, 3}})
+	_, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{PeerAddr: []byte{1, 2, 3}})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid session filter address")
 	assert.Equal(t, ReasonInvalidRequest, errInfoReason(t, err))
@@ -2464,6 +2505,14 @@ func TestBuildCapability(t *testing.T) {
 			},
 		},
 		{
+			name: "sr",
+			cap:  &pcep.SRPCECapability{IsNAISupported: true, MaximumSidDepth: testMSDPtr(8)},
+			want: &pb.Capability{
+				Type:   pb.CapabilityType_CAPABILITY_TYPE_SR,
+				Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{NaiSupported: true, Msd: proto.Uint32(8)}},
+			},
+		},
+		{
 			name: "path setup type",
 			cap:  &pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{1, 3}},
 			want: &pb.Capability{
@@ -2517,8 +2566,8 @@ func TestGetTED_Disabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resp, err := tt.s.GetTED(context.Background(), &pb.GetTEDRequest{})
 			require.NoError(t, err)
-			assert.False(t, resp.GetEnable())
-			assert.Empty(t, resp.GetLsNodes())
+			assert.False(t, resp.GetEnabled())
+			assert.Empty(t, resp.GetNodes())
 		})
 	}
 }
@@ -2584,11 +2633,11 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 	s := newTestAPIServer(ted)
 	resp, err := s.GetTED(context.Background(), &pb.GetTEDRequest{})
 	require.NoError(t, err)
-	require.True(t, resp.GetEnable())
-	require.Len(t, resp.GetLsNodes(), 2, "the nil TED entry must not produce a node")
+	require.True(t, resp.GetEnabled())
+	require.Len(t, resp.GetNodes(), 2, "the nil TED entry must not produce a node")
 
 	byRouterID := map[string]*pb.LsNode{}
-	for _, n := range resp.GetLsNodes() {
+	for _, n := range resp.GetNodes() {
 		byRouterID[n.GetRouterId()] = n
 	}
 
@@ -2599,7 +2648,7 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 		Hostname:   "pe1",
 		SrgbBegin:  16000,
 		SrgbEnd:    17000,
-		LsLinks: []*pb.LsLink{
+		Links: []*pb.LsLink{
 			{
 				LocalRouterId:  "0000.0000.0001",
 				LocalAsn:       65000,
@@ -2619,11 +2668,11 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 				},
 			},
 		},
-		LsPrefixes: []*pb.LsPrefix{
+		Prefixes: []*pb.LsPrefix{
 			{Prefix: "10.0.0.1/32", SidIndex: proto.Uint32(0)},
 			{Prefix: "10.0.0.0/24"},
 		},
-		LsSrv6Sids: []*pb.LsSrv6SID{
+		Srv6Sids: []*pb.LsSrv6SID{
 			{
 				Sids:         []*pb.SID{{Sid: "2001:db8:1::1"}},
 				MultiTopoIds: []*pb.MultiTopoID{{MultiTopoId: 0}, {MultiTopoId: 1}},
@@ -2647,14 +2696,14 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 func TestDeleteSession(t *testing.T) {
 	t.Run("malformed address", func(t *testing.T) {
 		s := &APIServer{pce: &Server{}, logger: zap.NewNop()}
-		_, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{Addr: []byte{1, 2, 3}})
+		_, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{PeerAddr: []byte{1, 2, 3}})
 		require.ErrorContains(t, err, "invalid PCEP session address")
 		assert.Equal(t, ReasonInvalidRequest, errInfoReason(t, err))
 	})
 
 	t.Run("no such session", func(t *testing.T) {
 		s := &APIServer{pce: &Server{}, logger: zap.NewNop()}
-		_, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{Addr: netip.MustParseAddr("10.0.255.1").AsSlice()})
+		_, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{PeerAddr: netip.MustParseAddr("10.0.255.1").AsSlice()})
 		require.ErrorContains(t, err, "no session with address")
 		assert.Equal(t, ReasonPCEPSessionNotFound, errInfoReason(t, err))
 	})
@@ -2670,9 +2719,9 @@ func TestDeleteSession(t *testing.T) {
 		require.NoError(t, server.Close(), "failed to close server connection")
 
 		s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
-		resp, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{Addr: peerAddr.AsSlice()})
+		resp, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{PeerAddr: peerAddr.AsSlice()})
 		require.Error(t, err)
-		assert.False(t, resp.GetIsSuccess())
+		assert.Nil(t, resp)
 		assert.Equal(t, ReasonPCEPRequestFailed, errInfoReason(t, err))
 	})
 
@@ -2687,9 +2736,8 @@ func TestDeleteSession(t *testing.T) {
 		pce := &Server{sessionList: []*Session{ss}}
 		s := &APIServer{pce: pce, logger: zap.NewNop()}
 
-		resp, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{Addr: peerAddr.AsSlice()})
+		_, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{PeerAddr: peerAddr.AsSlice()})
 		require.NoError(t, err)
-		assert.True(t, resp.GetIsSuccess())
 		assert.Nil(t, pce.SearchSession(peerAddr), "expected the session to be removed from the PCE")
 	})
 }

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -2511,11 +2511,39 @@ func TestBuildCapability(t *testing.T) {
 			},
 		},
 		{
+			name: "sr with unlimited MSD",
+			cap:  &pcep.SRPCECapability{HasUnlimitedMaxSIDDepth: true, MaximumSidDepth: 0},
+			want: &pb.Capability{
+				Type:   pb.CapabilityType_CAPABILITY_TYPE_SR,
+				Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{UnlimitedMsd: true}},
+			},
+		},
+		{
 			name: "path setup type",
 			cap:  &pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{1, 3}},
 			want: &pb.Capability{
 				Type:   pb.CapabilityType_CAPABILITY_TYPE_PATH_SETUP_TYPE,
 				Detail: &pb.Capability_PathSetupType{PathSetupType: &pb.PathSetupTypeCapability{PathSetupTypes: []uint32{1, 3}}},
+			},
+		},
+		{
+			name: "path setup type with SR/SRv6 sub-capabilities",
+			cap: &pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{1, 3},
+				SubTLVs: []pcep.TLVInterface{
+					&pcep.SRPCECapability{HasUnlimitedMaxSIDDepth: true},
+					&pcep.SRv6PCECapability{},
+				},
+			},
+			want: &pb.Capability{
+				Type: pb.CapabilityType_CAPABILITY_TYPE_PATH_SETUP_TYPE,
+				Detail: &pb.Capability_PathSetupType{PathSetupType: &pb.PathSetupTypeCapability{
+					PathSetupTypes: []uint32{1, 3},
+					SubCapabilities: []*pb.Capability{
+						{Type: pb.CapabilityType_CAPABILITY_TYPE_SR, Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{UnlimitedMsd: true}}},
+						{Type: pb.CapabilityType_CAPABILITY_TYPE_SRV6, Detail: &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{}}},
+					},
+				}},
 			},
 		},
 		{

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -653,6 +653,78 @@ func TestGetSessionList_MultipathCapabilityDoesNotSetMsd(t *testing.T) {
 	assert.Equal(t, uint32(8), multipath.GetMultipath().GetMaxMultipaths())
 }
 
+func TestGetSessionList_ReportsLocalAndPccTimersAndSessionID(t *testing.T) {
+	session := &Session{
+		peerAddr:  netip.MustParseAddr("10.0.0.1"),
+		isSynced:  true,
+		state:     sessionStateUp,
+		localOpen: &OpenParams{SessionID: 3, Keepalive: 30, DeadTimer: 120},
+		pccOpen:   &OpenParams{SessionID: 7, Keepalive: 10, DeadTimer: 40},
+	}
+	s := &APIServer{
+		pce:    &Server{sessionList: []*Session{session}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+
+	got := resp.Sessions[0]
+	assert.Equal(t, pb.SessionState_SESSION_STATE_UP, got.GetState())
+	assert.Equal(t, uint32(3), got.GetLocalSessionId())
+	assert.Equal(t, uint32(7), got.GetPccSessionId())
+	assert.Equal(t, uint32(30), got.GetLocalTimers().GetKeepalive())
+	assert.Equal(t, uint32(120), got.GetLocalTimers().GetDeadTimer())
+	assert.Equal(t, uint32(10), got.GetPccTimers().GetKeepalive())
+	assert.Equal(t, uint32(40), got.GetPccTimers().GetDeadTimer())
+	assert.Equal(t, uint32(30), got.GetEffectiveTimers().GetKeepalive())
+	assert.Equal(t, uint32(40), got.GetEffectiveTimers().GetDeadTimer())
+}
+
+func TestGetSessionList_LeavesAdvertisedValuesUnsetBeforeTheOpenExchange(t *testing.T) {
+	s := &APIServer{
+		pce: &Server{sessionList: []*Session{
+			{peerAddr: netip.MustParseAddr("10.0.0.1"), state: sessionStateOpenWait},
+		}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+
+	got := resp.Sessions[0]
+	assert.Equal(t, pb.SessionState_SESSION_STATE_OPEN_WAIT, got.GetState())
+	assert.Nil(t, got.LocalSessionId, "a SID of 0 must be distinguishable from an unsent Open message")
+	assert.Nil(t, got.PccSessionId, "a SID of 0 must be distinguishable from an unreceived Open message")
+	assert.Nil(t, got.GetLocalTimers())
+	assert.Nil(t, got.GetPccTimers())
+}
+
+func TestGetSessionList_ReportsZeroPccSessionIDAsAdvertised(t *testing.T) {
+	s := &APIServer{
+		pce: &Server{sessionList: []*Session{{
+			peerAddr:  netip.MustParseAddr("10.0.0.1"),
+			state:     sessionStateUp,
+			localOpen: &OpenParams{SessionID: 0, Keepalive: 30, DeadTimer: 120},
+			pccOpen:   &OpenParams{SessionID: 0, Keepalive: 0, DeadTimer: 0},
+		}}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSessionList(context.Background(), &pb.GetSessionListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+
+	got := resp.Sessions[0]
+	require.NotNil(t, got.LocalSessionId, "SID 0 is valid on the wire and must be reported")
+	assert.Zero(t, got.GetLocalSessionId())
+	require.NotNil(t, got.PccSessionId)
+	assert.Zero(t, got.GetPccSessionId())
+	assert.Zero(t, got.GetEffectiveTimers().GetDeadTimer())
+}
+
 func TestGetSessionList_SortsSessionsByAddr(t *testing.T) {
 	s := &APIServer{
 		pce: &Server{sessionList: []*Session{
@@ -722,6 +794,21 @@ func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing
 	assert.Equal(t, pb.SRPolicyState_SR_POLICY_STATE_ACTIVE, policy.GetState())
 	assert.Equal(t, "0000.0aff.0001", policy.GetSrcRouterId())
 	assert.Empty(t, policy.GetDstRouterId(), "no TED node owns the destination address")
+}
+
+func TestGetSRPolicyList_IncludesUnsyncedSessions(t *testing.T) {
+	s := &APIServer{
+		pce: &Server{sessionList: []*Session{
+			{peerAddr: netip.MustParseAddr("10.0.0.1"), isSynced: false},
+		}},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1, "unsynced sessions must still be reported so callers can see why policies are missing")
+	assert.False(t, resp.Sessions[0].GetIsSynced())
+	assert.Empty(t, resp.Sessions[0].GetSrPolicies())
 }
 
 func TestGetSRPolicyList_FiltersBySessionAddr(t *testing.T) {
@@ -955,7 +1042,7 @@ func TestSessionList_ConcurrentAccess(_ *testing.T) {
 	go func() {
 		defer close(done)
 		for i := range 100 {
-			ss := &Session{sessionID: uint8(i), peerAddr: addr, isSynced: true}
+			ss := &Session{localSessionID: uint8(i), peerAddr: addr, isSynced: true}
 
 			s.sessionMu.Lock()
 			s.sessionList = append(s.sessionList, ss)
@@ -963,7 +1050,7 @@ func TestSessionList_ConcurrentAccess(_ *testing.T) {
 
 			s.sessionMu.Lock()
 			for j, v := range s.sessionList {
-				if v.sessionID == ss.sessionID {
+				if v.localSessionID == ss.localSessionID {
 					s.sessionList[j] = s.sessionList[len(s.sessionList)-1]
 					s.sessionList = s.sessionList[:len(s.sessionList)-1]
 					break
@@ -974,9 +1061,10 @@ func TestSessionList_ConcurrentAccess(_ *testing.T) {
 	}()
 
 	for range 100 {
-		s.SearchSession(addr, false)
-		s.SRPolicies()
-		s.Sessions()
+		s.SearchSession(addr)
+		for _, ss := range s.Sessions() {
+			ss.SRPolicies()
+		}
 	}
 	<-done
 }
@@ -990,7 +1078,7 @@ func TestDeleteSRPolicy_SrcAddrOmitted(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
 
-	ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 	ss.isSynced = true
 	ss.srPolicies = []*table.SRPolicy{
 		{
@@ -1397,6 +1485,47 @@ func TestGetSyncedPCEPSession(t *testing.T) {
 	assert.Error(t, err, "expected an error when no synced session matches")
 }
 
+func TestResolveSession(t *testing.T) {
+	peerAddr := netip.MustParseAddr("10.0.255.1")
+
+	t.Run("the peer address identifies the session", func(t *testing.T) {
+		ss := &Session{peerAddr: peerAddr, isSynced: true}
+		pce := &Server{sessionList: []*Session{ss}}
+
+		got, err := resolveSession(pce, peerAddr.AsSlice(), true)
+		require.NoError(t, err)
+		assert.Same(t, ss, got)
+	})
+
+	t.Run("no session is NotFound", func(t *testing.T) {
+		pce := &Server{}
+
+		_, err := resolveSession(pce, peerAddr.AsSlice(), true)
+		require.Error(t, err)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+		assert.Equal(t, ReasonPCEPSessionNotFound, errInfoReason(t, err))
+	})
+
+	t.Run("an unsynced session reports not synced", func(t *testing.T) {
+		ss := &Session{peerAddr: peerAddr, isSynced: false}
+		pce := &Server{sessionList: []*Session{ss}}
+
+		_, err := resolveSession(pce, peerAddr.AsSlice(), true)
+		require.Error(t, err)
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+		assert.Equal(t, ReasonPCEPSessionNotSynced, errInfoReason(t, err))
+	})
+
+	t.Run("requireSynced false accepts an unsynced session", func(t *testing.T) {
+		ss := &Session{peerAddr: peerAddr, isSynced: false}
+		pce := &Server{sessionList: []*Session{ss}}
+
+		got, err := resolveSession(pce, peerAddr.AsSlice(), false)
+		require.NoError(t, err)
+		assert.Same(t, ss, got)
+	})
+}
+
 func TestParseSidStructure(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1686,7 +1815,7 @@ func TestCreateSRPolicy(t *testing.T) {
 		})
 
 		peerAddr := netip.MustParseAddr("10.0.255.1")
-		ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+		ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 		ss.isSynced = true
 
 		s := &APIServer{pce: &Server{ted: ted, sessionList: []*Session{ss}}, logger: zap.NewNop()}
@@ -1734,7 +1863,7 @@ func TestCreateSRPolicy_SRv6WithoutLocalAddr(t *testing.T) {
 	})
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 	ss.isSynced = true
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
@@ -1868,7 +1997,7 @@ func TestCreateSRPolicy_StatusCodes(t *testing.T) {
 			r.SrPolicy.Metric = pb.MetricType_METRIC_TYPE_TE
 			return r
 		}, codes.FailedPrecondition, "METRIC_NOT_CARRIED", "metric METRIC_TYPE_TE not defined"},
-		{"no synced PCEP session", true, explicitReq, codes.FailedPrecondition, "PCEP_SESSION_NOT_SYNCED", "no synced session"},
+		{"no PCEP session", true, explicitReq, codes.NotFound, "PCEP_SESSION_NOT_FOUND", "no session with address"},
 	}
 
 	for _, tt := range tests {
@@ -1975,7 +2104,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 			assert.NoError(t, client.Close(), "failed to close client connection")
 		})
 
-		ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+		ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 		ss.isSynced = true
 		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: "test-policy", DstAddr: dstAddr, Color: 100, Preference: 100}}
 		require.NoError(t, server.Close(), "failed to close server connection")
@@ -1993,7 +2122,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 			assert.NoError(t, client.Close(), "failed to close client connection")
 		})
 
-		ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+		ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 		ss.isSynced = true
 		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: "test-policy", DstAddr: dstAddr, Color: 100, Preference: 100}}
 
@@ -2157,7 +2286,7 @@ func TestSendSRPolicyRequest_CreatesNewPolicy(t *testing.T) {
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
-	ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 	ss.isSynced = true
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
@@ -2176,7 +2305,7 @@ func TestSendSRPolicyRequest_UpdatesExistingPolicy(t *testing.T) {
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
-	ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 	ss.isSynced = true
 	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, DstAddr: dstAddr}}
 
@@ -2196,7 +2325,7 @@ func TestSendSRPolicyRequest_UpdateSendFailure(t *testing.T) {
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
-	ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 	ss.isSynced = true
 	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, DstAddr: dstAddr}}
 	require.NoError(t, server.Close(), "failed to close server connection")
@@ -2218,7 +2347,7 @@ func TestSendSRPolicyRequest_CreateSendFailure(t *testing.T) {
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	dstAddr := netip.MustParseAddr("10.255.0.2")
-	ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 	ss.isSynced = true
 	require.NoError(t, server.Close(), "failed to close server connection")
 
@@ -2519,7 +2648,7 @@ func TestDeleteSession(t *testing.T) {
 	t.Run("malformed address", func(t *testing.T) {
 		s := &APIServer{pce: &Server{}, logger: zap.NewNop()}
 		_, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{Addr: []byte{1, 2, 3}})
-		require.ErrorContains(t, err, "invalid address")
+		require.ErrorContains(t, err, "invalid PCEP session address")
 		assert.Equal(t, ReasonInvalidRequest, errInfoReason(t, err))
 	})
 
@@ -2537,7 +2666,7 @@ func TestDeleteSession(t *testing.T) {
 		})
 
 		peerAddr := netip.MustParseAddr("10.0.255.1")
-		ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+		ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 		require.NoError(t, server.Close(), "failed to close server connection")
 
 		s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: zap.NewNop()}
@@ -2554,13 +2683,13 @@ func TestDeleteSession(t *testing.T) {
 		})
 
 		peerAddr := netip.MustParseAddr("10.0.255.1")
-		ss := NewSession(1, peerAddr, server, zap.NewNop(), nil, 0)
+		ss := NewSession(testLocalOpen(1), peerAddr, server, zap.NewNop(), nil, 0)
 		pce := &Server{sessionList: []*Session{ss}}
 		s := &APIServer{pce: pce, logger: zap.NewNop()}
 
 		resp, err := s.DeleteSession(context.Background(), &pb.DeleteSessionRequest{Addr: peerAddr.AsSlice()})
 		require.NoError(t, err)
 		assert.True(t, resp.GetIsSuccess())
-		assert.Nil(t, pce.SearchSession(peerAddr, false), "expected the session to be removed from the PCE")
+		assert.Nil(t, pce.SearchSession(peerAddr), "expected the session to be removed from the PCE")
 	})
 }

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -33,8 +33,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func testMSDPtr(v uint8) *uint8 { return &v }
-
 func TestStatusFromCSPFError(t *testing.T) {
 	reasonOf := func(t *testing.T, err error) (codes.Code, string) {
 		t.Helper()
@@ -571,7 +569,7 @@ func TestGetSessionList_BuildsStructuredCapabilities(t *testing.T) {
 		peerAddr:  netip.MustParseAddr("10.0.0.1"),
 		syncState: lspDBSyncFinished,
 		advertisedCapabilities: []pcep.CapabilityInterface{
-			&pcep.SRPCECapability{IsNAISupported: true, MaximumSidDepth: testMSDPtr(10)},
+			&pcep.SRPCECapability{IsNAISupported: true, MaximumSidDepth: 10},
 			&pcep.LSPDBVersion{VersionNumber: 42},
 		},
 	}
@@ -2506,7 +2504,7 @@ func TestBuildCapability(t *testing.T) {
 		},
 		{
 			name: "sr",
-			cap:  &pcep.SRPCECapability{IsNAISupported: true, MaximumSidDepth: testMSDPtr(8)},
+			cap:  &pcep.SRPCECapability{IsNAISupported: true, MaximumSidDepth: 8},
 			want: &pb.Capability{
 				Type:   pb.CapabilityType_CAPABILITY_TYPE_SR,
 				Detail: &pb.Capability_Sr{Sr: &pb.SrCapability{NaiSupported: true, Msd: proto.Uint32(8)}},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -45,16 +45,26 @@ type Server struct {
 	listener                 tcpListener
 	closed                   bool
 	shutdownSendCloseTimeout time.Duration
+	peerStatsMu              sync.Mutex
+	peerStats                map[netip.Addr]*peerSetupStats
 }
 
-// sessionIDAllocator allocates PCEP session IDs per peer.
+// peerSetupStats counts session establishment outcomes per peer.
+// Entries outlive individual Session objects.
+type peerSetupStats struct {
+	ok   uint64
+	fail uint64
+}
+
+// sessionIDAllocator allocates session IDs per peer.
+// IDs advance across reconnects so a new session does not immediately reuse
+// the previous session's ID.
 type sessionIDAllocator struct {
 	mu   sync.Mutex
 	next map[netip.Addr]uint8
 }
 
-// allocate returns the next available SID for peerAddr.
-func (a *sessionIDAllocator) allocate(peerAddr netip.Addr, inUse func(uint8) bool) (uint8, bool) {
+func (a *sessionIDAllocator) allocate(peerAddr netip.Addr) uint8 {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -62,16 +72,9 @@ func (a *sessionIDAllocator) allocate(peerAddr netip.Addr, inUse func(uint8) boo
 		a.next = make(map[netip.Addr]uint8)
 	}
 
-	candidate := a.next[peerAddr]
-	for range math.MaxUint8 + 1 {
-		id := candidate
-		candidate++
-		if inUse == nil || !inUse(id) {
-			a.next[peerAddr] = candidate
-			return id, true
-		}
-	}
-	return 0, false
+	id := a.next[peerAddr]
+	a.next[peerAddr] = id + 1
+	return id
 }
 
 type tcpListener interface {
@@ -272,7 +275,9 @@ func (s *Server) Serve(address string, port string) error {
 		}
 		ss.logger.Info("start PCEP session")
 		go func() {
-			ss.Established()
+			if err := ss.Established(); err != nil {
+				s.recordSetupResult(ss.peerAddr, false)
+			}
 			s.closeSession(ss)
 			ss.logger.Info("close PCEP session")
 		}()
@@ -293,27 +298,18 @@ func (s *Server) registerSession(conn net.Conn, peerAddr netip.Addr) *Session {
 	s.sessionMu.Lock()
 	if slices.ContainsFunc(s.sessionList, func(ss *Session) bool { return ss.peerAddr == peerAddr }) {
 		s.sessionMu.Unlock()
+		s.recordSetupResult(peerAddr, false)
 		s.rejectSecondSession(conn, peerAddr)
 		return nil
 	}
-	sessionID, ok := s.sessionIDs.allocate(peerAddr, func(id uint8) bool {
-		return slices.ContainsFunc(s.sessionList, func(ss *Session) bool {
-			return ss.peerAddr == peerAddr && ss.localSessionID == id
-		})
-	})
-	if !ok {
-		s.sessionMu.Unlock()
-		s.logger.Warn("no PCEP session ID available for peer, rejecting connection",
-			zap.String("peer", peerAddr.String()))
-		s.closeRejectedConn(conn, "session ID exhausted")
-		return nil
-	}
+	sessionID := s.sessionIDs.allocate(peerAddr)
 	localOpen := OpenParams{SessionID: sessionID, Keepalive: s.localKeepalive, DeadTimer: s.localDeadTimer}
 	ss := NewSession(localOpen, peerAddr, conn, s.logger, ted, s.asn)
 	ss.keepaliveRangeEnabled = s.keepaliveRangeEnabled
 	ss.minKeepalive = s.minKeepalive
 	ss.maxKeepalive = s.maxKeepalive
 	ss.allowNegotiation = s.allowNegotiation
+	ss.onEstablished = func() { s.recordSetupResult(peerAddr, true) }
 	s.sessionList = append(s.sessionList, ss)
 	s.sessionMu.Unlock()
 	return ss
@@ -367,11 +363,9 @@ func (s *Server) Shutdown() error {
 
 	var wg sync.WaitGroup
 	for _, ss := range sessions {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			s.gracefulCloseSession(ss)
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -432,4 +426,33 @@ func (s *Server) Sessions() []*Session {
 	s.sessionMu.RLock()
 	defer s.sessionMu.RUnlock()
 	return slices.Clone(s.sessionList)
+}
+
+func (s *Server) recordSetupResult(addr netip.Addr, ok bool) {
+	s.peerStatsMu.Lock()
+	defer s.peerStatsMu.Unlock()
+	if s.peerStats == nil {
+		s.peerStats = make(map[netip.Addr]*peerSetupStats)
+	}
+	stats, exists := s.peerStats[addr]
+	if !exists {
+		stats = &peerSetupStats{}
+		s.peerStats[addr] = stats
+	}
+	if ok {
+		stats.ok++
+	} else {
+		stats.fail++
+	}
+}
+
+// PeerSetupStats returns cumulative session establishment outcomes for addr.
+// Counters persist across session teardown to match RFC 9826 sess-setup-ok/fail.
+func (s *Server) PeerSetupStats(addr netip.Addr) (ok, fail uint64) {
+	s.peerStatsMu.Lock()
+	defer s.peerStatsMu.Unlock()
+	if stats, exists := s.peerStats[addr]; exists {
+		return stats.ok, stats.fail
+	}
+	return 0, 0
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,23 +24,54 @@ import (
 	"github.com/nttcom/pola/pkg/table"
 )
 
-// Maximum time to wait for the PCEP Close message during shutdown.
 const defaultShutdownSendCloseTimeout = 2 * time.Second
 
 // Server manages PCEP sessions and server lifecycle.
 type Server struct {
-	sessionMu   sync.RWMutex // guards sessionList
-	sessionList []*Session
-	tedMu       sync.RWMutex // guards ted
-	ted         *table.LsTED
-	logger      *zap.Logger
-	asn         uint32
+	sessionMu                sync.RWMutex
+	sessionList              []*Session
+	sessionIDs               sessionIDAllocator
+	tedMu                    sync.RWMutex
+	ted                      *table.LsTED
+	logger                   *zap.Logger
+	asn                      uint32
+	localKeepalive           uint8
+	localDeadTimer           uint8
+	keepaliveRangeEnabled    bool
+	minKeepalive             uint8
+	maxKeepalive             uint8
+	allowNegotiation         bool
+	listenerMu               sync.Mutex
+	listener                 tcpListener
+	closed                   bool
+	shutdownSendCloseTimeout time.Duration
+}
 
-	listenerMu sync.Mutex // guards listener and closed
-	listener   tcpListener
-	closed     bool // set by Shutdown; suppresses Serve/AcceptTCP errors
+// sessionIDAllocator allocates PCEP session IDs per peer.
+type sessionIDAllocator struct {
+	mu   sync.Mutex
+	next map[netip.Addr]uint8
+}
 
-	shutdownSendCloseTimeout time.Duration // zero uses the default
+// allocate returns the next available SID for peerAddr.
+func (a *sessionIDAllocator) allocate(peerAddr netip.Addr, inUse func(uint8) bool) (uint8, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.next == nil {
+		a.next = make(map[netip.Addr]uint8)
+	}
+
+	candidate := a.next[peerAddr]
+	for range math.MaxUint8 + 1 {
+		id := candidate
+		candidate++
+		if inUse == nil || !inUse(id) {
+			a.next[peerAddr] = candidate
+			return id, true
+		}
+	}
+	return 0, false
 }
 
 type tcpListener interface {
@@ -48,7 +79,7 @@ type tcpListener interface {
 	Close() error
 }
 
-// TED returns the current TED snapshot. Safe for concurrent use with setTED.
+// TED returns the current TED snapshot.
 func (s *Server) TED() *table.LsTED {
 	s.tedMu.RLock()
 	defer s.tedMu.RUnlock()
@@ -63,30 +94,71 @@ func (s *Server) setTED(ted *table.LsTED) {
 
 // PCEOptions contains configuration options for the PCE server.
 type PCEOptions struct {
-	PCEPAddr  string
-	PCEPPort  string
-	GRPCAddr  string
-	GRPCPort  string
-	TEDEnable bool
-	USidMode  bool
-	ASN       uint32
+	PCEPAddr         string
+	PCEPPort         string
+	GRPCAddr         string
+	GRPCPort         string
+	TEDEnable        bool
+	USidMode         bool
+	ASN              uint32
+	Keepalive        *uint8
+	DeadTimer        *uint8
+	MinKeepalive     *uint8
+	MaxKeepalive     *uint8
+	AllowNegotiation *bool
 }
 
-// NewPCE starts the PCEP and gRPC servers and blocks until they stop.
-// It returns an error if either server exits with a failure.
+func resolveKeepaliveRange(minKeepalive, maxKeepalive *uint8) (lo, hi uint8, enabled bool) {
+	if minKeepalive == nil && maxKeepalive == nil {
+		return 0, 0, false
+	}
+	hi = math.MaxUint8
+	if minKeepalive != nil {
+		lo = *minKeepalive
+	}
+	if maxKeepalive != nil {
+		hi = *maxKeepalive
+	}
+	return lo, hi, true
+}
+
+func resolveLocalTimers(keepalive, deadTimer *uint8) (uint8, uint8) {
+	localKeepalive := defaultLocalKeepalive
+	if keepalive != nil {
+		localKeepalive = *keepalive
+	}
+	if deadTimer != nil {
+		return localKeepalive, *deadTimer
+	}
+	if localKeepalive == 0 {
+		return 0, 0
+	}
+	return localKeepalive, pcep.DeadTimerFor(localKeepalive)
+}
+
+// NewPCE starts the PCEP and gRPC servers.
 func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem) Error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	localKeepalive, localDeadTimer := resolveLocalTimers(o.Keepalive, o.DeadTimer)
+	minKeepalive, maxKeepalive, keepaliveRangeEnabled := resolveKeepaliveRange(o.MinKeepalive, o.MaxKeepalive)
+	allowNegotiation := o.AllowNegotiation == nil || *o.AllowNegotiation
 	s := &Server{
-		logger: logger,
-		asn:    o.ASN,
+		logger:                logger,
+		asn:                   o.ASN,
+		localKeepalive:        localKeepalive,
+		localDeadTimer:        localDeadTimer,
+		keepaliveRangeEnabled: keepaliveRangeEnabled,
+		minKeepalive:          minKeepalive,
+		maxKeepalive:          maxKeepalive,
+		allowNegotiation:      allowNegotiation,
 	}
 	if o.TEDEnable {
 		s.setTED(&table.LsTED{
 			Nodes: map[string]*table.LsNode{},
 		})
-		go s.syncTEDLoop(ctx, tedElemsChan, o.ASN, logger)
+		go s.syncTEDLoop(ctx, tedElemsChan, o.ASN)
 	}
 
 	grpcServer := grpc.NewServer()
@@ -106,9 +178,8 @@ func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan
 		resultChan <- result{server: "grpc", err: apiServer.Serve(o.GRPCAddr, o.GRPCPort)}
 	}()
 
-	go s.awaitShutdown(ctx, logger, grpcServer.GracefulStop)
+	go s.awaitShutdown(ctx, grpcServer.GracefulStop)
 
-	// Wait for both servers to stop before returning the first error.
 	var firstErr Error
 	for range 2 {
 		r := <-resultChan
@@ -124,7 +195,7 @@ func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan
 	return firstErr
 }
 
-func (s *Server) syncTEDLoop(ctx context.Context, tedElemsChan <-chan []table.TEDElem, asn uint32, logger *zap.Logger) {
+func (s *Server) syncTEDLoop(ctx context.Context, tedElemsChan <-chan []table.TEDElem, asn uint32) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -138,7 +209,7 @@ func (s *Server) syncTEDLoop(ctx context.Context, tedElemsChan <-chan []table.TE
 			}
 			ted.Update(tedElems, asn)
 			s.setTED(ted)
-			logger.Debug("Update TED")
+			s.logger.Debug("Update TED")
 		}
 	}
 }
@@ -182,7 +253,6 @@ func (s *Server) Serve(address string, port string) error {
 		}
 	}()
 
-	sessionID := uint8(1)
 	for {
 		tcpConn, err := l.AcceptTCP()
 		if err != nil {
@@ -196,8 +266,7 @@ func (s *Server) Serve(address string, port string) error {
 			return fmt.Errorf("failed to parse remote address %s: %w", tcpConn.RemoteAddr().String(), err)
 		}
 
-		ss := s.registerSession(tcpConn, sessionID, peerAddrPort.Addr())
-		sessionID++
+		ss := s.registerSession(tcpConn, peerAddrPort.Addr())
 		if ss == nil {
 			continue
 		}
@@ -210,29 +279,71 @@ func (s *Server) Serve(address string, port string) error {
 	}
 }
 
-func (s *Server) registerSession(tcpConn *net.TCPConn, sessionID uint8, peerAddr netip.Addr) *Session {
+func (s *Server) registerSession(conn net.Conn, peerAddr netip.Addr) *Session {
 	s.listenerMu.Lock()
 	defer s.listenerMu.Unlock()
 
 	if s.closed {
-		if err := tcpConn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-			s.logger.Warn("failed to close TCP connection accepted after shutdown", zap.Error(err))
-		}
+		s.closeRejectedConn(conn, "accepted after shutdown")
 		return nil
 	}
 
-	ss := NewSession(sessionID, peerAddr, tcpConn, s.logger, s.TED(), s.asn)
+	ted := s.TED()
+
 	s.sessionMu.Lock()
+	if slices.ContainsFunc(s.sessionList, func(ss *Session) bool { return ss.peerAddr == peerAddr }) {
+		s.sessionMu.Unlock()
+		s.rejectSecondSession(conn, peerAddr)
+		return nil
+	}
+	sessionID, ok := s.sessionIDs.allocate(peerAddr, func(id uint8) bool {
+		return slices.ContainsFunc(s.sessionList, func(ss *Session) bool {
+			return ss.peerAddr == peerAddr && ss.localSessionID == id
+		})
+	})
+	if !ok {
+		s.sessionMu.Unlock()
+		s.logger.Warn("no PCEP session ID available for peer, rejecting connection",
+			zap.String("peer", peerAddr.String()))
+		s.closeRejectedConn(conn, "session ID exhausted")
+		return nil
+	}
+	localOpen := OpenParams{SessionID: sessionID, Keepalive: s.localKeepalive, DeadTimer: s.localDeadTimer}
+	ss := NewSession(localOpen, peerAddr, conn, s.logger, ted, s.asn)
+	ss.keepaliveRangeEnabled = s.keepaliveRangeEnabled
+	ss.minKeepalive = s.minKeepalive
+	ss.maxKeepalive = s.maxKeepalive
+	ss.allowNegotiation = s.allowNegotiation
 	s.sessionList = append(s.sessionList, ss)
 	s.sessionMu.Unlock()
 	return ss
 }
 
-func (s *Server) awaitShutdown(ctx context.Context, logger *zap.Logger, stopGRPC func()) {
+func (s *Server) rejectSecondSession(conn net.Conn, peerAddr netip.Addr) {
+	s.logger.Warn("rejecting second PCEP session attempt from peer", zap.String("peer", peerAddr.String()))
+
+	pcerrMessage := pcep.NewPCErrMessage(pcepErrorTypeSecondSessionAttempt, pcepErrorValueSecondSessionAttempt, nil)
+	if byteMessage, err := pcerrMessage.Serialize(); err != nil {
+		s.logger.Warn("failed to serialize PCErr for second session attempt", zap.Error(err))
+	} else if _, err := conn.Write(byteMessage); err != nil {
+		s.logger.Warn("failed to send PCErr for second session attempt", zap.Error(err))
+	}
+
+	s.closeRejectedConn(conn, "second PCEP session attempt from peer")
+}
+
+func (s *Server) closeRejectedConn(conn net.Conn, why string) {
+	if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+		s.logger.Warn("failed to close rejected TCP connection",
+			zap.String("reason", why), zap.Error(err))
+	}
+}
+
+func (s *Server) awaitShutdown(ctx context.Context, stopGRPC func()) {
 	<-ctx.Done()
-	logger.Info("shutdown requested, stopping PCE server")
+	s.logger.Info("shutdown requested, stopping PCE server")
 	if err := s.Shutdown(); err != nil {
-		logger.Warn("failed to shut down PCEP server", zap.Error(err))
+		s.logger.Warn("failed to shut down PCEP server", zap.Error(err))
 	}
 	stopGRPC()
 }
@@ -267,7 +378,7 @@ func (s *Server) Shutdown() error {
 	return err
 }
 
-// Sends a PCEP Close message with a bounded wait before force-closing the session.
+// gracefulCloseSession sends Close with a bounded wait before closing the connection.
 func (s *Server) gracefulCloseSession(ss *Session) {
 	sendDone := make(chan struct{})
 	go func() {
@@ -297,49 +408,28 @@ func (s *Server) closeSession(session *Session) {
 	session.clearSRPolicyIntents()
 
 	s.sessionMu.Lock()
-	for i, v := range s.sessionList {
-		if v.sessionID == session.sessionID {
-			s.sessionList[i] = s.sessionList[len(s.sessionList)-1]
-			s.sessionList = s.sessionList[:len(s.sessionList)-1]
-			break
-		}
+	if i := slices.Index(s.sessionList, session); i >= 0 {
+		s.sessionList[i] = s.sessionList[len(s.sessionList)-1]
+		s.sessionList = s.sessionList[:len(s.sessionList)-1]
 	}
 	s.sessionMu.Unlock()
 }
 
-// SearchSession returns a struct pointer of (Synced) session.
-// If not exist, return nil
-func (s *Server) SearchSession(peerAddr netip.Addr, onlySynced bool) *Session {
+// SearchSession returns the session for the given peer address.
+func (s *Server) SearchSession(peerAddr netip.Addr) *Session {
 	s.sessionMu.RLock()
 	defer s.sessionMu.RUnlock()
 	for _, pcepSession := range s.sessionList {
 		if pcepSession.peerAddr == peerAddr {
-			if !onlySynced || pcepSession.IsSynced() {
-				return pcepSession
-			}
+			return pcepSession
 		}
 	}
 	return nil
 }
 
-// Sessions returns a snapshot copy of the current session list, safe for concurrent use.
+// Sessions returns a copy of the current session list.
 func (s *Server) Sessions() []*Session {
 	s.sessionMu.RLock()
 	defer s.sessionMu.RUnlock()
 	return slices.Clone(s.sessionList)
-}
-
-// SRPolicies returns a map of registered SR Policy with key sessionAddr
-func (s *Server) SRPolicies() map[netip.Addr][]*table.SRPolicy {
-	s.sessionMu.RLock()
-	sessions := slices.Clone(s.sessionList)
-	s.sessionMu.RUnlock()
-
-	srPolicies := make(map[netip.Addr][]*table.SRPolicy)
-	for _, ss := range sessions {
-		if ss.IsSynced() {
-			srPolicies[ss.peerAddr] = ss.SRPolicies()
-		}
-	}
-	return srPolicies
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -125,6 +125,24 @@ func resolveKeepaliveRange(minKeepalive, maxKeepalive *uint8) (lo, hi uint8, ena
 	return lo, hi, true
 }
 
+// validatePCEOptions validates timer constraints before starting the server.
+func validatePCEOptions(o *PCEOptions) error {
+	if o == nil {
+		return errors.New("PCEOptions must not be nil")
+	}
+	keepalive := defaultLocalKeepalive
+	if o.Keepalive != nil {
+		keepalive = *o.Keepalive
+	}
+	if err := pcep.ValidateTimers(keepalive, o.DeadTimer); err != nil {
+		return err
+	}
+	if o.MinKeepalive != nil && o.MaxKeepalive != nil && *o.MinKeepalive > *o.MaxKeepalive {
+		return errors.New("MinKeepalive must be <= MaxKeepalive")
+	}
+	return nil
+}
+
 func resolveLocalTimers(keepalive, deadTimer *uint8) (uint8, uint8) {
 	localKeepalive := defaultLocalKeepalive
 	if keepalive != nil {
@@ -133,14 +151,15 @@ func resolveLocalTimers(keepalive, deadTimer *uint8) (uint8, uint8) {
 	if deadTimer != nil {
 		return localKeepalive, *deadTimer
 	}
-	if localKeepalive == 0 {
-		return 0, 0
-	}
 	return localKeepalive, pcep.DeadTimerFor(localKeepalive)
 }
 
 // NewPCE starts the PCEP and gRPC servers.
 func NewPCE(ctx context.Context, o *PCEOptions, logger *zap.Logger, tedElemsChan chan []table.TEDElem) Error {
+	if err := validatePCEOptions(o); err != nil {
+		return Error{Server: "config", Error: err}
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net"
 	"net/netip"
 	"sync"
@@ -143,7 +144,7 @@ func TestServer_Shutdown_BeforeServeStillReturnsCleanly(t *testing.T) {
 
 func TestServer_Shutdown_LogsWarnOnSendCloseFailure(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 	core, logs := observer.New(zap.WarnLevel)
 	s := &Server{sessionList: []*Session{ss}, logger: zap.New(core)}
 
@@ -190,7 +191,7 @@ func TestServer_CloseSession_SuppressesWarnOnAlreadyClosedConnection(t *testing.
 	})
 	require.NoError(t, server.Close(), "failed to pre-close server connection")
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 	core, logs := observer.New(zap.WarnLevel)
 	s := &Server{sessionList: []*Session{ss}, logger: zap.New(core)}
 
@@ -203,7 +204,7 @@ func TestServer_CloseSession_SuppressesWarnOnAlreadyClosedConnection(t *testing.
 
 func TestServer_CloseSession_LogsWarnOnOtherCloseFailure(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil), closeErr: errors.New("boom")}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 	core, logs := observer.New(zap.WarnLevel)
 	s := &Server{sessionList: []*Session{ss}, logger: zap.New(core)}
 
@@ -369,7 +370,7 @@ func TestServer_Shutdown_PropagatesOtherListenerCloseError(t *testing.T) {
 func TestServer_AwaitShutdown_LogsWarnOnShutdownError(t *testing.T) {
 	wantErr := errors.New("boom")
 	core, logs := observer.New(zap.WarnLevel)
-	s := &Server{logger: zap.NewNop(), listener: &fakeListener{closeErr: wantErr}}
+	s := &Server{logger: zap.New(core), listener: &fakeListener{closeErr: wantErr}}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -377,7 +378,7 @@ func TestServer_AwaitShutdown_LogsWarnOnShutdownError(t *testing.T) {
 	stopped := false
 	done := make(chan struct{})
 	go func() {
-		s.awaitShutdown(ctx, zap.New(core), func() { stopped = true })
+		s.awaitShutdown(ctx, func() { stopped = true })
 		close(done)
 	}()
 
@@ -392,22 +393,21 @@ func TestServer_AwaitShutdown_LogsWarnOnShutdownError(t *testing.T) {
 }
 
 func TestServer_SyncTEDLoop_AppliesReceivedElems(t *testing.T) {
-	s := &Server{}
-	core, logs := observer.New(zap.DebugLevel)
+	s := &Server{logger: zap.NewNop()}
 	tedElemsChan := make(chan []table.TEDElem, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	done := make(chan struct{})
 	go func() {
-		s.syncTEDLoop(ctx, tedElemsChan, 65000, zap.New(core))
+		s.syncTEDLoop(ctx, tedElemsChan, 65000)
 		close(done)
 	}()
 
 	tedElemsChan <- []table.TEDElem{}
 
 	require.Eventually(t, func() bool {
-		return len(logs.FilterMessage("Update TED").All()) > 0
+		return s.TED() != nil
 	}, 2*time.Second, 10*time.Millisecond, "expected the received TED elements to be applied")
 
 	cancel()
@@ -419,12 +419,12 @@ func TestServer_SyncTEDLoop_AppliesReceivedElems(t *testing.T) {
 }
 
 func TestServer_SyncTEDLoop_ExitsWhenChannelClosed(t *testing.T) {
-	s := &Server{}
+	s := &Server{logger: zap.NewNop()}
 	tedElemsChan := make(chan []table.TEDElem)
 
 	done := make(chan struct{})
 	go func() {
-		s.syncTEDLoop(context.Background(), tedElemsChan, 65000, zap.NewNop())
+		s.syncTEDLoop(context.Background(), tedElemsChan, 65000)
 		close(done)
 	}()
 
@@ -442,7 +442,7 @@ func TestServer_RegisterSession_ClosesConnWhenAlreadyShutdown(t *testing.T) {
 	t.Cleanup(func() { _ = client.Close() })
 
 	s := &Server{logger: zap.NewNop(), closed: true}
-	ss := s.registerSession(server, 1, netip.MustParseAddr("10.0.255.1"))
+	ss := s.registerSession(server, netip.MustParseAddr("10.0.255.1"))
 
 	assert.Nil(t, ss, "expected registerSession to reject a connection accepted after Shutdown")
 	assert.Empty(t, s.Sessions())
@@ -452,17 +452,169 @@ func TestServer_RegisterSession_ClosesConnWhenAlreadyShutdown(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF, "expected the connection accepted after shutdown to be closed immediately")
 }
 
+func TestServer_CloseRejectedConn_LogsNonClosedError(t *testing.T) {
+	wantErr := errors.New("boom")
+	core, logs := observer.New(zap.WarnLevel)
+	s := &Server{logger: zap.New(core)}
+
+	s.closeRejectedConn(&fakeConn{closeErr: wantErr}, "test reason")
+
+	entries := logs.FilterMessage("failed to close rejected TCP connection").All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "test reason", entries[0].ContextMap()["reason"])
+}
+
+func TestServer_CloseRejectedConn_ErrClosedIsNotLogged(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	s := &Server{logger: zap.New(core)}
+
+	s.closeRejectedConn(&fakeConn{closeErr: net.ErrClosed}, "test reason")
+
+	assert.Empty(t, logs.All(), "an already-closed connection must not be logged as a failure")
+}
+
 func TestServer_RegisterSession_AppendsWhenNotShutdown(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() { assert.NoError(t, client.Close()) })
 
 	s := &Server{logger: zap.NewNop()}
-	ss := s.registerSession(server, 1, netip.MustParseAddr("10.0.255.1"))
+	ss := s.registerSession(server, netip.MustParseAddr("10.0.255.1"))
 
 	require.NotNil(t, ss)
 	assert.Equal(t, []*Session{ss}, s.Sessions())
 
 	s.closeSession(ss)
+}
+
+func TestServer_RegisterSession_RejectsSecondSessionFromSamePeer(t *testing.T) {
+	peerAddr := netip.MustParseAddr("10.0.255.1")
+	core, logs := observer.New(zap.WarnLevel)
+	s := &Server{logger: zap.New(core)}
+
+	server1, client1 := newTCPConnPair(t)
+	t.Cleanup(func() { _ = client1.Close() })
+	ss1 := s.registerSession(server1, peerAddr)
+	require.NotNil(t, ss1)
+
+	server2, client2 := newTCPConnPair(t)
+	t.Cleanup(func() { _ = client2.Close() })
+	ss2 := s.registerSession(server2, peerAddr)
+
+	assert.Nil(t, ss2, "a second session with the same peer must not be accepted")
+	assert.Equal(t, []*Session{ss1}, s.Sessions(), "the existing session must be preserved")
+	assert.Len(t, logs.FilterMessage("rejecting second PCEP session attempt from peer").All(), 1)
+
+	require.NoError(t, client2.SetReadDeadline(time.Now().Add(2*time.Second)))
+	pcerrMessage := readPCErrMessage(t, client2)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, uint8(9), pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorValue)
+
+	_, err := client2.Read(make([]byte, 1))
+	require.ErrorIs(t, err, io.EOF, "expected the rejected connection to be closed")
+
+	s.closeSession(ss1)
+}
+
+func TestServer_RegisterSession_RejectSecondSession_LogsWarnOnSendFailure(t *testing.T) {
+	peerAddr := netip.MustParseAddr("10.0.255.1")
+	core, logs := observer.New(zap.WarnLevel)
+	s := &Server{logger: zap.New(core)}
+
+	server1, client1 := newTCPConnPair(t)
+	t.Cleanup(func() { _ = client1.Close() })
+	ss1 := s.registerSession(server1, peerAddr)
+	require.NotNil(t, ss1)
+
+	conn2 := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
+	ss2 := s.registerSession(conn2, peerAddr)
+
+	assert.Nil(t, ss2, "a second session with the same peer must not be accepted")
+	assert.Len(t, logs.FilterMessage("failed to send PCErr for second session attempt").All(), 1)
+
+	s.closeSession(ss1)
+}
+
+func TestServer_RegisterSession_SessionIDSequenceIsPerPeer(t *testing.T) {
+	s := &Server{logger: zap.NewNop()}
+
+	server1, client1 := newTCPConnPair(t)
+	t.Cleanup(func() { _ = client1.Close() })
+	ss1 := s.registerSession(server1, netip.MustParseAddr("10.0.255.1"))
+	require.NotNil(t, ss1)
+	assert.Zero(t, ss1.localSessionID)
+
+	server2, client2 := newTCPConnPair(t)
+	t.Cleanup(func() { _ = client2.Close() })
+	ss2 := s.registerSession(server2, netip.MustParseAddr("10.0.255.2"))
+	require.NotNil(t, ss2)
+	assert.Zero(t, ss2.localSessionID, "each peer has its own SID sequence")
+
+	s.closeSession(ss1)
+	s.closeSession(ss2)
+}
+
+func TestServer_CloseSession_MatchesByIdentityNotIDValue(t *testing.T) {
+	connA := &fakeConn{r: bytes.NewReader(nil)}
+	connB := &fakeConn{r: bytes.NewReader(nil)}
+	ssA := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), connA, zap.NewNop(), nil, 0)
+	ssB := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.2"), connB, zap.NewNop(), nil, 0)
+	s := &Server{logger: zap.NewNop(), sessionList: []*Session{ssA, ssB}}
+
+	s.closeSession(ssA)
+
+	assert.Equal(t, []*Session{ssB}, s.Sessions(), "expected only the closed session's own instance to be removed")
+}
+
+func TestSessionIDAllocator_IncrementsByOneAndWraps(t *testing.T) {
+	peerAddr := netip.MustParseAddr("10.0.255.1")
+	var a sessionIDAllocator
+
+	for want := range math.MaxUint8 + 1 {
+		id, ok := a.allocate(peerAddr, nil)
+		require.True(t, ok)
+		assert.Equal(t, uint8(want), id)
+	}
+
+	id, ok := a.allocate(peerAddr, nil)
+	require.True(t, ok)
+	assert.Zero(t, id, "the sequence wraps back to zero after 255")
+}
+
+func TestSessionIDAllocator_SequenceIsIndependentPerPeer(t *testing.T) {
+	peerA := netip.MustParseAddr("10.0.255.1")
+	peerB := netip.MustParseAddr("10.0.255.2")
+	var a sessionIDAllocator
+
+	for want := range uint8(3) {
+		id, ok := a.allocate(peerA, nil)
+		require.True(t, ok)
+		assert.Equal(t, want, id)
+	}
+
+	id, ok := a.allocate(peerB, nil)
+	require.True(t, ok)
+	assert.Zero(t, id, "peer B's sequence must not be advanced by peer A")
+}
+
+func TestSessionIDAllocator_SkipsSessionIDsInUse(t *testing.T) {
+	peerAddr := netip.MustParseAddr("10.0.255.1")
+	var a sessionIDAllocator
+
+	id, ok := a.allocate(peerAddr, func(id uint8) bool { return id < 3 })
+	require.True(t, ok)
+	assert.Equal(t, uint8(3), id)
+
+	id, ok = a.allocate(peerAddr, nil)
+	require.True(t, ok)
+	assert.Equal(t, uint8(4), id, "the sequence continues after the skipped IDs")
+}
+
+func TestSessionIDAllocator_ReportsFalseWhenEveryIDIsInUse(t *testing.T) {
+	var a sessionIDAllocator
+
+	_, ok := a.allocate(netip.MustParseAddr("10.0.255.1"), func(uint8) bool { return true })
+	assert.False(t, ok)
 }
 
 // blockingWriteConn simulates a peer that stopped reading.
@@ -492,7 +644,7 @@ func (c *blockingWriteConn) SetWriteDeadline(time.Time) error { return nil }
 
 func TestServer_Shutdown_BoundsBlockedSendClose(t *testing.T) {
 	conn := &blockingWriteConn{r: bytes.NewReader(nil), unblock: make(chan struct{})}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 	core, logs := observer.New(zap.WarnLevel)
 	s := &Server{
 		sessionList:              []*Session{ss},
@@ -514,4 +666,55 @@ func TestServer_Shutdown_BoundsBlockedSendClose(t *testing.T) {
 
 	assert.Len(t, logs.FilterMessage("timed out sending PCEP close message during shutdown").All(), 1)
 	assert.Empty(t, s.Sessions(), "expected the session to be force-closed and untracked despite the blocked write")
+}
+
+func TestResolveLocalTimers(t *testing.T) {
+	ptr := func(v uint8) *uint8 { return &v }
+
+	tests := []struct {
+		name          string
+		keepalive     *uint8
+		deadTimer     *uint8
+		wantKeepalive uint8
+		wantDeadTimer uint8
+	}{
+		{"unset uses defaults", nil, nil, 30, 120},
+		{"a configured keepalive derives a 4x dead timer", ptr(10), nil, 10, 40},
+		{"keepalive of zero derives a dead timer of zero", ptr(0), nil, 0, 0},
+		{"both configured are used verbatim", ptr(5), ptr(60), 5, 60},
+		{"a configured dead timer of zero is honored", ptr(30), ptr(0), 30, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keepalive, deadTimer := resolveLocalTimers(tt.keepalive, tt.deadTimer)
+			assert.Equal(t, tt.wantKeepalive, keepalive)
+			assert.Equal(t, tt.wantDeadTimer, deadTimer)
+		})
+	}
+}
+
+func TestResolveKeepaliveRange(t *testing.T) {
+	ptr := func(v uint8) *uint8 { return &v }
+
+	tests := []struct {
+		name        string
+		min         *uint8
+		max         *uint8
+		wantLo      uint8
+		wantHi      uint8
+		wantEnabled bool
+	}{
+		{"both unset disables the check", nil, nil, 0, 0, false},
+		{"only a minimum caps the upper bound at the widest value", ptr(10), nil, 10, math.MaxUint8, true},
+		{"only a maximum leaves the lower bound at zero", nil, ptr(60), 0, 60, true},
+		{"both set are used verbatim", ptr(10), ptr(60), 10, 60, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lo, hi, enabled := resolveKeepaliveRange(tt.min, tt.max)
+			assert.Equal(t, tt.wantLo, lo)
+			assert.Equal(t, tt.wantHi, hi)
+			assert.Equal(t, tt.wantEnabled, enabled)
+		})
+	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -571,14 +571,10 @@ func TestSessionIDAllocator_IncrementsByOneAndWraps(t *testing.T) {
 	var a sessionIDAllocator
 
 	for want := range math.MaxUint8 + 1 {
-		id, ok := a.allocate(peerAddr, nil)
-		require.True(t, ok)
-		assert.Equal(t, uint8(want), id)
+		assert.Equal(t, uint8(want), a.allocate(peerAddr))
 	}
 
-	id, ok := a.allocate(peerAddr, nil)
-	require.True(t, ok)
-	assert.Zero(t, id, "the sequence wraps back to zero after 255")
+	assert.Zero(t, a.allocate(peerAddr), "the sequence wraps back to zero after 255")
 }
 
 func TestSessionIDAllocator_SequenceIsIndependentPerPeer(t *testing.T) {
@@ -587,34 +583,10 @@ func TestSessionIDAllocator_SequenceIsIndependentPerPeer(t *testing.T) {
 	var a sessionIDAllocator
 
 	for want := range uint8(3) {
-		id, ok := a.allocate(peerA, nil)
-		require.True(t, ok)
-		assert.Equal(t, want, id)
+		assert.Equal(t, want, a.allocate(peerA))
 	}
 
-	id, ok := a.allocate(peerB, nil)
-	require.True(t, ok)
-	assert.Zero(t, id, "peer B's sequence must not be advanced by peer A")
-}
-
-func TestSessionIDAllocator_SkipsSessionIDsInUse(t *testing.T) {
-	peerAddr := netip.MustParseAddr("10.0.255.1")
-	var a sessionIDAllocator
-
-	id, ok := a.allocate(peerAddr, func(id uint8) bool { return id < 3 })
-	require.True(t, ok)
-	assert.Equal(t, uint8(3), id)
-
-	id, ok = a.allocate(peerAddr, nil)
-	require.True(t, ok)
-	assert.Equal(t, uint8(4), id, "the sequence continues after the skipped IDs")
-}
-
-func TestSessionIDAllocator_ReportsFalseWhenEveryIDIsInUse(t *testing.T) {
-	var a sessionIDAllocator
-
-	_, ok := a.allocate(netip.MustParseAddr("10.0.255.1"), func(uint8) bool { return true })
-	assert.False(t, ok)
+	assert.Zero(t, a.allocate(peerB), "peer B's sequence must not be advanced by peer A")
 }
 
 // blockingWriteConn simulates a peer that stopped reading.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -214,6 +214,58 @@ func TestServer_CloseSession_LogsWarnOnOtherCloseFailure(t *testing.T) {
 	assert.Empty(t, s.Sessions())
 }
 
+func TestValidatePCEOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		o       *PCEOptions
+		wantErr bool
+	}{
+		{name: "nil options rejected", o: nil, wantErr: true},
+		{name: "Keepalive=0/DeadTimer=0 OK", o: &PCEOptions{Keepalive: new(uint8(0)), DeadTimer: new(uint8(0))}, wantErr: false},
+		{name: "Keepalive=0/DeadTimer>0 rejected", o: &PCEOptions{Keepalive: new(uint8(0)), DeadTimer: new(uint8(1))}, wantErr: true},
+		{name: "DeadTimer<Keepalive rejected", o: &PCEOptions{Keepalive: new(uint8(30)), DeadTimer: new(uint8(29))}, wantErr: true},
+		{name: "DeadTimer==Keepalive rejected", o: &PCEOptions{Keepalive: new(uint8(30)), DeadTimer: new(uint8(30))}, wantErr: true},
+		{name: "DeadTimer>Keepalive OK", o: &PCEOptions{Keepalive: new(uint8(30)), DeadTimer: new(uint8(31))}, wantErr: false},
+		{name: "Keepalive=255 with default DeadTimer rejected", o: &PCEOptions{Keepalive: new(uint8(255))}, wantErr: true},
+		{name: "MinKeepalive==MaxKeepalive OK", o: &PCEOptions{MinKeepalive: new(uint8(30)), MaxKeepalive: new(uint8(30))}, wantErr: false},
+		{name: "MinKeepalive>MaxKeepalive rejected", o: &PCEOptions{MinKeepalive: new(uint8(31)), MaxKeepalive: new(uint8(30))}, wantErr: true},
+		{name: "no options set is OK", o: &PCEOptions{}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePCEOptions(tt.o)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewPCE_NilOptionsReturnsConfigErrorWithoutPanicking(t *testing.T) {
+	err := NewPCE(context.Background(), nil, zap.NewNop(), make(chan []table.TEDElem))
+	assert.Equal(t, "config", err.Server)
+	require.Error(t, err.Error)
+}
+
+func TestNewPCE_InvalidTimerConfigRejectedBeforeListening(t *testing.T) {
+	// A direct NewPCE caller (bypassing internal/config's own validation)
+	// must not be able to start a PCE with an invalid timer configuration.
+	o := &PCEOptions{
+		PCEPAddr:  "127.0.0.1",
+		PCEPPort:  "0",
+		GRPCAddr:  "127.0.0.1",
+		GRPCPort:  "0",
+		Keepalive: new(uint8(0)),
+		DeadTimer: new(uint8(1)),
+	}
+
+	err := NewPCE(context.Background(), o, zap.NewNop(), make(chan []table.TEDElem))
+	assert.Equal(t, "config", err.Server)
+	require.Error(t, err.Error)
+}
+
 func TestNewPCE_ReturnsTaggedError(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -574,13 +574,31 @@ func (ss *Session) sendPCErrBestEffort(errorType, errorValue uint8) {
 	}
 }
 
-// validateCapabilities logs known peer deviations from RFC-defined capabilities.
-// X=0 with MSD=0 is invalid per RFC 8664 §5.1, but tolerated for
-// compatibility with deployed Cisco XRd, Juniper vJunos, and FRRouting.
+// validateCapabilities validates peer capabilities and logs known RFC deviations.
 func (ss *Session) validateCapabilities(caps []pcep.CapabilityInterface) {
+	var hasSRCapability, hasSRv6Capability bool
+	for _, capability := range pcep.FlattenCapabilities(caps) {
+		switch c := capability.(type) {
+		case *pcep.SRPCECapability:
+			hasSRCapability = true
+			if c.HasInvalidZeroMSD() {
+				ss.logger.Warn("peer advertised SR-PCE-CAPABILITY with X=0 and MSD=0 (RFC 8664 §5.1); tolerating as a known deployed-peer deviation")
+			}
+		case *pcep.SRv6PCECapability:
+			hasSRv6Capability = true
+		}
+	}
+
 	for _, capability := range caps {
-		if sr, ok := capability.(*pcep.SRPCECapability); ok && sr.HasInvalidZeroMSD() {
-			ss.logger.Warn("peer advertised SR-PCE-CAPABILITY with X=0 and MSD=0 (RFC 8664 §5.1); tolerating as a known deployed-peer deviation")
+		pst, ok := capability.(*pcep.PathSetupTypeCapability)
+		if !ok {
+			continue
+		}
+		if pst.HasPathSetupType(pcep.PathSetupTypeSRTE) && !hasSRCapability {
+			ss.logger.Warn("peer advertised PST=1 (SR-TE) without an SR-PCE-CAPABILITY sub-TLV (RFC 8664 §4.1.2)")
+		}
+		if pst.HasPathSetupType(pcep.PathSetupTypeSRv6TE) && !hasSRv6Capability {
+			ss.logger.Warn("peer advertised PST=3 (SRv6-TE) without an SRv6-PCE-CAPABILITY sub-TLV (RFC 9603 §4.1.1)")
 		}
 	}
 }

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -428,92 +428,304 @@ func (ss *Session) sendPCEPMessage(message pcep.Message) error {
 	return err
 }
 
-// maxKeepWaitOpenAttempts limits Open negotiation to one retry.
-const maxKeepWaitOpenAttempts = 2
+// maxLocalOpenRetries limits resends of Pola's Open after adopting a peer's
+// proposed session characteristics. A peer that rejects its own proposal
+// cannot provide a convergent next negotiation round.
+const maxLocalOpenRetries = 1
 
-// Open establishes the PCEP session according to RFC 5440 §6.2.
+// openNegotiation tracks the Open negotiation state, including the independent
+// RemoteOK and LocalOK conditions from RFC 5440 Appendix A.
+type openNegotiation struct {
+	remoteOK          bool
+	localOK           bool
+	peerOpensRejected int
+	localOpenRetries  int
+	deadline          time.Time
+}
+
+type negotiationVars struct {
+	remoteOK, localOK                   bool
+	peerOpensRejected, localOpenRetries int
+}
+
+func (neg *openNegotiation) vars() negotiationVars {
+	return negotiationVars{neg.remoteOK, neg.localOK, neg.peerOpensRejected, neg.localOpenRetries}
+}
+
+func (neg *openNegotiation) established() bool {
+	return neg.remoteOK && neg.localOK
+}
+
+// peerOpened reports whether an Open has been received from the peer,
+// acceptable or not.
+func (neg *openNegotiation) peerOpened() bool {
+	return neg.remoteOK || neg.peerOpensRejected > 0
+}
+
+// state derives the Appendix A state from the negotiation conditions.
+func (neg *openNegotiation) state() sessionState {
+	switch {
+	case neg.established():
+		return sessionStateUp
+	case neg.peerOpened() && !neg.localOK:
+		return sessionStateKeepWait
+	default:
+		return sessionStateOpenWait
+	}
+}
+
+// Open sends Pola's Open and negotiates the PCEP session.
 func (ss *Session) Open() error {
-	ss.setState(sessionStateOpenWait)
 	if err := ss.SendOpen(); err != nil {
 		return err
 	}
-	if err := ss.negotiateOpen(); err != nil {
-		return err
-	}
+	return ss.negotiateOpen(&openNegotiation{})
+}
 
-	for attempt := range maxKeepWaitOpenAttempts {
-		if err := ss.SendKeepalive(); err != nil {
-			return err
-		}
+// negotiateOpen handles PCEP Open negotiation until both peers have
+// acknowledged each other's Open.
+func (ss *Session) negotiateOpen(neg *openNegotiation) error {
+	ss.restartInitializationTimer(neg)
 
-		ss.setState(sessionStateKeepWait)
-		renegotiable := attempt < maxKeepWaitOpenAttempts-1
-		retry, err := ss.awaitKeepalive(renegotiable)
-		if err != nil {
-			return err
+	var stopNegotiationKeepalive func()
+	defer func() {
+		if stopNegotiationKeepalive != nil {
+			stopNegotiationKeepalive()
 		}
-		if !retry {
-			ss.setState(sessionStateUp)
+	}()
+
+	for {
+		ss.setState(neg.state())
+		if neg.established() {
 			return nil
 		}
 
-		ss.setState(sessionStateOpenWait)
-		if err := ss.SendOpen(); err != nil {
+		before := neg.vars()
+		messageType, body, err := ss.readNegotiationMessage(neg)
+		if err != nil {
 			return err
 		}
+
+		switch messageType {
+		case pcep.MessageTypeOpen:
+			err = ss.handlePeerOpen(body, neg)
+		case pcep.MessageTypeKeepalive:
+			if !neg.peerOpened() {
+				ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+				return errors.New("received a Keepalive before the peer's Open message")
+			}
+			ss.logger.Debug("Received Keepalive acknowledging Pola's Open")
+			neg.localOK = true
+		case pcep.MessageTypeError:
+			if !neg.peerOpened() {
+				ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+				return errors.New("received a PCErr before the peer's Open message")
+			}
+			err = ss.handleNegotiationPCErr(body, neg)
+		default:
+			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+			return fmt.Errorf("received %s while establishing the PCEP session", messageType)
+		}
+		if err != nil {
+			return err
+		}
+
+		after := neg.vars()
+		// Restart the initialization timer only when the negotiation state changes.
+		if after != before {
+			ss.restartInitializationTimer(neg)
+		}
+
+		// Keepalive starts once the peer's Open is accepted.
+		if !before.remoteOK && after.remoteOK && stopNegotiationKeepalive == nil {
+			stopNegotiationKeepalive = ss.startNegotiationKeepalive()
+		}
 	}
-	return errors.New("peer repeatedly rejected Pola's session characteristics")
 }
 
-// awaitKeepalive returns retry=true when Open negotiation should be retried.
-// renegotiable reports whether another Open may still be sent.
-func (ss *Session) awaitKeepalive(renegotiable bool) (retry bool, err error) {
-	deadline := time.Now().Add(ss.keepWait)
-
-	commonHeader, err := ss.readCommonHeader(deadline)
-	if err != nil {
-		if isDeadlineExceeded(err) {
-			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueKeepWaitTimerExpired)
-			return false, errors.New("KeepWait timer expired without a Keepalive or PCErr message")
-		}
-		return false, err
+// restartInitializationTimer starts or restarts the initialization timer
+// for the current negotiation state.
+func (ss *Session) restartInitializationTimer(neg *openNegotiation) {
+	timer := ss.openWait
+	if neg.state() == sessionStateKeepWait {
+		timer = ss.keepWait
 	}
+	neg.deadline = time.Now().Add(timer)
+}
+
+// startNegotiationKeepalive starts the Keepalive timer once RemoteOK is set,
+// while Pola's Open is still awaiting acknowledgment.
+func (ss *Session) startNegotiationKeepalive() func() {
+	interval := ss.keepaliveInterval()
+	if interval == 0 {
+		return func() {}
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(time.Duration(interval) * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if err := ss.SendKeepalive(); err != nil {
+					ss.logger.Debug("ERROR! Send Keepalive Message during negotiation", zap.Error(err))
+					return
+				}
+			}
+		}
+	}()
+	return func() {
+		close(stop)
+		<-done
+	}
+}
+
+// readNegotiationMessage reads one message under the current initialization
+// timer and handles malformed messages according to session-establishment rules.
+func (ss *Session) readNegotiationMessage(neg *openNegotiation) (pcep.MessageType, []uint8, error) {
+	deadline := neg.deadline
+
+	headerBytes := make([]uint8, pcep.CommonHeaderLength)
+	if err := ss.readFullWithDeadline(headerBytes, deadline); err != nil {
+		if isDeadlineExceeded(err) {
+			return 0, nil, ss.negotiationTimerExpired(neg, "without a message from the peer")
+		}
+		return 0, nil, err
+	}
+
+	var commonHeader pcep.CommonHeader
+	if err := commonHeader.DecodeFromBytes(headerBytes); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+		return 0, nil, err
+	}
+	ss.countReceived(commonHeader.MessageType)
+
 	body, err := ss.readMessageBody(commonHeader.MessageLength, deadline)
 	if err != nil {
 		if isDeadlineExceeded(err) {
-			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueKeepWaitTimerExpired)
-			return false, errors.New("KeepWait timer expired while reading the message body")
+			return 0, nil, ss.negotiationTimerExpired(neg, "before the message was complete")
 		}
-		return false, err
+		return 0, nil, err
 	}
 
-	switch commonHeader.MessageType {
-	case pcep.MessageTypeKeepalive:
-		ss.stats.inc(&ss.stats.keepaliveRcvd)
-		ss.logger.Debug("Received Keepalive acknowledging Open")
-		return false, nil
-	case pcep.MessageTypeError:
-		ss.stats.inc(&ss.stats.pcerrRcvd)
-		return ss.handleKeepWaitPCErr(body, renegotiable)
-	default:
-		return false, fmt.Errorf("expected a Keepalive or PCErr message in KeepWait, got %s", commonHeader.MessageType.String())
-	}
+	return commonHeader.MessageType, body, nil
 }
 
-func (ss *Session) handleKeepWaitPCErr(body []uint8, renegotiable bool) (retry bool, err error) {
+// negotiationTimerExpired reports an initialization timer expiration using
+// the error value corresponding to the current negotiation state.
+func (ss *Session) negotiationTimerExpired(neg *openNegotiation, detail string) error {
+	timer, errorValue := "OpenWait", pcepErrorValueOpenWaitTimerExpired
+	if neg.state() == sessionStateKeepWait {
+		timer, errorValue = "KeepWait", pcepErrorValueKeepWaitTimerExpired
+	}
+	ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, errorValue)
+	return fmt.Errorf("%s timer expired %s", timer, detail)
+}
+
+// handlePeerOpen processes an Open received during session establishment,
+// accepting it or responding with an appropriate negotiation error.
+func (ss *Session) handlePeerOpen(body []uint8, neg *openNegotiation) error {
+	openMessage := &pcep.OpenMessage{}
+	if err := openMessage.DecodeFromBytes(body); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+		return err
+	}
+
+	if neg.remoteOK {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+		return fmt.Errorf("received a further Open (Keepalive=%d, DeadTimer=%d) after the peer's Open was already accepted",
+			openMessage.OpenObject.Keepalive, openMessage.OpenObject.Deadtime)
+	}
+
+	peerOpen, pccType, caps := ss.decodePeerOpen(openMessage)
+
+	if ss.acceptableOpen(peerOpen) {
+		ss.commitPeerOpen(peerOpen, pccType, caps)
+		if err := ss.SendKeepalive(); err != nil {
+			return err
+		}
+		neg.remoteOK = true
+		return nil
+	}
+	if neg.peerOpensRejected > 0 {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueSecondOpenStillUnacceptable)
+		return fmt.Errorf("peer's second Open still advertises unacceptable session characteristics (Keepalive=%d, DeadTimer=%d)",
+			peerOpen.Keepalive, peerOpen.DeadTimer)
+	}
+	if !ss.allowNegotiation {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNonNegotiable)
+		return fmt.Errorf("peer's session characteristics (Keepalive=%d, DeadTimer=%d) are unacceptable and non-negotiable",
+			peerOpen.Keepalive, peerOpen.DeadTimer)
+	}
+	if err := ss.proposeAcceptableOpen(peerOpen); err != nil {
+		return err
+	}
+	neg.peerOpensRejected++
+
+	return nil
+}
+
+// decodePeerOpen decodes the peer's Open without committing it to session state.
+// Capability validation is diagnostic and runs regardless of acceptability.
+func (ss *Session) decodePeerOpen(openMessage *pcep.OpenMessage) (OpenParams, pcep.PccType, []pcep.CapabilityInterface) {
+	receivedCaps := slices.Clone(openMessage.OpenObject.Caps)
+
+	ss.validateCapabilities(receivedCaps)
+
+	pccType := pcep.DeterminePccType(receivedCaps)
+	ss.logger.Debug("Determine PCC Type", zap.Int("pcc-type", int(pccType)))
+
+	peerOpen := OpenParams{
+		SessionID: openMessage.OpenObject.Sid,
+		Keepalive: openMessage.OpenObject.Keepalive,
+		DeadTimer: openMessage.OpenObject.Deadtime,
+	}
+	if peerOpen.Keepalive == 0 && peerOpen.DeadTimer != 0 {
+		ss.logger.Warn("peer advertised Keepalive=0 with a nonzero DeadTimer (RFC 5440 §7.3 SHOULD); ignoring the DeadTimer",
+			zap.Uint8("deadtimer", peerOpen.DeadTimer))
+	}
+
+	return peerOpen, pccType, receivedCaps
+}
+
+// commitPeerOpen publishes an accepted peer Open as session state.
+func (ss *Session) commitPeerOpen(peerOpen OpenParams, pccType pcep.PccType, caps []pcep.CapabilityInterface) {
+	ss.stateMu.Lock()
+	ss.receivedPccCapabilities = caps
+	ss.pccType = pccType
+	ss.pccOpen = &peerOpen
+	ss.stateMu.Unlock()
+}
+
+// handleNegotiationPCErr processes a PCErr received during session
+// establishment, continuing negotiation only for Error 1/4.
+func (ss *Session) handleNegotiationPCErr(body []uint8, neg *openNegotiation) error {
 	pcerrMessage := &pcep.PCErrMessage{}
 	if err := pcerrMessage.DecodeFromBytes(body); err != nil {
 		ss.stats.inc(&ss.stats.corruptRcvd)
-		return false, fmt.Errorf("received malformed PCErr in KeepWait: %w", err)
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+		return fmt.Errorf("received malformed PCErr while establishing the PCEP session: %w", err)
 	}
-	ss.logger.Debug("Received PCErr in KeepWait", zap.String("errors", formatPCErrErrors(pcerrMessage.Errors)))
+	ss.logger.Debug("Received PCErr while establishing the PCEP session",
+		zap.String("errors", formatPCErrErrors(pcerrMessage.Errors)))
 
-	for _, errObj := range pcerrMessage.Errors {
-		if errObj.ErrorType == pcepErrorTypeSessionEstablishmentFailure && errObj.ErrorValue == pcepErrorValueUnacceptableNegotiable {
-			return ss.handleProposedOpen(pcerrMessage.Open, renegotiable)
-		}
+	// A negotiable Error 1/4 may be accompanied by unrelated PCEP-ERROR objects.
+	negotiable := slices.ContainsFunc(pcerrMessage.Errors, func(errObj *pcep.ErrorObject) bool {
+		return errObj.ErrorType == pcepErrorTypeSessionEstablishmentFailure &&
+			errObj.ErrorValue == pcepErrorValueUnacceptableNegotiable
+	})
+	if !negotiable {
+		return fmt.Errorf("peer rejected session establishment (%s)", formatPCErrErrors(pcerrMessage.Errors))
 	}
-	return false, fmt.Errorf("peer rejected session establishment (%s)", formatPCErrErrors(pcerrMessage.Errors))
+
+	return ss.adoptProposedOpen(pcerrMessage.Open, neg)
 }
 
 func formatPCErrErrors(errors []*pcep.ErrorObject) string {
@@ -524,11 +736,12 @@ func formatPCErrErrors(errors []*pcep.ErrorObject) string {
 	return strings.Join(reasons, "; ")
 }
 
-// handleProposedOpen handles an Open proposal from PCErr(1,4).
-func (ss *Session) handleProposedOpen(proposedOpen *pcep.OpenObject, renegotiable bool) (retry bool, err error) {
+// adoptProposedOpen validates and adopts the peer's proposed session
+// characteristics, then re-sends Pola's Open.
+func (ss *Session) adoptProposedOpen(proposedOpen *pcep.OpenObject, neg *openNegotiation) error {
 	if proposedOpen == nil {
 		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
-		return false, errors.New("peer rejected Pola's session characteristics without proposing acceptable ones")
+		return errors.New("peer rejected Pola's session characteristics without proposing acceptable ones")
 	}
 
 	proposed := OpenParams{
@@ -536,14 +749,14 @@ func (ss *Session) handleProposedOpen(proposedOpen *pcep.OpenObject, renegotiabl
 		Keepalive: proposedOpen.Keepalive,
 		DeadTimer: proposedOpen.Deadtime,
 	}
-	if !renegotiable {
+	if neg.localOpenRetries >= maxLocalOpenRetries {
 		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
-		return false, fmt.Errorf("peer rejected Pola's renegotiated Open with a further proposal (Keepalive=%d, DeadTimer=%d)",
+		return fmt.Errorf("peer rejected Pola's re-sent Open with a further proposal (Keepalive=%d, DeadTimer=%d)",
 			proposed.Keepalive, proposed.DeadTimer)
 	}
-	if !validTimerRelationship(proposed) {
+	if !ss.acceptableOpen(proposed) {
 		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
-		return false, fmt.Errorf("peer proposed unacceptable session characteristics (Keepalive=%d, DeadTimer=%d)",
+		return fmt.Errorf("peer proposed unacceptable session characteristics (Keepalive=%d, DeadTimer=%d)",
 			proposed.Keepalive, proposed.DeadTimer)
 	}
 
@@ -553,7 +766,16 @@ func (ss *Session) handleProposedOpen(proposedOpen *pcep.OpenObject, renegotiabl
 	ss.stateMu.Unlock()
 	ss.logger.Debug("Adopting peer-proposed session characteristics",
 		zap.Uint8("keepalive", proposed.Keepalive), zap.Uint8("deadtimer", proposed.DeadTimer))
-	return true, nil
+
+	if err := ss.SendOpen(); err != nil {
+		return err
+	}
+	neg.localOpenRetries++
+
+	// A re-sent Open starts a new negotiation round.
+	neg.localOK = false
+
+	return nil
 }
 
 func (ss *Session) readDeadline() time.Duration {
@@ -619,135 +841,31 @@ func (ss *Session) messageDeadline() time.Time {
 	return deadline
 }
 
-func (ss *Session) parseOpenMessage() (*pcep.OpenMessage, error) {
-	deadline := time.Now().Add(ss.openWait)
-
-	byteOpenHeader := make([]uint8, pcep.CommonHeaderLength)
-	if err := ss.readFullWithDeadline(byteOpenHeader, deadline); err != nil {
-		if isDeadlineExceeded(err) {
-			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueOpenWaitTimerExpired)
-			return nil, errors.New("OpenWait timer expired without an Open message")
-		}
-		return nil, err
-	}
-
-	var openHeader pcep.CommonHeader
-	if err := openHeader.DecodeFromBytes(byteOpenHeader); err != nil {
-		ss.stats.inc(&ss.stats.corruptRcvd)
-		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
-		return nil, err
-	}
-
-	if openHeader.MessageType != pcep.MessageTypeOpen {
-		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
-		return nil, fmt.Errorf("this peer has not been opened (messageType: %s)", openHeader.MessageType.String())
-	}
-
-	byteOpenObject := make([]uint8, openHeader.MessageLength-pcep.CommonHeaderLength)
-	if err := ss.readFullWithDeadline(byteOpenObject, deadline); err != nil {
-		if isDeadlineExceeded(err) {
-			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueOpenWaitTimerExpired)
-			return nil, errors.New("OpenWait timer expired before the Open message was complete")
-		}
-		return nil, err
-	}
-
-	var openMessage pcep.OpenMessage
-	if err := openMessage.DecodeFromBytes(byteOpenObject); err != nil {
-		ss.stats.inc(&ss.stats.corruptRcvd)
-		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
-		return nil, err
-	}
-
-	return &openMessage, nil
-}
-
-// ReceiveOpen receives and processes a PCEP Open message from the peer.
-func (ss *Session) ReceiveOpen() error {
-	ss.logger.Debug("Receive Open Message")
-	openMessage, err := ss.parseOpenMessage()
-	if err != nil {
-		return err
-	}
-
-	receivedCaps := slices.Clone(openMessage.OpenObject.Caps)
-
-	ss.stats.inc(&ss.stats.openRcvd)
-
-	ss.validateCapabilities(receivedCaps)
-
-	pccType := pcep.DeterminePccType(receivedCaps)
-	ss.logger.Debug("Determine PCC Type", zap.Int("pcc-type", int(pccType)))
-
-	ss.stateMu.Lock()
-	ss.receivedPccCapabilities = receivedCaps
-	ss.pccType = pccType
-	ss.pccOpen = &OpenParams{
-		SessionID: openMessage.OpenObject.Sid,
-		Keepalive: openMessage.OpenObject.Keepalive,
-		DeadTimer: openMessage.OpenObject.Deadtime,
-	}
-	ss.stateMu.Unlock()
-
-	return nil
-}
-
-func (ss *Session) negotiateOpen() error {
-	if err := ss.ReceiveOpen(); err != nil {
-		return err
-	}
-	pccOpen, _ := ss.PccOpen()
-	if ss.acceptableOpen(pccOpen) {
-		return nil
-	}
-	if !ss.allowNegotiation {
-		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNonNegotiable)
-		return fmt.Errorf("peer's session characteristics (Keepalive=%d, DeadTimer=%d) are unacceptable and non-negotiable",
-			pccOpen.Keepalive, pccOpen.DeadTimer)
-	}
-	if err := ss.proposeAcceptableOpen(pccOpen); err != nil {
-		return err
-	}
-
-	if err := ss.ReceiveOpen(); err != nil {
-		return err
-	}
-	pccOpen, _ = ss.PccOpen()
-	if ss.acceptableOpen(pccOpen) {
-		return nil
-	}
-	ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueSecondOpenStillUnacceptable)
-	return fmt.Errorf("peer's second Open still advertises unacceptable session characteristics (Keepalive=%d, DeadTimer=%d)",
-		pccOpen.Keepalive, pccOpen.DeadTimer)
-}
-
-// validTimerRelationship reports whether Keepalive and DeadTimer satisfy
-// RFC 5440 §7.3.
+// validTimerRelationship reports whether Keepalive and DeadTimer are
+// mutually consistent. A nonzero DeadTimer is ignored when Keepalive is 0
+// (RFC 5440 §7.3); otherwise DeadTimer must exceed Keepalive (§6.3).
 func validTimerRelationship(open OpenParams) bool {
-	if open.Keepalive == 0 && open.DeadTimer != 0 {
-		return false
+	if open.Keepalive == 0 {
+		return true
 	}
-	if open.Keepalive != 0 && open.DeadTimer != 0 && open.DeadTimer <= open.Keepalive {
-		return false
-	}
-	return true
+	return open.DeadTimer == 0 || open.DeadTimer > open.Keepalive
 }
 
-// acceptableOpen reports whether the PCC's proposed session parameters
-// are acceptable.
-func (ss *Session) acceptableOpen(pccOpen OpenParams) bool {
-	if !validTimerRelationship(pccOpen) {
+// acceptableOpen reports whether the proposed session parameters are
+// acceptable, including a peer's counter-proposal.
+func (ss *Session) acceptableOpen(peerOpen OpenParams) bool {
+	if !validTimerRelationship(peerOpen) {
 		return false
 	}
 	if !ss.keepaliveRangeEnabled {
 		return true
 	}
-	return pccOpen.Keepalive >= ss.minKeepalive && pccOpen.Keepalive <= ss.maxKeepalive
+	return peerOpen.Keepalive >= ss.minKeepalive && peerOpen.Keepalive <= ss.maxKeepalive
 }
 
 // proposedTimers returns acceptable Keepalive and DeadTimer values.
-func (ss *Session) proposedTimers(pccOpen OpenParams) (keepalive, deadTimer uint8) {
-	keepalive = pccOpen.Keepalive
+func (ss *Session) proposedTimers(peerOpen OpenParams) (keepalive, deadTimer uint8) {
+	keepalive = peerOpen.Keepalive
 	if ss.keepaliveRangeEnabled {
 		switch {
 		case keepalive < ss.minKeepalive:
@@ -765,9 +883,9 @@ func (ss *Session) proposedTimers(pccOpen OpenParams) (keepalive, deadTimer uint
 }
 
 // proposeAcceptableOpen sends a PCErr proposing acceptable session characteristics.
-func (ss *Session) proposeAcceptableOpen(pccOpen OpenParams) error {
-	keepalive, deadTimer := ss.proposedTimers(pccOpen)
-	openObject := pcep.NewOpenObject(pccOpen.SessionID, keepalive, deadTimer, nil)
+func (ss *Session) proposeAcceptableOpen(peerOpen OpenParams) error {
+	keepalive, deadTimer := ss.proposedTimers(peerOpen)
+	openObject := pcep.NewOpenObject(peerOpen.SessionID, keepalive, deadTimer, nil)
 
 	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, openObject)
 	ss.logger.Debug("Send PCErr Message proposing session characteristics",
@@ -878,6 +996,8 @@ func (ss *Session) receiveOnePCEPMessage() (done bool, err error) {
 // countReceived updates the RFC 9826 receive-side counter for a message type.
 func (ss *Session) countReceived(mt pcep.MessageType) {
 	switch mt {
+	case pcep.MessageTypeOpen:
+		ss.stats.inc(&ss.stats.openRcvd)
 	case pcep.MessageTypeKeepalive:
 		ss.stats.inc(&ss.stats.keepaliveRcvd)
 	case pcep.MessageTypeReport:

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -55,13 +55,10 @@ const (
 	pcepErrorValueSecondOpenStillUnacceptable uint8 = 5
 	pcepErrorValueUnacceptableProposal        uint8 = 6
 	pcepErrorValueKeepWaitTimerExpired        uint8 = 7
-
-	pcepErrorTypeCapabilityNotSupported uint8 = 2
-
-	pcepErrorTypeSecondSessionAttempt  uint8 = 9
-	pcepErrorValueSecondSessionAttempt uint8 = 1
-
-	pcepErrorValueUnassigned uint8 = 0
+	pcepErrorTypeCapabilityNotSupported       uint8 = 2
+	pcepErrorTypeSecondSessionAttempt         uint8 = 9
+	pcepErrorValueSecondSessionAttempt        uint8 = 1
+	pcepErrorValueUnassigned                  uint8 = 0
 )
 
 // sessionState represents the PCEP session state (RFC 5440 Appendix A).
@@ -91,8 +88,7 @@ const (
 	sessionInitiatorLocal
 )
 
-// sessionStats holds the per-session PCEP message counters tracked by Pola.
-
+// sessionStats holds per-session PCEP message counters (RFC 9826).
 type sessionStats struct {
 	mu             sync.Mutex
 	openSent       uint64
@@ -349,24 +345,25 @@ func (ss *Session) clearSRPolicyIntents() {
 // NewSession creates a new PCEP session with the given local Open parameters.
 func NewSession(localOpen OpenParams, peerAddr netip.Addr, tcpConn net.Conn, logger *zap.Logger, ted *table.LsTED, asn uint32) *Session {
 	return &Session{
-		localSessionID:    localOpen.SessionID,
-		localKeepalive:    localOpen.Keepalive,
-		localDeadTimer:    localOpen.DeadTimer,
-		openWait:          openWaitTimer,
-		keepWait:          keepWaitTimer,
-		createdAt:         time.Now(),
-		srpIDHead:         uint32(1),
-		srpIDMax:          math.MaxUint32,
-		srPolicyIntentTTL: defaultSRPolicyIntentTTL,
-		sweepInterval:     defaultSRPolicyIntentSweepInterval,
-		maxUnknownMsgs:    defaultMaxUnknownMsgs,
-		unknownMsgWindow:  defaultUnknownMsgWindow,
-		logger:            logger.With(zap.String("server", "pcep"), zap.String("session", peerAddr.String())),
-		pccType:           pcep.RFCCompliant,
-		peerAddr:          peerAddr,
-		tcpConn:           tcpConn,
-		ted:               ted,
-		asn:               asn,
+		localSessionID:         localOpen.SessionID,
+		localKeepalive:         localOpen.Keepalive,
+		localDeadTimer:         localOpen.DeadTimer,
+		openWait:               openWaitTimer,
+		keepWait:               keepWaitTimer,
+		createdAt:              time.Now(),
+		srpIDHead:              uint32(1),
+		srpIDMax:               math.MaxUint32,
+		srPolicyIntentTTL:      defaultSRPolicyIntentTTL,
+		sweepInterval:          defaultSRPolicyIntentSweepInterval,
+		maxUnknownMsgs:         defaultMaxUnknownMsgs,
+		unknownMsgWindow:       defaultUnknownMsgWindow,
+		logger:                 logger.With(zap.String("server", "pcep"), zap.String("session", peerAddr.String())),
+		pccType:                pcep.RFCCompliant,
+		peerAddr:               peerAddr,
+		tcpConn:                tcpConn,
+		ted:                    ted,
+		asn:                    asn,
+		advertisedCapabilities: pcep.DefaultCapabilities(),
 	}
 }
 
@@ -437,14 +434,14 @@ const maxKeepWaitOpenAttempts = 2
 // Open establishes the PCEP session according to RFC 5440 §6.2.
 func (ss *Session) Open() error {
 	ss.setState(sessionStateOpenWait)
+	if err := ss.SendOpen(); err != nil {
+		return err
+	}
 	if err := ss.negotiateOpen(); err != nil {
 		return err
 	}
 
 	for attempt := range maxKeepWaitOpenAttempts {
-		if err := ss.SendOpen(); err != nil {
-			return err
-		}
 		if err := ss.SendKeepalive(); err != nil {
 			return err
 		}
@@ -458,6 +455,11 @@ func (ss *Session) Open() error {
 		if !retry {
 			ss.setState(sessionStateUp)
 			return nil
+		}
+
+		ss.setState(sessionStateOpenWait)
+		if err := ss.SendOpen(); err != nil {
+			return err
 		}
 	}
 	return errors.New("peer repeatedly rejected Pola's session characteristics")
@@ -572,6 +574,17 @@ func (ss *Session) sendPCErrBestEffort(errorType, errorValue uint8) {
 	}
 }
 
+// validateCapabilities logs known peer deviations from RFC-defined capabilities.
+// X=0 with MSD=0 is invalid per RFC 8664 §5.1, but tolerated for
+// compatibility with deployed Cisco XRd, Juniper vJunos, and FRRouting.
+func (ss *Session) validateCapabilities(caps []pcep.CapabilityInterface) {
+	for _, capability := range caps {
+		if sr, ok := capability.(*pcep.SRPCECapability); ok && sr.HasInvalidZeroMSD() {
+			ss.logger.Warn("peer advertised SR-PCE-CAPABILITY with X=0 and MSD=0 (RFC 8664 §5.1); tolerating as a known deployed-peer deviation")
+		}
+	}
+}
+
 func (ss *Session) readFullWithDeadline(buf []uint8, deadline time.Time) error {
 	if err := ss.tcpConn.SetReadDeadline(deadline); err != nil {
 		return err
@@ -641,8 +654,10 @@ func (ss *Session) ReceiveOpen() error {
 
 	receivedCaps := slices.Clone(openMessage.OpenObject.Caps)
 
-	// pccType detection
-	// * FRRouting cannot be detected from the open message, so it is treated as an RFC compliant
+	ss.stats.inc(&ss.stats.openRcvd)
+
+	ss.validateCapabilities(receivedCaps)
+
 	pccType := pcep.DeterminePccType(receivedCaps)
 	ss.logger.Debug("Determine PCC Type", zap.Int("pcc-type", int(pccType)))
 
@@ -657,7 +672,6 @@ func (ss *Session) ReceiveOpen() error {
 	ss.stateMu.Unlock()
 
 	ss.setAdvertisedCapabilities(pcep.PolaCapability(openMessage.OpenObject.Caps))
-	ss.stats.inc(&ss.stats.openRcvd)
 
 	return nil
 }
@@ -693,7 +707,10 @@ func (ss *Session) negotiateOpen() error {
 
 // acceptableOpen reports whether the peer's session characteristics are acceptable.
 func (ss *Session) acceptableOpen(pccOpen OpenParams) bool {
-	if pccOpen.Keepalive != 0 && pccOpen.DeadTimer != 0 && pccOpen.DeadTimer < pccOpen.Keepalive {
+	if pccOpen.Keepalive == 0 && pccOpen.DeadTimer != 0 {
+		return false
+	}
+	if pccOpen.Keepalive != 0 && pccOpen.DeadTimer != 0 && pccOpen.DeadTimer <= pccOpen.Keepalive {
 		return false
 	}
 	if !ss.keepaliveRangeEnabled {
@@ -713,13 +730,18 @@ func (ss *Session) proposedTimers(pccOpen OpenParams) (keepalive, deadTimer uint
 			keepalive = ss.maxKeepalive
 		}
 	}
-	return keepalive, pcep.DeadTimerFor(keepalive)
+	deadTimer = pcep.DeadTimerFor(keepalive)
+	if deadTimer <= keepalive {
+		// No 8-bit DeadTimer exceeds keepalive (e.g. keepalive=255), so use 0.
+		deadTimer = 0
+	}
+	return keepalive, deadTimer
 }
 
 // proposeAcceptableOpen sends a PCErr proposing acceptable session characteristics.
 func (ss *Session) proposeAcceptableOpen(pccOpen OpenParams) error {
 	keepalive, deadTimer := ss.proposedTimers(pccOpen)
-	openObject := pcep.NewOpenObject(ss.localSessionID, keepalive, deadTimer, nil)
+	openObject := pcep.NewOpenObject(pccOpen.SessionID, keepalive, deadTimer, nil)
 
 	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, openObject)
 	ss.logger.Debug("Send PCErr Message proposing session characteristics",
@@ -1136,6 +1158,53 @@ func effectiveKeepalive(localKeepalive, localDeadTimer uint8) uint8 {
 		limit = 1
 	}
 	return min(localKeepalive, limit)
+}
+
+// sessionSnapshot is a consistent view of session state.
+type sessionSnapshot struct {
+	state                   sessionState
+	pccType                 pcep.PccType
+	localOpen               *OpenParams
+	pccOpen                 *OpenParams
+	initiator               sessionInitiator
+	syncState               lspDBSyncState
+	createdAt               time.Time
+	establishedAt           time.Time
+	advertisedCapabilities  []pcep.CapabilityInterface
+	receivedPccCapabilities []pcep.CapabilityInterface
+}
+
+func (ss *Session) snapshot() sessionSnapshot {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return sessionSnapshot{
+		state:                   ss.state,
+		pccType:                 ss.pccType,
+		localOpen:               ss.localOpen,
+		pccOpen:                 ss.pccOpen,
+		initiator:               ss.initiator,
+		syncState:               ss.syncState,
+		createdAt:               ss.createdAt,
+		establishedAt:           ss.establishedAt,
+		advertisedCapabilities:  slices.Clone(ss.advertisedCapabilities),
+		receivedPccCapabilities: slices.Clone(ss.receivedPccCapabilities),
+	}
+}
+
+// keepaliveInterval returns Pola's effective Keepalive interval.
+func (snap sessionSnapshot) keepaliveInterval() uint8 {
+	if snap.localOpen == nil {
+		return 0
+	}
+	return effectiveKeepalive(snap.localOpen.Keepalive, snap.localOpen.DeadTimer)
+}
+
+// readDeadline returns the deadline derived from the peer's DeadTimer.
+func (snap sessionSnapshot) readDeadline() time.Duration {
+	if snap.pccOpen == nil || snap.pccOpen.Keepalive == 0 || snap.pccOpen.DeadTimer == 0 {
+		return 0
+	}
+	return time.Duration(snap.pccOpen.DeadTimer) * time.Second
 }
 
 // ReceivedCapabilities returns a snapshot of the capabilities advertised by the PCC.

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -541,7 +541,7 @@ func (ss *Session) handleProposedOpen(proposedOpen *pcep.OpenObject, renegotiabl
 		return false, fmt.Errorf("peer rejected Pola's renegotiated Open with a further proposal (Keepalive=%d, DeadTimer=%d)",
 			proposed.Keepalive, proposed.DeadTimer)
 	}
-	if !ss.acceptableOpen(proposed) {
+	if !validTimerRelationship(proposed) {
 		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
 		return false, fmt.Errorf("peer proposed unacceptable session characteristics (Keepalive=%d, DeadTimer=%d)",
 			proposed.Keepalive, proposed.DeadTimer)
@@ -671,8 +671,6 @@ func (ss *Session) ReceiveOpen() error {
 	}
 	ss.stateMu.Unlock()
 
-	ss.setAdvertisedCapabilities(pcep.PolaCapability(openMessage.OpenObject.Caps))
-
 	return nil
 }
 
@@ -705,12 +703,22 @@ func (ss *Session) negotiateOpen() error {
 		pccOpen.Keepalive, pccOpen.DeadTimer)
 }
 
-// acceptableOpen reports whether the peer's session characteristics are acceptable.
-func (ss *Session) acceptableOpen(pccOpen OpenParams) bool {
-	if pccOpen.Keepalive == 0 && pccOpen.DeadTimer != 0 {
+// validTimerRelationship reports whether Keepalive and DeadTimer satisfy
+// RFC 5440 §7.3.
+func validTimerRelationship(open OpenParams) bool {
+	if open.Keepalive == 0 && open.DeadTimer != 0 {
 		return false
 	}
-	if pccOpen.Keepalive != 0 && pccOpen.DeadTimer != 0 && pccOpen.DeadTimer <= pccOpen.Keepalive {
+	if open.Keepalive != 0 && open.DeadTimer != 0 && open.DeadTimer <= open.Keepalive {
+		return false
+	}
+	return true
+}
+
+// acceptableOpen reports whether the PCC's proposed session parameters
+// are acceptable.
+func (ss *Session) acceptableOpen(pccOpen OpenParams) bool {
+	if !validTimerRelationship(pccOpen) {
 		return false
 	}
 	if !ss.keepaliveRangeEnabled {
@@ -1219,12 +1227,6 @@ func (ss *Session) AdvertisedCapabilities() []pcep.CapabilityInterface {
 	ss.stateMu.RLock()
 	defer ss.stateMu.RUnlock()
 	return slices.Clone(ss.advertisedCapabilities)
-}
-
-func (ss *Session) setAdvertisedCapabilities(caps []pcep.CapabilityInterface) {
-	ss.stateMu.Lock()
-	defer ss.stateMu.Unlock()
-	ss.advertisedCapabilities = caps
 }
 
 // Response to request from PCE (SrpID != 0)

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"net"
 	"net/netip"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -31,41 +32,102 @@ const (
 	defaultMaxUnknownMsgs   = 5
 	defaultUnknownMsgWindow = 1 * time.Minute
 
-	pcepErrorTypeCapabilityNotSupported uint8 = 2
-	pcepErrorValueUnassigned            uint8 = 0
+	// RFC 5440 §6.2: OpenWait and KeepWait have a fixed value of 1 minute.
+	openWaitTimer = 1 * time.Minute
+	keepWaitTimer = 1 * time.Minute
 
-	defaultDeadTimer = 120 * time.Second
+	// RFC 5440 §7.3 RECOMMENDED Keepalive frequency.
+	defaultLocalKeepalive uint8 = 30
+
+	// Keepalive is set below the advertised DeadTimer per RFC 5440 §7.3.
+	// The divisor is a Pola safety margin, not an RFC requirement.
+	localDeadTimerKeepaliveDivisor = 4
 )
+
+// PCEP error codes used during session management (RFC 5440 §7.15).
+const (
+	pcepErrorTypeSessionEstablishmentFailure  uint8 = 1
+	pcepErrorValueInvalidOpenMessage          uint8 = 1
+	pcepErrorValueOpenWaitTimerExpired        uint8 = 2
+	pcepErrorValueUnacceptableNonNegotiable   uint8 = 3
+	pcepErrorValueUnacceptableNegotiable      uint8 = 4
+	pcepErrorValueSecondOpenStillUnacceptable uint8 = 5
+	pcepErrorValueUnacceptableProposal        uint8 = 6
+	pcepErrorValueKeepWaitTimerExpired        uint8 = 7
+
+	pcepErrorTypeCapabilityNotSupported uint8 = 2
+
+	pcepErrorTypeSecondSessionAttempt  uint8 = 9
+	pcepErrorValueSecondSessionAttempt uint8 = 1
+
+	pcepErrorValueUnassigned uint8 = 0
+)
+
+// sessionState represents the PCEP session state (RFC 5440 Appendix A).
+type sessionState uint8
+
+const (
+	sessionStateTCPPending sessionState = iota
+	sessionStateOpenWait
+	sessionStateKeepWait
+	sessionStateUp
+)
+
+// OpenParams contains PCEP session parameters advertised in an OPEN object.
+type OpenParams struct {
+	SessionID uint8
+	Keepalive uint8
+	DeadTimer uint8
+}
 
 // Session represents a PCEP session with a PCC.
 type Session struct {
-	sessionID               uint8
-	peerAddr                netip.Addr
-	tcpConn                 net.Conn
-	sendMu                  sync.Mutex
-	stateMu                 sync.RWMutex // guards isSynced and advertisedCapabilities.
-	isSynced                bool
-	srpIDMu                 sync.Mutex   // guards SRP-ID allocation and intent registration.
-	srpIDHead               uint32       // 0x00000000 and 0xFFFFFFFF are reserved.
-	srpIDMax                uint32       // upper bound for SRP-ID allocation.
-	srPoliciesMu            sync.RWMutex // guards srPolicies.
-	srPolicies              []*table.SRPolicy
-	srPolicyIntentsMu       sync.Mutex
-	srPolicyIntents         map[uint32]srPolicyIntent
-	srPolicyIntentTTL       time.Duration
-	sweepInterval           time.Duration
-	sweepMu                 sync.Mutex
-	sweepStop               chan struct{}
-	sweepDone               chan struct{}
-	unknownMsgMu            sync.Mutex // guards unknownMsgTimes.
-	unknownMsgTimes         []time.Time
-	maxUnknownMsgs          uint32
-	unknownMsgWindow        time.Duration
-	logger                  *zap.Logger
-	keepAlive               uint8
+	peerAddr          netip.Addr
+	tcpConn           net.Conn
+	sendMu            sync.Mutex
+	stateMu           sync.RWMutex
+	isSynced          bool
+	srpIDMu           sync.Mutex
+	srpIDHead         uint32
+	srpIDMax          uint32
+	srPoliciesMu      sync.RWMutex
+	srPolicies        []*table.SRPolicy
+	srPolicyIntentsMu sync.Mutex
+	srPolicyIntents   map[uint32]srPolicyIntent
+	srPolicyIntentTTL time.Duration
+	sweepInterval     time.Duration
+	sweepMu           sync.Mutex
+	sweepStop         chan struct{}
+	sweepDone         chan struct{}
+	unknownMsgMu      sync.Mutex
+	unknownMsgTimes   []time.Time
+	maxUnknownMsgs    uint32
+	unknownMsgWindow  time.Duration
+	logger            *zap.Logger
+	state             sessionState
+
+	// Session establishment timers of RFC 5440 §6.2.
+	openWait time.Duration
+	keepWait time.Duration
+
+	// Session characteristics Pola advertises in its own Open message.
+	localSessionID uint8
+	localKeepalive uint8
+	localDeadTimer uint8
+
+	// Peer Keepalive range and negotiation policy.
+	keepaliveRangeEnabled bool
+	minKeepalive          uint8
+	maxKeepalive          uint8
+	allowNegotiation      bool
+
+	// Open parameters actually sent or received; nil means not yet known.
+	localOpen *OpenParams
+	pccOpen   *OpenParams
+
 	pccType                 pcep.PccType
-	advertisedCapabilities  []pcep.CapabilityInterface // Capabilities Pola advertises to the PCC.
-	receivedPccCapabilities []pcep.CapabilityInterface // Capabilities received from the PCC.
+	advertisedCapabilities  []pcep.CapabilityInterface
+	receivedPccCapabilities []pcep.CapabilityInterface
 	ted                     *table.LsTED
 	asn                     uint32
 }
@@ -185,10 +247,14 @@ func (ss *Session) clearSRPolicyIntents() {
 	ss.srPolicyIntents = nil
 }
 
-// NewSession creates a new PCEP session.
-func NewSession(sessionID uint8, peerAddr netip.Addr, tcpConn net.Conn, logger *zap.Logger, ted *table.LsTED, asn uint32) *Session {
+// NewSession creates a new PCEP session with the given local Open parameters.
+func NewSession(localOpen OpenParams, peerAddr netip.Addr, tcpConn net.Conn, logger *zap.Logger, ted *table.LsTED, asn uint32) *Session {
 	return &Session{
-		sessionID:         sessionID,
+		localSessionID:    localOpen.SessionID,
+		localKeepalive:    localOpen.Keepalive,
+		localDeadTimer:    localOpen.DeadTimer,
+		openWait:          openWaitTimer,
+		keepWait:          keepWaitTimer,
 		isSynced:          false,
 		srpIDHead:         uint32(1),
 		srpIDMax:          math.MaxUint32,
@@ -205,19 +271,13 @@ func NewSession(sessionID uint8, peerAddr netip.Addr, tcpConn net.Conn, logger *
 	}
 }
 
-// Established establishes the PCEP session.
+// Established runs the PCEP session until it terminates.
 func (ss *Session) Established() {
 	if err := ss.Open(); err != nil {
-		ss.logger.Debug("ERROR! PCEP OPEN", zap.Error(err))
+		ss.logger.Debug("ERROR! PCEP session establishment failed", zap.Error(err))
 		return
 	}
 	ss.logger.Debug("PCEP session established")
-
-	// Send the initial keepalive message
-	if err := ss.SendKeepalive(); err != nil {
-		ss.logger.Debug("ERROR! Send Keepalive Message", zap.Error(err))
-		return
-	}
 
 	ss.startIntentSweep()
 	defer ss.stopIntentSweep()
@@ -232,13 +292,13 @@ func (ss *Session) Established() {
 		done <- struct{}{}
 	}()
 
-	// Keepalive == 0 means no periodic Keepalive is required.
-	if ss.keepAlive == 0 {
+	interval := ss.keepaliveInterval()
+	if interval == 0 {
 		<-done
 		return
 	}
 
-	ticker := time.NewTicker(time.Duration(ss.keepAlive) * time.Second)
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	defer ticker.Stop()
 
 	for {
@@ -268,21 +328,70 @@ func (ss *Session) sendPCEPMessage(message pcep.Message) error {
 	return err
 }
 
-// Open performs the PCEP open exchange with the peer.
+// Open establishes the PCEP session according to RFC 5440 §6.2.
 func (ss *Session) Open() error {
-	if err := ss.ReceiveOpen(); err != nil {
+	ss.setState(sessionStateOpenWait)
+	if err := ss.negotiateOpen(); err != nil {
+		return err
+	}
+	if err := ss.SendOpen(); err != nil {
+		return err
+	}
+	if err := ss.SendKeepalive(); err != nil {
 		return err
 	}
 
-	return ss.SendOpen()
+	ss.setState(sessionStateKeepWait)
+	if err := ss.awaitKeepalive(); err != nil {
+		return err
+	}
+	ss.setState(sessionStateUp)
+	return nil
 }
 
-// Keepalive == 0 disables the read deadline.
+func (ss *Session) awaitKeepalive() error {
+	deadline := time.Now().Add(ss.keepWait)
+
+	commonHeader, err := ss.readCommonHeader(deadline)
+	if err != nil {
+		if isDeadlineExceeded(err) {
+			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueKeepWaitTimerExpired)
+			return errors.New("KeepWait timer expired without a Keepalive or PCErr message")
+		}
+		return err
+	}
+	if _, err := ss.readMessageBody(commonHeader.MessageLength, deadline); err != nil {
+		return err
+	}
+
+	switch commonHeader.MessageType {
+	case pcep.MessageTypeKeepalive:
+		ss.logger.Debug("Received Keepalive acknowledging Open")
+		return nil
+	case pcep.MessageTypeError:
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+		return errors.New("peer proposed session characteristics Pola cannot accept")
+	default:
+		return fmt.Errorf("expected a Keepalive or PCErr message in KeepWait, got %s", commonHeader.MessageType.String())
+	}
+}
+
 func (ss *Session) readDeadline() time.Duration {
-	if ss.keepAlive == 0 {
+	pccOpen, ok := ss.PccOpen()
+	if !ok || pccOpen.Keepalive == 0 || pccOpen.DeadTimer == 0 {
 		return 0
 	}
-	return time.Duration(pcep.DeadTimerFor(ss.keepAlive)) * time.Second
+	return time.Duration(pccOpen.DeadTimer) * time.Second
+}
+
+func isDeadlineExceeded(err error) bool {
+	return errors.Is(err, os.ErrDeadlineExceeded)
+}
+
+func (ss *Session) sendPCErrBestEffort(errorType, errorValue uint8) {
+	if err := ss.SendPCErr(errorType, errorValue); err != nil {
+		ss.logger.Debug("ERROR! Send PCErr Message", zap.Error(err))
+	}
 }
 
 func (ss *Session) readFullWithDeadline(buf []uint8, deadline time.Time) error {
@@ -302,30 +411,40 @@ func (ss *Session) messageDeadline() time.Time {
 }
 
 func (ss *Session) parseOpenMessage() (*pcep.OpenMessage, error) {
-	// Keepalive is not negotiated yet, so use the default DeadTimer for the handshake.
-	deadline := time.Now().Add(defaultDeadTimer)
+	deadline := time.Now().Add(ss.openWait)
 
 	byteOpenHeader := make([]uint8, pcep.CommonHeaderLength)
 	if err := ss.readFullWithDeadline(byteOpenHeader, deadline); err != nil {
+		if isDeadlineExceeded(err) {
+			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueOpenWaitTimerExpired)
+			return nil, errors.New("OpenWait timer expired without an Open message")
+		}
 		return nil, err
 	}
 
 	var openHeader pcep.CommonHeader
 	if err := openHeader.DecodeFromBytes(byteOpenHeader); err != nil {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 		return nil, err
 	}
 
 	if openHeader.MessageType != pcep.MessageTypeOpen {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 		return nil, fmt.Errorf("this peer has not been opened (messageType: %s)", openHeader.MessageType.String())
 	}
 
 	byteOpenObject := make([]uint8, openHeader.MessageLength-pcep.CommonHeaderLength)
 	if err := ss.readFullWithDeadline(byteOpenObject, deadline); err != nil {
+		if isDeadlineExceeded(err) {
+			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueOpenWaitTimerExpired)
+			return nil, errors.New("OpenWait timer expired before the Open message was complete")
+		}
 		return nil, err
 	}
 
 	var openMessage pcep.OpenMessage
 	if err := openMessage.DecodeFromBytes(byteOpenObject); err != nil {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 		return nil, err
 	}
 
@@ -340,16 +459,94 @@ func (ss *Session) ReceiveOpen() error {
 		return err
 	}
 
-	ss.receivedPccCapabilities = slices.Clone(openMessage.OpenObject.Caps)
-	ss.setAdvertisedCapabilities(pcep.PolaCapability(openMessage.OpenObject.Caps))
+	receivedCaps := slices.Clone(openMessage.OpenObject.Caps)
 
 	// pccType detection
 	// * FRRouting cannot be detected from the open message, so it is treated as an RFC compliant
-	ss.pccType = pcep.DeterminePccType(ss.receivedPccCapabilities)
-	ss.logger.Debug("Determine PCC Type", zap.Int("pcc-type", int(ss.pccType)))
-	ss.keepAlive = openMessage.OpenObject.Keepalive
+	pccType := pcep.DeterminePccType(receivedCaps)
+	ss.logger.Debug("Determine PCC Type", zap.Int("pcc-type", int(pccType)))
+
+	ss.stateMu.Lock()
+	ss.receivedPccCapabilities = receivedCaps
+	ss.pccType = pccType
+	ss.pccOpen = &OpenParams{
+		SessionID: openMessage.OpenObject.Sid,
+		Keepalive: openMessage.OpenObject.Keepalive,
+		DeadTimer: openMessage.OpenObject.Deadtime,
+	}
+	ss.stateMu.Unlock()
+
+	ss.setAdvertisedCapabilities(pcep.PolaCapability(openMessage.OpenObject.Caps))
 
 	return nil
+}
+
+func (ss *Session) negotiateOpen() error {
+	if err := ss.ReceiveOpen(); err != nil {
+		return err
+	}
+	pccOpen, _ := ss.PccOpen()
+	if ss.acceptableOpen(pccOpen) {
+		return nil
+	}
+	if !ss.allowNegotiation {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNonNegotiable)
+		return fmt.Errorf("peer's session characteristics (Keepalive=%d, DeadTimer=%d) are unacceptable and non-negotiable",
+			pccOpen.Keepalive, pccOpen.DeadTimer)
+	}
+	if err := ss.proposeAcceptableOpen(pccOpen); err != nil {
+		return err
+	}
+
+	if err := ss.ReceiveOpen(); err != nil {
+		return err
+	}
+	pccOpen, _ = ss.PccOpen()
+	if ss.acceptableOpen(pccOpen) {
+		return nil
+	}
+	ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueSecondOpenStillUnacceptable)
+	return fmt.Errorf("peer's second Open still advertises unacceptable session characteristics (Keepalive=%d, DeadTimer=%d)",
+		pccOpen.Keepalive, pccOpen.DeadTimer)
+}
+
+// acceptableOpen reports whether the peer's session characteristics are acceptable.
+func (ss *Session) acceptableOpen(pccOpen OpenParams) bool {
+	if pccOpen.Keepalive != 0 && pccOpen.DeadTimer != 0 && pccOpen.DeadTimer < pccOpen.Keepalive {
+		return false
+	}
+	if !ss.keepaliveRangeEnabled {
+		return true
+	}
+	return pccOpen.Keepalive >= ss.minKeepalive && pccOpen.Keepalive <= ss.maxKeepalive
+}
+
+// proposedTimers returns acceptable Keepalive and DeadTimer values.
+func (ss *Session) proposedTimers(pccOpen OpenParams) (keepalive, deadTimer uint8) {
+	keepalive = pccOpen.Keepalive
+	if ss.keepaliveRangeEnabled {
+		switch {
+		case keepalive < ss.minKeepalive:
+			keepalive = ss.minKeepalive
+		case keepalive > ss.maxKeepalive:
+			keepalive = ss.maxKeepalive
+		}
+	}
+	return keepalive, pcep.DeadTimerFor(keepalive)
+}
+
+// proposeAcceptableOpen sends a PCErr proposing acceptable session characteristics.
+func (ss *Session) proposeAcceptableOpen(pccOpen OpenParams) error {
+	keepalive, deadTimer := ss.proposedTimers(pccOpen)
+	openObject := pcep.NewOpenObject(ss.localSessionID, keepalive, deadTimer, nil)
+
+	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, openObject)
+	ss.logger.Debug("Send PCErr Message proposing session characteristics",
+		zap.Uint8("error-Type", pcepErrorTypeSessionEstablishmentFailure),
+		zap.Uint8("error-value", pcepErrorValueUnacceptableNegotiable),
+		zap.Uint8("proposed-keepalive", keepalive),
+		zap.Uint8("proposed-deadtimer", deadTimer))
+	return ss.sendPCEPMessage(pcerrMessage)
 }
 
 // SendKeepalive sends a PCEP Keepalive message to the peer.
@@ -383,12 +580,17 @@ func (ss *Session) SendPCErr(errorType, errorValue uint8) error {
 // ReceivePCEPMessage receives and processes PCEP messages from the peer.
 func (ss *Session) ReceivePCEPMessage() error {
 	for {
-		commonHeader, deadline, err := ss.readCommonHeader()
+		deadline := ss.messageDeadline()
+		commonHeader, err := ss.readCommonHeader(deadline)
 		if err != nil {
+			if isDeadlineExceeded(err) {
+				// RFC 5440 Appendix A: DeadTimer expiry terminates the session per §6.8.
+				if closeErr := ss.SendClose(pcep.CloseReasonDeadTimerExpired); closeErr != nil {
+					ss.logger.Debug("ERROR! Send Close Message", zap.Error(closeErr))
+				}
+			}
 			return err
 		}
-		// wait TCP reassembly packet
-		time.Sleep(10 * time.Millisecond)
 
 		switch commonHeader.MessageType {
 		case pcep.MessageTypeKeepalive:
@@ -459,20 +661,18 @@ func (ss *Session) handleUnsupportedMessage(commonHeader *pcep.CommonHeader, dea
 	return nil
 }
 
-func (ss *Session) readCommonHeader() (*pcep.CommonHeader, time.Time, error) {
-	deadline := ss.messageDeadline()
-
+func (ss *Session) readCommonHeader(deadline time.Time) (*pcep.CommonHeader, error) {
 	commonHeaderBytes := make([]uint8, pcep.CommonHeaderLength)
 	if err := ss.readFullWithDeadline(commonHeaderBytes, deadline); err != nil {
-		return nil, time.Time{}, err
+		return nil, err
 	}
 
 	commonHeader := &pcep.CommonHeader{}
 	if err := commonHeader.DecodeFromBytes(commonHeaderBytes); err != nil {
-		return nil, time.Time{}, err
+		return nil, err
 	}
 
-	return commonHeader, deadline, nil
+	return commonHeader, nil
 }
 
 func (ss *Session) readMessageBody(messageLength uint16, deadline time.Time) ([]uint8, error) {
@@ -584,6 +784,80 @@ func (ss *Session) setSynced() {
 	ss.stateMu.Lock()
 	defer ss.stateMu.Unlock()
 	ss.isSynced = true
+}
+
+// State returns the PCEP session state (RFC 5440 Appendix A).
+func (ss *Session) State() sessionState {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return ss.state
+}
+
+func (ss *Session) setState(state sessionState) {
+	ss.stateMu.Lock()
+	defer ss.stateMu.Unlock()
+	ss.state = state
+}
+
+// Up reports whether the PCEP session is up.
+func (ss *Session) Up() bool {
+	return ss.State() == sessionStateUp
+}
+
+// PccType returns the PCC implementation type detected from the Open handshake.
+func (ss *Session) PccType() pcep.PccType {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return ss.pccType
+}
+
+// LocalOpen returns the session characteristics Pola advertised.
+func (ss *Session) LocalOpen() (OpenParams, bool) {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	if ss.localOpen == nil {
+		return OpenParams{}, false
+	}
+	return *ss.localOpen, true
+}
+
+// PccOpen returns the session characteristics the PCC advertised.
+func (ss *Session) PccOpen() (OpenParams, bool) {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	if ss.pccOpen == nil {
+		return OpenParams{}, false
+	}
+	return *ss.pccOpen, true
+}
+
+func (ss *Session) keepaliveInterval() uint8 {
+	localOpen, ok := ss.LocalOpen()
+	if !ok {
+		return 0
+	}
+	return effectiveKeepalive(localOpen.Keepalive, localOpen.DeadTimer)
+}
+
+// effectiveKeepalive returns the Keepalive interval Pola uses.
+// It keeps the interval within Pola's advertised DeadTimer.
+func effectiveKeepalive(localKeepalive, localDeadTimer uint8) uint8 {
+	if localKeepalive == 0 || localDeadTimer == 0 {
+		return localKeepalive
+	}
+	limit := localDeadTimer / localDeadTimerKeepaliveDivisor
+	if limit == 0 {
+		// RFC 5440 §4.2.2: the minimum Keepalive timer value is 1 second.
+		limit = 1
+	}
+	return min(localKeepalive, limit)
+}
+
+// ReceivedCapabilities returns a snapshot of the capabilities advertised by the PCC.
+func (ss *Session) ReceivedCapabilities() []pcep.CapabilityInterface {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return slices.Clone(ss.receivedPccCapabilities)
 }
 
 // AdvertisedCapabilities returns a snapshot of the capabilities Pola advertises to the PCC.
@@ -796,9 +1070,25 @@ func (ss *Session) RequestSRPolicyCreated(srPolicy table.SRPolicy) error {
 
 // SendOpen sends a PCEP Open message to the peer.
 func (ss *Session) SendOpen() error {
-	openMessage := pcep.NewOpenMessage(ss.sessionID, ss.keepAlive, ss.AdvertisedCapabilities())
+	ss.stateMu.RLock()
+	sessionID, keepalive, deadTimer := ss.localSessionID, ss.localKeepalive, ss.localDeadTimer
+	ss.stateMu.RUnlock()
+
+	openMessage := pcep.NewOpenMessage(sessionID, keepalive, deadTimer, ss.AdvertisedCapabilities())
 	ss.logger.Debug("Send Open Message")
-	return ss.sendPCEPMessage(openMessage)
+	if err := ss.sendPCEPMessage(openMessage); err != nil {
+		return err
+	}
+
+	ss.stateMu.Lock()
+	ss.localOpen = &OpenParams{
+		SessionID: openMessage.OpenObject.Sid,
+		Keepalive: openMessage.OpenObject.Keepalive,
+		DeadTimer: openMessage.OpenObject.Deadtime,
+	}
+	ss.stateMu.Unlock()
+
+	return nil
 }
 
 // nextUnusedSRPID returns an unused SRP-ID, wrapping at max.
@@ -819,7 +1109,6 @@ func nextUnusedSRPID(head, max uint32, used func(uint32) bool) (srpID uint32, ne
 }
 
 // allocateSRPID allocates an unused SRP-ID and records its intent.
-// In-use IDs are skipped on wraparound.
 func (ss *Session) allocateSRPID(polType table.PolicyType, metric table.MetricType) (uint32, error) {
 	ss.srpIDMu.Lock()
 	defer ss.srpIDMu.Unlock()

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -14,6 +14,7 @@ import (
 	"net/netip"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -73,6 +74,93 @@ const (
 	sessionStateUp
 )
 
+// lspDBSyncState is the LSP-DB synchronization state of RFC 8231 §5.6.
+type lspDBSyncState uint8
+
+const (
+	lspDBSyncPending  lspDBSyncState = iota // no PCRpt with the S-flag seen yet
+	lspDBSyncOngoing                        // S-flag reports received, end-of-sync pending
+	lspDBSyncFinished                       // PCRpt with PLSP-ID 0 received
+)
+
+// sessionInitiator records which side started the TCP connection.
+type sessionInitiator uint8
+
+const (
+	sessionInitiatorRemote sessionInitiator = iota
+	sessionInitiatorLocal
+)
+
+// sessionStats holds the per-session PCEP message counters tracked by Pola.
+
+type sessionStats struct {
+	mu             sync.Mutex
+	openSent       uint64
+	openRcvd       uint64
+	keepaliveSent  uint64
+	keepaliveRcvd  uint64
+	closeSent      uint64
+	closeRcvd      uint64
+	pcerrSent      uint64
+	pcerrRcvd      uint64
+	pcntfRcvd      uint64
+	pcreqRcvd      uint64
+	pcrepRcvd      uint64
+	rptRcvd        uint64
+	updSent        uint64
+	pcinitiateSent uint64
+	unknownRcvd    uint64
+	corruptRcvd    uint64
+}
+
+func (s *sessionStats) inc(counter *uint64) {
+	s.mu.Lock()
+	*counter++
+	s.mu.Unlock()
+}
+
+type sessionStatsSnapshot struct {
+	OpenSent       uint64
+	OpenRcvd       uint64
+	KeepaliveSent  uint64
+	KeepaliveRcvd  uint64
+	CloseSent      uint64
+	CloseRcvd      uint64
+	PCErrSent      uint64
+	PCErrRcvd      uint64
+	PCNtfRcvd      uint64
+	PCReqRcvd      uint64
+	PCRepRcvd      uint64
+	RptRcvd        uint64
+	UpdSent        uint64
+	PCInitiateSent uint64
+	UnknownRcvd    uint64
+	CorruptRcvd    uint64
+}
+
+func (s *sessionStats) snapshot() sessionStatsSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return sessionStatsSnapshot{
+		OpenSent:       s.openSent,
+		OpenRcvd:       s.openRcvd,
+		KeepaliveSent:  s.keepaliveSent,
+		KeepaliveRcvd:  s.keepaliveRcvd,
+		CloseSent:      s.closeSent,
+		CloseRcvd:      s.closeRcvd,
+		PCErrSent:      s.pcerrSent,
+		PCErrRcvd:      s.pcerrRcvd,
+		PCNtfRcvd:      s.pcntfRcvd,
+		PCReqRcvd:      s.pcreqRcvd,
+		PCRepRcvd:      s.pcrepRcvd,
+		RptRcvd:        s.rptRcvd,
+		UpdSent:        s.updSent,
+		PCInitiateSent: s.pcinitiateSent,
+		UnknownRcvd:    s.unknownRcvd,
+		CorruptRcvd:    s.corruptRcvd,
+	}
+}
+
 // OpenParams contains PCEP session parameters advertised in an OPEN object.
 type OpenParams struct {
 	SessionID uint8
@@ -86,7 +174,6 @@ type Session struct {
 	tcpConn           net.Conn
 	sendMu            sync.Mutex
 	stateMu           sync.RWMutex
-	isSynced          bool
 	srpIDMu           sync.Mutex
 	srpIDHead         uint32
 	srpIDMax          uint32
@@ -106,22 +193,31 @@ type Session struct {
 	logger            *zap.Logger
 	state             sessionState
 
+	// Session lifetime timestamps.
+	createdAt     time.Time
+	establishedAt time.Time
+
+	// syncState is the RFC 8231 LSP-DB synchronization state.
+	syncState lspDBSyncState
+
+	// initiator records which side started the TCP connection.
+	initiator sessionInitiator
+
+	stats sessionStats
+
 	// Session establishment timers of RFC 5440 §6.2.
 	openWait time.Duration
 	keepWait time.Duration
 
-	// Session characteristics Pola advertises in its own Open message.
 	localSessionID uint8
 	localKeepalive uint8
 	localDeadTimer uint8
 
-	// Peer Keepalive range and negotiation policy.
 	keepaliveRangeEnabled bool
 	minKeepalive          uint8
 	maxKeepalive          uint8
 	allowNegotiation      bool
 
-	// Open parameters actually sent or received; nil means not yet known.
 	localOpen *OpenParams
 	pccOpen   *OpenParams
 
@@ -130,6 +226,9 @@ type Session struct {
 	receivedPccCapabilities []pcep.CapabilityInterface
 	ted                     *table.LsTED
 	asn                     uint32
+
+	// onEstablished is called when the session reaches the established state.
+	onEstablished func()
 }
 
 // srPolicyIntent stores policy information not reported by PCEP.
@@ -255,7 +354,7 @@ func NewSession(localOpen OpenParams, peerAddr netip.Addr, tcpConn net.Conn, log
 		localDeadTimer:    localOpen.DeadTimer,
 		openWait:          openWaitTimer,
 		keepWait:          keepWaitTimer,
-		isSynced:          false,
+		createdAt:         time.Now(),
 		srpIDHead:         uint32(1),
 		srpIDMax:          math.MaxUint32,
 		srPolicyIntentTTL: defaultSRPolicyIntentTTL,
@@ -272,10 +371,14 @@ func NewSession(localOpen OpenParams, peerAddr netip.Addr, tcpConn net.Conn, log
 }
 
 // Established runs the PCEP session until it terminates.
-func (ss *Session) Established() {
+// The returned error indicates the session establishment outcome (RFC 9826).
+func (ss *Session) Established() error {
 	if err := ss.Open(); err != nil {
 		ss.logger.Debug("ERROR! PCEP session establishment failed", zap.Error(err))
-		return
+		return err
+	}
+	if ss.onEstablished != nil {
+		ss.onEstablished()
 	}
 	ss.logger.Debug("PCEP session established")
 
@@ -295,7 +398,7 @@ func (ss *Session) Established() {
 	interval := ss.keepaliveInterval()
 	if interval == 0 {
 		<-done
-		return
+		return nil
 	}
 
 	ticker := time.NewTicker(time.Duration(interval) * time.Second)
@@ -304,11 +407,11 @@ func (ss *Session) Established() {
 	for {
 		select {
 		case <-done:
-			return
+			return nil
 		case <-ticker.C:
 			if err := ss.SendKeepalive(); err != nil {
 				ss.logger.Debug("ERROR! Send Keepalive Message", zap.Error(err))
-				return
+				return nil
 			}
 		}
 	}
@@ -328,52 +431,127 @@ func (ss *Session) sendPCEPMessage(message pcep.Message) error {
 	return err
 }
 
+// maxKeepWaitOpenAttempts limits Open negotiation to one retry.
+const maxKeepWaitOpenAttempts = 2
+
 // Open establishes the PCEP session according to RFC 5440 §6.2.
 func (ss *Session) Open() error {
 	ss.setState(sessionStateOpenWait)
 	if err := ss.negotiateOpen(); err != nil {
 		return err
 	}
-	if err := ss.SendOpen(); err != nil {
-		return err
-	}
-	if err := ss.SendKeepalive(); err != nil {
-		return err
-	}
 
-	ss.setState(sessionStateKeepWait)
-	if err := ss.awaitKeepalive(); err != nil {
-		return err
+	for attempt := range maxKeepWaitOpenAttempts {
+		if err := ss.SendOpen(); err != nil {
+			return err
+		}
+		if err := ss.SendKeepalive(); err != nil {
+			return err
+		}
+
+		ss.setState(sessionStateKeepWait)
+		renegotiable := attempt < maxKeepWaitOpenAttempts-1
+		retry, err := ss.awaitKeepalive(renegotiable)
+		if err != nil {
+			return err
+		}
+		if !retry {
+			ss.setState(sessionStateUp)
+			return nil
+		}
 	}
-	ss.setState(sessionStateUp)
-	return nil
+	return errors.New("peer repeatedly rejected Pola's session characteristics")
 }
 
-func (ss *Session) awaitKeepalive() error {
+// awaitKeepalive returns retry=true when Open negotiation should be retried.
+// renegotiable reports whether another Open may still be sent.
+func (ss *Session) awaitKeepalive(renegotiable bool) (retry bool, err error) {
 	deadline := time.Now().Add(ss.keepWait)
 
 	commonHeader, err := ss.readCommonHeader(deadline)
 	if err != nil {
 		if isDeadlineExceeded(err) {
 			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueKeepWaitTimerExpired)
-			return errors.New("KeepWait timer expired without a Keepalive or PCErr message")
+			return false, errors.New("KeepWait timer expired without a Keepalive or PCErr message")
 		}
-		return err
+		return false, err
 	}
-	if _, err := ss.readMessageBody(commonHeader.MessageLength, deadline); err != nil {
-		return err
+	body, err := ss.readMessageBody(commonHeader.MessageLength, deadline)
+	if err != nil {
+		if isDeadlineExceeded(err) {
+			ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueKeepWaitTimerExpired)
+			return false, errors.New("KeepWait timer expired while reading the message body")
+		}
+		return false, err
 	}
 
 	switch commonHeader.MessageType {
 	case pcep.MessageTypeKeepalive:
+		ss.stats.inc(&ss.stats.keepaliveRcvd)
 		ss.logger.Debug("Received Keepalive acknowledging Open")
-		return nil
+		return false, nil
 	case pcep.MessageTypeError:
-		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
-		return errors.New("peer proposed session characteristics Pola cannot accept")
+		ss.stats.inc(&ss.stats.pcerrRcvd)
+		return ss.handleKeepWaitPCErr(body, renegotiable)
 	default:
-		return fmt.Errorf("expected a Keepalive or PCErr message in KeepWait, got %s", commonHeader.MessageType.String())
+		return false, fmt.Errorf("expected a Keepalive or PCErr message in KeepWait, got %s", commonHeader.MessageType.String())
 	}
+}
+
+func (ss *Session) handleKeepWaitPCErr(body []uint8, renegotiable bool) (retry bool, err error) {
+	pcerrMessage := &pcep.PCErrMessage{}
+	if err := pcerrMessage.DecodeFromBytes(body); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
+		return false, fmt.Errorf("received malformed PCErr in KeepWait: %w", err)
+	}
+	ss.logger.Debug("Received PCErr in KeepWait", zap.String("errors", formatPCErrErrors(pcerrMessage.Errors)))
+
+	for _, errObj := range pcerrMessage.Errors {
+		if errObj.ErrorType == pcepErrorTypeSessionEstablishmentFailure && errObj.ErrorValue == pcepErrorValueUnacceptableNegotiable {
+			return ss.handleProposedOpen(pcerrMessage.Open, renegotiable)
+		}
+	}
+	return false, fmt.Errorf("peer rejected session establishment (%s)", formatPCErrErrors(pcerrMessage.Errors))
+}
+
+func formatPCErrErrors(errors []*pcep.ErrorObject) string {
+	reasons := make([]string, 0, len(errors))
+	for _, errObj := range errors {
+		reasons = append(reasons, fmt.Sprintf("error-type=%d, error-value=%d", errObj.ErrorType, errObj.ErrorValue))
+	}
+	return strings.Join(reasons, "; ")
+}
+
+// handleProposedOpen handles an Open proposal from PCErr(1,4).
+func (ss *Session) handleProposedOpen(proposedOpen *pcep.OpenObject, renegotiable bool) (retry bool, err error) {
+	if proposedOpen == nil {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+		return false, errors.New("peer rejected Pola's session characteristics without proposing acceptable ones")
+	}
+
+	proposed := OpenParams{
+		SessionID: proposedOpen.Sid,
+		Keepalive: proposedOpen.Keepalive,
+		DeadTimer: proposedOpen.Deadtime,
+	}
+	if !renegotiable {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+		return false, fmt.Errorf("peer rejected Pola's renegotiated Open with a further proposal (Keepalive=%d, DeadTimer=%d)",
+			proposed.Keepalive, proposed.DeadTimer)
+	}
+	if !ss.acceptableOpen(proposed) {
+		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+		return false, fmt.Errorf("peer proposed unacceptable session characteristics (Keepalive=%d, DeadTimer=%d)",
+			proposed.Keepalive, proposed.DeadTimer)
+	}
+
+	ss.stateMu.Lock()
+	ss.localKeepalive = proposed.Keepalive
+	ss.localDeadTimer = proposed.DeadTimer
+	ss.stateMu.Unlock()
+	ss.logger.Debug("Adopting peer-proposed session characteristics",
+		zap.Uint8("keepalive", proposed.Keepalive), zap.Uint8("deadtimer", proposed.DeadTimer))
+	return true, nil
 }
 
 func (ss *Session) readDeadline() time.Duration {
@@ -424,6 +602,7 @@ func (ss *Session) parseOpenMessage() (*pcep.OpenMessage, error) {
 
 	var openHeader pcep.CommonHeader
 	if err := openHeader.DecodeFromBytes(byteOpenHeader); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
 		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 		return nil, err
 	}
@@ -444,6 +623,7 @@ func (ss *Session) parseOpenMessage() (*pcep.OpenMessage, error) {
 
 	var openMessage pcep.OpenMessage
 	if err := openMessage.DecodeFromBytes(byteOpenObject); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
 		ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 		return nil, err
 	}
@@ -477,6 +657,7 @@ func (ss *Session) ReceiveOpen() error {
 	ss.stateMu.Unlock()
 
 	ss.setAdvertisedCapabilities(pcep.PolaCapability(openMessage.OpenObject.Caps))
+	ss.stats.inc(&ss.stats.openRcvd)
 
 	return nil
 }
@@ -546,14 +727,22 @@ func (ss *Session) proposeAcceptableOpen(pccOpen OpenParams) error {
 		zap.Uint8("error-value", pcepErrorValueUnacceptableNegotiable),
 		zap.Uint8("proposed-keepalive", keepalive),
 		zap.Uint8("proposed-deadtimer", deadTimer))
-	return ss.sendPCEPMessage(pcerrMessage)
+	if err := ss.sendPCEPMessage(pcerrMessage); err != nil {
+		return err
+	}
+	ss.stats.inc(&ss.stats.pcerrSent)
+	return nil
 }
 
 // SendKeepalive sends a PCEP Keepalive message to the peer.
 func (ss *Session) SendKeepalive() error {
 	keepaliveMessage := pcep.NewKeepaliveMessage()
 	ss.logger.Debug("Send Keepalive Message")
-	return ss.sendPCEPMessage(keepaliveMessage)
+	if err := ss.sendPCEPMessage(keepaliveMessage); err != nil {
+		return err
+	}
+	ss.stats.inc(&ss.stats.keepaliveSent)
+	return nil
 }
 
 // SendClose sends a PCEP Close message to the peer.
@@ -563,7 +752,11 @@ func (ss *Session) SendClose(reason pcep.CloseReason) error {
 	ss.logger.Debug("Send Close Message",
 		zap.Uint8("reason", uint8(closeMessage.CloseObject.Reason)),
 		zap.String("detail", "See https://www.iana.org/assignments/pcep/pcep.xhtml#close-object-reason-field"))
-	return ss.sendPCEPMessage(closeMessage)
+	if err := ss.sendPCEPMessage(closeMessage); err != nil {
+		return err
+	}
+	ss.stats.inc(&ss.stats.closeSent)
+	return nil
 }
 
 // SendPCErr sends a PCErr message with the given error type and value.
@@ -574,14 +767,17 @@ func (ss *Session) SendPCErr(errorType, errorValue uint8) error {
 		zap.Uint8("error-Type", errorType),
 		zap.Uint8("error-value", errorValue),
 		zap.String("detail", "See https://www.iana.org/assignments/pcep/pcep.xhtml#pcep-error-object"))
-	return ss.sendPCEPMessage(pcerrMessage)
+	if err := ss.sendPCEPMessage(pcerrMessage); err != nil {
+		return err
+	}
+	ss.stats.inc(&ss.stats.pcerrSent)
+	return nil
 }
 
 // ReceivePCEPMessage receives and processes PCEP messages from the peer.
 func (ss *Session) ReceivePCEPMessage() error {
 	for {
-		deadline := ss.messageDeadline()
-		commonHeader, err := ss.readCommonHeader(deadline)
+		done, err := ss.receiveOnePCEPMessage()
 		if err != nil {
 			if isDeadlineExceeded(err) {
 				// RFC 5440 Appendix A: DeadTimer expiry terminates the session per §6.8.
@@ -591,25 +787,65 @@ func (ss *Session) ReceivePCEPMessage() error {
 			}
 			return err
 		}
-
-		switch commonHeader.MessageType {
-		case pcep.MessageTypeKeepalive:
-			ss.logger.Debug("Received Keepalive")
-		case pcep.MessageTypeReport:
-			if err := ss.handlePCRpt(commonHeader.MessageLength, deadline); err != nil {
-				return err
-			}
-		case pcep.MessageTypeError:
-			if err := ss.receivePCErr(commonHeader.MessageLength, deadline); err != nil {
-				return err
-			}
-		case pcep.MessageTypeClose:
-			return ss.receiveClose(commonHeader.MessageLength, deadline)
-		default:
-			if err := ss.handleUnsupportedMessage(commonHeader, deadline); err != nil {
-				return err
-			}
+		if done {
+			return nil
 		}
+	}
+}
+
+func (ss *Session) receiveOnePCEPMessage() (done bool, err error) {
+	deadline := ss.messageDeadline()
+	commonHeader, err := ss.readCommonHeader(deadline)
+	if err != nil {
+		return false, err
+	}
+	ss.countReceived(commonHeader.MessageType)
+
+	switch commonHeader.MessageType {
+	case pcep.MessageTypeKeepalive:
+		ss.logger.Debug("Received Keepalive")
+	case pcep.MessageTypeReport:
+		if err := ss.handlePCRpt(commonHeader.MessageLength, deadline); err != nil {
+			return false, err
+		}
+	case pcep.MessageTypeError:
+		if err := ss.receivePCErr(commonHeader.MessageLength, deadline); err != nil {
+			return false, err
+		}
+	case pcep.MessageTypeClose:
+		return true, ss.receiveClose(commonHeader.MessageLength, deadline)
+	case pcep.MessageTypeNotification:
+		if _, err := ss.readMessageBody(commonHeader.MessageLength, deadline); err != nil {
+			return false, err
+		}
+		ss.logger.Debug("Received Notification")
+	default:
+		if err := ss.handleUnsupportedMessage(commonHeader, deadline); err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+// countReceived updates the RFC 9826 receive-side counter for a message type.
+func (ss *Session) countReceived(mt pcep.MessageType) {
+	switch mt {
+	case pcep.MessageTypeKeepalive:
+		ss.stats.inc(&ss.stats.keepaliveRcvd)
+	case pcep.MessageTypeReport:
+		ss.stats.inc(&ss.stats.rptRcvd)
+	case pcep.MessageTypeError:
+		ss.stats.inc(&ss.stats.pcerrRcvd)
+	case pcep.MessageTypeNotification:
+		ss.stats.inc(&ss.stats.pcntfRcvd)
+	case pcep.MessageTypeClose:
+		ss.stats.inc(&ss.stats.closeRcvd)
+	case pcep.MessageTypePcreq:
+		ss.stats.inc(&ss.stats.pcreqRcvd)
+	case pcep.MessageTypePcrep:
+		ss.stats.inc(&ss.stats.pcrepRcvd)
+	default:
+		ss.stats.inc(&ss.stats.unknownRcvd)
 	}
 }
 
@@ -620,6 +856,7 @@ func (ss *Session) receivePCErr(messageLength uint16, deadline time.Time) error 
 	}
 	pcerrMessage := &pcep.PCErrMessage{}
 	if err := pcerrMessage.DecodeFromBytes(bytePCErrMessageBody); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
 		return err
 	}
 	ss.handlePCErr(pcerrMessage)
@@ -633,6 +870,7 @@ func (ss *Session) receiveClose(messageLength uint16, deadline time.Time) error 
 	}
 	closeMessage := &pcep.CloseMessage{}
 	if err := closeMessage.DecodeFromBytes(byteCloseMessageBody); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
 		return err
 	}
 	ss.logger.Debug("Received Close",
@@ -669,6 +907,7 @@ func (ss *Session) readCommonHeader(deadline time.Time) (*pcep.CommonHeader, err
 
 	commonHeader := &pcep.CommonHeader{}
 	if err := commonHeader.DecodeFromBytes(commonHeaderBytes); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
 		return nil, err
 	}
 
@@ -728,6 +967,7 @@ func (ss *Session) handlePCRpt(length uint16, deadline time.Time) error {
 
 	message := pcep.NewPCRptMessage()
 	if err := message.DecodeFromBytes(messageBodyBytes); err != nil {
+		ss.stats.inc(&ss.stats.corruptRcvd)
 		return err
 	}
 
@@ -759,6 +999,7 @@ func (ss *Session) handleStateReport(sr *pcep.StateReport, message *pcep.PCRptMe
 
 // Synchronization (S-Flag)
 func (ss *Session) handleSynchronization(sr *pcep.StateReport, message *pcep.PCRptMessage) error {
+	ss.setSyncState(lspDBSyncOngoing)
 	ss.logger.Debug("Synchronize SR Policy information", zap.Any("Message", message))
 	if err := ss.RegisterSRPolicy(*sr); err != nil {
 		ss.logger.Error("Failed to register SR Policy during synchronization", zap.Error(err), zap.Uint32("plspID", sr.LSPObject.PlspID))
@@ -775,15 +1016,13 @@ func (ss *Session) handleFinishSynchronization() {
 
 // IsSynced reports whether the session has finished PCRpt state synchronization.
 func (ss *Session) IsSynced() bool {
-	ss.stateMu.RLock()
-	defer ss.stateMu.RUnlock()
-	return ss.isSynced
+	return ss.SyncState() == lspDBSyncFinished
 }
 
 func (ss *Session) setSynced() {
 	ss.stateMu.Lock()
 	defer ss.stateMu.Unlock()
-	ss.isSynced = true
+	ss.syncState = lspDBSyncFinished
 }
 
 // State returns the PCEP session state (RFC 5440 Appendix A).
@@ -797,6 +1036,52 @@ func (ss *Session) setState(state sessionState) {
 	ss.stateMu.Lock()
 	defer ss.stateMu.Unlock()
 	ss.state = state
+	if state == sessionStateUp && ss.establishedAt.IsZero() {
+		ss.establishedAt = time.Now()
+	}
+}
+
+// CreatedAt returns when the TCP connection was accepted.
+func (ss *Session) CreatedAt() time.Time {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return ss.createdAt
+}
+
+// EstablishedAt returns when the session reached the Up state.
+// It returns the zero time if the session is not established.
+func (ss *Session) EstablishedAt() time.Time {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return ss.establishedAt
+}
+
+// Initiator returns which side started the TCP connection.
+func (ss *Session) Initiator() sessionInitiator {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return ss.initiator
+}
+
+// SyncState returns the RFC 8231 LSP-DB synchronization state.
+func (ss *Session) SyncState() lspDBSyncState {
+	ss.stateMu.RLock()
+	defer ss.stateMu.RUnlock()
+	return ss.syncState
+}
+
+func (ss *Session) setSyncState(state lspDBSyncState) {
+	ss.stateMu.Lock()
+	defer ss.stateMu.Unlock()
+	if ss.syncState == lspDBSyncFinished {
+		return
+	}
+	ss.syncState = state
+}
+
+// Stats returns a snapshot of the session's RFC 9826 message counters.
+func (ss *Session) Stats() sessionStatsSnapshot {
+	return ss.stats.snapshot()
 }
 
 // Up reports whether the PCEP session is up.
@@ -1087,6 +1372,7 @@ func (ss *Session) SendOpen() error {
 		DeadTimer: openMessage.OpenObject.Deadtime,
 	}
 	ss.stateMu.Unlock()
+	ss.stats.inc(&ss.stats.openSent)
 
 	return nil
 }
@@ -1144,6 +1430,7 @@ func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error
 		ss.forgetSRPolicyIntent(srpID)
 		return err
 	}
+	ss.stats.inc(&ss.stats.pcinitiateSent)
 	return nil
 }
 
@@ -1164,6 +1451,7 @@ func (ss *Session) SendPCUpdate(srPolicy table.SRPolicy) error {
 		ss.forgetSRPolicyIntent(srpID)
 		return err
 	}
+	ss.stats.inc(&ss.stats.updSent)
 	return nil
 }
 

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -980,6 +980,10 @@ func (ss *Session) receiveOnePCEPMessage() (done bool, err error) {
 		}
 	case pcep.MessageTypeClose:
 		return true, ss.receiveClose(commonHeader.MessageLength, deadline)
+	case pcep.MessageTypeOpen:
+		if err := ss.handleUnexpectedOpen(commonHeader.MessageLength, deadline); err != nil {
+			return false, err
+		}
 	case pcep.MessageTypeNotification:
 		if _, err := ss.readMessageBody(commonHeader.MessageLength, deadline); err != nil {
 			return false, err
@@ -1044,6 +1048,17 @@ func (ss *Session) receiveClose(messageLength uint16, deadline time.Time) error 
 	ss.logger.Debug("Received Close",
 		zap.String("reason", closeMessage.CloseObject.Reason.String()),
 		zap.String("detail", "See https://www.iana.org/assignments/pcep/pcep.xhtml#close-object-reason-field"))
+	return nil
+}
+
+// handleUnexpectedOpen rejects an Open received while the session is Up.
+// RFC 5440 Appendix A does not define Open as an event in the Up state.
+func (ss *Session) handleUnexpectedOpen(messageLength uint16, deadline time.Time) error {
+	if _, err := ss.readMessageBody(messageLength, deadline); err != nil {
+		return err
+	}
+	ss.logger.Debug("Received Open message while session is already Up")
+	ss.sendPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 	return nil
 }
 

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -459,7 +459,7 @@ func TestHandleStateReportRemove(t *testing.T) {
 	assert.False(t, found, "SR Policy is still registered after being reported as removed")
 }
 
-func TestReceiveOpenDoesNotOverwriteAdvertisedCapabilities(t *testing.T) {
+func TestPeerOpenDoesNotOverwriteAdvertisedCapabilities(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() {
 		assert.NoError(t, server.Close(), "failed to close server connection")
@@ -475,14 +475,11 @@ func TestReceiveOpenDoesNotOverwriteAdvertisedCapabilities(t *testing.T) {
 			ColorCapability:     true,
 		},
 	}
-	openMessage := pcep.NewOpenMessage(1, 30, pcep.DeadTimerFor(30), pccCaps)
-	byteOpenMessage, err := openMessage.Serialize()
-	require.NoError(t, err, "failed to serialize open message")
-	_, err = client.Write(byteOpenMessage)
-	require.NoError(t, err, "failed to write open message")
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, pcep.DeadTimerFor(30), pccCaps))
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
-	require.NoError(t, ss.ReceiveOpen())
+	require.NoError(t, ss.Open())
 
 	assert.Equal(t, pccCaps, ss.receivedPccCapabilities)
 	assert.Equal(t, pccCaps, ss.ReceivedCapabilities())
@@ -1075,41 +1072,98 @@ func TestSendOpen_ErrorPropagatesFromSendFailure(t *testing.T) {
 	require.Error(t, ss.SendOpen())
 }
 
-func TestReceiveOpen_StoresPccOpenParams(t *testing.T) {
-	server, client := newTCPConnPair(t)
-	t.Cleanup(func() {
-		assert.NoError(t, client.Close(), "failed to close client connection")
-	})
-	t.Cleanup(func() {
-		assert.NoError(t, server.Close(), "failed to close server connection")
-	})
+// openMessageBody returns the body of a serialized Open message, ready to be
+// handed to handlePeerOpen.
+func openMessageBody(t *testing.T, sessionID, keepalive, deadTimer uint8) []uint8 {
+	t.Helper()
 
-	writeMessage(t, client, pcep.NewOpenMessage(42, 10, 40, nil))
+	full, err := pcep.NewOpenMessage(sessionID, keepalive, deadTimer, nil).Serialize()
+	require.NoError(t, err, "failed to serialize Open message")
+	return full[pcep.CommonHeaderLength:]
+}
 
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+func TestHandlePeerOpen_AcknowledgesAndStoresPeerOpenParams(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
 	_, ok := ss.PccOpen()
-	require.False(t, ok, "nothing is known before the PCC's Open message arrives")
+	require.False(t, ok, "nothing is known before the peer's Open message arrives")
 
-	require.NoError(t, ss.ReceiveOpen())
+	neg := &openNegotiation{}
+	require.NoError(t, ss.handlePeerOpen(openMessageBody(t, 42, 10, 40), neg))
+
+	assert.True(t, neg.remoteOK, "an acceptable Open sets Appendix A's RemoteOK")
+	assert.False(t, neg.localOK, "LocalOK is only set by the peer's Keepalive")
+	assert.Zero(t, neg.peerOpensRejected, "an acceptable Open does not consume OpenRetry")
+	assert.Equal(t, sessionStateKeepWait, neg.state())
 
 	pccOpen, ok := ss.PccOpen()
 	require.True(t, ok)
 	assert.Equal(t, OpenParams{SessionID: 42, Keepalive: 10, DeadTimer: 40}, pccOpen)
+
+	writes := conn.writes()
+	require.Len(t, writes, 1, "Appendix A acknowledges an acceptable Open with a Keepalive")
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(writes[0]))
+	assert.Equal(t, pcep.MessageTypeKeepalive, header.MessageType)
 }
 
-func TestReceiveOpen_StoresSessionIDZeroAsAdvertised(t *testing.T) {
-	server, client := newTCPConnPair(t)
-	t.Cleanup(func() { assert.NoError(t, client.Close()) })
-	t.Cleanup(func() { assert.NoError(t, server.Close()) })
+func TestHandlePeerOpen_StoresSessionIDZeroAsAdvertised(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
-	writeMessage(t, client, pcep.NewOpenMessage(0, 30, 120, nil))
-
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
-	require.NoError(t, ss.ReceiveOpen())
+	require.NoError(t, ss.handlePeerOpen(openMessageBody(t, 0, 30, 120), &openNegotiation{}))
 
 	pccOpen, ok := ss.PccOpen()
 	require.True(t, ok, "a SID of 0 must be recorded, not treated as absent")
 	assert.Zero(t, pccOpen.SessionID)
+}
+
+func TestHandlePeerOpen_KeepaliveFailureIsPropagated(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.handlePeerOpen(openMessageBody(t, 1, 30, 120), neg), "write: broken pipe")
+	assert.False(t, neg.remoteOK, "RemoteOK must not be set when the acknowledging Keepalive cannot be sent")
+}
+
+func TestHandlePeerOpen_RejectedOpenDoesNotOverwriteNegotiatedTimers(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.handlePeerOpen(openMessageBody(t, 1, 30, 120), neg))
+	require.True(t, neg.remoteOK)
+
+	require.Error(t, ss.handlePeerOpen(openMessageBody(t, 1, 200, 255), neg))
+	assert.False(t, neg.localOK)
+
+	pccOpen, ok := ss.PccOpen()
+	require.True(t, ok)
+	assert.Equal(t, OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pccOpen,
+		"the rejected second Open must not overwrite the already-accepted session parameters")
+
+	writes := conn.writes()
+	require.Len(t, writes, 2, "the Keepalive acknowledging the first Open, then the PCErr rejecting the second")
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(writes[0]))
+	assert.Equal(t, pcep.MessageTypeKeepalive, header.MessageType)
+	assertPCErr(t, writes[1], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+}
+
+func TestHandlePeerOpen_RejectedOpenIsNotPublishedAsSessionState(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := negotiatingSession(t, conn) // Keepalive range [10, 60]
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.handlePeerOpen(openMessageBody(t, 1, 5, 20), neg))
+	assert.Equal(t, 1, neg.peerOpensRejected)
+
+	_, ok := ss.PccOpen()
+	assert.False(t, ok, "an unacceptable-but-negotiable Open must not be published as the PCC's Open")
+	assert.Equal(t, pcep.RFCCompliant, ss.PccType(), "PccType must stay at its default until an Open is accepted")
+	assert.Empty(t, ss.ReceivedCapabilities())
 }
 
 func TestAcceptableOpen(t *testing.T) {
@@ -1132,16 +1186,22 @@ func TestAcceptableOpen(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "zero keepalive requires zero deadtimer per RFC",
+			name:    "zero keepalive ignores a nonzero deadtimer per RFC 5440 §7.3",
 			session: &Session{},
 			pccOpen: OpenParams{Keepalive: 0, DeadTimer: 1},
-			want:    false,
+			want:    true,
 		},
 		{
 			name:    "zero keepalive with zero deadtimer is acceptable",
 			session: &Session{},
 			pccOpen: OpenParams{Keepalive: 0, DeadTimer: 0},
 			want:    true,
+		},
+		{
+			name:    "zero keepalive is still rejected when outside a configured range",
+			session: &Session{keepaliveRangeEnabled: true, minKeepalive: 10, maxKeepalive: 60},
+			pccOpen: OpenParams{Keepalive: 0, DeadTimer: 120},
+			want:    false,
 		},
 		{
 			name:    "zero deadtimer is exempt from the ratio check",
@@ -1739,6 +1799,44 @@ func TestEstablished_SecondOpenStillUnacceptableReportsErrorValue5(t *testing.T)
 	assert.False(t, ss.Up())
 }
 
+func TestEstablished_SecondOpenAfterAcceptanceDoesNotChangeNegotiatedTimers(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+
+	done := make(chan struct{})
+	go func() {
+		_ = ss.Established()
+		close(done)
+	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's initial Open")
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 200, 255, nil))
+
+	pcerrMessage := readPCErrMessage(t, client)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorValue,
+		"Appendix A has no Open event once RemoteOK=1; this is an invalid message in this state, not a second unacceptable proposal")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after a further Open arrived post-acceptance")
+	}
+	assert.False(t, ss.Up())
+
+	pccOpen, ok := ss.PccOpen()
+	require.True(t, ok)
+	assert.Equal(t, OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pccOpen,
+		"the rejected second Open must not overwrite the already-accepted session parameters")
+}
+
 func TestEstablished_ReturnsOnCloseMessage(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() {
@@ -1891,10 +1989,11 @@ func TestEstablished_ReturnsWhenInitialKeepaliveSendFails(t *testing.T) {
 	}
 }
 
-func TestReceiveOpen_MalformedOpenMessage(t *testing.T) {
+func TestOpen_MalformedOrUnexpectedPeerMessageIsRejected(t *testing.T) {
 	cases := []struct {
-		name  string
-		setup func(t *testing.T, client *net.TCPConn) (clientClosed bool)
+		name    string
+		wantErr string
+		setup   func(t *testing.T, client *net.TCPConn) (clientClosed bool)
 	}{
 		{
 			name: "PCEP version mismatch",
@@ -1906,11 +2005,18 @@ func TestReceiveOpen_MalformedOpenMessage(t *testing.T) {
 			},
 		},
 		{
-			name: "unexpected message type",
+			name:    "Keepalive before the peer's Open",
+			wantErr: "received a Keepalive before the peer's Open message",
 			setup: func(t *testing.T, client *net.TCPConn) bool {
-				header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeKeepalive, MessageLength: pcep.CommonHeaderLength}
-				_, err := client.Write(header.Serialize())
-				require.NoError(t, err, "failed to write header")
+				writeMessage(t, client, pcep.NewKeepaliveMessage())
+				return false
+			},
+		},
+		{
+			name:    "message that cannot appear during establishment",
+			wantErr: "while establishing the PCEP session",
+			setup: func(t *testing.T, client *net.TCPConn) bool {
+				writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
 				return false
 			},
 		},
@@ -1960,7 +2066,12 @@ func TestReceiveOpen_MalformedOpenMessage(t *testing.T) {
 			}
 
 			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
-			assert.Error(t, ss.ReceiveOpen())
+			err := ss.Open()
+			require.Error(t, err)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+			assert.False(t, ss.Up())
 		})
 	}
 }
@@ -1981,112 +2092,779 @@ func (r *errAfterReader) Read(p []byte) (int, error) {
 	return 0, r.err
 }
 
-func TestOpen_SendOpenFailureAfterSuccessfulNegotiation(t *testing.T) {
-	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
-	require.NoError(t, err)
+// concatMessages serializes messages into one byte stream, mimicking a peer
+// that sends them back-to-back.
+func concatMessages(t *testing.T, messages ...pcep.Message) []byte {
+	t.Helper()
 
-	conn := &fakeConn{r: bytes.NewReader(openBytes), writeErr: errors.New("write: broken pipe")}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-
-	require.Error(t, ss.Open(), "expected Open to fail once negotiation succeeds but SendOpen cannot write")
+	var stream []byte
+	for _, message := range messages {
+		b, err := message.Serialize()
+		require.NoError(t, err, "failed to serialize message")
+		stream = append(stream, b...)
+	}
+	return stream
 }
 
-func TestAwaitKeepalive_ReadCommonHeaderErrorIsPropagated(t *testing.T) {
-	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
-	require.NoError(t, err)
+// negotiableRejection builds the PCErr(1,4) used in Open negotiation.
+func negotiableRejection(keepalive, deadTimer uint8) *pcep.PCErrMessage {
+	return pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable,
+		pcep.NewOpenObject(1, keepalive, deadTimer, nil))
+}
 
-	// The peer disconnects during KeepWait without sending a Keepalive.
-	conn := &fakeConn{r: bytes.NewReader(openBytes)}
+// negotiatingSession returns a session with a configured Keepalive range.
+func negotiatingSession(t *testing.T, conn net.Conn) *Session {
+	t.Helper()
+
+	return negotiatingSessionWithLogger(t, conn, zap.NewNop())
+}
+
+func negotiatingSessionWithLogger(t *testing.T, conn net.Conn, logger *zap.Logger) *Session {
+	t.Helper()
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger, nil, 0)
+	ss.keepaliveRangeEnabled = true
+	ss.minKeepalive, ss.maxKeepalive = 10, 60
+	ss.allowNegotiation = true
+	return ss
+}
+
+// assertPCErr decodes write and asserts it is a PCErr carrying errorType/errorValue.
+func assertPCErr(t *testing.T, write []byte, errorType, errorValue uint8) {
+	t.Helper()
+
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(write))
+	require.Equal(t, pcep.MessageTypeError, header.MessageType, "expected a PCErr message")
+
+	pcerrMessage := &pcep.PCErrMessage{}
+	require.NoError(t, pcerrMessage.DecodeFromBytes(write[pcep.CommonHeaderLength:]))
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, errorType, pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, errorValue, pcerrMessage.Errors[0].ErrorValue)
+}
+
+func TestOpenNegotiation_DerivesAppendixAStateFromRemoteOKAndLocalOK(t *testing.T) {
+	cases := []struct {
+		name            string
+		neg             openNegotiation
+		wantState       sessionState
+		wantEstablished bool
+		wantPeerOpened  bool
+	}{
+		{
+			name:      "nothing acknowledged yet",
+			wantState: sessionStateOpenWait,
+		},
+		{
+			// Appendix A: OpenWait + unacceptable-but-negotiable + LocalOK=0
+			// clears the OpenWait timer, starts KeepWait and moves to KeepWait.
+			name:           "peer's Open answered with PCErr(1,4) while Pola's Open is unacknowledged",
+			neg:            openNegotiation{peerOpensRejected: 1},
+			wantState:      sessionStateKeepWait,
+			wantPeerOpened: true,
+		},
+		{
+			// Appendix A: KeepWait + Keepalive + RemoteOK=0 clears the KeepWait
+			// timer, starts OpenWait and moves back to OpenWait.
+			name:           "Pola's Open acknowledged while the peer's revised Open is awaited",
+			neg:            openNegotiation{peerOpensRejected: 1, localOK: true},
+			wantState:      sessionStateOpenWait,
+			wantPeerOpened: true,
+		},
+		{
+			name:           "peer's Open accepted, only its Keepalive outstanding",
+			neg:            openNegotiation{remoteOK: true},
+			wantState:      sessionStateKeepWait,
+			wantPeerOpened: true,
+		},
+		{
+			name:      "Pola's Open acknowledged, peer's Open still awaited",
+			neg:       openNegotiation{localOK: true},
+			wantState: sessionStateOpenWait,
+		},
+		{
+			name:            "both directions acknowledged",
+			neg:             openNegotiation{remoteOK: true, localOK: true},
+			wantState:       sessionStateUp,
+			wantEstablished: true,
+			wantPeerOpened:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantState, tc.neg.state())
+			assert.Equal(t, tc.wantEstablished, tc.neg.established())
+			assert.Equal(t, tc.wantPeerOpened, tc.neg.peerOpened())
+		})
+	}
+}
+
+func TestOpenNegotiation_TracksAppendixAState(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	assert.Equal(t, sessionStateOpenWait, neg.state(), "(0,0) awaits the peer's Open: OpenWait/1-2")
+	assert.False(t, neg.established())
+
+	require.NoError(t, ss.handlePeerOpen(openMessageBody(t, 1, 5, 20), neg))
+	assert.False(t, neg.remoteOK)
+	assert.Equal(t, 1, neg.peerOpensRejected)
+	assert.Equal(t, sessionStateKeepWait, neg.state(),
+		"Appendix A moves to KeepWait after PCErr(1,4) while LocalOK=0: KeepWait/1-7")
+
+	rejection, err := negotiableRejection(40, 160).Serialize()
+	require.NoError(t, err)
+	require.NoError(t, ss.handleNegotiationPCErr(rejection[pcep.CommonHeaderLength:], neg))
+	assert.Equal(t, 1, neg.localOpenRetries)
+	assert.Equal(t, sessionStateKeepWait, neg.state(),
+		"the re-sent Open is still unacknowledged, and an Open has been received, so 1/2 would misreport")
+
+	require.NoError(t, ss.handlePeerOpen(openMessageBody(t, 1, 30, 120), neg))
+	assert.True(t, neg.remoteOK)
+	assert.False(t, neg.localOK)
+	assert.Equal(t, sessionStateKeepWait, neg.state(), "only the acknowledgment of Pola's Open remains outstanding: KeepWait/1-7")
+	assert.False(t, neg.established())
+
+	neg.localOK = true
+	assert.True(t, neg.established())
+	assert.Equal(t, sessionStateUp, neg.state())
+}
+
+func TestOpen_SendOpenFailureIsPropagated(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
-	err = ss.Open()
+	require.ErrorContains(t, ss.Open(), "write: broken pipe")
+	assert.False(t, ss.Up())
+}
+
+func TestNegotiateOpen_PeerDisconnectIsNotReportedAsTimerExpiry(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(concatMessages(t, pcep.NewOpenMessage(1, 30, 120, nil)))}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	err := ss.negotiateOpen(&openNegotiation{})
 	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "KeepWait timer expired", "an abrupt disconnect is not a timer expiry")
+	assert.NotContains(t, err.Error(), "timer expired", "an abrupt disconnect is not a timer expiry")
 }
 
-func TestAwaitKeepalive_TruncatedMessageBodyReturnsError(t *testing.T) {
-	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
-	require.NoError(t, err)
-
+func TestNegotiateOpen_TruncatedMessageBodyReturnsError(t *testing.T) {
 	truncated := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeReport, MessageLength: pcep.CommonHeaderLength + 4}
-	stream := append([]byte{}, openBytes...)
-	stream = append(stream, truncated.Serialize()...)
-	stream = append(stream, 0x00, 0x00)
+	stream := slices.Concat(truncated.Serialize(), []byte{0x00, 0x00})
 
 	conn := &fakeConn{r: bytes.NewReader(stream)}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
-	require.Error(t, ss.Open(), "expected a truncated KeepWait message body to be reported as an error")
+	require.Error(t, ss.negotiateOpen(&openNegotiation{}), "a truncated message body must be reported as an error")
 }
 
-func TestAwaitKeepalive_UnexpectedMessageTypeIsRejected(t *testing.T) {
-	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
-	require.NoError(t, err)
-	closeBytes, err := pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided).Serialize()
-	require.NoError(t, err)
-
-	conn := &fakeConn{r: bytes.NewReader(append(openBytes, closeBytes...))}
+func TestNegotiateOpen_UnexpectedMessageTypeIsCounted(t *testing.T) {
+	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeReport, MessageLength: pcep.CommonHeaderLength}
+	conn := &fakeConn{r: bytes.NewReader(header.Serialize())}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
-	err = ss.Open()
-	assert.ErrorContains(t, err, "expected a Keepalive or PCErr message in KeepWait")
+	require.Error(t, ss.negotiateOpen(&openNegotiation{}))
+	assert.Equal(t, uint64(1), ss.Stats().RptRcvd)
 }
 
-func TestAwaitKeepalive_SendPCErrFailureIsLoggedNotFatal(t *testing.T) {
-	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
-	require.NoError(t, err)
+func TestNegotiateOpen_PreOpenKeepaliveIsCounted(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(concatMessages(t, pcep.NewKeepaliveMessage()))}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
-	// Allow the Open and Keepalive writes to succeed; fail the KeepWait-expiry PCErr.
-	conn := &fakeConn{
-		r:         &errAfterReader{prefix: openBytes, err: os.ErrDeadlineExceeded},
-		failAfter: 2,
-		writeErr:  errors.New("write: broken pipe"),
+	require.Error(t, ss.negotiateOpen(&openNegotiation{}))
+	assert.Equal(t, uint64(1), ss.Stats().KeepaliveRcvd)
+}
+
+func TestNegotiateOpen_PreOpenPCErrIsCounted(t *testing.T) {
+	full, err := pcep.NewPCErrMessage(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueSecondOpenStillUnacceptable, nil).Serialize()
+	require.NoError(t, err)
+	conn := &fakeConn{r: bytes.NewReader(full)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	require.Error(t, ss.negotiateOpen(&openNegotiation{}))
+	assert.Equal(t, uint64(1), ss.Stats().PCErrRcvd)
+}
+
+func TestNegotiateOpen_ReadMessageBodyErrorIsPropagated(t *testing.T) {
+	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeOpen, MessageLength: pcep.CommonHeaderLength + 10}
+	wantErr := errors.New("connection reset by peer")
+	conn := &fakeConn{r: &errAfterReader{prefix: header.Serialize(), err: wantErr}}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	assert.ErrorIs(t, ss.negotiateOpen(&openNegotiation{}), wantErr)
+}
+
+func TestNegotiateOpen_TimerExpiryFollowsTheDerivedState(t *testing.T) {
+	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeOpen, MessageLength: pcep.CommonHeaderLength + 10}
+
+	cases := []struct {
+		name           string
+		neg            openNegotiation
+		prefix         []byte
+		wantErr        string
+		wantErrorValue uint8
+	}{
+		{
+			name:           "OpenWait expires before any message arrives",
+			wantErr:        "OpenWait timer expired without a message from the peer",
+			wantErrorValue: pcepErrorValueOpenWaitTimerExpired,
+		},
+		{
+			name:           "OpenWait expires mid-message",
+			prefix:         header.Serialize(),
+			wantErr:        "OpenWait timer expired before the message was complete",
+			wantErrorValue: pcepErrorValueOpenWaitTimerExpired,
+		},
+		{
+			name:           "KeepWait expires after Pola answered the peer's Open with PCErr(1,4)",
+			neg:            openNegotiation{peerOpensRejected: 1},
+			wantErr:        "KeepWait timer expired without a message from the peer",
+			wantErrorValue: pcepErrorValueKeepWaitTimerExpired,
+		},
+		{
+			name:           "OpenWait expires while the peer's revised Open is awaited",
+			neg:            openNegotiation{peerOpensRejected: 1, localOK: true},
+			wantErr:        "OpenWait timer expired without a message from the peer",
+			wantErrorValue: pcepErrorValueOpenWaitTimerExpired,
+		},
+		{
+			name:           "KeepWait expires before any message arrives",
+			neg:            openNegotiation{remoteOK: true},
+			wantErr:        "KeepWait timer expired without a message from the peer",
+			wantErrorValue: pcepErrorValueKeepWaitTimerExpired,
+		},
+		{
+			name:           "KeepWait expires mid-message",
+			neg:            openNegotiation{remoteOK: true},
+			prefix:         header.Serialize(),
+			wantErr:        "KeepWait timer expired before the message was complete",
+			wantErrorValue: pcepErrorValueKeepWaitTimerExpired,
+		},
 	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &fakeConn{r: &errAfterReader{prefix: tc.prefix, err: os.ErrDeadlineExceeded}}
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+			neg := tc.neg
+			require.ErrorContains(t, ss.negotiateOpen(&neg), tc.wantErr)
+
+			writes := conn.writes()
+			require.Len(t, writes, 1)
+			assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, tc.wantErrorValue)
+		})
+	}
+}
+
+func TestNegotiateOpen_KeepWaitExpiryAfterOwnProposalReportsErrorValue7(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 30, 120, nil), // accepted: RemoteOK=1
+		negotiableRejection(20, 80),          // Pola adopts and re-sends its Open
+	)
+	conn := &fakeConn{r: &errAfterReader{prefix: stream, err: os.ErrDeadlineExceeded}}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.negotiateOpen(neg), "KeepWait timer expired")
+	assert.True(t, neg.remoteOK)
+	assert.Equal(t, 1, neg.localOpenRetries)
+
+	writes := conn.writes()
+	require.Len(t, writes, 3, "expected the acknowledging Keepalive, the re-sent Open, and the KeepWait PCErr")
+	assertPCErr(t, writes[2], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueKeepWaitTimerExpired)
+}
+
+func TestNegotiateOpen_PCErr14SelectsTheKeepWaitTimer(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := negotiatingSession(t, server)
+	ss.openWait = time.Hour
+	ss.keepWait = 50 * time.Millisecond
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 5, 20, nil))
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.negotiateOpen(neg), "KeepWait timer expired",
+		"the OpenWait timer must no longer guard the read once PCErr(1,4) has been sent")
+	assert.Equal(t, 1, neg.peerOpensRejected)
+	assert.False(t, neg.remoteOK)
+}
+
+func TestRestartInitializationTimer_SelectsTimerForCurrentState(t *testing.T) {
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.openWait = time.Hour
+	ss.keepWait = 30 * time.Minute
+
+	neg := &openNegotiation{}
+	ss.restartInitializationTimer(neg)
+	openWaitDeadline := neg.deadline
+	assert.WithinDuration(t, time.Now().Add(time.Hour), openWaitDeadline, time.Second)
+
+	neg.remoteOK = true
+	ss.restartInitializationTimer(neg)
+	assert.WithinDuration(t, time.Now().Add(30*time.Minute), neg.deadline, time.Second)
+	assert.NotEqual(t, openWaitDeadline, neg.deadline)
+}
+
+func TestNegotiateOpen_DuplicateKeepalivesDoNotExtendTheInitializationTimer(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := negotiatingSession(t, server)
+	ss.keepWait = time.Hour
+	ss.openWait = 100 * time.Millisecond
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 5, 20, nil))
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	neg := &openNegotiation{}
+	start := time.Now()
+	errCh := make(chan error, 1)
+	go func() { errCh <- ss.negotiateOpen(neg) }()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's PCErr(1,4)")
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				b, err := pcep.NewKeepaliveMessage().Serialize()
+				if err != nil {
+					return
+				}
+				if _, err := client.Write(b); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "OpenWait timer expired")
+		assert.Less(t, time.Since(start), 250*time.Millisecond,
+			"duplicate Keepalives that leave vars() unchanged must not extend the initialization timer")
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "duplicate Keepalives must not indefinitely extend the initialization timer")
+	}
+}
+
+func TestStartNegotiationKeepalive_NoopWhenKeepaliveIsZero(_ *testing.T) {
+	ss := &Session{localOpen: &OpenParams{Keepalive: 0, DeadTimer: 0}}
+	stop := ss.startNegotiationKeepalive()
+	stop()
+}
+
+func TestStartNegotiationKeepalive_HandlesKeepaliveSendFailure(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: connection reset")}
+	core, logs := observer.New(zap.DebugLevel)
+	ss := NewSession(
+		OpenParams{SessionID: 1, Keepalive: 1, DeadTimer: 4},
+		netip.MustParseAddr("10.0.255.1"),
+		conn,
+		zap.New(core),
+		nil,
+		0,
+	)
+
+	ss.localOpen = &OpenParams{SessionID: 1, Keepalive: 1, DeadTimer: 4}
+
+	stop := ss.startNegotiationKeepalive()
+	defer stop()
+
+	require.Eventually(t, func() bool {
+		return len(logs.FilterMessage("ERROR! Send Keepalive Message during negotiation").All()) > 0
+	}, 2*time.Second, 50*time.Millisecond, "expected negotiation keepalive send to fail and be logged")
+}
+
+func TestNegotiateOpen_SendsKeepalivesWhileAwaitingAcknowledgmentOfItsOwnOpen(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	localOpen := OpenParams{SessionID: 1, Keepalive: 1, DeadTimer: pcep.DeadTimerFor(1)}
+	ss := NewSession(localOpen, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.keepWait = 5 * time.Second
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- ss.Open() }()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's initial Open")
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+
+	require.NoError(t, readPCEPMessage(client), "expected a periodic Keepalive while awaiting the peer's acknowledgment")
+
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Open did not return once both sides acknowledged")
+	}
+	assert.True(t, ss.Up())
+}
+
+func TestNegotiateOpen_NegotiationKeepaliveStopsWhenNegotiationFails(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	localOpen := OpenParams{SessionID: 1, Keepalive: 1, DeadTimer: pcep.DeadTimerFor(1)}
+	ss := NewSession(localOpen, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- ss.Open() }()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's initial Open")
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 200, 255, nil))
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Open did not return")
+	}
+
+	require.NoError(t, readPCEPMessage(client), "failed to read the PCErr rejecting the second Open")
+
+	require.NoError(t, client.SetReadDeadline(time.Now().Add(1200*time.Millisecond)))
+	_, err := client.Read(make([]byte, 1))
+	assert.ErrorIs(t, err, os.ErrDeadlineExceeded,
+		"the negotiation Keepalive goroutine must stop before Open returns, not fire once more a second later")
+}
+
+func TestNegotiateOpen_SendPCErrFailureIsLoggedNotFatal(t *testing.T) {
+	conn := &fakeConn{r: &errAfterReader{err: os.ErrDeadlineExceeded}, writeErr: errors.New("write: broken pipe")}
 	core, logs := observer.New(zap.DebugLevel)
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.New(core), nil, 0)
 
-	err = ss.Open()
-	require.ErrorContains(t, err, "KeepWait timer expired",
+	require.ErrorContains(t, ss.negotiateOpen(&openNegotiation{remoteOK: true}), "KeepWait timer expired",
 		"the session must still report timer expiry even though the best-effort PCErr send failed")
 	assert.NotEmpty(t, logs.FilterMessage("ERROR! Send PCErr Message").All())
 }
 
-func TestAwaitKeepalive_KeepWaitExpiresWhileReadingBody(t *testing.T) {
-	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
-	require.NoError(t, err)
-
-	// Simulate a body read timeout after receiving the header.
-	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeReport, MessageLength: pcep.CommonHeaderLength + 4}
-	conn := &fakeConn{r: &errAfterReader{prefix: append(openBytes, header.Serialize()...), err: os.ErrDeadlineExceeded}}
+func TestNegotiateOpen_MalformedCommonHeaderIsRejectedWithErrorValue1(t *testing.T) {
+	header := &pcep.CommonHeader{Version: 2, MessageType: pcep.MessageTypeOpen, MessageLength: pcep.CommonHeaderLength}
+	conn := &fakeConn{r: bytes.NewReader(header.Serialize())}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
-	err = ss.Open()
-	require.ErrorContains(t, err, "KeepWait timer expired while reading the message body")
+	require.Error(t, ss.negotiateOpen(&openNegotiation{}))
+	assert.Equal(t, uint64(1), ss.stats.corruptRcvd)
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 }
 
-func TestHandleKeepWaitPCErr_MalformedPCErrReturnsError(t *testing.T) {
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+func TestNegotiateOpen_PeerOpenDecodeErrorIsRejectedWithErrorValue1(t *testing.T) {
+	body := pcep.NewCommonObjectHeader(pcep.ObjectClassClose, pcep.ObjectTypeOpenOpen, pcep.CommonHeaderLength).Serialize()
+	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeOpen, MessageLength: pcep.CommonHeaderLength + uint16(len(body))}
 
-	_, err := ss.handleKeepWaitPCErr([]byte{}, true)
-	require.ErrorContains(t, err, "malformed PCErr in KeepWait")
+	conn := &fakeConn{r: bytes.NewReader(slices.Concat(header.Serialize(), body))}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	require.Error(t, ss.negotiateOpen(&openNegotiation{}))
+	assert.Equal(t, uint64(1), ss.stats.corruptRcvd)
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 }
 
-func TestHandleKeepWaitPCErr_OtherErrorIsReportedAsIs(t *testing.T) {
+func TestNegotiateOpen_ProposeAcceptableOpenSendFailure(t *testing.T) {
+	conn := &fakeConn{
+		r:        bytes.NewReader(concatMessages(t, pcep.NewOpenMessage(1, 5, 20, nil))),
+		writeErr: errors.New("write: broken pipe"),
+	}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.negotiateOpen(neg), "write: broken pipe")
+	assert.Zero(t, neg.peerOpensRejected, "OpenRetry must not be spent when the PCErr(1,4) cannot be sent")
+}
+
+func TestNegotiateOpen_SecondOpenAfterAnAcceptableOpenIsRejected(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 30, 120, nil),
+		pcep.NewOpenMessage(1, 200, 255, nil),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.Error(t, ss.negotiateOpen(neg))
+	assert.False(t, neg.localOK)
+	assert.NotEqual(t, sessionStateUp, ss.State())
+
+	pccOpen, ok := ss.PccOpen()
+	require.True(t, ok)
+	assert.Equal(t, OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pccOpen)
+
+	writes := conn.writes()
+	require.Len(t, writes, 2)
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(writes[0]))
+	assert.Equal(t, pcep.MessageTypeKeepalive, header.MessageType)
+	assertPCErr(t, writes[1], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+}
+
+func TestNegotiateOpen_SecondPeerOpenStillUnacceptableReportsErrorValue5(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 5, 20, nil),
+		pcep.NewOpenMessage(1, 5, 20, nil),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.negotiateOpen(neg), "peer's second Open still advertises unacceptable session characteristics")
+	assert.Equal(t, 1, neg.peerOpensRejected, "OpenRetry stops at 1; the second rejection ends the session")
+	assert.Zero(t, neg.localOpenRetries, "rejecting the peer's Open must not spend Pola's own Open retry budget")
+
+	writes := conn.writes()
+	require.Len(t, writes, 2)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable)
+	assertPCErr(t, writes[1], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueSecondOpenStillUnacceptable)
+}
+
+func TestNegotiateOpen_ZeroKeepaliveWithNonzeroDeadTimerIsAccepted(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 0, 120, nil),
+		pcep.NewKeepaliveMessage(),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.negotiateOpen(neg))
+	assert.True(t, neg.established())
+
+	writes := conn.writes()
+	require.Len(t, writes, 1, "only the acknowledging Keepalive; a Keepalive=0 Open must not draw a PCErr")
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(writes[0]))
+	assert.Equal(t, pcep.MessageTypeKeepalive, header.MessageType)
+}
+
+func TestNegotiateOpen_UnacceptableOpenIsRejectedWithErrorValue3WhenNegotiationIsDisabled(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(concatMessages(t, pcep.NewOpenMessage(1, 5, 20, nil)))}
+	ss := negotiatingSession(t, conn)
+	ss.allowNegotiation = false
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.negotiateOpen(neg), "unacceptable and non-negotiable")
+	assert.Zero(t, neg.peerOpensRejected)
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNonNegotiable)
+}
+
+func TestNegotiateOpen_PCErrBeforeThePeersOpenIsRejected(t *testing.T) {
+	stream := concatMessages(t,
+		negotiableRejection(20, 80),
+		pcep.NewOpenMessage(1, 30, 120, nil),
+		pcep.NewKeepaliveMessage(),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.negotiateOpen(neg), "received a PCErr before the peer's Open message")
+
+	assert.Zero(t, neg.localOpenRetries, "the proposal must not be adopted")
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+}
+
+func TestNegotiateOpen_KeepWaitRenegotiationSpendsTheLocalOpenRetryBudget(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 30, 120, nil),
+		negotiableRejection(20, 80),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.Error(t, ss.negotiateOpen(neg), "the peer never acknowledges the re-sent Open")
+
+	assert.Equal(t, 1, neg.localOpenRetries, "adopting the proposal spends one local Open retry")
+	assert.True(t, neg.remoteOK)
+	assert.Equal(t, sessionStateKeepWait, ss.State(), "RemoteOK=1 keeps the session in KeepWait across the re-sent Open")
+
+	writes := conn.writes()
+	require.Len(t, writes, 2, "expected the Keepalive acknowledging the peer's Open and the re-sent Open")
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(writes[0]))
+	assert.Equal(t, pcep.MessageTypeKeepalive, header.MessageType)
+	require.NoError(t, header.DecodeFromBytes(writes[1]))
+	assert.Equal(t, pcep.MessageTypeOpen, header.MessageType, "Pola must not re-acknowledge an Open it already accepted")
+}
+
+func TestNegotiateOpen_OpenWaitAndKeepWaitShareOneLocalOpenRetryBudget(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 5, 20, nil),
+		negotiableRejection(20, 80),
+		pcep.NewOpenMessage(1, 30, 120, nil),
+		negotiableRejection(40, 160),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	err := ss.negotiateOpen(neg)
+	require.ErrorContains(t, err, "further proposal",
+		"the KeepWait renegotiation must see the budget already spent in OpenWait")
+
+	assert.Equal(t, 1, neg.localOpenRetries, "the budget is spent once, not once per state")
+	assert.Equal(t, 1, neg.peerOpensRejected, "OpenRetry is independent of the local Open retry budget")
+	assert.Equal(t, uint8(20), ss.localKeepalive, "the second proposal must not be adopted")
+	assert.Equal(t, uint8(80), ss.localDeadTimer)
+
+	writes := conn.writes()
+	require.Len(t, writes, 4)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable)
+	assertPCErr(t, writes[3], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+}
+
+func TestNegotiateOpen_SimultaneousRejectionInterleavesPCErrBeforeRevisedOpen(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 5, 20, nil),
+		negotiableRejection(20, 80),
+		pcep.NewOpenMessage(1, 30, 120, nil),
+		pcep.NewKeepaliveMessage(),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.negotiateOpen(neg), "the interleaved PCErr must not be mistaken for an invalid Open")
+
+	assert.Equal(t, 1, neg.localOpenRetries)
+	assert.Equal(t, 1, neg.peerOpensRejected)
+	assert.Equal(t, uint8(20), ss.localKeepalive)
+	assert.Equal(t, uint8(80), ss.localDeadTimer)
+	assert.Equal(t, sessionStateUp, ss.State())
+
+	pccOpen, ok := ss.PccOpen()
+	require.True(t, ok)
+	assert.Equal(t, OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pccOpen)
+}
+
+func TestNegotiateOpen_KeepaliveMayArriveBeforeThePeersRevisedOpen(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 5, 20, nil),
+		pcep.NewKeepaliveMessage(),
+		pcep.NewOpenMessage(1, 30, 120, nil),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.negotiateOpen(neg), "a Keepalive after the peer's first Open acknowledges Pola's Open")
+
+	assert.True(t, neg.localOK)
+	assert.True(t, neg.remoteOK)
+	assert.Zero(t, neg.localOpenRetries, "acknowledging Pola's Open costs no retry budget")
+	assert.Equal(t, sessionStateUp, ss.State())
+}
+
+func TestNegotiateOpen_RevisedOpenMayArriveBeforeTheAcknowledgmentOfPolasOpen(t *testing.T) {
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 5, 20, nil),
+		pcep.NewOpenMessage(1, 30, 120, nil),
+		pcep.NewKeepaliveMessage(),
+	)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.negotiateOpen(neg), "the peer's revised Open must be accepted before its Keepalive")
+
+	assert.Equal(t, 1, neg.peerOpensRejected, "the revised Open is acceptable, so it must not draw PCErr(1,5)")
+	assert.Zero(t, neg.localOpenRetries, "Pola never re-sent its own Open")
+	assert.Equal(t, sessionStateUp, ss.State())
+
+	writes := conn.writes()
+	require.Len(t, writes, 2)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable)
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(writes[1]))
+	assert.Equal(t, pcep.MessageTypeKeepalive, header.MessageType, "the revised Open must be acknowledged")
+
+	pccOpen, ok := ss.PccOpen()
+	require.True(t, ok)
+	assert.Equal(t, OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pccOpen)
+}
+
+func TestNegotiateOpen_ResentOpenMustBeAcknowledgedBeforeUp(t *testing.T) {
+	reader := bytes.NewReader(concatMessages(t,
+		pcep.NewOpenMessage(1, 5, 20, nil),
+		pcep.NewKeepaliveMessage(),
+		negotiableRejection(40, 160),
+		pcep.NewOpenMessage(1, 30, 120, nil),
+		pcep.NewKeepaliveMessage(),
+	))
+	conn := &fakeConn{r: reader}
+	ss := negotiatingSession(t, conn)
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.negotiateOpen(neg))
+
+	assert.True(t, neg.established())
+	assert.Equal(t, sessionStateUp, ss.State())
+	assert.Equal(t, uint64(2), ss.Stats().KeepaliveRcvd,
+		"only the Keepalive acknowledging the re-sent Open may complete establishment")
+}
+
+func TestHandleNegotiationPCErr_MalformedPCErrIsRejectedWithErrorValue1(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil)}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
-	pcerrMessage := pcep.NewPCErrMessage(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueSecondOpenStillUnacceptable, nil)
-	full, err := pcerrMessage.Serialize()
-	require.NoError(t, err)
+	require.ErrorContains(t, ss.handleNegotiationPCErr([]byte{}, &openNegotiation{}),
+		"malformed PCErr while establishing the PCEP session")
+	assert.Equal(t, uint64(1), ss.stats.corruptRcvd)
 
-	_, err = ss.handleKeepWaitPCErr(full[pcep.CommonHeaderLength:], true)
-	require.ErrorContains(t, err, "peer rejected session establishment")
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
 }
 
-func TestHandleKeepWaitPCErr_NegotiableProposalIsFoundBehindOtherErrors(t *testing.T) {
+func TestHandleNegotiationPCErr_NonNegotiableRejectionIsReportedAsIs(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil)}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-	ss.allowNegotiation = true
+
+	full, err := pcep.NewPCErrMessage(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueSecondOpenStillUnacceptable, nil).Serialize()
+	require.NoError(t, err)
+
+	require.ErrorContains(t, ss.handleNegotiationPCErr(full[pcep.CommonHeaderLength:], &openNegotiation{}),
+		"peer rejected session establishment")
+	assert.Zero(t, conn.writeCount, "a rejection Pola cannot answer must not be answered with PCErr 1/6")
+}
+
+func TestHandleNegotiationPCErr_NegotiableProposalIsFoundBehindOtherErrors(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
 	pcerrMessage := &pcep.PCErrMessage{
 		Errors: []*pcep.ErrorObject{
@@ -2098,13 +2876,13 @@ func TestHandleKeepWaitPCErr_NegotiableProposalIsFoundBehindOtherErrors(t *testi
 	full, err := pcerrMessage.Serialize()
 	require.NoError(t, err)
 
-	retry, err := ss.handleKeepWaitPCErr(full[pcep.CommonHeaderLength:], true)
-	require.NoError(t, err)
-	assert.True(t, retry, "an Error 1/4 must drive renegotiation even when it is not the first PCEP-ERROR object")
+	neg := &openNegotiation{}
+	require.NoError(t, ss.handleNegotiationPCErr(full[pcep.CommonHeaderLength:], neg))
+	assert.Equal(t, 1, neg.localOpenRetries, "an Error 1/4 must drive renegotiation even when it is not the first PCEP-ERROR object")
 	assert.Equal(t, uint8(20), ss.localKeepalive)
 }
 
-func TestHandleKeepWaitPCErr_AllErrorsAreReported(t *testing.T) {
+func TestHandleNegotiationPCErr_AllErrorsAreReported(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil)}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
@@ -2117,44 +2895,133 @@ func TestHandleKeepWaitPCErr_AllErrorsAreReported(t *testing.T) {
 	full, err := pcerrMessage.Serialize()
 	require.NoError(t, err)
 
-	_, err = ss.handleKeepWaitPCErr(full[pcep.CommonHeaderLength:], true)
+	err = ss.handleNegotiationPCErr(full[pcep.CommonHeaderLength:], &openNegotiation{})
 	require.ErrorContains(t, err, "error-type=2, error-value=0")
 	require.ErrorContains(t, err, "error-type=1, error-value=3")
 	assert.Zero(t, conn.writeCount, "a non-negotiable rejection must not be answered with PCErr 1/6")
 }
 
+func TestAdoptProposedOpen_MissingOpenObjectIsRejected(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.adoptProposedOpen(nil, neg), "without proposing acceptable ones")
+	assert.Zero(t, neg.localOpenRetries)
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+}
+
+func TestAdoptProposedOpen_UnacceptableProposalIsRejected(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.adoptProposedOpen(pcep.NewOpenObject(1, 50, 10, nil), neg),
+		"peer proposed unacceptable session characteristics")
+	assert.Zero(t, neg.localOpenRetries, "a proposal Pola cannot adopt must not spend the retry budget")
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+}
+
+func TestAdoptProposedOpen_ProposalOutsideTheConfiguredKeepaliveRangeIsRejectedWithErrorValue6(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := negotiatingSession(t, conn) // range [10,60]
+
+	neg := &openNegotiation{}
+	err := ss.adoptProposedOpen(pcep.NewOpenObject(1, 5, 20, nil), neg)
+	require.ErrorContains(t, err, "peer proposed unacceptable session characteristics (Keepalive=5, DeadTimer=20)")
+	assert.Zero(t, neg.localOpenRetries, "a proposal outside the configured range must not be adopted")
+	assert.Equal(t, defaultLocalKeepalive, ss.localKeepalive, "Pola's own advertised Keepalive must be unchanged")
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+}
+
+func TestAdoptProposedOpen_AcceptsProposalWithinTheConfiguredKeepaliveRange(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := negotiatingSession(t, conn) // range [10,60]
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.adoptProposedOpen(pcep.NewOpenObject(1, 40, 160, nil), neg))
+	assert.Equal(t, 1, neg.localOpenRetries)
+	assert.Equal(t, uint8(40), ss.localKeepalive)
+	assert.Equal(t, uint8(160), ss.localDeadTimer)
+}
+
+func TestAdoptProposedOpen_ExhaustedBudgetIsRejectedWithErrorValue6(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	neg := &openNegotiation{localOpenRetries: maxLocalOpenRetries}
+	require.ErrorContains(t, ss.adoptProposedOpen(pcep.NewOpenObject(1, 20, 80, nil), neg), "further proposal")
+	assert.Equal(t, maxLocalOpenRetries, neg.localOpenRetries, "an exhausted budget must not be overspent")
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableProposal)
+}
+
+func TestAdoptProposedOpen_SendOpenFailureDoesNotSpendTheBudget(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.adoptProposedOpen(pcep.NewOpenObject(1, 20, 80, nil), neg), "write: broken pipe")
+	assert.Zero(t, neg.localOpenRetries, "the budget tracks Opens that actually reached the peer")
+}
+
+func TestAdoptProposedOpen_ClearsTheAcknowledgmentOfThePreviousOpen(t *testing.T) {
+	for _, initialLocalOK := range []bool{true, false} {
+		t.Run(fmt.Sprintf("localOK=%v", initialLocalOK), func(t *testing.T) {
+			conn := &fakeConn{r: bytes.NewReader(nil)}
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+			neg := &openNegotiation{localOK: initialLocalOK}
+			require.NoError(t, ss.adoptProposedOpen(pcep.NewOpenObject(1, 20, 80, nil), neg))
+			assert.False(t, neg.localOK, "the re-sent Open must be acknowledged by a fresh Keepalive")
+		})
+	}
+}
+
+func TestAdoptProposedOpen_ZeroKeepaliveProposalIsAdopted(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.adoptProposedOpen(pcep.NewOpenObject(1, 0, 0, nil), neg))
+	assert.Equal(t, 1, neg.localOpenRetries)
+	assert.Equal(t, uint8(0), ss.localKeepalive)
+	assert.Zero(t, ss.keepaliveInterval(), "Pola must not send periodic Keepalives once it has adopted Keepalive=0")
+}
+
 func TestOpen_RetriesAfterAcceptablePCErrProposal(t *testing.T) {
-	peerOpenBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
-	require.NoError(t, err)
-
-	proposedOpen := pcep.NewOpenObject(1, 20, 80, nil)
-	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, proposedOpen)
-	pcerrBytes, err := pcerrMessage.Serialize()
-	require.NoError(t, err)
-
-	keepaliveBytes, err := pcep.NewKeepaliveMessage().Serialize()
-	require.NoError(t, err)
-
-	stream := append(append(peerOpenBytes, pcerrBytes...), keepaliveBytes...)
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(1, 30, 120, nil),
+		negotiableRejection(20, 80),
+		pcep.NewKeepaliveMessage(),
+	)
 	conn := &fakeConn{r: bytes.NewReader(stream)}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
 	require.NoError(t, ss.Open(), "Open must retry with the peer's acceptable proposal instead of failing")
+	assert.True(t, ss.Up())
 	assert.Equal(t, uint8(20), ss.localKeepalive)
 	assert.Equal(t, uint8(80), ss.localDeadTimer)
+	assert.Len(t, conn.writes(), 3, "expected the initial Open, the Keepalive acknowledging the peer's Open, and the re-sent Open")
 }
 
 func TestOpen_SendOpenFailsAfterRetryingWithProposal(t *testing.T) {
-	// Use distinct SIDs to verify that retrying keeps Pola's own SID.
-	peerOpenBytes, err := pcep.NewOpenMessage(2, 30, 120, nil).Serialize()
-	require.NoError(t, err)
-
-	proposedOpen := pcep.NewOpenObject(2, 20, 80, nil)
-	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, proposedOpen)
-	pcerrBytes, err := pcerrMessage.Serialize()
-	require.NoError(t, err)
-
-	stream := append(append([]byte(nil), peerOpenBytes...), pcerrBytes...)
+	stream := concatMessages(t,
+		pcep.NewOpenMessage(2, 30, 120, nil),
+		pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable,
+			pcep.NewOpenObject(2, 20, 80, nil)),
+	)
 	conn := &fakeConn{
 		r:         bytes.NewReader(stream),
 		failAfter: 2,
@@ -2162,9 +3029,7 @@ func TestOpen_SendOpenFailsAfterRetryingWithProposal(t *testing.T) {
 	}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
-	err = ss.Open()
-	require.Error(t, err)
-	require.ErrorContains(t, err, "write: broken pipe")
+	require.ErrorContains(t, ss.Open(), "write: broken pipe")
 
 	writes := conn.writes()
 	require.Len(t, writes, 3, "expected initial Open, Keepalive, and retry Open")
@@ -2180,66 +3045,21 @@ func TestOpen_SendOpenFailsAfterRetryingWithProposal(t *testing.T) {
 	assert.Equal(t, uint8(1), retryOpen.OpenObject.Sid, "retry SendOpen must still use Pola's own SID, not the peer's proposed one")
 }
 
-func TestHandleProposedOpen_UnacceptableProposalIsRejected(t *testing.T) {
-	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-
-	proposedOpen := pcep.NewOpenObject(1, 50, 10, nil)
-	retry, err := ss.handleProposedOpen(proposedOpen, true)
-	assert.False(t, retry)
-	require.ErrorContains(t, err, "peer proposed unacceptable session characteristics")
-}
-
-func TestHandleProposedOpen_IgnoresPCCKeepaliveRange(t *testing.T) {
-	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-	ss.keepaliveRangeEnabled = true
-	ss.minKeepalive, ss.maxKeepalive = 10, 60
-
-	proposedOpen := pcep.NewOpenObject(1, 5, 20, nil)
-	retry, err := ss.handleProposedOpen(proposedOpen, true)
-	require.NoError(t, err)
-	assert.True(t, retry)
-	assert.Equal(t, uint8(5), ss.localKeepalive)
-	assert.Equal(t, uint8(20), ss.localDeadTimer)
-}
-
-func TestHandleProposedOpen_MissingOpenObjectIsRejected(t *testing.T) {
-	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-
-	retry, err := ss.handleProposedOpen(nil, true)
-	assert.False(t, retry)
-	require.ErrorContains(t, err, "without proposing acceptable ones")
-}
-
-func TestHandleProposedOpen_FurtherProposalAfterRetryIsRejected(t *testing.T) {
-	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-
-	retry, err := ss.handleProposedOpen(pcep.NewOpenObject(1, 20, 80, nil), false)
-	assert.False(t, retry)
-	require.ErrorContains(t, err, "further proposal")
-	assert.Equal(t, 1, conn.writeCount, "an exhausted negotiation must be answered with PCErr 1/6")
-}
-
 func TestOpen_RejectsSecondProposalWithErrorValue6(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() { assert.NoError(t, client.Close()) })
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
-	proposedOpen := pcep.NewOpenObject(1, 20, 80, nil)
-	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, proposedOpen)
-
 	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
-	writeMessage(t, client, pcerrMessage)
-	writeMessage(t, client, pcerrMessage)
+	writeMessage(t, client, negotiableRejection(20, 80))
+	writeMessage(t, client, negotiableRejection(20, 80))
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- ss.Open() }()
 
-	for range 4 {
+	// Pola's initial Open, the Keepalive acknowledging the peer's Open, and the re-sent Open.
+	for range 3 {
 		require.NoError(t, readPCEPMessage(client))
 	}
 
@@ -2255,41 +3075,6 @@ func TestOpen_RejectsSecondProposalWithErrorValue6(t *testing.T) {
 		require.Fail(t, "Open did not return after rejecting the second proposal")
 	}
 	assert.False(t, ss.Up())
-}
-
-func TestReceiveOpen_OpenWaitExpiresWhileReadingBody(t *testing.T) {
-	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeOpen, MessageLength: pcep.CommonHeaderLength + 10}
-	conn := &fakeConn{r: &errAfterReader{prefix: header.Serialize(), err: os.ErrDeadlineExceeded}}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-
-	err := ss.ReceiveOpen()
-	assert.ErrorContains(t, err, "OpenWait timer expired before the Open message was complete")
-}
-
-func TestNegotiateOpen_ProposeAcceptableOpenSendFailure(t *testing.T) {
-	openBytes, err := pcep.NewOpenMessage(1, 5, 20, nil).Serialize()
-	require.NoError(t, err)
-
-	conn := &fakeConn{r: bytes.NewReader(openBytes), writeErr: errors.New("write: broken pipe")}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-	ss.keepaliveRangeEnabled = true
-	ss.minKeepalive, ss.maxKeepalive = 10, 60
-	ss.allowNegotiation = true
-
-	require.Error(t, ss.negotiateOpen(), "expected negotiateOpen to fail once proposeAcceptableOpen cannot send")
-}
-
-func TestNegotiateOpen_SecondReceiveOpenFailure(t *testing.T) {
-	openBytes, err := pcep.NewOpenMessage(1, 5, 20, nil).Serialize()
-	require.NoError(t, err)
-
-	conn := &fakeConn{r: bytes.NewReader(openBytes)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
-	ss.keepaliveRangeEnabled = true
-	ss.minKeepalive, ss.maxKeepalive = 10, 60
-	ss.allowNegotiation = true
-
-	require.Error(t, ss.negotiateOpen(), "expected negotiateOpen to fail once the peer's second Open never arrives")
 }
 
 func TestReceivePCEPMessage_SendCloseFailureIsLoggedNotFatal(t *testing.T) {
@@ -3449,29 +4234,12 @@ func TestSessionStats_SendCountersIncrementOnSuccess(t *testing.T) {
 	assert.Equal(t, uint64(1), ss.Stats().PCInitiateSent)
 }
 
-func TestSessionStats_OpenRcvdIncrementsOnSuccess(t *testing.T) {
-	server, client := newTCPConnPair(t)
-	t.Cleanup(func() {
-		assert.NoError(t, server.Close(), "failed to close server connection")
-		assert.NoError(t, client.Close(), "failed to close client connection")
-	})
-
-	openMessage := pcep.NewOpenMessage(1, 30, pcep.DeadTimerFor(30), nil)
-	byteOpenMessage, err := openMessage.Serialize()
-	require.NoError(t, err, "failed to serialize open message")
-	_, err = client.Write(byteOpenMessage)
-	require.NoError(t, err, "failed to write open message")
-
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
-	require.NoError(t, ss.ReceiveOpen())
-	assert.Equal(t, uint64(1), ss.Stats().OpenRcvd)
-}
-
 func TestCountReceived_IncrementsExpectedCounter(t *testing.T) {
 	cases := map[string]struct {
 		messageType pcep.MessageType
 		get         func(sessionStatsSnapshot) uint64
 	}{
+		"Open":         {pcep.MessageTypeOpen, func(s sessionStatsSnapshot) uint64 { return s.OpenRcvd }},
 		"Keepalive":    {pcep.MessageTypeKeepalive, func(s sessionStatsSnapshot) uint64 { return s.KeepaliveRcvd }},
 		"Report":       {pcep.MessageTypeReport, func(s sessionStatsSnapshot) uint64 { return s.RptRcvd }},
 		"Error":        {pcep.MessageTypeError, func(s sessionStatsSnapshot) uint64 { return s.PCErrRcvd }},

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -317,7 +317,7 @@ func TestSendSRPolicyRequest_ForgetsIntentOnSendFailure(t *testing.T) {
 	})
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
-	ss.isSynced = true
+	ss.syncState = lspDBSyncFinished
 	wantSRPID := ss.srpIDHead
 
 	// Close the PCEP-side connection so the send inside sendSRPolicyRequest fails.
@@ -329,11 +329,11 @@ func TestSendSRPolicyRequest_ForgetsIntentOnSendFailure(t *testing.T) {
 	dstAddr := netip.MustParseAddr("10.255.0.2")
 	req := &pb.CreateSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
-			PcepSessionAddr: ss.peerAddr.AsSlice(),
-			DstAddr:         dstAddr.AsSlice(),
-			Color:           100,
-			PolicyName:      "test-policy",
-			Type:            pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
+			PeerAddr:   ss.peerAddr.AsSlice(),
+			DstAddr:    dstAddr.AsSlice(),
+			Color:      100,
+			PolicyName: "test-policy",
+			Type:       pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 		},
 		DisablePathCompute: true,
 	}
@@ -1291,7 +1291,7 @@ func TestOpen_Established_ReturnsWhenOpenFails(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1319,7 +1319,7 @@ func TestEstablished_StateMachineFollowsRFC5440(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1358,7 +1358,7 @@ func TestEstablished_KeepWaitExpiryReportsErrorValue7(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1388,7 +1388,7 @@ func TestEstablished_OpenWaitExpiryReportsErrorValue2(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1416,7 +1416,7 @@ func TestEstablished_NonOpenFirstMessageReportsErrorValue1(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1444,7 +1444,7 @@ func TestEstablished_PCErrDuringKeepWaitReportsErrorValue6(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1478,7 +1478,7 @@ func TestEstablished_UnacceptableKeepaliveNonNegotiableReportsErrorValue3(t *tes
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1510,7 +1510,7 @@ func TestEstablished_NegotiatesAcceptableKeepaliveThenEstablishes(t *testing.T) 
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1554,7 +1554,7 @@ func TestEstablished_SecondOpenStillUnacceptableReportsErrorValue5(t *testing.T)
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1590,7 +1590,7 @@ func TestEstablished_ReturnsOnCloseMessage(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1621,7 +1621,7 @@ func TestEstablished_ZeroKeepaliveDoesNotPanic(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1651,7 +1651,7 @@ func TestEstablished_ReturnsWhenPeerDisconnectsAbruptly(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1688,7 +1688,7 @@ func TestEstablished_ReturnsWhenPeriodicKeepaliveSendFails(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -1718,7 +1718,7 @@ func TestEstablished_ReturnsWhenInitialKeepaliveSendFails(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -2046,7 +2046,7 @@ func TestEstablished_DoesNotTimeOutAPccThatSendsNoKeepalives(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -2075,7 +2075,7 @@ func TestEstablished_SendsCloseWhenTheDeadTimerExpires(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ss.Established()
+		_ = ss.Established()
 		close(done)
 	}()
 
@@ -2913,4 +2913,289 @@ func TestSelectMetricType_AlwaysUsableForCSPF(t *testing.T) {
 		assert.Truef(t, got.IsValid() && got != table.UnspecifiedMetric,
 			"pccType %v with no METRIC object mapped to a metric CSPF rejects: %v", pccType, got)
 	}
+}
+
+func TestSession_CreatedAtSetOnConstruction(t *testing.T) {
+	before := time.Now()
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	after := time.Now()
+
+	assert.False(t, ss.CreatedAt().Before(before))
+	assert.False(t, ss.CreatedAt().After(after))
+	assert.True(t, ss.EstablishedAt().IsZero(), "EstablishedAt must be zero before the session comes up")
+}
+
+func TestSession_InitiatorDefaultsToRemote(t *testing.T) {
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	assert.Equal(t, sessionInitiatorRemote, ss.Initiator(), "Pola only accepts connections, so the initiator is always remote today")
+}
+
+func TestEstablished_SetsEstablishedAtOnceUp(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close(), "failed to close client connection") })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	require.True(t, ss.EstablishedAt().IsZero())
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+
+	done := make(chan struct{})
+	go func() {
+		_ = ss.Established()
+		close(done)
+	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	require.Eventually(t, ss.Up, 2*time.Second, 10*time.Millisecond, "the session must come up")
+	assert.False(t, ss.EstablishedAt().IsZero(), "EstablishedAt must be set once the session is up")
+
+	writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after the peer sent a Close message")
+	}
+}
+
+func TestEstablished_ReturnsErrorOnlyWhenEstablishmentFails(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, server.Close(), "failed to close server connection") })
+	require.NoError(t, client.Close(), "failed to close client connection")
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	assert.Error(t, ss.Established(), "Established must report an error when Open fails")
+}
+
+func TestSyncState_TransitionsPendingOngoingFinished(t *testing.T) {
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	assert.Equal(t, lspDBSyncPending, ss.SyncState())
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.LSPObject.SFlag = true
+	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
+	assert.Equal(t, lspDBSyncOngoing, ss.SyncState())
+
+	finish := newTestStateReport(t, 0, 0)
+	require.NoError(t, ss.handleStateReport(finish, pcep.NewPCRptMessage()))
+	assert.Equal(t, lspDBSyncFinished, ss.SyncState())
+}
+
+func TestSyncState_DoesNotRegressAfterFinished(t *testing.T) {
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.setSynced()
+	require.Equal(t, lspDBSyncFinished, ss.SyncState())
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.LSPObject.SFlag = true
+	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
+
+	assert.Equal(t, lspDBSyncFinished, ss.SyncState(), "sync state must not regress once finished")
+}
+
+func TestSessionStats_SendCountersIncrementOnSuccess(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	require.NoError(t, ss.SendKeepalive())
+	require.NoError(t, readPCEPMessage(client))
+	assert.Equal(t, uint64(1), ss.Stats().KeepaliveSent)
+
+	require.NoError(t, ss.SendPCErr(pcepErrorTypeCapabilityNotSupported, pcepErrorValueUnassigned))
+	require.NoError(t, readPCEPMessage(client))
+	assert.Equal(t, uint64(1), ss.Stats().PCErrSent)
+
+	require.NoError(t, ss.SendPCUpdate(table.SRPolicy{
+		Name:    "stats-test",
+		SrcAddr: netip.MustParseAddr("10.255.0.1"),
+		DstAddr: netip.MustParseAddr("10.255.0.2"),
+		Type:    table.PolicyTypeDynamic,
+		Metric:  table.TEMetric,
+	}))
+	require.NoError(t, readPCEPMessage(client))
+	assert.Equal(t, uint64(1), ss.Stats().UpdSent)
+
+	require.NoError(t, ss.SendPCInitiate(table.SRPolicy{
+		Name:    "stats-test",
+		SrcAddr: netip.MustParseAddr("10.255.0.1"),
+		DstAddr: netip.MustParseAddr("10.255.0.2"),
+		Type:    table.PolicyTypeDynamic,
+		Metric:  table.TEMetric,
+	}, false))
+	require.NoError(t, readPCEPMessage(client))
+	assert.Equal(t, uint64(1), ss.Stats().PCInitiateSent)
+}
+
+func TestCountReceived_IncrementsExpectedCounter(t *testing.T) {
+	cases := map[string]struct {
+		messageType pcep.MessageType
+		get         func(sessionStatsSnapshot) uint64
+	}{
+		"Keepalive":    {pcep.MessageTypeKeepalive, func(s sessionStatsSnapshot) uint64 { return s.KeepaliveRcvd }},
+		"Report":       {pcep.MessageTypeReport, func(s sessionStatsSnapshot) uint64 { return s.RptRcvd }},
+		"Error":        {pcep.MessageTypeError, func(s sessionStatsSnapshot) uint64 { return s.PCErrRcvd }},
+		"Notification": {pcep.MessageTypeNotification, func(s sessionStatsSnapshot) uint64 { return s.PCNtfRcvd }},
+		"Unknown":      {pcep.MessageTypeStartTLS, func(s sessionStatsSnapshot) uint64 { return s.UnknownRcvd }},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+			ss.countReceived(tt.messageType)
+			assert.Equal(t, uint64(1), tt.get(ss.Stats()), "unexpected counter value for message type %s", name)
+		})
+	}
+}
+
+func TestCountReceived_CloseHasNoCounter(t *testing.T) {
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss.countReceived(pcep.MessageTypeClose)
+	snap := ss.Stats()
+	assert.Zero(t, snap.UnknownRcvd, "Close must not be counted as an unrecognized message")
+	assert.Zero(t, snap.KeepaliveRcvd)
+	assert.Zero(t, snap.RptRcvd)
+	assert.Zero(t, snap.PCErrRcvd)
+	assert.Zero(t, snap.PCNtfRcvd)
+}
+
+func TestSessionStats_CorruptRcvdOnMalformedPCErr(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	// A truncated object header cannot form a valid PCEP-ERROR object.
+	malformedBody := []byte{0x00, 0x00}
+	_, err := client.Write(malformedBody)
+	require.NoError(t, err)
+
+	err = ss.receivePCErr(pcep.CommonHeaderLength+uint16(len(malformedBody)), time.Time{})
+	require.Error(t, err)
+	assert.Equal(t, uint64(1), ss.Stats().CorruptRcvd)
+}
+
+func TestSessionStats_CorruptRcvdOnMalformedPCRpt(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	// A truncated object header cannot form a valid state report.
+	malformedBody := []byte{0x00, 0x00}
+	_, err := client.Write(malformedBody)
+	require.NoError(t, err)
+
+	err = ss.handlePCRpt(pcep.CommonHeaderLength+uint16(len(malformedBody)), time.Time{})
+	require.Error(t, err)
+	assert.Equal(t, uint64(1), ss.Stats().CorruptRcvd)
+}
+
+func TestSessionStats_CorruptRcvdOnMalformedCommonHeader(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	// Version 0 is not a supported PCEP version.
+	_, err := client.Write([]byte{0x00, 0x00, 0x00, 0x04})
+	require.NoError(t, err)
+
+	_, err = ss.readCommonHeader(time.Time{})
+	require.Error(t, err)
+	assert.Equal(t, uint64(1), ss.Stats().CorruptRcvd)
+}
+
+func TestServer_PeerSetupStats_RecordsOkAndFail(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to reserve a port")
+	addr, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, ln.Close(), "failed to release the reserved port")
+
+	s := &Server{logger: zap.NewNop()}
+	go func() { _ = s.Serve(addr, port) }()
+	t.Cleanup(func() { assert.NoError(t, s.Shutdown()) })
+
+	var client net.Conn
+	require.Eventually(t, func() bool {
+		c, dialErr := net.DialTimeout("tcp", net.JoinHostPort(addr, port), 100*time.Millisecond)
+		if dialErr != nil {
+			return false
+		}
+		client = c
+		return true
+	}, 2*time.Second, 10*time.Millisecond, "expected to dial the PCEP listener once it starts")
+
+	clientAddr, err := netip.ParseAddrPort(client.LocalAddr().String())
+	require.NoError(t, err)
+	peerAddr := clientAddr.Addr()
+
+	// Establishment fails: the client disconnects before completing the Open handshake.
+	require.NoError(t, client.Close())
+
+	require.Eventually(t, func() bool {
+		_, fail := s.PeerSetupStats(peerAddr)
+		return fail == 1
+	}, 2*time.Second, 10*time.Millisecond, "expected a failed establishment to be recorded")
+
+	ok, fail := s.PeerSetupStats(peerAddr)
+	assert.Equal(t, uint64(0), ok)
+	assert.Equal(t, uint64(1), fail)
+}
+
+func TestServer_PeerSetupStats_RecordsOkOnSuccessfulEstablishment(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to reserve a port")
+	addr, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, ln.Close(), "failed to release the reserved port")
+
+	s := &Server{logger: zap.NewNop(), localKeepalive: defaultLocalKeepalive, localDeadTimer: pcep.DeadTimerFor(defaultLocalKeepalive)}
+	go func() { _ = s.Serve(addr, port) }()
+	t.Cleanup(func() { assert.NoError(t, s.Shutdown()) })
+
+	var client net.Conn
+	require.Eventually(t, func() bool {
+		c, dialErr := net.DialTimeout("tcp", net.JoinHostPort(addr, port), 100*time.Millisecond)
+		if dialErr != nil {
+			return false
+		}
+		client = c
+		return true
+	}, 2*time.Second, 10*time.Millisecond, "expected to dial the PCEP listener once it starts")
+	t.Cleanup(func() { _ = client.Close() })
+
+	clientAddr, err := netip.ParseAddrPort(client.LocalAddr().String())
+	require.NoError(t, err)
+	peerAddr := clientAddr.Addr()
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	require.Eventually(t, func() bool {
+		ok, _ := s.PeerSetupStats(peerAddr)
+		return ok == 1
+	}, 2*time.Second, 10*time.Millisecond, "expected a successful establishment to be recorded")
+
+	ok, fail := s.PeerSetupStats(peerAddr)
+	assert.Equal(t, uint64(1), ok)
+	assert.Equal(t, uint64(0), fail)
 }

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -1889,6 +1889,162 @@ func TestAwaitKeepalive_SendPCErrFailureIsLoggedNotFatal(t *testing.T) {
 	assert.NotEmpty(t, logs.FilterMessage("ERROR! Send PCErr Message").All())
 }
 
+func TestAwaitKeepalive_KeepWaitExpiresWhileReadingBody(t *testing.T) {
+	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
+	require.NoError(t, err)
+
+	// Simulate a body read timeout after receiving the header.
+	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeReport, MessageLength: pcep.CommonHeaderLength + 4}
+	conn := &fakeConn{r: &errAfterReader{prefix: append(openBytes, header.Serialize()...), err: os.ErrDeadlineExceeded}}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	err = ss.Open()
+	require.ErrorContains(t, err, "KeepWait timer expired while reading the message body")
+}
+
+func TestHandleKeepWaitPCErr_MalformedPCErrReturnsError(t *testing.T) {
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+
+	_, err := ss.handleKeepWaitPCErr([]byte{}, true)
+	require.ErrorContains(t, err, "malformed PCErr in KeepWait")
+}
+
+func TestHandleKeepWaitPCErr_OtherErrorIsReportedAsIs(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	pcerrMessage := pcep.NewPCErrMessage(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueSecondOpenStillUnacceptable, nil)
+	full, err := pcerrMessage.Serialize()
+	require.NoError(t, err)
+
+	_, err = ss.handleKeepWaitPCErr(full[pcep.CommonHeaderLength:], true)
+	require.ErrorContains(t, err, "peer rejected session establishment")
+}
+
+func TestHandleKeepWaitPCErr_NegotiableProposalIsFoundBehindOtherErrors(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss.allowNegotiation = true
+
+	pcerrMessage := &pcep.PCErrMessage{
+		Errors: []*pcep.ErrorObject{
+			pcep.NewErrorObject(pcepErrorTypeCapabilityNotSupported, pcepErrorValueUnassigned, nil),
+			pcep.NewErrorObject(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, nil),
+		},
+		Open: pcep.NewOpenObject(1, 20, 80, nil),
+	}
+	full, err := pcerrMessage.Serialize()
+	require.NoError(t, err)
+
+	retry, err := ss.handleKeepWaitPCErr(full[pcep.CommonHeaderLength:], true)
+	require.NoError(t, err)
+	assert.True(t, retry, "an Error 1/4 must drive renegotiation even when it is not the first PCEP-ERROR object")
+	assert.Equal(t, uint8(20), ss.localKeepalive)
+}
+
+func TestHandleKeepWaitPCErr_AllErrorsAreReported(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	pcerrMessage := &pcep.PCErrMessage{
+		Errors: []*pcep.ErrorObject{
+			pcep.NewErrorObject(pcepErrorTypeCapabilityNotSupported, pcepErrorValueUnassigned, nil),
+			pcep.NewErrorObject(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNonNegotiable, nil),
+		},
+	}
+	full, err := pcerrMessage.Serialize()
+	require.NoError(t, err)
+
+	_, err = ss.handleKeepWaitPCErr(full[pcep.CommonHeaderLength:], true)
+	require.ErrorContains(t, err, "error-type=2, error-value=0")
+	require.ErrorContains(t, err, "error-type=1, error-value=3")
+	assert.Zero(t, conn.writeCount, "a non-negotiable rejection must not be answered with PCErr 1/6")
+}
+
+func TestOpen_RetriesAfterAcceptablePCErrProposal(t *testing.T) {
+	peerOpenBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
+	require.NoError(t, err)
+
+	proposedOpen := pcep.NewOpenObject(1, 20, 80, nil)
+	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, proposedOpen)
+	pcerrBytes, err := pcerrMessage.Serialize()
+	require.NoError(t, err)
+
+	keepaliveBytes, err := pcep.NewKeepaliveMessage().Serialize()
+	require.NoError(t, err)
+
+	stream := append(append(peerOpenBytes, pcerrBytes...), keepaliveBytes...)
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	require.NoError(t, ss.Open(), "Open must retry with the peer's acceptable proposal instead of failing")
+	assert.Equal(t, uint8(20), ss.localKeepalive)
+	assert.Equal(t, uint8(80), ss.localDeadTimer)
+}
+
+func TestHandleProposedOpen_UnacceptableProposalIsRejected(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	proposedOpen := pcep.NewOpenObject(1, 50, 10, nil)
+	retry, err := ss.handleProposedOpen(proposedOpen, true)
+	assert.False(t, retry)
+	require.ErrorContains(t, err, "peer proposed unacceptable session characteristics")
+}
+
+func TestHandleProposedOpen_MissingOpenObjectIsRejected(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	retry, err := ss.handleProposedOpen(nil, true)
+	assert.False(t, retry)
+	require.ErrorContains(t, err, "without proposing acceptable ones")
+}
+
+func TestHandleProposedOpen_FurtherProposalAfterRetryIsRejected(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	retry, err := ss.handleProposedOpen(pcep.NewOpenObject(1, 20, 80, nil), false)
+	assert.False(t, retry)
+	require.ErrorContains(t, err, "further proposal")
+	assert.Equal(t, 1, conn.writeCount, "an exhausted negotiation must be answered with PCErr 1/6")
+}
+
+func TestOpen_RejectsSecondProposalWithErrorValue6(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	proposedOpen := pcep.NewOpenObject(1, 20, 80, nil)
+	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, proposedOpen)
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+	writeMessage(t, client, pcerrMessage)
+	writeMessage(t, client, pcerrMessage)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- ss.Open() }()
+
+	for range 4 {
+		require.NoError(t, readPCEPMessage(client))
+	}
+
+	rejection := readPCErrMessage(t, client)
+	require.Len(t, rejection.Errors, 1)
+	assert.Equal(t, pcepErrorTypeSessionEstablishmentFailure, rejection.Errors[0].ErrorType)
+	assert.Equal(t, pcepErrorValueUnacceptableProposal, rejection.Errors[0].ErrorValue)
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "further proposal")
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Open did not return after rejecting the second proposal")
+	}
+	assert.False(t, ss.Up())
+}
+
 func TestReceiveOpen_OpenWaitExpiresWhileReadingBody(t *testing.T) {
 	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeOpen, MessageLength: pcep.CommonHeaderLength + 10}
 	conn := &fakeConn{r: &errAfterReader{prefix: header.Serialize(), err: os.ErrDeadlineExceeded}}

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -3503,6 +3503,98 @@ func TestHandleUnsupportedMessage_SendCloseFailureStillReturnsError(t *testing.T
 		"the too-many-unknown-messages error must surface even when sending the Close message fails")
 }
 
+func TestReceivePCEPMessage_OpenAfterSessionUpIsRejectedWithErrorValue1(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.pccOpen = &OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}
+	ss.setState(sessionStateUp)
+
+	writeMessage(t, client, pcep.NewOpenMessage(2, 60, 240, nil))
+	writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
+
+	require.NoError(t, ss.ReceivePCEPMessage(), "an Open received while Up must not abort the receive loop")
+
+	pcerrMessage := readPCErrMessage(t, client)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, pcepErrorTypeSessionEstablishmentFailure, pcerrMessage.Errors[0].ErrorType,
+		"expected Error-Type 1 (PCEP session establishment failure), not Error-Type 2 (Capability not supported)")
+	assert.Equal(t, pcepErrorValueInvalidOpenMessage, pcerrMessage.Errors[0].ErrorValue,
+		"expected Error-value 1 (reception of an invalid Open message)")
+}
+
+func TestReceivePCEPMessage_OpenAfterSessionUpDoesNotOverwriteNegotiatedOpen(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.pccOpen = &OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}
+	ss.setState(sessionStateUp)
+
+	writeMessage(t, client, pcep.NewOpenMessage(2, 60, 240, nil))
+	writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
+
+	require.NoError(t, ss.ReceivePCEPMessage())
+	readPCErrMessage(t, client)
+
+	pccOpen, ok := ss.PccOpen()
+	require.True(t, ok)
+	assert.Equal(t, OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pccOpen,
+		"the already negotiated Open parameters must not be overwritten by a later Open")
+}
+
+func TestReceivePCEPMessage_OpenAfterSessionUpDoesNotDisruptSubsequentMessageHandling(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.pccOpen = &OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}
+	ss.setState(sessionStateUp)
+
+	writeMessage(t, client, pcep.NewOpenMessage(2, 60, 240, nil))
+	writeStateReportMessage(t, client, newTestStateReport(t, 5, 0))
+	writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
+
+	require.NoError(t, ss.ReceivePCEPMessage())
+	readPCErrMessage(t, client)
+
+	_, found := ss.SearchSRPolicy(5)
+	assert.True(t, found, "the PCRpt following an unexpected Open must still be processed")
+}
+
+func TestReceivePCEPMessage_UnexpectedOpenMessageBodyReadError(t *testing.T) {
+	openMsg := pcep.NewOpenMessage(2, 60, 240, nil)
+	msgBytes, err := openMsg.Serialize()
+	require.NoError(t, err)
+
+	headerOnly := msgBytes[:pcep.CommonHeaderLength]
+	conn := &fakeConn{r: bytes.NewReader(headerOnly)}
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss.pccOpen = &OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}
+	ss.setState(sessionStateUp)
+
+	err = ss.ReceivePCEPMessage()
+	require.Error(t, err, "reading incomplete Open message body should return an error")
+	assert.ErrorIs(t, err, io.EOF, "expected io.EOF when Open message body is missing")
+}
+
 // RFC 5440 §6.9: close the session when unrecognized messages exceed the allowed rate.
 func TestReceivePCEPMessage_TooManyUnknownMessagesClosesSession(t *testing.T) {
 	server, client := newTCPConnPair(t)

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"net"
 	"net/netip"
+	"os"
 	"slices"
 	"sync"
 	"testing"
@@ -21,11 +22,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	pb "github.com/nttcom/pola/api/pola/v1"
 	"github.com/nttcom/pola/pkg/packet/pcep"
 	"github.com/nttcom/pola/pkg/table"
 )
+
+// testLocalOpen returns the default local Open parameters for tests.
+func testLocalOpen(sessionID uint8) OpenParams {
+	return OpenParams{
+		SessionID: sessionID,
+		Keepalive: defaultLocalKeepalive,
+		DeadTimer: pcep.DeadTimerFor(defaultLocalKeepalive),
+	}
+}
 
 // newTCPConnPair returns a connected TCP connection pair over loopback.
 func newTCPConnPair(t *testing.T) (server, client *net.TCPConn) {
@@ -117,7 +128,7 @@ func newTestStateReport(t *testing.T, plspID uint32, srpID uint32) *pcep.StateRe
 
 // A PCC may report an SR Policy with SRP-ID 0 even when TED is unavailable.
 func TestHandleStateReportWithoutTED(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
@@ -129,7 +140,7 @@ func TestHandleStateReportWithoutTED(t *testing.T) {
 }
 
 func TestSRPolicies_SnapshotSegmentListIsIndependent(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
@@ -147,7 +158,7 @@ func TestSRPolicies_SnapshotSegmentListIsIndependent(t *testing.T) {
 }
 
 func TestSRPolicies_SnapshotSRv6StructureIsIndependent(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 
 	srv6Seg := table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1005::"))
 	srv6Seg.Structure = table.SIDStructureBytes{32, 16, 0, 80}
@@ -170,7 +181,7 @@ func TestSRPolicies_SnapshotSRv6StructureIsIndependent(t *testing.T) {
 }
 
 func TestSRPolicyIntent_AttachedOnCreationBySRPID(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 7)
 
 	ss.rememberSRPolicyIntent(7, table.PolicyTypeDynamic, table.TEMetric)
@@ -184,7 +195,7 @@ func TestSRPolicyIntent_AttachedOnCreationBySRPID(t *testing.T) {
 }
 
 func TestSRPolicyIntent_AttachedOnUpdateBySRPID(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeExplicit, table.UnspecifiedMetric)
 	sr := newTestStateReport(t, 1, 1)
@@ -207,7 +218,7 @@ func TestSRPolicyIntent_AttachedOnUpdateBySRPID(t *testing.T) {
 }
 
 func TestSRPolicyIntent_UnknownWhenNeverRemembered(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
@@ -219,7 +230,7 @@ func TestSRPolicyIntent_UnknownWhenNeverRemembered(t *testing.T) {
 }
 
 func TestSRPolicyIntent_IndependentPerSRPID(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeExplicit, table.UnspecifiedMetric)
 	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
@@ -247,7 +258,7 @@ func TestSRPolicyIntent_IndependentPerSRPID(t *testing.T) {
 }
 
 func TestSRPolicyIntent_UnsolicitedPCRptDoesNotConsume(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
 
 	sr := newTestStateReport(t, 1, 0)
@@ -262,7 +273,7 @@ func TestSRPolicyIntent_UnsolicitedPCRptDoesNotConsume(t *testing.T) {
 }
 
 func TestSRPolicyIntent_ClearedOnRFlagDelete(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 
 	// Create the policy unsolicited so its creation does not consume the intent below.
 	sr := newTestStateReport(t, 1, 0)
@@ -282,7 +293,7 @@ func TestSRPolicyIntent_ClearedOnRFlagDelete(t *testing.T) {
 }
 
 func TestHandlePCErr_ForgetsReportedSRPIDIntents(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
 	ss.rememberSRPolicyIntent(2, table.PolicyTypeExplicit, table.UnspecifiedMetric)
 
@@ -305,7 +316,7 @@ func TestSendSRPolicyRequest_ForgetsIntentOnSendFailure(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 	ss.isSynced = true
 	wantSRPID := ss.srpIDHead
 
@@ -341,7 +352,7 @@ func TestCloseSession_ClearsSRPolicyIntents(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
 
 	s := &Server{sessionList: []*Session{ss}, logger: zap.NewNop()}
@@ -374,7 +385,7 @@ func TestConcurrentSRPolicyRequestsAllocateUniqueSRPIDs(t *testing.T) {
 		<-done
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	const goroutines = 20
 	var wg sync.WaitGroup
@@ -415,7 +426,7 @@ func TestConcurrentSRPolicyRequestsAllocateUniqueSRPIDs(t *testing.T) {
 }
 
 func TestAllocateSRPID_SkipsReservedValues(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srpIDHead = math.MaxUint32 - 1
 
 	for i, want := range []uint32{math.MaxUint32 - 1, 1, 2} {
@@ -428,7 +439,7 @@ func TestAllocateSRPID_SkipsReservedValues(t *testing.T) {
 
 // The same report with the R-Flag set removes the SR Policy instead of registering it.
 func TestHandleStateReportRemove(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
@@ -456,13 +467,13 @@ func TestReceiveOpenSeparatesPccAndPolaCapabilities(t *testing.T) {
 			ColorCapability:     true,
 		},
 	}
-	openMessage := pcep.NewOpenMessage(1, 30, pccCaps)
+	openMessage := pcep.NewOpenMessage(1, 30, pcep.DeadTimerFor(30), pccCaps)
 	byteOpenMessage, err := openMessage.Serialize()
 	require.NoError(t, err, "failed to serialize open message")
 	_, err = client.Write(byteOpenMessage)
 	require.NoError(t, err, "failed to write open message")
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 	require.NoError(t, ss.ReceiveOpen())
 
 	assert.Equal(t, pccCaps, ss.receivedPccCapabilities)
@@ -481,7 +492,7 @@ func TestReceiveOpenSeparatesPccAndPolaCapabilities(t *testing.T) {
 }
 
 func TestSweepExpiredSRPolicyIntents_RemovesExpired(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srPolicyIntentsMu.Lock()
 	ss.srPolicyIntents = map[uint32]srPolicyIntent{
 		1: {polType: table.PolicyTypeDynamic, metric: table.TEMetric, expiresAt: time.Now().Add(-time.Second)},
@@ -495,7 +506,7 @@ func TestSweepExpiredSRPolicyIntents_RemovesExpired(t *testing.T) {
 }
 
 func TestSweepExpiredSRPolicyIntents_KeepsUnexpired(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srPolicyIntentsMu.Lock()
 	ss.srPolicyIntents = map[uint32]srPolicyIntent{
 		1: {polType: table.PolicyTypeDynamic, metric: table.TEMetric, expiresAt: time.Now().Add(time.Hour)},
@@ -509,7 +520,7 @@ func TestSweepExpiredSRPolicyIntents_KeepsUnexpired(t *testing.T) {
 }
 
 func TestSweepExpiredSRPolicyIntents_KeepsUnrelatedIntent(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
 	ss.rememberSRPolicyIntent(2, table.PolicyTypeExplicit, table.UnspecifiedMetric)
 
@@ -523,7 +534,7 @@ func TestSweepExpiredSRPolicyIntents_KeepsUnrelatedIntent(t *testing.T) {
 }
 
 func TestIntentSweep_RunsInBackgroundAndStopsCleanly(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srPolicyIntentTTL = 10 * time.Millisecond
 	ss.sweepInterval = 5 * time.Millisecond
 
@@ -538,13 +549,13 @@ func TestIntentSweep_RunsInBackgroundAndStopsCleanly(t *testing.T) {
 }
 
 func TestRememberSRPolicyIntent_IgnoresReservedSRPID(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.rememberSRPolicyIntent(0, table.PolicyTypeDynamic, table.TEMetric)
 	assert.False(t, ss.srPolicyIntentExists(0))
 }
 
 func TestStartIntentSweep_Idempotent(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.startIntentSweep()
 	firstStop := ss.sweepStop
 	ss.startIntentSweep()
@@ -554,12 +565,12 @@ func TestStartIntentSweep_Idempotent(t *testing.T) {
 }
 
 func TestStopIntentSweep_NoopWhenNeverStarted(_ *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.stopIntentSweep()
 }
 
 func TestIntentSweep_StopsCleanly(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.startIntentSweep()
 
 	done := make(chan struct{})
@@ -576,7 +587,7 @@ func TestIntentSweep_StopsCleanly(t *testing.T) {
 }
 
 func TestIntentSweep_ConcurrentWithIntentConsumption(_ *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srPolicyIntentTTL = 5 * time.Millisecond
 	ss.sweepInterval = 2 * time.Millisecond
 	ss.startIntentSweep()
@@ -609,7 +620,7 @@ func TestNextUnusedSRPID_ErrorsWhenExhausted(t *testing.T) {
 }
 
 func TestAllocateSRPID_SkipsInUseIDsOnWraparound(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srpIDHead = math.MaxUint32 - 1
 
 	// Pre-occupy SRP-ID 1 so the wraparound scan must skip over it.
@@ -628,7 +639,7 @@ func TestAllocateSRPID_SkipsInUseIDsOnWraparound(t *testing.T) {
 }
 
 func TestAllocateSRPID_ErrorsWhenExhausted(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srpIDMax = 3 // valid range is [1, 2]; 0 and 3 are reserved.
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
 	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
@@ -638,7 +649,7 @@ func TestAllocateSRPID_ErrorsWhenExhausted(t *testing.T) {
 }
 
 func TestSendPCInitiate_ErrorsWhenSRPIDExhausted(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srpIDMax = 3
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
 	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
@@ -655,7 +666,7 @@ func TestSendPCInitiate_ErrorsWhenSRPIDExhausted(t *testing.T) {
 }
 
 func TestSendPCUpdate_ErrorsWhenSRPIDExhausted(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.srpIDMax = 3
 	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
 	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
@@ -785,7 +796,7 @@ func TestSendPCEPMessage_ConcurrentSendsDoNotInterleave(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	const goroutines = 40
 
@@ -807,7 +818,7 @@ func TestSendPCEPMessage_UnlocksAfterSendFailure(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	require.NoError(t, server.Close(), "failed to close server connection")
 
@@ -827,7 +838,7 @@ func TestSendPCEPMessage_UnlocksAfterSendFailure(t *testing.T) {
 }
 
 func TestSearchPlspID_FindsByColorAndEndpoint(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	endpoint := netip.MustParseAddr("10.255.0.2")
 	ss.srPolicies = append(ss.srPolicies,
 		table.NewSRPolicy(1, "pe01-policy1", nil, netip.MustParseAddr("10.255.0.1"), endpoint, 100, 0, 0, table.PolicyUp),
@@ -840,7 +851,7 @@ func TestSearchPlspID_FindsByColorAndEndpoint(t *testing.T) {
 }
 
 func TestSearchPlspID_NotFoundWhenColorOrEndpointDiffer(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	endpoint := netip.MustParseAddr("10.255.0.2")
 	ss.srPolicies = append(ss.srPolicies,
 		table.NewSRPolicy(1, "pe01-policy1", nil, netip.MustParseAddr("10.255.0.1"), endpoint, 100, 0, 0, table.PolicyUp),
@@ -920,7 +931,7 @@ func TestExtractSrcDstRouterIDs(t *testing.T) {
 	dstNode := table.NewLsNode(0, "10.255.0.2")
 	ted.Nodes[dstNode.RouterID] = dstNode
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
 
 	sr := newTestStateReport(t, 1, 0)
 	srcRouterID, dstRouterID, err := ss.extractSrcDstRouterIDs(*sr)
@@ -931,7 +942,7 @@ func TestExtractSrcDstRouterIDs(t *testing.T) {
 
 func TestExtractSrcDstRouterIDs_AddressNotFound(t *testing.T) {
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
 
 	sr := newTestStateReport(t, 1, 0)
 	_, _, err := ss.extractSrcDstRouterIDs(*sr)
@@ -940,7 +951,7 @@ func TestExtractSrcDstRouterIDs_AddressNotFound(t *testing.T) {
 
 func TestExtractSrcDstRouterIDs_InvalidAddresses(t *testing.T) {
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = netip.Addr{}
@@ -955,7 +966,7 @@ func TestExtractSrcDstRouterIDs_DestinationNotFound(t *testing.T) {
 	srcNode := table.NewLsNode(0, "10.255.0.1")
 	ted.Nodes[srcNode.RouterID] = srcNode
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	_, _, err := ss.extractSrcDstRouterIDs(*sr)
@@ -968,6 +979,280 @@ func writeMessage(t *testing.T, w io.Writer, message pcep.Message) {
 	require.NoError(t, err, "failed to serialize message")
 	_, err = w.Write(b)
 	require.NoError(t, err, "failed to write message")
+}
+
+func readOpenMessage(t *testing.T, r io.Reader) *pcep.OpenMessage {
+	t.Helper()
+
+	headerBytes := make([]byte, pcep.CommonHeaderLength)
+	_, err := io.ReadFull(r, headerBytes)
+	require.NoError(t, err, "failed to read common header")
+
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(headerBytes))
+	require.Equal(t, pcep.MessageTypeOpen, header.MessageType)
+
+	body := make([]byte, int(header.MessageLength)-int(pcep.CommonHeaderLength))
+	_, err = io.ReadFull(r, body)
+	require.NoError(t, err, "failed to read message body")
+
+	openMessage := &pcep.OpenMessage{}
+	require.NoError(t, openMessage.DecodeFromBytes(body))
+	return openMessage
+}
+
+func TestSendOpen_StoresWireValuesAsLocalOpen(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+	})
+
+	ss := NewSession(testLocalOpen(7), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	_, ok := ss.LocalOpen()
+	require.False(t, ok, "nothing is advertised before the Open message is sent")
+
+	require.NoError(t, ss.SendOpen())
+
+	sent := readOpenMessage(t, client)
+	localOpen, ok := ss.LocalOpen()
+	require.True(t, ok)
+	assert.Equal(t, sent.OpenObject.Sid, localOpen.SessionID, "local SID must match the value actually sent")
+	assert.Equal(t, sent.OpenObject.Keepalive, localOpen.Keepalive, "local Keepalive must match the value actually sent")
+	assert.Equal(t, sent.OpenObject.Deadtime, localOpen.DeadTimer, "local DeadTimer must match the value actually sent")
+	assert.Equal(t, uint8(7), localOpen.SessionID)
+	assert.Equal(t, defaultLocalKeepalive, localOpen.Keepalive)
+	assert.Equal(t, pcep.DeadTimerFor(defaultLocalKeepalive), localOpen.DeadTimer)
+}
+
+func TestSendOpen_AdvertisesConfiguredTimers(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+	t.Cleanup(func() { assert.NoError(t, server.Close()) })
+
+	// RFC 5440 §8.1: the local Keepalive and DeadTimer are configurable.
+	local := OpenParams{SessionID: 1, Keepalive: 5, DeadTimer: 60}
+	ss := NewSession(local, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	require.NoError(t, ss.SendOpen())
+
+	sent := readOpenMessage(t, client)
+	assert.Equal(t, uint8(5), sent.OpenObject.Keepalive)
+	assert.Equal(t, uint8(60), sent.OpenObject.Deadtime)
+}
+
+func TestSendOpen_ErrorPropagatesFromSendFailure(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	require.Error(t, ss.SendOpen())
+}
+
+func TestReceiveOpen_StoresPccOpenParams(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+	})
+
+	writeMessage(t, client, pcep.NewOpenMessage(42, 10, 40, nil))
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	_, ok := ss.PccOpen()
+	require.False(t, ok, "nothing is known before the PCC's Open message arrives")
+
+	require.NoError(t, ss.ReceiveOpen())
+
+	pccOpen, ok := ss.PccOpen()
+	require.True(t, ok)
+	assert.Equal(t, OpenParams{SessionID: 42, Keepalive: 10, DeadTimer: 40}, pccOpen)
+}
+
+func TestReceiveOpen_StoresSessionIDZeroAsAdvertised(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+	t.Cleanup(func() { assert.NoError(t, server.Close()) })
+
+	writeMessage(t, client, pcep.NewOpenMessage(0, 30, 120, nil))
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	require.NoError(t, ss.ReceiveOpen())
+
+	pccOpen, ok := ss.PccOpen()
+	require.True(t, ok, "a SID of 0 must be recorded, not treated as absent")
+	assert.Zero(t, pccOpen.SessionID)
+}
+
+func TestAcceptableOpen(t *testing.T) {
+	tests := []struct {
+		name    string
+		session *Session
+		pccOpen OpenParams
+		want    bool
+	}{
+		{
+			name:    "range disabled accepts any nonconflicting keepalive",
+			session: &Session{},
+			pccOpen: OpenParams{Keepalive: 250, DeadTimer: 255},
+			want:    true,
+		},
+		{
+			name:    "deadtimer shorter than keepalive is never acceptable",
+			session: &Session{},
+			pccOpen: OpenParams{Keepalive: 30, DeadTimer: 10},
+			want:    false,
+		},
+		{
+			name:    "zero keepalive ignores deadtimer regardless of value",
+			session: &Session{},
+			pccOpen: OpenParams{Keepalive: 0, DeadTimer: 1},
+			want:    true,
+		},
+		{
+			name:    "zero deadtimer is exempt from the ratio check",
+			session: &Session{},
+			pccOpen: OpenParams{Keepalive: 30, DeadTimer: 0},
+			want:    true,
+		},
+		{
+			name:    "below the configured minimum is rejected",
+			session: &Session{keepaliveRangeEnabled: true, minKeepalive: 10, maxKeepalive: 60},
+			pccOpen: OpenParams{Keepalive: 5, DeadTimer: 20},
+			want:    false,
+		},
+		{
+			name:    "at the configured minimum is accepted",
+			session: &Session{keepaliveRangeEnabled: true, minKeepalive: 10, maxKeepalive: 60},
+			pccOpen: OpenParams{Keepalive: 10, DeadTimer: 40},
+			want:    true,
+		},
+		{
+			name:    "at the configured maximum is accepted",
+			session: &Session{keepaliveRangeEnabled: true, minKeepalive: 10, maxKeepalive: 60},
+			pccOpen: OpenParams{Keepalive: 60, DeadTimer: 240},
+			want:    true,
+		},
+		{
+			name:    "above the configured maximum is rejected",
+			session: &Session{keepaliveRangeEnabled: true, minKeepalive: 10, maxKeepalive: 60},
+			pccOpen: OpenParams{Keepalive: 61, DeadTimer: 244},
+			want:    false,
+		},
+		{
+			name:    "zero keepalive outside a strictly positive range is rejected",
+			session: &Session{keepaliveRangeEnabled: true, minKeepalive: 10, maxKeepalive: 60},
+			pccOpen: OpenParams{Keepalive: 0, DeadTimer: 0},
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.session.acceptableOpen(tt.pccOpen))
+		})
+	}
+}
+
+func TestProposedTimers(t *testing.T) {
+	tests := []struct {
+		name          string
+		session       *Session
+		pccOpen       OpenParams
+		wantKeepalive uint8
+		wantDeadTimer uint8
+	}{
+		{
+			name:          "range disabled keeps the peer's keepalive and fixes only the ratio",
+			session:       &Session{},
+			pccOpen:       OpenParams{Keepalive: 30, DeadTimer: 10},
+			wantKeepalive: 30,
+			wantDeadTimer: 120,
+		},
+		{
+			name:          "below range clamps up to the minimum",
+			session:       &Session{keepaliveRangeEnabled: true, minKeepalive: 10, maxKeepalive: 60},
+			pccOpen:       OpenParams{Keepalive: 5, DeadTimer: 20},
+			wantKeepalive: 10,
+			wantDeadTimer: 40,
+		},
+		{
+			name:          "above range clamps down to the maximum",
+			session:       &Session{keepaliveRangeEnabled: true, minKeepalive: 10, maxKeepalive: 60},
+			pccOpen:       OpenParams{Keepalive: 200, DeadTimer: 255},
+			wantKeepalive: 60,
+			wantDeadTimer: 240,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keepalive, deadTimer := tt.session.proposedTimers(tt.pccOpen)
+			assert.Equal(t, tt.wantKeepalive, keepalive)
+			assert.Equal(t, tt.wantDeadTimer, deadTimer)
+		})
+	}
+}
+
+func TestEffectiveKeepalive(t *testing.T) {
+	tests := []struct {
+		name           string
+		localKeepalive uint8
+		localDeadTimer uint8
+		want           uint8
+	}{
+		{"own dead timer disabled keeps the advertised keepalive", 30, 0, 30},
+		{"keepalive of zero stays zero", 0, 0, 0},
+		{"keepalive of zero is never overridden by a dead timer", 0, 40, 0},
+		{"a short own dead timer shortens the interval", 30, 8, 2},
+		{"a very short own dead timer floors at one second", 30, 2, 1},
+		{"a generous own dead timer keeps the advertised keepalive", 30, 200, 30},
+		{"the RFC default ratio needs no shortening", 30, 120, 30},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, effectiveKeepalive(tt.localKeepalive, tt.localDeadTimer))
+		})
+	}
+}
+
+func TestKeepaliveInterval_IgnoresPccAdvertisedValues(t *testing.T) {
+	// RFC 5440 §7.3: advertising 0 disables Keepalive transmissions.
+	ss := &Session{localOpen: &OpenParams{Keepalive: 30, DeadTimer: 120}}
+	assert.Equal(t, uint8(30), ss.keepaliveInterval())
+
+	ss.pccOpen = &OpenParams{Keepalive: 5, DeadTimer: 8}
+	assert.Equal(t, uint8(30), ss.keepaliveInterval())
+}
+
+func TestKeepaliveInterval_ConstrainedByOwnDeadTimer(t *testing.T) {
+	ss := &Session{localOpen: &OpenParams{Keepalive: 30, DeadTimer: 20}}
+	assert.Equal(t, uint8(5), ss.keepaliveInterval())
+}
+
+func TestKeepaliveInterval_ZeroBeforeOpenIsSent(t *testing.T) {
+	ss := &Session{}
+	assert.Zero(t, ss.keepaliveInterval())
+}
+
+func TestKeepaliveInterval_ZeroWhenPolaAdvertisedKeepaliveZero(t *testing.T) {
+	ss := &Session{localOpen: &OpenParams{Keepalive: 0, DeadTimer: 0}}
+	assert.Zero(t, ss.keepaliveInterval())
+}
+
+// handshakeBytes returns an Open message followed by its Keepalive acknowledgment.
+func handshakeBytes(t *testing.T, openMessage *pcep.OpenMessage) ([]byte, error) {
+	t.Helper()
+
+	openBytes, err := openMessage.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	keepaliveBytes, err := pcep.NewKeepaliveMessage().Serialize()
+	if err != nil {
+		return nil, err
+	}
+	return append(openBytes, keepaliveBytes...), nil
 }
 
 // writeStateReportMessage writes sr as an unsolicited PCRpt.
@@ -1000,10 +1285,9 @@ func TestOpen_Established_ReturnsWhenOpenFails(t *testing.T) {
 		assert.NoError(t, server.Close(), "failed to close server connection")
 	})
 
-	// The peer disconnects before ever sending an Open message.
 	require.NoError(t, client.Close(), "failed to close client connection")
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -1016,6 +1300,281 @@ func TestOpen_Established_ReturnsWhenOpenFails(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "Established did not return after Open failed")
 	}
+
+	assert.False(t, ss.Up())
+}
+
+func TestEstablished_StateMachineFollowsRFC5440(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	assert.Equal(t, sessionStateTCPPending, ss.State(), "a freshly accepted session is TCP pending")
+	assert.Equal(t, pb.SessionState_SESSION_STATE_TCP_PENDING, toPBSessionState(ss.State()))
+	assert.False(t, ss.Up())
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+
+	// RFC 5440 §6.2: the session is established only once both peers have received
+	// a Keepalive, so Pola stays in KeepWait until the PCC acknowledges its Open.
+	require.Eventually(t, func() bool { return ss.State() == sessionStateKeepWait }, 2*time.Second, 10*time.Millisecond,
+		"Pola must wait in KeepWait for the peer's Keepalive")
+	assert.Equal(t, pb.SessionState_SESSION_STATE_KEEP_WAIT, toPBSessionState(ss.State()))
+	assert.False(t, ss.Up(), "the session must not be up before the peer acknowledges Pola's Open")
+
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	require.Eventually(t, ss.Up, 2*time.Second, 10*time.Millisecond,
+		"the session must come up once the peer's Keepalive arrives")
+	assert.Equal(t, pb.SessionState_SESSION_STATE_UP, toPBSessionState(ss.State()))
+
+	writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after the peer sent a Close message")
+	}
+}
+
+func TestEstablished_KeepWaitExpiryReportsErrorValue7(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.keepWait = 50 * time.Millisecond
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+
+	// RFC 5440 §6.2 and Appendix A: KeepWait expiry sends PCErr Error-value=7.
+	pcerrMessage := readPCErrMessage(t, client)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, uint8(7), pcerrMessage.Errors[0].ErrorValue)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after KeepWait expired")
+	}
+	assert.False(t, ss.Up())
+}
+
+func TestEstablished_OpenWaitExpiryReportsErrorValue2(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.openWait = 50 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	// RFC 5440 §6.2 and Appendix A: OpenWait expiry sends PCErr Error-value=2.
+	pcerrMessage := readPCErrMessage(t, client)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, uint8(2), pcerrMessage.Errors[0].ErrorValue)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after OpenWait expired")
+	}
+}
+
+func TestEstablished_NonOpenFirstMessageReportsErrorValue1(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	// RFC 5440 §6.2: any message received before an Open message is an error.
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	pcerrMessage := readPCErrMessage(t, client)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorValue)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after a non-Open first message")
+	}
+}
+
+func TestEstablished_PCErrDuringKeepWaitReportsErrorValue6(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+	// Pola does not negotiate, so a proposal in KeepWait is unacceptable.
+	writeMessage(t, client, pcep.NewPCErrMessage(1, 4, nil))
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+
+	pcerrMessage := readPCErrMessage(t, client)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, uint8(6), pcerrMessage.Errors[0].ErrorValue)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after receiving a PCErr in KeepWait")
+	}
+	assert.False(t, ss.Up())
+}
+
+func TestEstablished_UnacceptableKeepaliveNonNegotiableReportsErrorValue3(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.keepaliveRangeEnabled = true
+	ss.minKeepalive, ss.maxKeepalive = 10, 60
+	ss.allowNegotiation = false
+
+	// RFC 7420 pcePcepEntityMin/MaxKeepAliveTimer: outside [10,60] is unacceptable.
+	writeMessage(t, client, pcep.NewOpenMessage(1, 5, 20, nil))
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	// RFC 5440 §6.2: negotiation disabled sends Error-Value=3 (non-negotiable).
+	pcerrMessage := readPCErrMessage(t, client)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, uint8(3), pcerrMessage.Errors[0].ErrorValue)
+	assert.Nil(t, pcerrMessage.Open, "a non-negotiable rejection carries no proposed OPEN object")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after an unacceptable, non-negotiable Open")
+	}
+	assert.False(t, ss.Up())
+}
+
+func TestEstablished_NegotiatesAcceptableKeepaliveThenEstablishes(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.keepaliveRangeEnabled = true
+	ss.minKeepalive, ss.maxKeepalive = 10, 60
+	ss.allowNegotiation = true
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 5, 20, nil))
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	// RFC 5440 §7.15: propose acceptable session characteristics with Error-Value=4.
+	pcerrMessage := readPCErrMessage(t, client)
+	require.Len(t, pcerrMessage.Errors, 1)
+	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, uint8(4), pcerrMessage.Errors[0].ErrorValue)
+	require.NotNil(t, pcerrMessage.Open, "a negotiable rejection proposes an OPEN object")
+	assert.Equal(t, uint8(10), pcerrMessage.Open.Keepalive, "the proposal clamps up to the configured minimum")
+	assert.Equal(t, uint8(40), pcerrMessage.Open.Deadtime)
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	require.Eventually(t, ss.Up, 2*time.Second, 10*time.Millisecond,
+		"the session must come up once the peer proposes acceptable session characteristics")
+
+	writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after the peer sent a Close message")
+	}
+}
+
+func TestEstablished_SecondOpenStillUnacceptableReportsErrorValue5(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss.keepaliveRangeEnabled = true
+	ss.minKeepalive, ss.maxKeepalive = 10, 60
+	ss.allowNegotiation = true
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 5, 20, nil))
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	firstErr := readPCErrMessage(t, client)
+	require.Equal(t, uint8(4), firstErr.Errors[0].ErrorValue)
+
+	writeMessage(t, client, pcep.NewOpenMessage(1, 200, 255, nil))
+
+	// RFC 5440 §6.2: a second unacceptable Open sends Error-Value=5 and gives up.
+	secondErr := readPCErrMessage(t, client)
+	require.Len(t, secondErr.Errors, 1)
+	assert.Equal(t, uint8(1), secondErr.Errors[0].ErrorType)
+	assert.Equal(t, uint8(5), secondErr.Errors[0].ErrorValue)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after a second unacceptable Open")
+	}
+	assert.False(t, ss.Up())
 }
 
 func TestEstablished_ReturnsOnCloseMessage(t *testing.T) {
@@ -1024,10 +1583,10 @@ func TestEstablished_ReturnsOnCloseMessage(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	openMessage := pcep.NewOpenMessage(1, 30, nil)
-	writeMessage(t, client, openMessage)
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -1055,10 +1614,10 @@ func TestEstablished_ZeroKeepaliveDoesNotPanic(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	openMessage := pcep.NewOpenMessage(1, 0, nil)
-	writeMessage(t, client, openMessage)
+	writeMessage(t, client, pcep.NewOpenMessage(1, 0, 0, nil))
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -1085,10 +1644,10 @@ func TestEstablished_ReturnsWhenPeerDisconnectsAbruptly(t *testing.T) {
 		assert.NoError(t, server.Close(), "failed to close server connection")
 	})
 
-	openMessage := pcep.NewOpenMessage(1, 30, nil)
-	writeMessage(t, client, openMessage)
+	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -1109,24 +1668,23 @@ func TestEstablished_ReturnsWhenPeerDisconnectsAbruptly(t *testing.T) {
 }
 
 func TestEstablished_ReturnsWhenPeriodicKeepaliveSendFails(t *testing.T) {
-	openMessage := pcep.NewOpenMessage(1, 1, nil) // 1-second keepalive interval
-	openBytes, err := openMessage.Serialize()
+	// Use a 1-second Keepalive so the periodic send fails quickly.
+	openBytes, err := handshakeBytes(t, pcep.NewOpenMessage(1, 30, 120, nil))
 	require.NoError(t, err)
 
-	// Keep the receive loop blocked until the test finishes.
+	// Block the receive loop so the test observes the periodic send failure.
 	pr, pw := io.Pipe()
 	t.Cleanup(func() {
 		assert.NoError(t, pw.Close(), "failed to close pipe writer")
 	})
 
-	// Fail the periodic keepalive send after the Open reply and initial Keepalive.
 	conn := &fakeConn{
 		r:         io.MultiReader(bytes.NewReader(openBytes), pr),
 		failAfter: 2,
 		writeErr:  errors.New("write: broken pipe"),
 	}
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(OpenParams{SessionID: 1, Keepalive: 1, DeadTimer: 4}, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -1142,8 +1700,7 @@ func TestEstablished_ReturnsWhenPeriodicKeepaliveSendFails(t *testing.T) {
 }
 
 func TestEstablished_ReturnsWhenInitialKeepaliveSendFails(t *testing.T) {
-	openMessage := pcep.NewOpenMessage(1, 30, nil)
-	openBytes, err := openMessage.Serialize()
+	openBytes, err := handshakeBytes(t, pcep.NewOpenMessage(1, 30, 120, nil))
 	require.NoError(t, err)
 
 	pr, pw := io.Pipe()
@@ -1157,7 +1714,7 @@ func TestEstablished_ReturnsWhenInitialKeepaliveSendFails(t *testing.T) {
 		writeErr:  errors.New("write: broken pipe"),
 	}
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -1240,10 +1797,142 @@ func TestReceiveOpen_MalformedOpenMessage(t *testing.T) {
 				})
 			}
 
-			ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 			assert.Error(t, ss.ReceiveOpen())
 		})
 	}
+}
+
+// errAfterReader returns prefix once, then always returns err. It allows
+// deadline-exceeded handling to be tested without waiting for a real timer.
+type errAfterReader struct {
+	prefix []byte
+	err    error
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if len(r.prefix) > 0 {
+		n := copy(p, r.prefix)
+		r.prefix = r.prefix[n:]
+		return n, nil
+	}
+	return 0, r.err
+}
+
+func TestOpen_SendOpenFailureAfterSuccessfulNegotiation(t *testing.T) {
+	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
+	require.NoError(t, err)
+
+	conn := &fakeConn{r: bytes.NewReader(openBytes), writeErr: errors.New("write: broken pipe")}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	require.Error(t, ss.Open(), "expected Open to fail once negotiation succeeds but SendOpen cannot write")
+}
+
+func TestAwaitKeepalive_ReadCommonHeaderErrorIsPropagated(t *testing.T) {
+	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
+	require.NoError(t, err)
+
+	// The peer disconnects during KeepWait without sending a Keepalive.
+	conn := &fakeConn{r: bytes.NewReader(openBytes)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	err = ss.Open()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "KeepWait timer expired", "an abrupt disconnect is not a timer expiry")
+}
+
+func TestAwaitKeepalive_TruncatedMessageBodyReturnsError(t *testing.T) {
+	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
+	require.NoError(t, err)
+
+	truncated := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeReport, MessageLength: pcep.CommonHeaderLength + 4}
+	stream := append([]byte{}, openBytes...)
+	stream = append(stream, truncated.Serialize()...)
+	stream = append(stream, 0x00, 0x00)
+
+	conn := &fakeConn{r: bytes.NewReader(stream)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	require.Error(t, ss.Open(), "expected a truncated KeepWait message body to be reported as an error")
+}
+
+func TestAwaitKeepalive_UnexpectedMessageTypeIsRejected(t *testing.T) {
+	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
+	require.NoError(t, err)
+	closeBytes, err := pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided).Serialize()
+	require.NoError(t, err)
+
+	conn := &fakeConn{r: bytes.NewReader(append(openBytes, closeBytes...))}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	err = ss.Open()
+	assert.ErrorContains(t, err, "expected a Keepalive or PCErr message in KeepWait")
+}
+
+func TestAwaitKeepalive_SendPCErrFailureIsLoggedNotFatal(t *testing.T) {
+	openBytes, err := pcep.NewOpenMessage(1, 30, 120, nil).Serialize()
+	require.NoError(t, err)
+
+	// Allow the Open and Keepalive writes to succeed; fail the KeepWait-expiry PCErr.
+	conn := &fakeConn{
+		r:         &errAfterReader{prefix: openBytes, err: os.ErrDeadlineExceeded},
+		failAfter: 2,
+		writeErr:  errors.New("write: broken pipe"),
+	}
+	core, logs := observer.New(zap.DebugLevel)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.New(core), nil, 0)
+
+	err = ss.Open()
+	require.ErrorContains(t, err, "KeepWait timer expired",
+		"the session must still report timer expiry even though the best-effort PCErr send failed")
+	assert.NotEmpty(t, logs.FilterMessage("ERROR! Send PCErr Message").All())
+}
+
+func TestReceiveOpen_OpenWaitExpiresWhileReadingBody(t *testing.T) {
+	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeOpen, MessageLength: pcep.CommonHeaderLength + 10}
+	conn := &fakeConn{r: &errAfterReader{prefix: header.Serialize(), err: os.ErrDeadlineExceeded}}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	err := ss.ReceiveOpen()
+	assert.ErrorContains(t, err, "OpenWait timer expired before the Open message was complete")
+}
+
+func TestNegotiateOpen_ProposeAcceptableOpenSendFailure(t *testing.T) {
+	openBytes, err := pcep.NewOpenMessage(1, 5, 20, nil).Serialize()
+	require.NoError(t, err)
+
+	conn := &fakeConn{r: bytes.NewReader(openBytes), writeErr: errors.New("write: broken pipe")}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss.keepaliveRangeEnabled = true
+	ss.minKeepalive, ss.maxKeepalive = 10, 60
+	ss.allowNegotiation = true
+
+	require.Error(t, ss.negotiateOpen(), "expected negotiateOpen to fail once proposeAcceptableOpen cannot send")
+}
+
+func TestNegotiateOpen_SecondReceiveOpenFailure(t *testing.T) {
+	openBytes, err := pcep.NewOpenMessage(1, 5, 20, nil).Serialize()
+	require.NoError(t, err)
+
+	conn := &fakeConn{r: bytes.NewReader(openBytes)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss.keepaliveRangeEnabled = true
+	ss.minKeepalive, ss.maxKeepalive = 10, 60
+	ss.allowNegotiation = true
+
+	require.Error(t, ss.negotiateOpen(), "expected negotiateOpen to fail once the peer's second Open never arrives")
+}
+
+func TestReceivePCEPMessage_SendCloseFailureIsLoggedNotFatal(t *testing.T) {
+	conn := &fakeConn{r: &errAfterReader{err: os.ErrDeadlineExceeded}, writeErr: errors.New("write: broken pipe")}
+	core, logs := observer.New(zap.DebugLevel)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.New(core), nil, 0)
+	ss.pccOpen = &OpenParams{Keepalive: 1, DeadTimer: 1}
+
+	err := ss.ReceivePCEPMessage()
+	require.Error(t, err, "the DeadTimer expiry error must still be returned even if the Close send fails")
+	assert.NotEmpty(t, logs.FilterMessage("ERROR! Send Close Message").All())
 }
 
 func TestReceivePCEPMessage_ProcessesMessagesThenReturnsOnClose(t *testing.T) {
@@ -1255,7 +1944,7 @@ func TestReceivePCEPMessage_ProcessesMessagesThenReturnsOnClose(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 	ss.rememberSRPolicyIntent(9, table.PolicyTypeExplicit, table.UnspecifiedMetric)
 
 	keepaliveMessage := pcep.NewKeepaliveMessage()
@@ -1294,32 +1983,113 @@ func TestReadCommonHeader_TimesOutOnStalledPeer(t *testing.T) {
 		assert.NoError(t, server.Close(), "failed to close server connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
-	ss.keepAlive = 1 // shrinks the dead timer to a few seconds so the test stays fast
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	// The DeadTimer the PCC advertised bounds the read (RFC 5440 §7.3).
+	ss.pccOpen = &OpenParams{Keepalive: 1, DeadTimer: 1}
 
 	_, err := client.Write([]byte{0x20, 0x01}) // half of a 4-byte common header
 	require.NoError(t, err)
 
 	start := time.Now()
-	_, _, err = ss.readCommonHeader()
+	_, err = ss.readCommonHeader(ss.messageDeadline())
 	elapsed := time.Since(start)
 
 	require.Error(t, err, "a stalled peer must not block the read indefinitely")
-	assert.Less(t, elapsed, 10*time.Second, "read should time out near the negotiated dead timer, not hang")
+	assert.Less(t, elapsed, 10*time.Second, "read should time out near the PCC's dead timer, not hang")
 }
 
-func TestReadDeadline_MatchesAdvertisedDeadTimer(t *testing.T) {
+func TestReadDeadline_UsesPccAdvertisedDeadTimer(t *testing.T) {
 	tests := []struct {
-		keepAlive uint8
-		want      time.Duration
+		name    string
+		pccOpen *OpenParams
+		want    time.Duration
 	}{
-		{0, 0},
-		{30, 120 * time.Second},
-		{65, time.Duration(math.MaxUint8) * time.Second},
+		{"no Open received yet", nil, 0},
+		{"PCC dead timer is used verbatim", &OpenParams{Keepalive: 30, DeadTimer: 120}, 120 * time.Second},
+		{"maximum PCC dead timer", &OpenParams{Keepalive: 60, DeadTimer: math.MaxUint8}, time.Duration(math.MaxUint8) * time.Second},
+		// RFC 5440 §7.3: the DeadTimer MUST be ignored when the Keepalive is 0, and
+		// RFC 5440 §6.3 forbids declaring such a session inactive.
+		{"PCC keepalive of zero disables the deadline", &OpenParams{Keepalive: 0, DeadTimer: 120}, 0},
+		{"PCC dead timer of zero disables the deadline", &OpenParams{Keepalive: 30, DeadTimer: 0}, 0},
 	}
 	for _, tt := range tests {
-		ss := &Session{keepAlive: tt.keepAlive}
-		assert.Equal(t, tt.want, ss.readDeadline())
+		t.Run(tt.name, func(t *testing.T) {
+			ss := &Session{pccOpen: tt.pccOpen}
+			assert.Equal(t, tt.want, ss.readDeadline())
+		})
+	}
+}
+
+func TestReadDeadline_IgnoresLocalDeadTimer(t *testing.T) {
+	// Pola's own DeadTimer tells the PCC when to declare Pola down; it must never
+	// bound Pola's own reads (RFC 5440 §7.3).
+	ss := &Session{
+		localOpen: &OpenParams{Keepalive: 30, DeadTimer: 120},
+		pccOpen:   &OpenParams{Keepalive: 0, DeadTimer: 0},
+	}
+	assert.Zero(t, ss.readDeadline())
+
+	ss.pccOpen = &OpenParams{Keepalive: 10, DeadTimer: 40}
+	assert.Equal(t, 40*time.Second, ss.readDeadline())
+}
+
+func TestEstablished_DoesNotTimeOutAPccThatSendsNoKeepalives(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	// RFC 5440 §6.3: a peer that advertises Keepalive=0 sends none, and the
+	// receiver MUST NOT declare the session inactive.
+	writeMessage(t, client, pcep.NewOpenMessage(1, 0, 0, nil))
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read initial Keepalive")
+	require.Eventually(t, ss.Up, 2*time.Second, 10*time.Millisecond)
+
+	assert.Zero(t, ss.readDeadline(), "a PCC advertising Keepalive=0 must never be timed out")
+
+	select {
+	case <-done:
+		require.Fail(t, "Established must not return while the silent peer is still connected")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func TestEstablished_SendsCloseWhenTheDeadTimerExpires(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	// A 1-second DeadTimer from the PCC keeps the test fast.
+	writeMessage(t, client, pcep.NewOpenMessage(1, 1, 1, nil))
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	ss := NewSession(OpenParams{SessionID: 1, Keepalive: 0, DeadTimer: 0}, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	done := make(chan struct{})
+	go func() {
+		ss.Established()
+		close(done)
+	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read initial Keepalive")
+
+	// RFC 5440 §6.8 and Appendix A: DeadTimer expiry terminates the session.
+	closeMessage := readCloseMessage(t, client)
+	assert.Equal(t, pcep.CloseReasonDeadTimerExpired, closeMessage.CloseObject.Reason)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after the DeadTimer expired")
 	}
 }
 
@@ -1327,7 +2097,7 @@ func TestReadFullWithDeadline_SetReadDeadlineErrorIsPropagated(t *testing.T) {
 	wantErr := errors.New("use of closed network connection")
 	conn := &fakeConn{r: bytes.NewReader(nil), setReadDeadlineErr: wantErr}
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
 	err := ss.readFullWithDeadline(make([]byte, pcep.CommonHeaderLength), ss.messageDeadline())
 	assert.ErrorIs(t, err, wantErr, "readFullWithDeadline must surface a failure to set the read deadline instead of attempting the read")
@@ -1342,7 +2112,7 @@ func TestReceivePCEPMessage_StateReportHandlingErrorIsLoggedNotFatal(t *testing.
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	sr := newTestStateReport(t, 7, 0)
 	byteSrp, err := sr.SrpObject.Serialize()
@@ -1441,7 +2211,7 @@ func TestReceivePCEPMessage_Errors(t *testing.T) {
 				})
 			}
 
-			ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 			assert.Error(t, ss.ReceivePCEPMessage())
 		})
 	}
@@ -1462,7 +2232,7 @@ func TestReceivePCEPMessage_ShortMessageLengthIsRejected(t *testing.T) {
 			_, err := client.Write(header.Serialize())
 			require.NoError(t, err, "failed to write header")
 
-			ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 			assert.Error(t, ss.ReceivePCEPMessage())
 		})
 	}
@@ -1482,7 +2252,7 @@ func TestReceivePCEPMessage_KeepaliveWithBodyIsRejected(t *testing.T) {
 	_, err := client.Write(append(header.Serialize(), 0x00, 0x00, 0x00, 0x00))
 	require.NoError(t, err, "failed to write keepalive with body")
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 	assert.Error(t, ss.ReceivePCEPMessage())
 }
 
@@ -1495,7 +2265,7 @@ func TestReceivePCEPMessage_UnsupportedMessageBodyIsConsumed(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	// Use a valid Close message as the body to catch framing bugs: without consuming
 	// the body, it would be parsed as the next message and stop before the PCRpt.
@@ -1514,7 +2284,7 @@ func TestReceivePCEPMessage_UnsupportedMessageBodyIsConsumed(t *testing.T) {
 
 func TestHandleUnsupportedMessage_ReadBodyErrorIsReturned(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
 	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageType(0x63), MessageLength: pcep.CommonHeaderLength + 4}
 	assert.Error(t, ss.handleUnsupportedMessage(header, ss.messageDeadline()), "a truncated unsupported message body must be reported")
@@ -1522,7 +2292,7 @@ func TestHandleUnsupportedMessage_ReadBodyErrorIsReturned(t *testing.T) {
 
 func TestHandleUnsupportedMessage_SendPCErrFailureIsLoggedNotFatal(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 
 	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageType(0x63), MessageLength: pcep.CommonHeaderLength}
 	err := ss.handleUnsupportedMessage(header, ss.messageDeadline())
@@ -1531,7 +2301,7 @@ func TestHandleUnsupportedMessage_SendPCErrFailureIsLoggedNotFatal(t *testing.T)
 
 func TestHandleUnsupportedMessage_SendCloseFailureStillReturnsError(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
 	ss.maxUnknownMsgs = 0
 
 	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageType(0x63), MessageLength: pcep.CommonHeaderLength}
@@ -1550,7 +2320,7 @@ func TestReceivePCEPMessage_TooManyUnknownMessagesClosesSession(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	for i := uint32(0); i <= ss.maxUnknownMsgs; i++ {
 		writeRawPCEPMessage(t, client, pcep.MessageType(0x63), nil)
@@ -1578,7 +2348,7 @@ func TestReceivePCEPMessage_FewUnknownMessagesToleratedWithinWindow(t *testing.T
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	for range ss.maxUnknownMsgs {
 		writeRawPCEPMessage(t, client, pcep.MessageType(0x63), nil)
@@ -1633,7 +2403,7 @@ func readCloseMessage(t *testing.T, r io.Reader) *pcep.CloseMessage {
 }
 
 func TestIsSynced_ConcurrentAccess(_ *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -1652,7 +2422,7 @@ func TestIsSynced_ConcurrentAccess(_ *testing.T) {
 // RFC 8231 §5.6: an LSP report with the S-Flag is part of state synchronization
 // and is registered regardless of PLSP-ID or SRP-ID..
 func TestHandleStateReport_Synchronization(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SFlag = true
 
@@ -1664,7 +2434,7 @@ func TestHandleStateReport_Synchronization(t *testing.T) {
 }
 
 func TestHandleStateReport_SynchronizationRegistrationFailure(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SFlag = true
 	sr.EroObject = nil
@@ -1674,7 +2444,7 @@ func TestHandleStateReport_SynchronizationRegistrationFailure(t *testing.T) {
 
 // RFC 8231 §5.6: PLSP-ID 0 marks the end of state synchronization.
 func TestHandleStateReport_FinishSynchronization(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	require.False(t, ss.IsSynced())
 
 	sr := newTestStateReport(t, 0, 0)
@@ -1684,7 +2454,7 @@ func TestHandleStateReport_FinishSynchronization(t *testing.T) {
 }
 
 func TestHandleStateReport_StatefulPCERequestRegistrationFailure(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 3) // non-zero SRP-ID uses handleStatefulPCERequest
 	sr.EroObject = nil
 
@@ -1695,7 +2465,7 @@ func TestHandleStateReport_StatefulPCERequestRegistrationFailure(t *testing.T) {
 }
 
 func TestHandleStateReport_ReportedSRPolicyRegistrationFailure(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 	sr.EroObject = nil // no TED available and no explicit path reported
 
@@ -1703,7 +2473,7 @@ func TestHandleStateReport_ReportedSRPolicyRegistrationFailure(t *testing.T) {
 }
 
 func TestComputePathFromTED_NoTED(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	_, err := ss.computePathFromTED(*sr)
@@ -1712,7 +2482,7 @@ func TestComputePathFromTED_NoTED(t *testing.T) {
 
 func TestHandleSRPolicyWithPLSPID_ExtractRouterIDsFails(t *testing.T) {
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
 	sr := newTestStateReport(t, 1, 0) // src/dst addresses are absent from the TED
 
 	assert.Error(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
@@ -1729,7 +2499,7 @@ func TestComputePathFromTED_CSPFFailsWithoutNodeSID(t *testing.T) {
 	dstNode := table.NewLsNode(0, "10.255.0.2")
 	ted.Nodes[dstNode.RouterID] = dstNode
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
 	sr := newTestStateReport(t, 1, 0)
 
 	_, err := ss.computePathFromTED(*sr)
@@ -1788,7 +2558,7 @@ func TestHandleSRPolicyWithPLSPID_CreateEroFromSegmentListErrorIsPropagated(t *t
 	srcNode, dstNode := newLinkedSRv6Nodes(srcAddr, dstAddr, 10)
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{srcNode.RouterID: srcNode, dstNode.RouterID: dstNode}}
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = srcAddr
@@ -1814,7 +2584,7 @@ func TestHandleSRPolicyWithPLSPID_ComputesPathFromTED(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), ted, 0)
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = srcAddr
@@ -1841,7 +2611,7 @@ func TestHandleSRPolicyWithPLSPID_EmptyComputedPathIsRejected(t *testing.T) {
 	node.SrgbBegin, node.SrgbEnd = 16000, 23999
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), ted, 0)
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = selfAddr
@@ -1865,7 +2635,7 @@ func TestHandleSRPolicyWithPLSPID_SendPCUpdateFailureIsPropagated(t *testing.T) 
 	})
 	require.NoError(t, server.Close(), "failed to close server connection")
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), ted, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), ted, 0)
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = srcAddr
@@ -1897,7 +2667,7 @@ func TestSelectMetricType(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 			ss.pccType = tc.pccType
 			sr := *newTestStateReport(t, 1, 0)
 			if tc.hasMetric {
@@ -1909,7 +2679,7 @@ func TestSelectMetricType(t *testing.T) {
 }
 
 func TestResolveColorPreference_CiscoLegacy(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.pccType = pcep.CiscoLegacy
 
 	sr := newTestStateReport(t, 1, 0)
@@ -1923,7 +2693,7 @@ func TestResolveColorPreference_CiscoLegacy(t *testing.T) {
 }
 
 func TestResolveColorPreference_AssociationColorTakesPrecedence(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.receivedPccCapabilities = []pcep.CapabilityInterface{&pcep.StatefulPCECapability{ColorCapability: true}}
 
 	sr := newTestStateReport(t, 1, 0)
@@ -1975,7 +2745,7 @@ func TestValidateSegmentList_EmptySegmentList(t *testing.T) {
 }
 
 func TestUpdateOrCreatePolicy_SrcAddrFallsBackToAssociationSrc(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := *newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = netip.Addr{}
 	sr.AssociationObject.AssocSrc = netip.MustParseAddr("192.0.2.9")
@@ -1988,7 +2758,7 @@ func TestUpdateOrCreatePolicy_SrcAddrFallsBackToAssociationSrc(t *testing.T) {
 }
 
 func TestUpdateOrCreatePolicy_InvalidSrcAddr(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := *newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = netip.Addr{}
 
@@ -1997,7 +2767,7 @@ func TestUpdateOrCreatePolicy_InvalidSrcAddr(t *testing.T) {
 }
 
 func TestUpdateOrCreatePolicy_DstAddrFallsBackToAssociationEndpoint(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := *newTestStateReport(t, 1, 0)
 	sr.LSPObject.DstAddr = netip.Addr{}
 	sr.AssociationObject.TLVs = append(sr.AssociationObject.TLVs,
@@ -2011,7 +2781,7 @@ func TestUpdateOrCreatePolicy_DstAddrFallsBackToAssociationEndpoint(t *testing.T
 }
 
 func TestUpdateOrCreatePolicy_InvalidDstAddr(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := *newTestStateReport(t, 1, 0)
 	sr.LSPObject.DstAddr = netip.Addr{}
 
@@ -2021,7 +2791,7 @@ func TestUpdateOrCreatePolicy_InvalidDstAddr(t *testing.T) {
 
 // RFC 8231 §7.3: a stale LSP-ID must not overwrite newer state.
 func TestUpdateOrCreatePolicy_StaleLSPIDIsIgnored(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	sr := *newTestStateReport(t, 1, 0)
 	sr.LSPObject.LSPID = 5
 	require.NoError(t, ss.updateOrCreatePolicy(sr, sr.EroObject.ToSegmentList(), 10, 20, table.PolicyUp))
@@ -2076,7 +2846,7 @@ func (failingMessage) Serialize() ([]uint8, error) {
 }
 
 func TestSendPCEPMessage_SerializeErrorIsPropagated(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	assert.Error(t, ss.sendPCEPMessage(failingMessage{}))
 }
 
@@ -2085,7 +2855,7 @@ type unknownSegment struct{}
 func (unknownSegment) SidString() string { return "unknown" }
 
 func TestSendPCInitiate_InvalidSegmentTypeIsRejected(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	wantSRPID := ss.srpIDHead
 	srPolicy := table.SRPolicy{
 		Name:        "bad-segment",
@@ -2101,7 +2871,7 @@ func TestSendPCInitiate_InvalidSegmentTypeIsRejected(t *testing.T) {
 }
 
 func TestSendPCUpdate_InvalidSegmentTypeIsRejected(t *testing.T) {
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	wantSRPID := ss.srpIDHead
 	srPolicy := table.SRPolicy{
 		Name:        "bad-segment",
@@ -2123,7 +2893,7 @@ func TestRequestAllSRPolicyDeleted(t *testing.T) {
 		assert.NoError(t, client.Close(), "failed to close client connection")
 	})
 
-	ss := NewSession(1, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
 	require.NoError(t, ss.RequestAllSRPolicyDeleted())
 	require.NoError(t, readPCEPMessage(client))

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -459,7 +459,7 @@ func TestHandleStateReportRemove(t *testing.T) {
 	assert.False(t, found, "SR Policy is still registered after being reported as removed")
 }
 
-func TestReceiveOpenSeparatesPccAndPolaCapabilities(t *testing.T) {
+func TestReceiveOpenDoesNotOverwriteAdvertisedCapabilities(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() {
 		assert.NoError(t, server.Close(), "failed to close server connection")
@@ -485,9 +485,10 @@ func TestReceiveOpenSeparatesPccAndPolaCapabilities(t *testing.T) {
 	require.NoError(t, ss.ReceiveOpen())
 
 	assert.Equal(t, pccCaps, ss.receivedPccCapabilities)
-	assert.Equal(t, pcep.PolaCapability(pccCaps), ss.advertisedCapabilities)
 	assert.Equal(t, pccCaps, ss.ReceivedCapabilities())
 	assert.Equal(t, pcep.RFCCompliant, ss.PccType())
+	assert.Equal(t, pcep.DefaultCapabilities(), ss.advertisedCapabilities)
+	assert.Equal(t, pcep.DefaultCapabilities(), ss.AdvertisedCapabilities())
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.TLVs = append(sr.LSPObject.TLVs, &pcep.Color{Color: 100})
@@ -1050,6 +1051,21 @@ func TestSendOpen_AdvertisesConfiguredTimers(t *testing.T) {
 	sent := readOpenMessage(t, client)
 	assert.Equal(t, uint8(5), sent.OpenObject.Keepalive)
 	assert.Equal(t, uint8(60), sent.OpenObject.Deadtime)
+}
+
+func TestSendOpen_AdvertisesFullCapabilitySetOnTheWire(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+	t.Cleanup(func() { assert.NoError(t, server.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	require.NoError(t, ss.SendOpen())
+
+	sent := readOpenMessage(t, client)
+	assert.Equal(t, pcep.DefaultCapabilities(), sent.OpenObject.Caps,
+		"the wire-level Open must carry Pola's complete capability set, not a partial default")
+	assert.Equal(t, pcep.DefaultCapabilities(), ss.AdvertisedCapabilities(),
+		"AdvertisedCapabilities must match what was actually sent on the wire")
 }
 
 func TestSendOpen_ErrorPropagatesFromSendFailure(t *testing.T) {
@@ -2097,6 +2113,20 @@ func TestHandleProposedOpen_UnacceptableProposalIsRejected(t *testing.T) {
 	retry, err := ss.handleProposedOpen(proposedOpen, true)
 	assert.False(t, retry)
 	require.ErrorContains(t, err, "peer proposed unacceptable session characteristics")
+}
+
+func TestHandleProposedOpen_IgnoresPCCKeepaliveRange(t *testing.T) {
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+	ss.keepaliveRangeEnabled = true
+	ss.minKeepalive, ss.maxKeepalive = 10, 60
+
+	proposedOpen := pcep.NewOpenObject(1, 5, 20, nil)
+	retry, err := ss.handleProposedOpen(proposedOpen, true)
+	require.NoError(t, err)
+	assert.True(t, retry)
+	assert.Equal(t, uint8(5), ss.localKeepalive)
+	assert.Equal(t, uint8(20), ss.localDeadTimer)
 }
 
 func TestHandleProposedOpen_MissingOpenObjectIsRejected(t *testing.T) {

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -3160,9 +3160,17 @@ func TestSessionStats_SendCountersIncrementOnSuccess(t *testing.T) {
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
 
+	require.NoError(t, ss.SendOpen())
+	require.NoError(t, readPCEPMessage(client))
+	assert.Equal(t, uint64(1), ss.Stats().OpenSent)
+
 	require.NoError(t, ss.SendKeepalive())
 	require.NoError(t, readPCEPMessage(client))
 	assert.Equal(t, uint64(1), ss.Stats().KeepaliveSent)
+
+	require.NoError(t, ss.SendClose(pcep.CloseReasonNoExplanationProvided))
+	require.NoError(t, readPCEPMessage(client))
+	assert.Equal(t, uint64(1), ss.Stats().CloseSent)
 
 	require.NoError(t, ss.SendPCErr(pcepErrorTypeCapabilityNotSupported, pcepErrorValueUnassigned))
 	require.NoError(t, readPCEPMessage(client))
@@ -3189,6 +3197,24 @@ func TestSessionStats_SendCountersIncrementOnSuccess(t *testing.T) {
 	assert.Equal(t, uint64(1), ss.Stats().PCInitiateSent)
 }
 
+func TestSessionStats_OpenRcvdIncrementsOnSuccess(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	openMessage := pcep.NewOpenMessage(1, 30, pcep.DeadTimerFor(30), nil)
+	byteOpenMessage, err := openMessage.Serialize()
+	require.NoError(t, err, "failed to serialize open message")
+	_, err = client.Write(byteOpenMessage)
+	require.NoError(t, err, "failed to write open message")
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	require.NoError(t, ss.ReceiveOpen())
+	assert.Equal(t, uint64(1), ss.Stats().OpenRcvd)
+}
+
 func TestCountReceived_IncrementsExpectedCounter(t *testing.T) {
 	cases := map[string]struct {
 		messageType pcep.MessageType
@@ -3198,6 +3224,9 @@ func TestCountReceived_IncrementsExpectedCounter(t *testing.T) {
 		"Report":       {pcep.MessageTypeReport, func(s sessionStatsSnapshot) uint64 { return s.RptRcvd }},
 		"Error":        {pcep.MessageTypeError, func(s sessionStatsSnapshot) uint64 { return s.PCErrRcvd }},
 		"Notification": {pcep.MessageTypeNotification, func(s sessionStatsSnapshot) uint64 { return s.PCNtfRcvd }},
+		"Close":        {pcep.MessageTypeClose, func(s sessionStatsSnapshot) uint64 { return s.CloseRcvd }},
+		"Pcreq":        {pcep.MessageTypePcreq, func(s sessionStatsSnapshot) uint64 { return s.PCReqRcvd }},
+		"Pcrep":        {pcep.MessageTypePcrep, func(s sessionStatsSnapshot) uint64 { return s.PCRepRcvd }},
 		"Unknown":      {pcep.MessageTypeStartTLS, func(s sessionStatsSnapshot) uint64 { return s.UnknownRcvd }},
 	}
 
@@ -3210,10 +3239,11 @@ func TestCountReceived_IncrementsExpectedCounter(t *testing.T) {
 	}
 }
 
-func TestCountReceived_CloseHasNoCounter(t *testing.T) {
+func TestCountReceived_CloseHasDedicatedCounter(t *testing.T) {
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.NewNop(), nil, 0)
 	ss.countReceived(pcep.MessageTypeClose)
 	snap := ss.Stats()
+	assert.Equal(t, uint64(1), snap.CloseRcvd)
 	assert.Zero(t, snap.UnknownRcvd, "Close must not be counted as an unrecognized message")
 	assert.Zero(t, snap.KeepaliveRcvd)
 	assert.Zero(t, snap.RptRcvd)

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -1514,6 +1514,81 @@ func TestEstablished_InvalidZeroMSDIsToleratedWithWarning(t *testing.T) {
 	}
 }
 
+func TestValidateCapabilities_ChecksSRPCECapabilityNestedInPathSetupType(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.New(core), nil, 0)
+
+	caps := []pcep.CapabilityInterface{
+		&pcep.PathSetupTypeCapability{
+			PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+			SubTLVs: []pcep.TLVInterface{
+				&pcep.SRPCECapability{},
+			},
+		},
+	}
+
+	ss.validateCapabilities(caps)
+
+	assert.Len(t, logs.FilterMessage(
+		"peer advertised SR-PCE-CAPABILITY with X=0 and MSD=0 (RFC 8664 §5.1); tolerating as a known deployed-peer deviation").All(), 1)
+}
+
+func TestValidateCapabilities_WarnsWhenSRTEAdvertisedWithoutSRCapability(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.New(core), nil, 0)
+
+	caps := []pcep.CapabilityInterface{
+		&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE}},
+	}
+
+	ss.validateCapabilities(caps)
+
+	assert.Len(t, logs.FilterMessage(
+		"peer advertised PST=1 (SR-TE) without an SR-PCE-CAPABILITY sub-TLV (RFC 8664 §4.1.2)").All(), 1)
+}
+
+func TestValidateCapabilities_WarnsWhenSRv6TEAdvertisedWithoutSRv6Capability(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.New(core), nil, 0)
+
+	caps := []pcep.CapabilityInterface{
+		&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE}},
+	}
+
+	ss.validateCapabilities(caps)
+
+	assert.Len(t, logs.FilterMessage(
+		"peer advertised PST=3 (SRv6-TE) without an SRv6-PCE-CAPABILITY sub-TLV (RFC 9603 §4.1.1)").All(), 1)
+}
+
+func TestValidateCapabilities_NoWarningWhenSRCapabilityAdvertisedAtTopLevel(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.New(core), nil, 0)
+
+	caps := []pcep.CapabilityInterface{
+		&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE}},
+		&pcep.SRPCECapability{HasUnlimitedMaxSIDDepth: true},
+	}
+
+	ss.validateCapabilities(caps)
+
+	assert.Zero(t, logs.Len())
+}
+
+func TestValidateCapabilities_NoWarningWhenSRv6CapabilityAdvertisedAtTopLevel(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, zap.New(core), nil, 0)
+
+	caps := []pcep.CapabilityInterface{
+		&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE}},
+		&pcep.SRv6PCECapability{},
+	}
+
+	ss.validateCapabilities(caps)
+
+	assert.Zero(t, logs.Len())
+}
+
 func TestEstablished_PCErrDuringKeepWaitReportsErrorValue6(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() { assert.NoError(t, client.Close()) })

--- a/pkg/server/session_test.go
+++ b/pkg/server/session_test.go
@@ -78,7 +78,8 @@ type fakeConn struct {
 
 	mu                 sync.Mutex
 	writeCount         int
-	failAfter          int // number of successful writes before writeErr is returned; ignored if writeErr is nil.
+	written            [][]byte // raw bytes passed to each Write call, in order
+	failAfter          int      // number of successful writes before writeErr; ignored if writeErr is nil
 	writeErr           error
 	setReadDeadlineErr error
 	closeErr           error
@@ -90,10 +91,18 @@ func (c *fakeConn) Write(p []byte) (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.writeCount++
+	c.written = append(c.written, append([]byte{}, p...))
 	if c.writeErr != nil && c.writeCount > c.failAfter {
 		return 0, c.writeErr
 	}
 	return len(p), nil
+}
+
+// writes returns a snapshot of the bytes passed to each Write call, in order.
+func (c *fakeConn) writes() [][]byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([][]byte{}, c.written...)
 }
 
 func (c *fakeConn) Close() error                       { return c.closeErr }
@@ -101,8 +110,7 @@ func (c *fakeConn) LocalAddr() net.Addr                { return nil }
 func (c *fakeConn) RemoteAddr() net.Addr               { return nil }
 func (c *fakeConn) SetDeadline(_ time.Time) error      { return nil }
 func (c *fakeConn) SetWriteDeadline(_ time.Time) error { return nil }
-
-func (c *fakeConn) SetReadDeadline(_ time.Time) error { return c.setReadDeadlineErr }
+func (c *fakeConn) SetReadDeadline(_ time.Time) error  { return c.setReadDeadlineErr }
 
 // newTestStateReport builds a PCRpt state report for an SR-MPLS policy with an explicit path.
 func newTestStateReport(t *testing.T, plspID uint32, srpID uint32) *pcep.StateReport {
@@ -478,6 +486,8 @@ func TestReceiveOpenSeparatesPccAndPolaCapabilities(t *testing.T) {
 
 	assert.Equal(t, pccCaps, ss.receivedPccCapabilities)
 	assert.Equal(t, pcep.PolaCapability(pccCaps), ss.advertisedCapabilities)
+	assert.Equal(t, pccCaps, ss.ReceivedCapabilities())
+	assert.Equal(t, pcep.RFCCompliant, ss.PccType())
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.TLVs = append(sr.LSPObject.TLVs, &pcep.Color{Color: 100})
@@ -1106,9 +1116,15 @@ func TestAcceptableOpen(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "zero keepalive ignores deadtimer regardless of value",
+			name:    "zero keepalive requires zero deadtimer per RFC",
 			session: &Session{},
 			pccOpen: OpenParams{Keepalive: 0, DeadTimer: 1},
+			want:    false,
+		},
+		{
+			name:    "zero keepalive with zero deadtimer is acceptable",
+			session: &Session{},
+			pccOpen: OpenParams{Keepalive: 0, DeadTimer: 0},
 			want:    true,
 		},
 		{
@@ -1183,6 +1199,13 @@ func TestProposedTimers(t *testing.T) {
 			pccOpen:       OpenParams{Keepalive: 200, DeadTimer: 255},
 			wantKeepalive: 60,
 			wantDeadTimer: 240,
+		},
+		{
+			name:          "high keepalive has deadtimer disabled when capped at 255",
+			session:       &Session{},
+			pccOpen:       OpenParams{Keepalive: 255, DeadTimer: 255},
+			wantKeepalive: 255,
+			wantDeadTimer: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -1392,6 +1415,8 @@ func TestEstablished_OpenWaitExpiryReportsErrorValue2(t *testing.T) {
 		close(done)
 	}()
 
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's initial Open")
+
 	// RFC 5440 §6.2 and Appendix A: OpenWait expiry sends PCErr Error-value=2.
 	pcerrMessage := readPCErrMessage(t, client)
 	require.Len(t, pcerrMessage.Errors, 1)
@@ -1420,6 +1445,8 @@ func TestEstablished_NonOpenFirstMessageReportsErrorValue1(t *testing.T) {
 		close(done)
 	}()
 
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's initial Open")
+
 	pcerrMessage := readPCErrMessage(t, client)
 	require.Len(t, pcerrMessage.Errors, 1)
 	assert.Equal(t, uint8(1), pcerrMessage.Errors[0].ErrorType)
@@ -1429,6 +1456,45 @@ func TestEstablished_NonOpenFirstMessageReportsErrorValue1(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "Established did not return after a non-Open first message")
+	}
+}
+
+func TestEstablished_InvalidZeroMSDIsToleratedWithWarning(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+	core, logs := observer.New(zap.WarnLevel)
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.New(core), nil, 0)
+
+	// RFC 8664 §5.1 forbids X=0 with a zero MSD, but Cisco XRd, Juniper
+	// vJunos, and FRRouting all advertise it in practice; the session must
+	// still come up.
+	pccCaps := []pcep.CapabilityInterface{&pcep.SRPCECapability{}}
+	openMessage := pcep.NewOpenMessage(1, 30, pcep.DeadTimerFor(30), pccCaps)
+	writeMessage(t, client, openMessage)
+
+	done := make(chan struct{})
+	go func() {
+		_ = ss.Established()
+		close(done)
+	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
+	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
+
+	writeMessage(t, client, pcep.NewKeepaliveMessage())
+
+	require.Eventually(t, ss.Up, 2*time.Second, 10*time.Millisecond,
+		"the session must come up despite the peer's invalid SR-PCE-CAPABILITY")
+
+	assert.Len(t, logs.FilterMessage(
+		"peer advertised SR-PCE-CAPABILITY with X=0 and MSD=0 (RFC 8664 §5.1); tolerating as a known deployed-peer deviation").All(), 1)
+
+	writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Established did not return after the peer sent a Close message")
 	}
 }
 
@@ -1482,6 +1548,8 @@ func TestEstablished_UnacceptableKeepaliveNonNegotiableReportsErrorValue3(t *tes
 		close(done)
 	}()
 
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's initial Open")
+
 	// RFC 5440 §6.2: negotiation disabled sends Error-Value=3 (non-negotiable).
 	pcerrMessage := readPCErrMessage(t, client)
 	require.Len(t, pcerrMessage.Errors, 1)
@@ -1514,6 +1582,8 @@ func TestEstablished_NegotiatesAcceptableKeepaliveThenEstablishes(t *testing.T) 
 		close(done)
 	}()
 
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's initial Open")
+
 	// RFC 5440 §7.15: propose acceptable session characteristics with Error-Value=4.
 	pcerrMessage := readPCErrMessage(t, client)
 	require.Len(t, pcerrMessage.Errors, 1)
@@ -1525,7 +1595,6 @@ func TestEstablished_NegotiatesAcceptableKeepaliveThenEstablishes(t *testing.T) 
 
 	writeMessage(t, client, pcep.NewOpenMessage(1, 30, 120, nil))
 
-	require.NoError(t, readPCEPMessage(client), "failed to read Open reply")
 	require.NoError(t, readPCEPMessage(client), "failed to read the Keepalive acknowledging the peer's Open")
 
 	writeMessage(t, client, pcep.NewKeepaliveMessage())
@@ -1557,6 +1626,8 @@ func TestEstablished_SecondOpenStillUnacceptableReportsErrorValue5(t *testing.T)
 		_ = ss.Established()
 		close(done)
 	}()
+
+	require.NoError(t, readPCEPMessage(client), "failed to read Pola's initial Open")
 
 	firstErr := readPCErrMessage(t, client)
 	require.Equal(t, uint8(4), firstErr.Errors[0].ErrorValue)
@@ -1982,6 +2053,42 @@ func TestOpen_RetriesAfterAcceptablePCErrProposal(t *testing.T) {
 	assert.Equal(t, uint8(80), ss.localDeadTimer)
 }
 
+func TestOpen_SendOpenFailsAfterRetryingWithProposal(t *testing.T) {
+	// Use distinct SIDs to verify that retrying keeps Pola's own SID.
+	peerOpenBytes, err := pcep.NewOpenMessage(2, 30, 120, nil).Serialize()
+	require.NoError(t, err)
+
+	proposedOpen := pcep.NewOpenObject(2, 20, 80, nil)
+	pcerrMessage := pcep.NewPCErrMessageWithOpen(pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueUnacceptableNegotiable, proposedOpen)
+	pcerrBytes, err := pcerrMessage.Serialize()
+	require.NoError(t, err)
+
+	stream := append(append([]byte(nil), peerOpenBytes...), pcerrBytes...)
+	conn := &fakeConn{
+		r:         bytes.NewReader(stream),
+		failAfter: 2,
+		writeErr:  errors.New("write: broken pipe"),
+	}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
+
+	err = ss.Open()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "write: broken pipe")
+
+	writes := conn.writes()
+	require.Len(t, writes, 3, "expected initial Open, Keepalive, and retry Open")
+
+	initialOpen := readOpenMessage(t, bytes.NewReader(writes[0]))
+	assert.Equal(t, uint8(1), initialOpen.OpenObject.Sid, "initial SendOpen must use Pola's own SID")
+
+	var keepaliveHeader pcep.CommonHeader
+	require.NoError(t, keepaliveHeader.DecodeFromBytes(writes[1]))
+	assert.Equal(t, pcep.MessageTypeKeepalive, keepaliveHeader.MessageType, "second write must be the Keepalive")
+
+	retryOpen := readOpenMessage(t, bytes.NewReader(writes[2]))
+	assert.Equal(t, uint8(1), retryOpen.OpenObject.Sid, "retry SendOpen must still use Pola's own SID, not the peer's proposed one")
+}
+
 func TestHandleProposedOpen_UnacceptableProposalIsRejected(t *testing.T) {
 	conn := &fakeConn{r: bytes.NewReader(nil)}
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, zap.NewNop(), nil, 0)
@@ -2223,8 +2330,8 @@ func TestEstablished_SendsCloseWhenTheDeadTimerExpires(t *testing.T) {
 	server, client := newTCPConnPair(t)
 	t.Cleanup(func() { assert.NoError(t, client.Close()) })
 
-	// A 1-second DeadTimer from the PCC keeps the test fast.
-	writeMessage(t, client, pcep.NewOpenMessage(1, 1, 1, nil))
+	// A 2-second DeadTimer from the PCC keeps the test fast.
+	writeMessage(t, client, pcep.NewOpenMessage(1, 1, 2, nil))
 	writeMessage(t, client, pcep.NewKeepaliveMessage())
 
 	ss := NewSession(OpenParams{SessionID: 1, Keepalive: 0, DeadTimer: 0}, netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
@@ -2436,6 +2543,46 @@ func TestReceivePCEPMessage_UnsupportedMessageBodyIsConsumed(t *testing.T) {
 
 	_, found := ss.SearchSRPolicy(5)
 	assert.True(t, found, "the PCRpt following an unsupported message was not processed")
+}
+
+func TestReceivePCEPMessage_NotificationBodyIsConsumed(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+
+	trap, err := pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided).Serialize()
+	require.NoError(t, err, "failed to serialize the message body")
+	writeRawPCEPMessage(t, client, pcep.MessageTypeNotification, trap)
+
+	writeStateReportMessage(t, client, newTestStateReport(t, 5, 0))
+	writeMessage(t, client, pcep.NewCloseMessage(pcep.CloseReasonNoExplanationProvided))
+
+	require.NoError(t, ss.ReceivePCEPMessage())
+
+	_, found := ss.SearchSRPolicy(5)
+	assert.True(t, found, "the PCRpt following a Notification was not processed")
+	assert.Equal(t, uint64(1), ss.Stats().PCNtfRcvd)
+}
+
+func TestReceivePCEPMessage_NotificationTruncatedBodyReturnsError(t *testing.T) {
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+	})
+
+	header := &pcep.CommonHeader{Version: 1, MessageType: pcep.MessageTypeNotification, MessageLength: pcep.CommonHeaderLength + 4}
+	_, err := client.Write(header.Serialize())
+	require.NoError(t, err, "failed to write header")
+	require.NoError(t, client.Close(), "failed to close client connection")
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, zap.NewNop(), nil, 0)
+	assert.Error(t, ss.ReceivePCEPMessage(), "a truncated Notification body must be reported")
 }
 
 func TestHandleUnsupportedMessage_ReadBodyErrorIsReturned(t *testing.T) {

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -199,7 +199,6 @@ func printNodeSRv6SIDs(node *LsNode) {
 	}
 }
 
-
 // TEDElem is an interface for elements that can update the TED.
 type TEDElem interface {
 	UpdateTED(ted *LsTED, cfgASN uint32)

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -199,6 +199,7 @@ func printNodeSRv6SIDs(node *LsNode) {
 	}
 }
 
+
 // TEDElem is an interface for elements that can update the TED.
 type TEDElem interface {
 	UpdateTED(ted *LsTED, cfgASN uint32)

--- a/pkg/table/ted_test.go
+++ b/pkg/table/ted_test.go
@@ -6,39 +6,12 @@
 package table
 
 import (
-	"bytes"
-	"io"
 	"net/netip"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// captureStdout redirects os.Stdout while fn runs and returns everything written to it.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-
-	var buf bytes.Buffer
-	done := make(chan struct{})
-	go func() {
-		_, _ = io.Copy(&buf, r)
-		close(done)
-	}()
-
-	fn()
-
-	require.NoError(t, w.Close())
-	os.Stdout = old
-	<-done
-	return buf.String()
-}
 
 func TestLsNodeNodeSegment(t *testing.T) {
 	tests := []struct {
@@ -510,97 +483,6 @@ func TestLsTEDUpdate(t *testing.T) {
 
 	assert.Same(t, node, ted.Nodes["R1"])
 	require.Contains(t, ted.Nodes, "R2")
-}
-
-func TestLsTEDPrint_Empty(t *testing.T) {
-	tests := []struct {
-		name string
-		ted  *LsTED
-	}{
-		{"nil TED", nil},
-		{"TED with nil Nodes map", &LsTED{}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			out := captureStdout(t, tt.ted.Print)
-			assert.Equal(t, "TED is empty\n", out)
-		})
-	}
-}
-
-func TestLsTEDPrint_Populated(t *testing.T) {
-	minimalNode := &LsNode{RouterID: "0000.0000.0002"}
-
-	remoteNode := &LsNode{RouterID: "0000.0000.0003"}
-	fullNode := &LsNode{
-		RouterID:   "0000.0000.0001",
-		Hostname:   "full-host",
-		IsisAreaID: "49.0001",
-		SrgbBegin:  16000,
-		SrgbEnd:    24000,
-		Prefixes: []*LsPrefix{
-			nil,
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32")},
-			{Prefix: netip.MustParsePrefix("10.0.0.2/32"), SidIndex: 5, HasSidIndex: true},
-		},
-		Links: []*LsLink{
-			nil,
-			{},
-			{
-				LocalIP:    netip.MustParseAddr("10.0.0.1"),
-				RemoteIP:   netip.MustParseAddr("10.0.0.2"),
-				RemoteNode: remoteNode,
-				Metrics:    []*Metric{nil, {Type: IGPMetric, Value: 10}},
-				AdjSid:     24001,
-				Srv6EndXSID: &Srv6EndXSID{
-					EndpointBehavior: BehaviorENDX,
-					Sids:             []string{"2001:db8:1::1"},
-					Srv6SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
-				},
-			},
-		},
-		SRv6SIDs: []*LsSrv6SID{
-			nil,
-			{
-				Sids:             []string{"2001:db8:1::"},
-				SIDStructure:     SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
-				EndpointBehavior: EndpointBehavior{Behavior: BehaviorUN, Flags: 1, Algorithm: 0},
-				MultiTopoIDs:     []uint32{1},
-			},
-		},
-	}
-
-	ted := newTestTED(minimalNode, fullNode)
-	ted.Nodes["0000.0000.0004"] = nil
-
-	out := captureStdout(t, ted.Print)
-
-	nodeHeaders := 0
-	for _, line := range strings.Split(out, "\n") {
-		if strings.HasPrefix(line, "Node: ") {
-			nodeHeaders++
-		}
-	}
-	assert.Equal(t, 2, nodeHeaders, "expected exactly the two non-nil nodes to be printed")
-	assert.Contains(t, out, "Hostname: full-host")
-	assert.Contains(t, out, "ISIS Area ID: 49.0001")
-	assert.Contains(t, out, "SRGB: 16000 - 24000")
-	assert.Contains(t, out, "10.0.0.1/32")
-	assert.Contains(t, out, "10.0.0.2/32")
-	assert.Contains(t, out, "index: 5")
-	assert.Contains(t, out, "Local: 10.0.0.1 Remote: 10.0.0.2")
-	assert.Contains(t, out, "Local: None Remote: None")
-	assert.Contains(t, out, "RemoteNode: 0000.0000.0003")
-	assert.Contains(t, out, "RemoteNode: None")
-	assert.Contains(t, out, "igp: 10")
-	assert.Contains(t, out, "Adj-SID: 24001")
-	assert.Contains(t, out, "EndpointBehavior: ENDX")
-	assert.Contains(t, out, "SIDs: [2001:db8:1::1]")
-	assert.Contains(t, out, "SID Structure: Block: 32, Node: 16, Func: 16, Arg: 0")
-	assert.Contains(t, out, "SIDs: [2001:db8:1::]")
-	assert.Contains(t, out, "Block: 32, Node: 16, Func: 16, Arg: 0")
-	assert.Contains(t, out, "EndpointBehavior: UN, Flags: 1, Algorithm: 0")
-	assert.Contains(t, out, "MultiTopoIDs: [1]")
 }
 
 func TestLsTEDRouterIDIndex(t *testing.T) {

--- a/test/helpers/wait.py
+++ b/test/helpers/wait.py
@@ -156,7 +156,7 @@ def wait_until_ted_has_routers(
     router_ids: list[str],
     timeout: int = 600,
     interval: int = 5,
-) -> dict:
+) -> list:
     """Wait until TED contains all router IDs."""
 
     router_ids = set(router_ids)
@@ -182,7 +182,7 @@ def wait_until_ted_has_links(
     expected_links: set[frozenset[str]],
     timeout: int = 600,
     interval: int = 5,
-) -> dict:
+) -> list:
     """Wait until TED contains all expected links."""
 
     def predicate(ted):
@@ -211,10 +211,10 @@ def wait_until_ted_has_links(
 
 def wait_until_ted_matches(
     pola_container: str,
-    expected: dict,
+    expected: list,
     timeout: int = 600,
     interval: int = 5,
-) -> dict:
+) -> list:
     """Wait until TED JSON matches expected."""
 
     def predicate(ted):

--- a/test/helpers/wait.py
+++ b/test/helpers/wait.py
@@ -113,8 +113,8 @@ def wait_until_command_output_contains(
         time.sleep(interval)
 
 
-def get_ted(pola_container: str) -> dict:
-    """Get current TED JSON. Raises RuntimeError/JSONDecodeError on failure."""
+def get_ted(pola_container: str) -> list:
+    """Get current TED JSON (a list of nodes). Raises RuntimeError/JSONDecodeError on failure."""
 
     cmd = f"docker exec {pola_container} /bin/pola -p 50052 ted -j"
     result = run_command(cmd)
@@ -127,10 +127,10 @@ def get_ted(pola_container: str) -> dict:
 
 def wait_until_ted(
     pola_container: str,
-    predicate: Callable[[dict], bool],
+    predicate: Callable[[list], bool],
     timeout: int = 600,
     interval: int = 5,
-) -> dict:
+) -> list:
     """Wait until predicate(ted_json) becomes True."""
 
     start = time.time()
@@ -162,7 +162,7 @@ def wait_until_ted_has_routers(
     router_ids = set(router_ids)
 
     def predicate(ted):
-        present = {node.get("routerID") for node in ted.get("ted", [])}
+        present = {node.get("routerId") for node in ted}
         missing = router_ids - present
         if missing:
             print(f"Waiting for routers: {missing}")
@@ -188,10 +188,10 @@ def wait_until_ted_has_links(
     def predicate(ted):
         found = set()
 
-        for node in ted.get("ted", []):
-            local = node.get("routerID")
+        for node in ted:
+            local = node.get("routerId")
             for link in node.get("links", []):
-                remote = link.get("remoteNode")
+                remote = link.get("remoteRouterId")
                 if local and remote:
                     found.add(frozenset((local, remote)))
 

--- a/test/scenario/dynamic-path/test_dynamic_path.py
+++ b/test/scenario/dynamic-path/test_dynamic_path.py
@@ -52,7 +52,7 @@ def srv6_usid_lab(clab_deploy_module):
     print("Waiting for PCEP session")
     wait_until_command_success(
         f"docker exec {POLA} /bin/pola session -p {GRPC_PORT} "
-        "| grep 'sessionAddr(0): fd00::2'"
+        "| grep 'Session #0: fd00::2'"
     )
 
     wait_until_ted_has_routers(POLA, ROUTER_IDS)

--- a/test/scenario/show-ted/sr-mpls/expected/ted-after-link-down.json
+++ b/test/scenario/show-ted/sr-mpls/expected/ted-after-link-down.json
@@ -1,53 +1,55 @@
-{
-    "ted": [
-        {
-            "asn": 65000,
-            "hostname": "pe01",
-            "isisAreaID": "49.0000",
-            "links": [],
-            "prefixes": [
-                {
-                    "prefix": "10.255.0.1/32",
-                    "sidIndex": 1
-                }
-            ],
-            "routerID": "0000.0aff.0001",
-            "srgbBegin": 800000,
-            "srgbEnd": 804096,
-            "srv6SIDs": []
+[
+    {
+        "asn": 65000,
+        "routerId": "0000.0aff.0001",
+        "hostname": "pe01",
+        "isisAreaId": "49.0000",
+        "srgb": {
+            "begin": 800000,
+            "end": 804096
         },
-        {
-            "asn": 65000,
-            "hostname": "pe02",
-            "isisAreaID": "49.0000",
-            "links": [
-                {
-                    "adjSid": 299776,
-                    "localIP": "10.0.0.2",
-                    "metrics": [
-                        {
-                            "type": "METRIC_TYPE_IGP",
-                            "value": 10
-                        },
-                        {
-                            "type": "METRIC_TYPE_TE",
-                            "value": 10
-                        }
-                    ],
-                    "remoteIP": "10.0.0.1",
-                    "remoteNode": "0000.0aff.0001"
-                }
-            ],
-            "prefixes": [
-                {
-                    "prefix": "10.255.0.2/32",
-                    "sidIndex": 2
-                }
-            ],
-            "routerID": "0000.0aff.0002",
-            "srgbBegin": 800000,
-            "srgbEnd": 804096,
-            "srv6SIDs": []
-        }
-    ]
-}
+        "prefixes": [
+            {
+                "prefix": "10.255.0.1/32",
+                "sidIndex": 1
+            }
+        ],
+        "links": [],
+        "srv6Sids": []
+    },
+    {
+        "asn": 65000,
+        "routerId": "0000.0aff.0002",
+        "hostname": "pe02",
+        "isisAreaId": "49.0000",
+        "srgb": {
+            "begin": 800000,
+            "end": 804096
+        },
+        "prefixes": [
+            {
+                "prefix": "10.255.0.2/32",
+                "sidIndex": 2
+            }
+        ],
+        "links": [
+            {
+                "localIp": "10.0.0.2",
+                "remoteIp": "10.0.0.1",
+                "remoteRouterId": "0000.0aff.0001",
+                "metrics": [
+                    {
+                        "type": "igp",
+                        "value": 10
+                    },
+                    {
+                        "type": "te",
+                        "value": 10
+                    }
+                ],
+                "adjSid": 299776
+            }
+        ],
+        "srv6Sids": []
+    }
+]

--- a/test/scenario/show-ted/sr-mpls/expected/ted.json
+++ b/test/scenario/show-ted/sr-mpls/expected/ted.json
@@ -1,70 +1,72 @@
-{
-    "ted": [
-        {
-            "asn": 65000,
-            "hostname": "pe01",
-            "isisAreaID": "49.0000",
-            "links": [
-                {
-                    "adjSid": 299776,
-                    "localIP": "10.0.0.1",
-                    "metrics": [
-                        {
-                            "type": "METRIC_TYPE_IGP",
-                            "value": 10
-                        },
-                        {
-                            "type": "METRIC_TYPE_TE",
-                            "value": 10
-                        }
-                    ],
-                    "remoteIP": "10.0.0.2",
-                    "remoteNode": "0000.0aff.0002"
-                }
-            ],
-            "prefixes": [
-                {
-                    "prefix": "10.255.0.1/32",
-                    "sidIndex": 1
-                }
-            ],
-            "routerID": "0000.0aff.0001",
-            "srgbBegin": 800000,
-            "srgbEnd": 804096,
-            "srv6SIDs": []
+[
+    {
+        "asn": 65000,
+        "routerId": "0000.0aff.0001",
+        "hostname": "pe01",
+        "isisAreaId": "49.0000",
+        "srgb": {
+            "begin": 800000,
+            "end": 804096
         },
-        {
-            "asn": 65000,
-            "hostname": "pe02",
-            "isisAreaID": "49.0000",
-            "links": [
-                {
-                    "adjSid": 299776,
-                    "localIP": "10.0.0.2",
-                    "metrics": [
-                        {
-                            "type": "METRIC_TYPE_IGP",
-                            "value": 10
-                        },
-                        {
-                            "type": "METRIC_TYPE_TE",
-                            "value": 10
-                        }
-                    ],
-                    "remoteIP": "10.0.0.1",
-                    "remoteNode": "0000.0aff.0001"
-                }
-            ],
-            "prefixes": [
-                {
-                    "prefix": "10.255.0.2/32",
-                    "sidIndex": 2
-                }
-            ],
-            "routerID": "0000.0aff.0002",
-            "srgbBegin": 800000,
-            "srgbEnd": 804096,
-            "srv6SIDs": []
-        }
-    ]
-}
+        "prefixes": [
+            {
+                "prefix": "10.255.0.1/32",
+                "sidIndex": 1
+            }
+        ],
+        "links": [
+            {
+                "localIp": "10.0.0.1",
+                "remoteIp": "10.0.0.2",
+                "remoteRouterId": "0000.0aff.0002",
+                "metrics": [
+                    {
+                        "type": "igp",
+                        "value": 10
+                    },
+                    {
+                        "type": "te",
+                        "value": 10
+                    }
+                ],
+                "adjSid": 299776
+            }
+        ],
+        "srv6Sids": []
+    },
+    {
+        "asn": 65000,
+        "routerId": "0000.0aff.0002",
+        "hostname": "pe02",
+        "isisAreaId": "49.0000",
+        "srgb": {
+            "begin": 800000,
+            "end": 804096
+        },
+        "prefixes": [
+            {
+                "prefix": "10.255.0.2/32",
+                "sidIndex": 2
+            }
+        ],
+        "links": [
+            {
+                "localIp": "10.0.0.2",
+                "remoteIp": "10.0.0.1",
+                "remoteRouterId": "0000.0aff.0001",
+                "metrics": [
+                    {
+                        "type": "igp",
+                        "value": 10
+                    },
+                    {
+                        "type": "te",
+                        "value": 10
+                    }
+                ],
+                "adjSid": 299776
+            }
+        ],
+        "srv6Sids": []
+    }
+]

--- a/test/scenario/show-ted/srv6-usid/expected/ted-after-link-down.json
+++ b/test/scenario/show-ted/srv6-usid/expected/ted-after-link-down.json
@@ -29,10 +29,10 @@
                     "algorithm": 0
                 },
                 "sidStructure": {
-                    "localBlock": 0,
-                    "localNode": 0,
+                    "localBlock": 32,
+                    "localNode": 16,
                     "localFunc": 0,
-                    "localArg": 0
+                    "localArg": 80
                 },
                 "multiTopoIds": [
                     2
@@ -67,7 +67,22 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 0
+                "adjSid": 0,
+                "srv6EndXSid": {
+                    "endpointBehavior": {
+                        "behavior": 57,
+                        "name": "UA"
+                    },
+                    "sids": [
+                        "fcbb:bb00:1002:e000::"
+                    ],
+                    "sidStructure": {
+                        "localBlock": 32,
+                        "localNode": 16,
+                        "localFunc": 16,
+                        "localArg": 64
+                    }
+                }
             }
         ],
         "srv6Sids": [
@@ -82,10 +97,10 @@
                     "algorithm": 0
                 },
                 "sidStructure": {
-                    "localBlock": 0,
-                    "localNode": 0,
+                    "localBlock": 32,
+                    "localNode": 16,
                     "localFunc": 0,
-                    "localArg": 0
+                    "localArg": 80
                 },
                 "multiTopoIds": [
                     2

--- a/test/scenario/show-ted/srv6-usid/expected/ted-after-link-down.json
+++ b/test/scenario/show-ted/srv6-usid/expected/ted-after-link-down.json
@@ -1,82 +1,96 @@
-{
-    "ted": [
-        {
-            "asn": 65000,
-            "hostname": "pe01",
-            "isisAreaID": "49.0000",
-            "links": [],
-            "prefixes": [
-                {
-                    "prefix": "fd00::/64"
-                },
-                {
-                    "prefix": "fcbb:bb00:1001::/48"
-                }
-            ],
-            "routerID": "0000.0aff.0001",
-            "srgbBegin": 0,
-            "srgbEnd": 0,
-            "srv6SIDs": [
-                {
-                    "endpointBehavior": {
-                        "Behavior": 48,
-                        "Flags": 0,
-                        "Algorithm": 0
-                    },
-                    "multiTopoIDs": [
-                        2
-                    ],
-                    "sids": [
-                        "fcbb:bb00:1001::"
-                    ]
-                }
-            ]
+[
+    {
+        "asn": 65000,
+        "routerId": "0000.0aff.0001",
+        "hostname": "pe01",
+        "isisAreaId": "49.0000",
+        "srgb": {
+            "begin": 0,
+            "end": 0
         },
-        {
-            "asn": 65000,
-            "hostname": "pe02",
-            "isisAreaID": "49.0000",
-            "links": [
-                {
-                    "adjSid": 0,
-                    "localIP": "None",
-                    "metrics": [
-                        {
-                            "type": "METRIC_TYPE_IGP",
-                            "value": 10
-                        },
-                        {
-                            "type": "METRIC_TYPE_TE",
-                            "value": 10
-                        }
-                    ],
-                    "remoteIP": "None",
-                    "remoteNode": "0000.0aff.0001"
-                }
-            ],
-            "prefixes": [
-                {
-                    "prefix": "fcbb:bb00:1002::/48"
-                }
-            ],
-            "routerID": "0000.0aff.0002",
-            "srgbBegin": 0,
-            "srgbEnd": 0,
-            "srv6SIDs": [
-                {
-                    "endpointBehavior": {
-                        "Behavior": 48,
-                        "Flags": 0,
-                        "Algorithm": 0
+        "prefixes": [
+            {
+                "prefix": "fd00::/64"
+            },
+            {
+                "prefix": "fcbb:bb00:1001::/48"
+            }
+        ],
+        "links": [],
+        "srv6Sids": [
+            {
+                "sids": [
+                    "fcbb:bb00:1001::"
+                ],
+                "endpointBehavior": {
+                    "behavior": 48,
+                    "name": "UN",
+                    "flags": 0,
+                    "algorithm": 0
+                },
+                "sidStructure": {
+                    "localBlock": 0,
+                    "localNode": 0,
+                    "localFunc": 0,
+                    "localArg": 0
+                },
+                "multiTopoIds": [
+                    2
+                ]
+            }
+        ]
+    },
+    {
+        "asn": 65000,
+        "routerId": "0000.0aff.0002",
+        "hostname": "pe02",
+        "isisAreaId": "49.0000",
+        "srgb": {
+            "begin": 0,
+            "end": 0
+        },
+        "prefixes": [
+            {
+                "prefix": "fcbb:bb00:1002::/48"
+            }
+        ],
+        "links": [
+            {
+                "remoteRouterId": "0000.0aff.0001",
+                "metrics": [
+                    {
+                        "type": "igp",
+                        "value": 10
                     },
-                    "multiTopoIDs": [
-                        2
-                    ],
-                    "sids": [
-                        "fcbb:bb00:1002::"
-                    ]
-                }
-            ]
-        }
-    ]
-}
+                    {
+                        "type": "te",
+                        "value": 10
+                    }
+                ],
+                "adjSid": 0
+            }
+        ],
+        "srv6Sids": [
+            {
+                "sids": [
+                    "fcbb:bb00:1002::"
+                ],
+                "endpointBehavior": {
+                    "behavior": 48,
+                    "name": "UN",
+                    "flags": 0,
+                    "algorithm": 0
+                },
+                "sidStructure": {
+                    "localBlock": 0,
+                    "localNode": 0,
+                    "localFunc": 0,
+                    "localArg": 0
+                },
+                "multiTopoIds": [
+                    2
+                ]
+            }
+        ]
+    }
+]

--- a/test/scenario/show-ted/srv6-usid/expected/ted.json
+++ b/test/scenario/show-ted/srv6-usid/expected/ted.json
@@ -1,99 +1,111 @@
-{
-    "ted": [
-        {
-            "asn": 65000,
-            "hostname": "pe01",
-            "isisAreaID": "49.0000",
-            "links": [
-                {
-                    "adjSid": 0,
-                    "localIP": "None",
-                    "metrics": [
-                        {
-                            "type": "METRIC_TYPE_IGP",
-                            "value": 10
-                        },
-                        {
-                            "type": "METRIC_TYPE_TE",
-                            "value": 10
-                        }
-                    ],
-                    "remoteIP": "None",
-                    "remoteNode": "0000.0aff.0002"
-                }
-            ],
-            "prefixes": [
-                {
-                    "prefix": "fd00::/64"
-                },
-                {
-                    "prefix": "fcbb:bb00:1001::/48"
-                }
-            ],
-            "routerID": "0000.0aff.0001",
-            "srgbBegin": 0,
-            "srgbEnd": 0,
-            "srv6SIDs": [
-                {
-                    "endpointBehavior": {
-                        "Behavior": 48,
-                        "Flags": 0,
-                        "Algorithm": 0
-                    },
-                    "multiTopoIDs": [
-                        2
-                    ],
-                    "sids": [
-                        "fcbb:bb00:1001::"
-                    ]
-                }
-            ]
+[
+    {
+        "asn": 65000,
+        "routerId": "0000.0aff.0001",
+        "hostname": "pe01",
+        "isisAreaId": "49.0000",
+        "srgb": {
+            "begin": 0,
+            "end": 0
         },
-        {
-            "asn": 65000,
-            "hostname": "pe02",
-            "isisAreaID": "49.0000",
-            "links": [
-                {
-                    "adjSid": 0,
-                    "localIP": "None",
-                    "metrics": [
-                        {
-                            "type": "METRIC_TYPE_IGP",
-                            "value": 10
-                        },
-                        {
-                            "type": "METRIC_TYPE_TE",
-                            "value": 10
-                        }
-                    ],
-                    "remoteIP": "None",
-                    "remoteNode": "0000.0aff.0001"
-                }
-            ],
-            "prefixes": [
-                {
-                    "prefix": "fcbb:bb00:1002::/48"
-                }
-            ],
-            "routerID": "0000.0aff.0002",
-            "srgbBegin": 0,
-            "srgbEnd": 0,
-            "srv6SIDs": [
-                {
-                    "endpointBehavior": {
-                        "Behavior": 48,
-                        "Flags": 0,
-                        "Algorithm": 0
+        "prefixes": [
+            {
+                "prefix": "fd00::/64"
+            },
+            {
+                "prefix": "fcbb:bb00:1001::/48"
+            }
+        ],
+        "links": [
+            {
+                "remoteRouterId": "0000.0aff.0002",
+                "metrics": [
+                    {
+                        "type": "igp",
+                        "value": 10
                     },
-                    "multiTopoIDs": [
-                        2
-                    ],
-                    "sids": [
-                        "fcbb:bb00:1002::"
-                    ]
-                }
-            ]
-        }
-    ]
-}
+                    {
+                        "type": "te",
+                        "value": 10
+                    }
+                ],
+                "adjSid": 0
+            }
+        ],
+        "srv6Sids": [
+            {
+                "sids": [
+                    "fcbb:bb00:1001::"
+                ],
+                "endpointBehavior": {
+                    "behavior": 48,
+                    "name": "UN",
+                    "flags": 0,
+                    "algorithm": 0
+                },
+                "sidStructure": {
+                    "localBlock": 0,
+                    "localNode": 0,
+                    "localFunc": 0,
+                    "localArg": 0
+                },
+                "multiTopoIds": [
+                    2
+                ]
+            }
+        ]
+    },
+    {
+        "asn": 65000,
+        "routerId": "0000.0aff.0002",
+        "hostname": "pe02",
+        "isisAreaId": "49.0000",
+        "srgb": {
+            "begin": 0,
+            "end": 0
+        },
+        "prefixes": [
+            {
+                "prefix": "fcbb:bb00:1002::/48"
+            }
+        ],
+        "links": [
+            {
+                "remoteRouterId": "0000.0aff.0001",
+                "metrics": [
+                    {
+                        "type": "igp",
+                        "value": 10
+                    },
+                    {
+                        "type": "te",
+                        "value": 10
+                    }
+                ],
+                "adjSid": 0
+            }
+        ],
+        "srv6Sids": [
+            {
+                "sids": [
+                    "fcbb:bb00:1002::"
+                ],
+                "endpointBehavior": {
+                    "behavior": 48,
+                    "name": "UN",
+                    "flags": 0,
+                    "algorithm": 0
+                },
+                "sidStructure": {
+                    "localBlock": 0,
+                    "localNode": 0,
+                    "localFunc": 0,
+                    "localArg": 0
+                },
+                "multiTopoIds": [
+                    2
+                ]
+            }
+        ]
+    }
+]

--- a/test/scenario/show-ted/srv6-usid/expected/ted.json
+++ b/test/scenario/show-ted/srv6-usid/expected/ted.json
@@ -29,7 +29,22 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 0
+                "adjSid": 0,
+                "srv6EndXSid": {
+                    "endpointBehavior": {
+                        "behavior": 57,
+                        "name": "UA"
+                    },
+                    "sids": [
+                        "fcbb:bb00:1001:e000::"
+                    ],
+                    "sidStructure": {
+                        "localBlock": 32,
+                        "localNode": 16,
+                        "localFunc": 16,
+                        "localArg": 64
+                    }
+                }
             }
         ],
         "srv6Sids": [
@@ -44,10 +59,10 @@
                     "algorithm": 0
                 },
                 "sidStructure": {
-                    "localBlock": 0,
-                    "localNode": 0,
+                    "localBlock": 32,
+                    "localNode": 16,
                     "localFunc": 0,
-                    "localArg": 0
+                    "localArg": 80
                 },
                 "multiTopoIds": [
                     2
@@ -82,7 +97,22 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 0
+                "adjSid": 0,
+                "srv6EndXSid": {
+                    "endpointBehavior": {
+                        "behavior": 57,
+                        "name": "UA"
+                    },
+                    "sids": [
+                        "fcbb:bb00:1002:e000::"
+                    ],
+                    "sidStructure": {
+                        "localBlock": 32,
+                        "localNode": 16,
+                        "localFunc": 16,
+                        "localArg": 64
+                    }
+                }
             }
         ],
         "srv6Sids": [
@@ -97,10 +127,10 @@
                     "algorithm": 0
                 },
                 "sidStructure": {
-                    "localBlock": 0,
-                    "localNode": 0,
+                    "localBlock": 32,
+                    "localNode": 16,
                     "localFunc": 0,
-                    "localArg": 0
+                    "localArg": 80
                 },
                 "multiTopoIds": [
                     2

--- a/tools/coverage-diff/main.go
+++ b/tools/coverage-diff/main.go
@@ -333,15 +333,15 @@ func parseProfileLine(s string) (block, bool) {
 
 // posOf parses a "<line>.<col>" coverage profile position.
 func posOf(pos string) (line, col int, ok bool) {
-	dot := strings.IndexByte(pos, '.')
-	if dot < 0 {
+	before, after, ok0 := strings.Cut(pos, ".")
+	if !ok0 {
 		return 0, 0, false
 	}
-	line, err := strconv.Atoi(pos[:dot])
+	line, err := strconv.Atoi(before)
 	if err != nil || line < 1 {
 		return 0, 0, false
 	}
-	col, err = strconv.Atoi(pos[dot+1:])
+	col, err = strconv.Atoi(after)
 	if err != nil || col < 1 {
 		return 0, 0, false
 	}
@@ -408,7 +408,7 @@ func (idx *sourceIndex) ensure(file string) {
 			}
 		}
 	}
-	sort.Slice(code, func(i, j int) bool { return code[i] < code[j] })
+	slices.Sort(code)
 	idx.files[file] = tf
 	idx.code[file] = code
 }


### PR DESCRIPTION
## Description
Implements RFC 5440 PCEP session establishment and state handling, and exposes detailed session information through the gRPC API and CLI.

- Implement PCEP session state machine, Open negotiation, and Keepalive/DeadTimer handling.
- Expose session state, capabilities, timers, IDs, timestamps, initiator, and message statistics.
- Expose LSP-DB synchronization state and separate session information from SR Policy information.
- Add peer filtering and detailed human-readable/JSON CLI output.
- Update TED/SR Policy output and CLI documentation.

## Type of change
- [x] New feature
- [x] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?
- `make ci`
- Added unit tests for session state transitions, Open message negotiation, timers, gRPC conversion, statistics, CLI output, and configuration validation.
- `examples/containerlab`
  
## Checklist
- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed