### PR TITLE
feat(table,server): replace flat SID lookup with path-aware ValidateExplicitPath

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -443,17 +443,26 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []ta
 			"TED is enabled but empty (not yet synchronized), SID validation cannot be performed")
 	}
 
-	missingSegments := table.MissingSegments(ted, segmentList)
-	if len(missingSegments) == 0 {
-		return nil
+	// Resolve source router ID for path traversal.
+	var srcRouterID string
+	if req.GetDisablePathCompute() {
+		srcAddr, ok := netip.AddrFromSlice(req.GetSrPolicy().GetSrcAddr())
+		if !ok {
+			return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid source address in request")
+		}
+		srcRouterID, ok = ted.FindRouterIDByLoopback(srcAddr)
+		if !ok {
+			return newStatus(codes.InvalidArgument, ReasonInvalidRequest,
+				"source address %s not found in TED", srcAddr)
+		}
+	} else {
+		srcRouterID = req.GetSrPolicy().GetSrcRouterId()
 	}
 
-	descriptions := make([]string, 0, len(missingSegments))
-	for _, m := range missingSegments {
-		descriptions = append(descriptions, m.String())
+	if err := table.ValidateExplicitPath(ted, srcRouterID, segmentList); err != nil {
+		return newStatus(codes.FailedPrecondition, ReasonSIDValidationFailed, "SID validation failed: %s", err)
 	}
-	return newStatus(codes.FailedPrecondition, ReasonSIDValidationFailed,
-		"SID validation failed, the following SIDs are not found in TED: %s", strings.Join(descriptions, ", "))
+	return nil
 }
 
 // DeleteSRPolicy deletes an existing SR Policy.

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -197,6 +197,7 @@ func explicitPolicyRequest(noSIDValidate bool, sid string) *pb.CreateSRPolicyReq
 			Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 			PolicyName:  "test",
 			Color:       100,
+			SrcRouterId: "0000.0000.0001",
 			SegmentList: []*pb.Segment{{Sid: sid}},
 		},
 		NoSidValidate: noSIDValidate,
@@ -322,6 +323,54 @@ func TestValidateSIDs_EndpointFormIsStillValidated(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
 	assert.Contains(t, st.Message(), "hop 1", "expected the missing hop to be listed")
+}
+
+func TestValidateSIDs_DisablePathComputeInvalidSourceAddress(t *testing.T) {
+	node := &table.LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
+		},
+	}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
+	s := newTestAPIServer(ted)
+
+	req := explicitPolicyRequest(false, "16003")
+	req.DisablePathCompute = true
+	req.SrPolicy.SrcAddr = []byte{1, 2, 3}
+	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
+
+	err := s.validateSIDs(req, segmentList)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid source address in request")
+}
+
+func TestValidateSIDs_DisablePathComputeSourceAddressNotFound(t *testing.T) {
+	node := &table.LsNode{
+		RouterID:  "0000.0000.0001",
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
+		},
+	}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
+	s := newTestAPIServer(ted)
+
+	req := explicitPolicyRequest(false, "16003")
+	req.DisablePathCompute = true
+	req.SrPolicy.SrcAddr = netip.MustParseAddr("10.0.0.9").AsSlice()
+	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
+	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
+
+	err := s.validateSIDs(req, segmentList)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "source address 10.0.0.9 not found in TED")
 }
 
 func TestValidateSIDs_LabelOutOfRangeIsRejectedEvenWithNoSidValidate(t *testing.T) {

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -217,10 +217,19 @@ func (idx *SIDIndex) NextHop(owner string, seg Segment) (string, error) {
 	}
 }
 
+// ownerUnknown indicates that the current router is unknown.
+const ownerUnknown = ""
+
 func (idx *SIDIndex) nextHopMPLS(owner string, s SegmentSRMPLS) (string, error) {
 	// Node SID (prefix SID)?
 	if next, ok := idx.mplsNodeSIDOwner[s.Sid]; ok {
 		return next, nil
+	}
+	if owner == ownerUnknown {
+		if _, exists := idx.mplsSIDs[s.Sid]; exists {
+			return ownerUnknown, nil
+		}
+		return "", fmt.Errorf("SID %s not found in TED", s.SidString())
 	}
 	// Adjacency SID — must be on owner.
 	if next, ok := idx.mplsAdjSIDNextHop[adjKeyMPLS{owner, s.Sid}]; ok {
@@ -237,6 +246,12 @@ func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
 	if next, ok := idx.srv6NodeSIDOwner[s.Sid]; ok {
 		return next, nil
 	}
+	if owner == ownerUnknown {
+		if idx.hasSRv6(s) {
+			return ownerUnknown, nil
+		}
+		return "", fmt.Errorf("SID %s not found in TED", s.SidString())
+	}
 	// Adjacency SID (End.X) — must be on owner.
 	if next, ok := idx.srv6AdjSIDNextHop[adjKeySRv6{owner, s.Sid}]; ok {
 		return next, nil
@@ -252,6 +267,19 @@ func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
 //   - Node SIDs are valid from any owner; the owner advances to that node.
 //   - Adjacency SIDs must be local to the current owner; owner advances to the link's remote node.
 func ValidateExplicitPath(ted *LsTED, srcRouterID string, segmentList []Segment) error {
+	if ted == nil {
+		return errors.New("TED is nil")
+	}
+	if srcRouterID == "" {
+		return errors.New("source router ID is empty")
+	}
+	if _, ok := ted.Nodes[srcRouterID]; !ok {
+		return fmt.Errorf("source router ID %s not found in TED", srcRouterID)
+	}
+
+	if len(segmentList) == 0 {
+		return nil
+	}
 	idx := NewSIDIndex(ted)
 	owner := srcRouterID
 	for i, seg := range segmentList {

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -6,9 +6,22 @@
 package table
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 )
+
+// adjKeyMPLS is the lookup key for an SR-MPLS adjacency SID owned by a specific node.
+type adjKeyMPLS struct {
+	owner string
+	sid   uint32
+}
+
+// adjKeySRv6 is the lookup key for an SRv6 End.X SID owned by a specific node.
+type adjKeySRv6 struct {
+	owner string
+	sid   netip.Addr
+}
 
 // MPLSLabelMax is the maximum 20-bit MPLS label value.
 const MPLSLabelMax uint32 = 0xFFFFF
@@ -18,6 +31,14 @@ type SIDIndex struct {
 	mplsSIDs     map[uint32]struct{}       // prefix SIDs and adjacency SIDs
 	srv6SIDs     map[netip.Addr]struct{}   // End / End.X SIDs, matched exactly
 	srv6Locators map[netip.Prefix]struct{} // locator prefixes derived from SID structures
+
+	// path-aware: node SID → owning router ID
+	mplsNodeSIDOwner map[uint32]string
+	srv6NodeSIDOwner map[netip.Addr]string
+
+	// path-aware: (owner router ID, adj SID) → next-hop router ID
+	mplsAdjSIDNextHop map[adjKeyMPLS]string
+	srv6AdjSIDNextHop map[adjKeySRv6]string
 }
 
 // MissingSegment identifies one rejected segment by its position in the
@@ -34,9 +55,13 @@ func (m MissingSegment) String() string {
 // NewSIDIndex builds a SIDIndex from the TED.
 func NewSIDIndex(ted *LsTED) *SIDIndex {
 	idx := &SIDIndex{
-		mplsSIDs:     map[uint32]struct{}{},
-		srv6SIDs:     map[netip.Addr]struct{}{},
-		srv6Locators: map[netip.Prefix]struct{}{},
+		mplsSIDs:          map[uint32]struct{}{},
+		srv6SIDs:          map[netip.Addr]struct{}{},
+		srv6Locators:      map[netip.Prefix]struct{}{},
+		mplsNodeSIDOwner:  map[uint32]string{},
+		srv6NodeSIDOwner:  map[netip.Addr]string{},
+		mplsAdjSIDNextHop: map[adjKeyMPLS]string{},
+		srv6AdjSIDNextHop: map[adjKeySRv6]string{},
 	}
 	if ted == nil {
 		return idx
@@ -64,6 +89,7 @@ func (idx *SIDIndex) addNodePrefixSIDs(node *LsNode) {
 		}
 		if label, ok := srgbLabel(node, p.SidIndex); ok {
 			idx.mplsSIDs[label] = struct{}{}
+			idx.mplsNodeSIDOwner[label] = node.RouterID
 		}
 	}
 }
@@ -89,9 +115,19 @@ func (idx *SIDIndex) addLinkSIDs(node *LsNode) {
 		}
 		if l.AdjSid != 0 {
 			idx.mplsSIDs[l.AdjSid] = struct{}{}
+			if l.RemoteNode != nil {
+				idx.mplsAdjSIDNextHop[adjKeyMPLS{node.RouterID, l.AdjSid}] = l.RemoteNode.RouterID
+			}
 		}
 		if l.Srv6EndXSID != nil {
 			idx.addSRv6(l.Srv6EndXSID.Sids, l.Srv6EndXSID.Srv6SIDStructure)
+			if l.RemoteNode != nil {
+				for _, s := range l.Srv6EndXSID.Sids {
+					if addr, err := netip.ParseAddr(s); err == nil {
+						idx.srv6AdjSIDNextHop[adjKeySRv6{node.RouterID, addr}] = l.RemoteNode.RouterID
+					}
+				}
+			}
 		}
 	}
 }
@@ -101,6 +137,11 @@ func (idx *SIDIndex) addSRv6NodeSIDs(node *LsNode) {
 	for _, s := range node.SRv6SIDs {
 		if s != nil {
 			idx.addSRv6(s.Sids, s.SIDStructure)
+			for _, sidStr := range s.Sids {
+				if addr, err := netip.ParseAddr(sidStr); err == nil {
+					idx.srv6NodeSIDOwner[addr] = node.RouterID
+				}
+			}
 		}
 	}
 }
@@ -159,6 +200,71 @@ func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
 		return true
 	}
 	return false
+}
+
+// NextHop returns the next-hop router ID after traversing seg from owner.
+// For node SIDs it returns the SID's owning router ID (valid from any owner).
+// For adjacency SIDs it verifies the SID is local to owner, then returns the remote router ID.
+// Returns an error if the SID is unknown or does not belong to owner.
+func (idx *SIDIndex) NextHop(owner string, seg Segment) (string, error) {
+	switch s := seg.(type) {
+	case SegmentSRMPLS:
+		return idx.nextHopMPLS(owner, s)
+	case SegmentSRv6:
+		return idx.nextHopSRv6(owner, s)
+	default:
+		return "", errors.New("unknown segment family")
+	}
+}
+
+func (idx *SIDIndex) nextHopMPLS(owner string, s SegmentSRMPLS) (string, error) {
+	// Node SID (prefix SID)?
+	if next, ok := idx.mplsNodeSIDOwner[s.Sid]; ok {
+		return next, nil
+	}
+	// Adjacency SID — must be on owner.
+	if next, ok := idx.mplsAdjSIDNextHop[adjKeyMPLS{owner, s.Sid}]; ok {
+		return next, nil
+	}
+	if _, exists := idx.mplsSIDs[s.Sid]; exists {
+		return "", fmt.Errorf("%s does not have adjacency SID %s", owner, s.SidString())
+	}
+	return "", fmt.Errorf("SID %s not found in TED", s.SidString())
+}
+
+func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
+	// Node SID (End SID)?
+	if next, ok := idx.srv6NodeSIDOwner[s.Sid]; ok {
+		return next, nil
+	}
+	// Adjacency SID (End.X) — must be on owner.
+	if next, ok := idx.srv6AdjSIDNextHop[adjKeySRv6{owner, s.Sid}]; ok {
+		return next, nil
+	}
+	if idx.hasSRv6(s) {
+		return "", fmt.Errorf("%s does not have adjacency SID %s", owner, s.SidString())
+	}
+	return "", fmt.Errorf("SID %s not found in TED", s.SidString())
+}
+
+// ValidateExplicitPath performs path-aware SID validation on an explicit segment list.
+// Starting from srcRouterID, it verifies each SID via SIDIndex.NextHop:
+//   - Node SIDs are valid from any owner; the owner advances to that node.
+//   - Adjacency SIDs must be local to the current owner; owner advances to the link's remote node.
+func ValidateExplicitPath(ted *LsTED, srcRouterID string, segmentList []Segment) error {
+	idx := NewSIDIndex(ted)
+	owner := srcRouterID
+	for i, seg := range segmentList {
+		if seg == nil {
+			return fmt.Errorf("hop %d: nil segment", i+1)
+		}
+		next, err := idx.NextHop(owner, seg)
+		if err != nil {
+			return fmt.Errorf("hop %d (%s): %w", i+1, seg.SidString(), err)
+		}
+		owner = next
+	}
+	return nil
 }
 
 // MissingSegments reports the segments not found in the TED.

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -7,6 +7,7 @@ package table
 
 import (
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -529,6 +530,173 @@ func TestHasMixedSegmentTypes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, HasMixedSegmentTypes(tt.segs))
+		})
+	}
+}
+
+func TestValidateExplicitPath(t *testing.T) {
+	// Topology: A --adj24001--> B --adj24002--> C
+	// A has node SID 16001, B has node SID 16002, C has node SID 16003.
+	nodeA := &LsNode{
+		RouterID:  "0000.0000.000a",
+		SrgbBegin: 16000,
+		Prefixes:  []*LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.10/32"), SidIndex: 1, HasSidIndex: true}},
+	}
+	nodeB := &LsNode{
+		RouterID:  "0000.0000.000b",
+		SrgbBegin: 16000,
+		Prefixes:  []*LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.11/32"), SidIndex: 2, HasSidIndex: true}},
+	}
+	nodeC := &LsNode{
+		RouterID:  "0000.0000.000c",
+		SrgbBegin: 16000,
+		Prefixes:  []*LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.12/32"), SidIndex: 3, HasSidIndex: true}},
+	}
+	nodeA.Links = []*LsLink{{LocalNode: nodeA, RemoteNode: nodeB, AdjSid: 24001}}
+	nodeB.Links = []*LsLink{{LocalNode: nodeB, RemoteNode: nodeC, AdjSid: 24002}}
+
+	ted := newTestTED(nodeA, nodeB, nodeC)
+
+	tests := []struct {
+		name    string
+		src     string
+		segs    []Segment
+		wantErr string // empty means expect nil error
+	}{
+		{
+			name: "valid: A to B via node SID, B to C via adj SID on B",
+			src:  "0000.0000.000a",
+			segs: []Segment{
+				NewSegmentSRMPLS(16002), // node SID of B
+				NewSegmentSRMPLS(24002), // adj SID on B -> C
+			},
+			wantErr: "",
+		},
+		{
+			name: "adj SID on wrong owner: B adj SID used while owner is A",
+			src:  "0000.0000.000a",
+			segs: []Segment{
+				NewSegmentSRMPLS(24002), // belongs to B, not A
+			},
+			wantErr: "does not have adjacency SID",
+		},
+		{
+			name: "SID not in TED",
+			src:  "0000.0000.000a",
+			segs: []Segment{
+				NewSegmentSRMPLS(99999),
+			},
+			wantErr: "not found in TED",
+		},
+		{
+			name: "single node SID valid",
+			src:  "0000.0000.000a",
+			segs: []Segment{
+				NewSegmentSRMPLS(16001), // node SID of A
+			},
+			wantErr: "",
+		},
+		{
+			name:    "empty segment list",
+			src:     "0000.0000.000a",
+			segs:    []Segment{},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExplicitPath(ted, tt.src, tt.segs)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected nil error, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateExplicitPathSRv6(t *testing.T) {
+	// Topology: A --End.X:fc00::a:b--> B --End.X:fc00::b:c--> C
+	// A has End SID fc00::a:1, B has End SID fc00::b:1, C has End SID fc00::c:1.
+	nodeA := &LsNode{
+		RouterID: "0000.0000.000a",
+		SRv6SIDs: []*LsSrv6SID{{Sids: []string{"fc00::a:1"}}},
+	}
+	nodeB := &LsNode{
+		RouterID: "0000.0000.000b",
+		SRv6SIDs: []*LsSrv6SID{{Sids: []string{"fc00::b:1"}}},
+	}
+	nodeC := &LsNode{
+		RouterID: "0000.0000.000c",
+		SRv6SIDs: []*LsSrv6SID{{Sids: []string{"fc00::c:1"}}},
+	}
+	nodeA.Links = []*LsLink{{LocalNode: nodeA, RemoteNode: nodeB, Srv6EndXSID: &Srv6EndXSID{Sids: []string{"fc00::a:b"}}}}
+	nodeB.Links = []*LsLink{{LocalNode: nodeB, RemoteNode: nodeC, Srv6EndXSID: &Srv6EndXSID{Sids: []string{"fc00::b:c"}}}}
+
+	ted := newTestTED(nodeA, nodeB, nodeC)
+
+	tests := []struct {
+		name    string
+		src     string
+		segs    []Segment
+		wantErr string // empty means expect nil error
+	}{
+		{
+			name: "valid: A to B via End SID, B to C via End.X on B",
+			src:  "0000.0000.000a",
+			segs: []Segment{
+				NewSegmentSRv6(netip.MustParseAddr("fc00::b:1")), // End SID of B
+				NewSegmentSRv6(netip.MustParseAddr("fc00::b:c")), // End.X on B -> C
+			},
+			wantErr: "",
+		},
+		{
+			name: "End.X on wrong owner: B End.X used while owner is A",
+			src:  "0000.0000.000a",
+			segs: []Segment{
+				NewSegmentSRv6(netip.MustParseAddr("fc00::b:c")), // belongs to B, not A
+			},
+			wantErr: "does not have adjacency SID",
+		},
+		{
+			name: "SRv6 SID not in TED",
+			src:  "0000.0000.000a",
+			segs: []Segment{
+				NewSegmentSRv6(netip.MustParseAddr("fd00::dead:beef")),
+			},
+			wantErr: "not found in TED",
+		},
+		{
+			name: "single End SID valid",
+			src:  "0000.0000.000a",
+			segs: []Segment{
+				NewSegmentSRv6(netip.MustParseAddr("fc00::a:1")), // End SID of A
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExplicitPath(ted, tt.src, tt.segs)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected nil error, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+			}
 		})
 	}
 }

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -700,3 +700,76 @@ func TestValidateExplicitPathSRv6(t *testing.T) {
 		})
 	}
 }
+
+func TestSIDIndexNextHop_OwnerUnknownBranches(t *testing.T) {
+	node := &LsNode{
+		RouterID: "0000.0000.0001",
+		Links: []*LsLink{
+			{AdjSid: 24001, Srv6EndXSID: &Srv6EndXSID{Sids: []string{"2001:db8::a"}}},
+		},
+		SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"2001:db8::1"}},
+		},
+	}
+	idx := NewSIDIndex(newTestTED(node))
+
+	t.Run("owner unknown with known SR-MPLS SID", func(t *testing.T) {
+		next, err := idx.NextHop(ownerUnknown, NewSegmentSRMPLS(24001))
+		require.NoError(t, err)
+		assert.Equal(t, ownerUnknown, next)
+	})
+
+	t.Run("owner unknown with unknown SR-MPLS SID", func(t *testing.T) {
+		_, err := idx.NextHop(ownerUnknown, NewSegmentSRMPLS(16099))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in TED")
+	})
+
+	t.Run("owner unknown with known SRv6 adjacency SID", func(t *testing.T) {
+		next, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(netip.MustParseAddr("2001:db8::a")))
+		require.NoError(t, err)
+		assert.Equal(t, ownerUnknown, next)
+	})
+
+	t.Run("owner unknown with unknown SRv6 SID", func(t *testing.T) {
+		_, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(netip.MustParseAddr("2001:db8::99")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in TED")
+	})
+}
+
+func TestSIDIndexNextHop_UnknownSegmentFamily(t *testing.T) {
+	idx := NewSIDIndex(newTestTED())
+	_, err := idx.NextHop("0000.0000.0001", fakeUnknownSegment{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown segment family")
+}
+
+func TestValidateExplicitPath_InputErrors(t *testing.T) {
+	node := &LsNode{RouterID: "0000.0000.0001"}
+	ted := newTestTED(node)
+
+	t.Run("nil TED", func(t *testing.T) {
+		err := ValidateExplicitPath(nil, node.RouterID, []Segment{NewSegmentSRMPLS(16003)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TED is nil")
+	})
+
+	t.Run("empty source router ID", func(t *testing.T) {
+		err := ValidateExplicitPath(ted, "", []Segment{NewSegmentSRMPLS(16003)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "source router ID is empty")
+	})
+
+	t.Run("source router ID not found", func(t *testing.T) {
+		err := ValidateExplicitPath(ted, "missing", []Segment{NewSegmentSRMPLS(16003)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "source router ID missing not found in TED")
+	})
+
+	t.Run("nil segment in list", func(t *testing.T) {
+		err := ValidateExplicitPath(ted, node.RouterID, []Segment{nil})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hop 1: nil segment")
+	})
+}

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -61,6 +61,16 @@ func (ted *LsTED) AddressRouterIDIndex() map[netip.Addr]string {
 	return index
 }
 
+// FindRouterIDByLoopback returns the router ID of the node whose loopback address matches addr.
+func (ted *LsTED) FindRouterIDByLoopback(addr netip.Addr) (string, bool) {
+	for routerID, node := range ted.Nodes {
+		if loopback, err := node.LoopbackAddr(); err == nil && loopback == addr {
+			return routerID, true
+		}
+	}
+	return "", false
+}
+
 // Print prints the TED, listing each node with its prefixes, links and SRv6 SIDs.
 func (ted *LsTED) Print() {
 	if ted == nil || ted.Nodes == nil {

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -63,12 +63,8 @@ func (ted *LsTED) AddressRouterIDIndex() map[netip.Addr]string {
 
 // FindRouterIDByLoopback returns the router ID of the node whose loopback address matches addr.
 func (ted *LsTED) FindRouterIDByLoopback(addr netip.Addr) (string, bool) {
-	for routerID, node := range ted.Nodes {
-		if loopback, err := node.LoopbackAddr(); err == nil && loopback == addr {
-			return routerID, true
-		}
-	}
-	return "", false
+	routerID, ok := ted.RouterIDIndex()[addr]
+	return routerID, ok
 }
 
 // Print prints the TED, listing each node with its prefixes, links and SRv6 SIDs.

--- a/pkg/table/ted_test.go
+++ b/pkg/table/ted_test.go
@@ -666,3 +666,20 @@ func TestLsTEDAddressRouterIDIndex(t *testing.T) {
 	var nilTED *LsTED
 	assert.Nil(t, nilTED.AddressRouterIDIndex())
 }
+
+func TestLsTEDFindRouterIDByLoopback(t *testing.T) {
+	ted := &LsTED{Nodes: map[string]*LsNode{}}
+
+	node := NewLsNode(65000, "router-v4")
+	prefix := NewLsPrefix(node)
+	prefix.Prefix = netip.MustParsePrefix("192.0.2.10/32")
+	node.Prefixes = append(node.Prefixes, prefix)
+	ted.Nodes[node.RouterID] = node
+
+	routerID, ok := ted.FindRouterIDByLoopback(netip.MustParseAddr("192.0.2.10"))
+	require.True(t, ok)
+	assert.Equal(t, "router-v4", routerID)
+
+	_, ok = ted.FindRouterIDByLoopback(netip.MustParseAddr("192.0.2.99"))
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary

Replace the flat `MissingSegments()` SID check in SR policy creation with a new path-aware `ValidateExplicitPath()` that walks the segment list hop-by-hop.

## Background / Motivation

`MissingSegments()` calls `SIDIndex.Has()`, which only checks whether a SIDexists *somewhere* in the TED. This means adjacency SIDs — which are local toa specific node — pass validation even when placed at the wrong hop in theexplicit path.

For example, given topology `A --adj:24001--> B --adj:24002--> C`, a segment list `[24002]` (B's adjacency SID) sent from A would be accepted by the old check because 24002 exists in the TED, even though A does not own it.

## Changes

### `pkg/table/sid_validate.go`

Extend `SIDIndex` with owner-scoped lookup maps built during index construction:

| New field | Purpose |
|---|---|
| `mplsNodeSIDOwner map[uint32]string` | node SID → owning router ID |
| `srv6NodeSIDOwner map[netip.Addr]string` | SRv6 End SID → owning router ID |
| `mplsAdjSIDNextHop map[adjKeyMPLS]string` | (owner, adj SID) → next-hop router ID |
| `srv6AdjSIDNextHop map[adjKeySRv6]string` | (owner, End.X SID) → next-hop router ID |

Add `NextHop(owner, seg) (string, error)`:
- Node SIDs resolve to the owning node and are valid from any owner
- Adjacency SIDs must be local to the current owner node

Add `ValidateExplicitPath(ted, srcRouterID, segmentList) error`:
- Initialises a `SIDIndex`, then iterates segments advancing the owner node
- Returns a descriptive error identifying the failing hop number and SID

Existing `Has()` and `MissingSegments()` are unchanged.

### `pkg/table/ted.go`

Add `(*LsTED).FindRouterIDByLoopback(addr netip.Addr) (string, bool)` to map a loopback address to a router ID, needed to resolve `SrcAddr` when `DisablePathCompute=true`.

### `pkg/server/grpc_server.go`

Update `validateSIDs` to:
1. Resolve `srcRouterID` from `SrcAddr` via `FindRouterIDByLoopback` when `DisablePathCompute=true`, or from `SrcRouterId` otherwise
2. Return an explicit `InvalidArgument` error for malformed `SrcAddr` bytes or an empty `SrcRouterId`
3. Call `ValidateExplicitPath` instead of `MissingSegments`

### `pkg/table/sid_validate_test.go`

- `TestValidateExplicitPath` — 5 SR-MPLS cases: valid multi-hop, adj SID on wrong owner, unknown SID, single node SID, empty list
- `TestValidateExplicitPathSRv6` — 4 SRv6 cases: valid multi-hop (End → End.X), End.X on wrong owner, unknown SID, single End SID

## Test

```bash
go test ./pkg/table/... -v -run 'TestValidateExplicitPath'
go test ./pkg/table/... ./pkg/server/...
go vet ./...

All tests pass.
```