### PR TITLE
Improve PCEP capability handling

### DIFF
--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -1094,16 +1094,69 @@ func (x *SrCapability) GetMsd() uint32 {
 	return 0
 }
 
+type Msd struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Type          uint32                 `protobuf:"varint,1,opt,name=type,proto3" json:"type,omitempty"`
+	Value         uint32                 `protobuf:"varint,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Msd) Reset() {
+	*x = Msd{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Msd) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Msd) ProtoMessage() {}
+
+func (x *Msd) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Msd.ProtoReflect.Descriptor instead.
+func (*Msd) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *Msd) GetType() uint32 {
+	if x != nil {
+		return x.Type
+	}
+	return 0
+}
+
+func (x *Msd) GetValue() uint32 {
+	if x != nil {
+		return x.Value
+	}
+	return 0
+}
+
 type Srv6Capability struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NaiSupported  bool                   `protobuf:"varint,1,opt,name=nai_supported,json=naiSupported,proto3" json:"nai_supported,omitempty"`
+	Msds          []*Msd                 `protobuf:"bytes,2,rep,name=msds,proto3" json:"msds,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Srv6Capability) Reset() {
 	*x = Srv6Capability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1115,7 +1168,7 @@ func (x *Srv6Capability) String() string {
 func (*Srv6Capability) ProtoMessage() {}
 
 func (x *Srv6Capability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1128,7 +1181,7 @@ func (x *Srv6Capability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Srv6Capability.ProtoReflect.Descriptor instead.
 func (*Srv6Capability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{9}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Srv6Capability) GetNaiSupported() bool {
@@ -1136,6 +1189,13 @@ func (x *Srv6Capability) GetNaiSupported() bool {
 		return x.NaiSupported
 	}
 	return false
+}
+
+func (x *Srv6Capability) GetMsds() []*Msd {
+	if x != nil {
+		return x.Msds
+	}
+	return nil
 }
 
 type PathSetupTypeCapability struct {
@@ -1149,7 +1209,7 @@ type PathSetupTypeCapability struct {
 
 func (x *PathSetupTypeCapability) Reset() {
 	*x = PathSetupTypeCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1161,7 +1221,7 @@ func (x *PathSetupTypeCapability) String() string {
 func (*PathSetupTypeCapability) ProtoMessage() {}
 
 func (x *PathSetupTypeCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1174,7 +1234,7 @@ func (x *PathSetupTypeCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PathSetupTypeCapability.ProtoReflect.Descriptor instead.
 func (*PathSetupTypeCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{10}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *PathSetupTypeCapability) GetPathSetupTypes() []uint32 {
@@ -1200,7 +1260,7 @@ type AssocTypeListCapability struct {
 
 func (x *AssocTypeListCapability) Reset() {
 	*x = AssocTypeListCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1212,7 +1272,7 @@ func (x *AssocTypeListCapability) String() string {
 func (*AssocTypeListCapability) ProtoMessage() {}
 
 func (x *AssocTypeListCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1225,7 +1285,7 @@ func (x *AssocTypeListCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssocTypeListCapability.ProtoReflect.Descriptor instead.
 func (*AssocTypeListCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{11}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *AssocTypeListCapability) GetAssocTypes() []uint32 {
@@ -1244,7 +1304,7 @@ type LspDbVersionCapability struct {
 
 func (x *LspDbVersionCapability) Reset() {
 	*x = LspDbVersionCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1256,7 +1316,7 @@ func (x *LspDbVersionCapability) String() string {
 func (*LspDbVersionCapability) ProtoMessage() {}
 
 func (x *LspDbVersionCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1269,7 +1329,7 @@ func (x *LspDbVersionCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LspDbVersionCapability.ProtoReflect.Descriptor instead.
 func (*LspDbVersionCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{12}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *LspDbVersionCapability) GetVersionNumber() uint64 {
@@ -1292,7 +1352,7 @@ type MultipathCapability struct {
 
 func (x *MultipathCapability) Reset() {
 	*x = MultipathCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1304,7 +1364,7 @@ func (x *MultipathCapability) String() string {
 func (*MultipathCapability) ProtoMessage() {}
 
 func (x *MultipathCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1317,7 +1377,7 @@ func (x *MultipathCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultipathCapability.ProtoReflect.Descriptor instead.
 func (*MultipathCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{13}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *MultipathCapability) GetMaxMultipaths() uint32 {
@@ -1364,7 +1424,7 @@ type VendorInformationCapability struct {
 
 func (x *VendorInformationCapability) Reset() {
 	*x = VendorInformationCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1376,7 +1436,7 @@ func (x *VendorInformationCapability) String() string {
 func (*VendorInformationCapability) ProtoMessage() {}
 
 func (x *VendorInformationCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1389,7 +1449,7 @@ func (x *VendorInformationCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VendorInformationCapability.ProtoReflect.Descriptor instead.
 func (*VendorInformationCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{14}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *VendorInformationCapability) GetEnterpriseNumber() uint32 {
@@ -1408,7 +1468,7 @@ type UnknownCapability struct {
 
 func (x *UnknownCapability) Reset() {
 	*x = UnknownCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1420,7 +1480,7 @@ func (x *UnknownCapability) String() string {
 func (*UnknownCapability) ProtoMessage() {}
 
 func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1433,7 +1493,7 @@ func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnknownCapability.ProtoReflect.Descriptor instead.
 func (*UnknownCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{15}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *UnknownCapability) GetTlvType() uint32 {
@@ -1464,7 +1524,7 @@ type Capability struct {
 
 func (x *Capability) Reset() {
 	*x = Capability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1476,7 +1536,7 @@ func (x *Capability) String() string {
 func (*Capability) ProtoMessage() {}
 
 func (x *Capability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1489,7 +1549,7 @@ func (x *Capability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Capability.ProtoReflect.Descriptor instead.
 func (*Capability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{16}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Capability) GetType() CapabilityType {
@@ -1655,7 +1715,7 @@ type SessionTimers struct {
 
 func (x *SessionTimers) Reset() {
 	*x = SessionTimers{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1667,7 +1727,7 @@ func (x *SessionTimers) String() string {
 func (*SessionTimers) ProtoMessage() {}
 
 func (x *SessionTimers) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1680,7 +1740,7 @@ func (x *SessionTimers) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionTimers.ProtoReflect.Descriptor instead.
 func (*SessionTimers) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{17}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SessionTimers) GetKeepalive() uint32 {
@@ -1707,7 +1767,7 @@ type EffectiveTimers struct {
 
 func (x *EffectiveTimers) Reset() {
 	*x = EffectiveTimers{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1719,7 +1779,7 @@ func (x *EffectiveTimers) String() string {
 func (*EffectiveTimers) ProtoMessage() {}
 
 func (x *EffectiveTimers) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1732,7 +1792,7 @@ func (x *EffectiveTimers) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EffectiveTimers.ProtoReflect.Descriptor instead.
 func (*EffectiveTimers) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{18}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *EffectiveTimers) GetKeepalive() uint32 {
@@ -1760,7 +1820,7 @@ type MessageCounter struct {
 
 func (x *MessageCounter) Reset() {
 	*x = MessageCounter{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1772,7 +1832,7 @@ func (x *MessageCounter) String() string {
 func (*MessageCounter) ProtoMessage() {}
 
 func (x *MessageCounter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1785,7 +1845,7 @@ func (x *MessageCounter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageCounter.ProtoReflect.Descriptor instead.
 func (*MessageCounter) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *MessageCounter) GetSent() uint64 {
@@ -1826,7 +1886,7 @@ type SessionStats struct {
 
 func (x *SessionStats) Reset() {
 	*x = SessionStats{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1838,7 +1898,7 @@ func (x *SessionStats) String() string {
 func (*SessionStats) ProtoMessage() {}
 
 func (x *SessionStats) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1851,7 +1911,7 @@ func (x *SessionStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionStats.ProtoReflect.Descriptor instead.
 func (*SessionStats) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SessionStats) GetKeepalive() *MessageCounter {
@@ -1978,7 +2038,7 @@ type Session struct {
 
 func (x *Session) Reset() {
 	*x = Session{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1990,7 +2050,7 @@ func (x *Session) String() string {
 func (*Session) ProtoMessage() {}
 
 func (x *Session) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2003,7 +2063,7 @@ func (x *Session) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Session.ProtoReflect.Descriptor instead.
 func (*Session) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Session) GetPeerAddr() []byte {
@@ -2130,7 +2190,7 @@ type SRPolicySession struct {
 
 func (x *SRPolicySession) Reset() {
 	*x = SRPolicySession{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2142,7 +2202,7 @@ func (x *SRPolicySession) String() string {
 func (*SRPolicySession) ProtoMessage() {}
 
 func (x *SRPolicySession) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2155,7 +2215,7 @@ func (x *SRPolicySession) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRPolicySession.ProtoReflect.Descriptor instead.
 func (*SRPolicySession) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SRPolicySession) GetPeerAddr() []byte {
@@ -2197,7 +2257,7 @@ type EndpointBehavior struct {
 
 func (x *EndpointBehavior) Reset() {
 	*x = EndpointBehavior{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2209,7 +2269,7 @@ func (x *EndpointBehavior) String() string {
 func (*EndpointBehavior) ProtoMessage() {}
 
 func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2222,7 +2282,7 @@ func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointBehavior.ProtoReflect.Descriptor instead.
 func (*EndpointBehavior) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *EndpointBehavior) GetBehavior() uint32 {
@@ -2258,7 +2318,7 @@ type SidStructure struct {
 
 func (x *SidStructure) Reset() {
 	*x = SidStructure{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2270,7 +2330,7 @@ func (x *SidStructure) String() string {
 func (*SidStructure) ProtoMessage() {}
 
 func (x *SidStructure) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2283,7 +2343,7 @@ func (x *SidStructure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidStructure.ProtoReflect.Descriptor instead.
 func (*SidStructure) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SidStructure) GetLocalBlock() uint32 {
@@ -2323,7 +2383,7 @@ type SID struct {
 
 func (x *SID) Reset() {
 	*x = SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2335,7 +2395,7 @@ func (x *SID) String() string {
 func (*SID) ProtoMessage() {}
 
 func (x *SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2348,7 +2408,7 @@ func (x *SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SID.ProtoReflect.Descriptor instead.
 func (*SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SID) GetSid() string {
@@ -2367,7 +2427,7 @@ type MultiTopoID struct {
 
 func (x *MultiTopoID) Reset() {
 	*x = MultiTopoID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2379,7 +2439,7 @@ func (x *MultiTopoID) String() string {
 func (*MultiTopoID) ProtoMessage() {}
 
 func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2392,7 +2452,7 @@ func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultiTopoID.ProtoReflect.Descriptor instead.
 func (*MultiTopoID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *MultiTopoID) GetMultiTopoId() uint32 {
@@ -2414,7 +2474,7 @@ type LsSrv6SID struct {
 
 func (x *LsSrv6SID) Reset() {
 	*x = LsSrv6SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2426,7 +2486,7 @@ func (x *LsSrv6SID) String() string {
 func (*LsSrv6SID) ProtoMessage() {}
 
 func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2439,7 +2499,7 @@ func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6SID.ProtoReflect.Descriptor instead.
 func (*LsSrv6SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LsSrv6SID) GetSids() []*SID {
@@ -2480,7 +2540,7 @@ type LsPrefix struct {
 
 func (x *LsPrefix) Reset() {
 	*x = LsPrefix{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2492,7 +2552,7 @@ func (x *LsPrefix) String() string {
 func (*LsPrefix) ProtoMessage() {}
 
 func (x *LsPrefix) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2505,7 +2565,7 @@ func (x *LsPrefix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsPrefix.ProtoReflect.Descriptor instead.
 func (*LsPrefix) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *LsPrefix) GetPrefix() string {
@@ -2532,7 +2592,7 @@ type Metric struct {
 
 func (x *Metric) Reset() {
 	*x = Metric{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2544,7 +2604,7 @@ func (x *Metric) String() string {
 func (*Metric) ProtoMessage() {}
 
 func (x *Metric) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2557,7 +2617,7 @@ func (x *Metric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metric.ProtoReflect.Descriptor instead.
 func (*Metric) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Metric) GetType() MetricType {
@@ -2585,7 +2645,7 @@ type Srv6EndXSID struct {
 
 func (x *Srv6EndXSID) Reset() {
 	*x = Srv6EndXSID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2597,7 +2657,7 @@ func (x *Srv6EndXSID) String() string {
 func (*Srv6EndXSID) ProtoMessage() {}
 
 func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2610,7 +2670,7 @@ func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Srv6EndXSID.ProtoReflect.Descriptor instead.
 func (*Srv6EndXSID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *Srv6EndXSID) GetEndpointBehavior() uint32 {
@@ -2651,7 +2711,7 @@ type LsLink struct {
 
 func (x *LsLink) Reset() {
 	*x = LsLink{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2663,7 +2723,7 @@ func (x *LsLink) String() string {
 func (*LsLink) ProtoMessage() {}
 
 func (x *LsLink) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2676,7 +2736,7 @@ func (x *LsLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsLink.ProtoReflect.Descriptor instead.
 func (*LsLink) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LsLink) GetLocalRouterId() string {
@@ -2759,7 +2819,7 @@ type LsNode struct {
 
 func (x *LsNode) Reset() {
 	*x = LsNode{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2771,7 +2831,7 @@ func (x *LsNode) String() string {
 func (*LsNode) ProtoMessage() {}
 
 func (x *LsNode) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2784,7 +2844,7 @@ func (x *LsNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsNode.ProtoReflect.Descriptor instead.
 func (*LsNode) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *LsNode) GetAsn() uint32 {
@@ -2860,7 +2920,7 @@ type GetSessionListRequest struct {
 
 func (x *GetSessionListRequest) Reset() {
 	*x = GetSessionListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2872,7 +2932,7 @@ func (x *GetSessionListRequest) String() string {
 func (*GetSessionListRequest) ProtoMessage() {}
 
 func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2885,7 +2945,7 @@ func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListRequest.ProtoReflect.Descriptor instead.
 func (*GetSessionListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetSessionListRequest) GetPeerAddr() []byte {
@@ -2911,7 +2971,7 @@ type GetSessionListResponse struct {
 
 func (x *GetSessionListResponse) Reset() {
 	*x = GetSessionListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2923,7 +2983,7 @@ func (x *GetSessionListResponse) String() string {
 func (*GetSessionListResponse) ProtoMessage() {}
 
 func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2936,7 +2996,7 @@ func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListResponse.ProtoReflect.Descriptor instead.
 func (*GetSessionListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetSessionListResponse) GetSessions() []*Session {
@@ -2955,7 +3015,7 @@ type GetSRPolicyListRequest struct {
 
 func (x *GetSRPolicyListRequest) Reset() {
 	*x = GetSRPolicyListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2967,7 +3027,7 @@ func (x *GetSRPolicyListRequest) String() string {
 func (*GetSRPolicyListRequest) ProtoMessage() {}
 
 func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2980,7 +3040,7 @@ func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListRequest.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetSRPolicyListRequest) GetPeerAddr() []byte {
@@ -2999,7 +3059,7 @@ type GetSRPolicyListResponse struct {
 
 func (x *GetSRPolicyListResponse) Reset() {
 	*x = GetSRPolicyListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3011,7 +3071,7 @@ func (x *GetSRPolicyListResponse) String() string {
 func (*GetSRPolicyListResponse) ProtoMessage() {}
 
 func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3024,7 +3084,7 @@ func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListResponse.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetSRPolicyListResponse) GetSessions() []*SRPolicySession {
@@ -3042,7 +3102,7 @@ type GetTEDRequest struct {
 
 func (x *GetTEDRequest) Reset() {
 	*x = GetTEDRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3054,7 +3114,7 @@ func (x *GetTEDRequest) String() string {
 func (*GetTEDRequest) ProtoMessage() {}
 
 func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3067,7 +3127,7 @@ func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDRequest.ProtoReflect.Descriptor instead.
 func (*GetTEDRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
 }
 
 type GetTEDResponse struct {
@@ -3080,7 +3140,7 @@ type GetTEDResponse struct {
 
 func (x *GetTEDResponse) Reset() {
 	*x = GetTEDResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3092,7 +3152,7 @@ func (x *GetTEDResponse) String() string {
 func (*GetTEDResponse) ProtoMessage() {}
 
 func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3105,7 +3165,7 @@ func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDResponse.ProtoReflect.Descriptor instead.
 func (*GetTEDResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetTEDResponse) GetEnabled() bool {
@@ -3131,7 +3191,7 @@ type DeleteSessionRequest struct {
 
 func (x *DeleteSessionRequest) Reset() {
 	*x = DeleteSessionRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3143,7 +3203,7 @@ func (x *DeleteSessionRequest) String() string {
 func (*DeleteSessionRequest) ProtoMessage() {}
 
 func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3156,7 +3216,7 @@ func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{39}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *DeleteSessionRequest) GetPeerAddr() []byte {
@@ -3174,7 +3234,7 @@ type DeleteSessionResponse struct {
 
 func (x *DeleteSessionResponse) Reset() {
 	*x = DeleteSessionResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3186,7 +3246,7 @@ func (x *DeleteSessionResponse) String() string {
 func (*DeleteSessionResponse) ProtoMessage() {}
 
 func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3199,7 +3259,7 @@ func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{40}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{41}
 }
 
 var File_api_pola_v1_pola_proto protoreflect.FileDescriptor
@@ -3264,9 +3324,13 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\runlimited_msd\x18\x01 \x01(\bR\funlimitedMsd\x12#\n" +
 	"\rnai_supported\x18\x02 \x01(\bR\fnaiSupported\x12\x15\n" +
 	"\x03msd\x18\x03 \x01(\rH\x00R\x03msd\x88\x01\x01B\x06\n" +
-	"\x04_msd\"5\n" +
+	"\x04_msd\"/\n" +
+	"\x03Msd\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\rR\x04type\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\rR\x05value\"[\n" +
 	"\x0eSrv6Capability\x12#\n" +
-	"\rnai_supported\x18\x01 \x01(\bR\fnaiSupported\"\x87\x01\n" +
+	"\rnai_supported\x18\x01 \x01(\bR\fnaiSupported\x12$\n" +
+	"\x04msds\x18\x02 \x03(\v2\x10.api.pola.v1.MsdR\x04msds\"\x87\x01\n" +
 	"\x17PathSetupTypeCapability\x12(\n" +
 	"\x10path_setup_types\x18\x01 \x03(\rR\x0epathSetupTypes\x12B\n" +
 	"\x10sub_capabilities\x18\x02 \x03(\v2\x17.api.pola.v1.CapabilityR\x0fsubCapabilities\":\n" +
@@ -3498,7 +3562,7 @@ func file_api_pola_v1_pola_proto_rawDescGZIP() []byte {
 }
 
 var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
+var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_api_pola_v1_pola_proto_goTypes = []any{
 	(SRPolicyType)(0),                   // 0: api.pola.v1.SRPolicyType
 	(SRPolicyState)(0),                  // 1: api.pola.v1.SRPolicyState
@@ -3517,38 +3581,39 @@ var file_api_pola_v1_pola_proto_goTypes = []any{
 	(*DeleteSRPolicyResponse)(nil),      // 14: api.pola.v1.DeleteSRPolicyResponse
 	(*StatefulCapability)(nil),          // 15: api.pola.v1.StatefulCapability
 	(*SrCapability)(nil),                // 16: api.pola.v1.SrCapability
-	(*Srv6Capability)(nil),              // 17: api.pola.v1.Srv6Capability
-	(*PathSetupTypeCapability)(nil),     // 18: api.pola.v1.PathSetupTypeCapability
-	(*AssocTypeListCapability)(nil),     // 19: api.pola.v1.AssocTypeListCapability
-	(*LspDbVersionCapability)(nil),      // 20: api.pola.v1.LspDbVersionCapability
-	(*MultipathCapability)(nil),         // 21: api.pola.v1.MultipathCapability
-	(*VendorInformationCapability)(nil), // 22: api.pola.v1.VendorInformationCapability
-	(*UnknownCapability)(nil),           // 23: api.pola.v1.UnknownCapability
-	(*Capability)(nil),                  // 24: api.pola.v1.Capability
-	(*SessionTimers)(nil),               // 25: api.pola.v1.SessionTimers
-	(*EffectiveTimers)(nil),             // 26: api.pola.v1.EffectiveTimers
-	(*MessageCounter)(nil),              // 27: api.pola.v1.MessageCounter
-	(*SessionStats)(nil),                // 28: api.pola.v1.SessionStats
-	(*Session)(nil),                     // 29: api.pola.v1.Session
-	(*SRPolicySession)(nil),             // 30: api.pola.v1.SRPolicySession
-	(*EndpointBehavior)(nil),            // 31: api.pola.v1.EndpointBehavior
-	(*SidStructure)(nil),                // 32: api.pola.v1.SidStructure
-	(*SID)(nil),                         // 33: api.pola.v1.SID
-	(*MultiTopoID)(nil),                 // 34: api.pola.v1.MultiTopoID
-	(*LsSrv6SID)(nil),                   // 35: api.pola.v1.LsSrv6SID
-	(*LsPrefix)(nil),                    // 36: api.pola.v1.LsPrefix
-	(*Metric)(nil),                      // 37: api.pola.v1.Metric
-	(*Srv6EndXSID)(nil),                 // 38: api.pola.v1.Srv6EndXSID
-	(*LsLink)(nil),                      // 39: api.pola.v1.LsLink
-	(*LsNode)(nil),                      // 40: api.pola.v1.LsNode
-	(*GetSessionListRequest)(nil),       // 41: api.pola.v1.GetSessionListRequest
-	(*GetSessionListResponse)(nil),      // 42: api.pola.v1.GetSessionListResponse
-	(*GetSRPolicyListRequest)(nil),      // 43: api.pola.v1.GetSRPolicyListRequest
-	(*GetSRPolicyListResponse)(nil),     // 44: api.pola.v1.GetSRPolicyListResponse
-	(*GetTEDRequest)(nil),               // 45: api.pola.v1.GetTEDRequest
-	(*GetTEDResponse)(nil),              // 46: api.pola.v1.GetTEDResponse
-	(*DeleteSessionRequest)(nil),        // 47: api.pola.v1.DeleteSessionRequest
-	(*DeleteSessionResponse)(nil),       // 48: api.pola.v1.DeleteSessionResponse
+	(*Msd)(nil),                         // 17: api.pola.v1.Msd
+	(*Srv6Capability)(nil),              // 18: api.pola.v1.Srv6Capability
+	(*PathSetupTypeCapability)(nil),     // 19: api.pola.v1.PathSetupTypeCapability
+	(*AssocTypeListCapability)(nil),     // 20: api.pola.v1.AssocTypeListCapability
+	(*LspDbVersionCapability)(nil),      // 21: api.pola.v1.LspDbVersionCapability
+	(*MultipathCapability)(nil),         // 22: api.pola.v1.MultipathCapability
+	(*VendorInformationCapability)(nil), // 23: api.pola.v1.VendorInformationCapability
+	(*UnknownCapability)(nil),           // 24: api.pola.v1.UnknownCapability
+	(*Capability)(nil),                  // 25: api.pola.v1.Capability
+	(*SessionTimers)(nil),               // 26: api.pola.v1.SessionTimers
+	(*EffectiveTimers)(nil),             // 27: api.pola.v1.EffectiveTimers
+	(*MessageCounter)(nil),              // 28: api.pola.v1.MessageCounter
+	(*SessionStats)(nil),                // 29: api.pola.v1.SessionStats
+	(*Session)(nil),                     // 30: api.pola.v1.Session
+	(*SRPolicySession)(nil),             // 31: api.pola.v1.SRPolicySession
+	(*EndpointBehavior)(nil),            // 32: api.pola.v1.EndpointBehavior
+	(*SidStructure)(nil),                // 33: api.pola.v1.SidStructure
+	(*SID)(nil),                         // 34: api.pola.v1.SID
+	(*MultiTopoID)(nil),                 // 35: api.pola.v1.MultiTopoID
+	(*LsSrv6SID)(nil),                   // 36: api.pola.v1.LsSrv6SID
+	(*LsPrefix)(nil),                    // 37: api.pola.v1.LsPrefix
+	(*Metric)(nil),                      // 38: api.pola.v1.Metric
+	(*Srv6EndXSID)(nil),                 // 39: api.pola.v1.Srv6EndXSID
+	(*LsLink)(nil),                      // 40: api.pola.v1.LsLink
+	(*LsNode)(nil),                      // 41: api.pola.v1.LsNode
+	(*GetSessionListRequest)(nil),       // 42: api.pola.v1.GetSessionListRequest
+	(*GetSessionListResponse)(nil),      // 43: api.pola.v1.GetSessionListResponse
+	(*GetSRPolicyListRequest)(nil),      // 44: api.pola.v1.GetSRPolicyListRequest
+	(*GetSRPolicyListResponse)(nil),     // 45: api.pola.v1.GetSRPolicyListResponse
+	(*GetTEDRequest)(nil),               // 46: api.pola.v1.GetTEDRequest
+	(*GetTEDResponse)(nil),              // 47: api.pola.v1.GetTEDResponse
+	(*DeleteSessionRequest)(nil),        // 48: api.pola.v1.DeleteSessionRequest
+	(*DeleteSessionResponse)(nil),       // 49: api.pola.v1.DeleteSessionResponse
 }
 var file_api_pola_v1_pola_proto_depIdxs = []int32{
 	0,  // 0: api.pola.v1.SRPolicy.type:type_name -> api.pola.v1.SRPolicyType
@@ -3558,72 +3623,73 @@ var file_api_pola_v1_pola_proto_depIdxs = []int32{
 	1,  // 4: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
 	10, // 5: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
 	10, // 6: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	24, // 7: api.pola.v1.PathSetupTypeCapability.sub_capabilities:type_name -> api.pola.v1.Capability
-	4,  // 8: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
-	15, // 9: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
-	16, // 10: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
-	17, // 11: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
-	18, // 12: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
-	19, // 13: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
-	20, // 14: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
-	21, // 15: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
-	22, // 16: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
-	23, // 17: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
-	27, // 18: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
-	27, // 19: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
-	27, // 20: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
-	27, // 21: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
-	27, // 22: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
-	27, // 23: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
-	27, // 24: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
-	27, // 25: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
-	27, // 26: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
-	27, // 27: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
-	2,  // 28: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
-	24, // 29: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
-	3,  // 30: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
-	24, // 31: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
-	25, // 32: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
-	25, // 33: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
-	26, // 34: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
-	5,  // 35: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
-	6,  // 36: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	28, // 37: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
-	2,  // 38: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
-	6,  // 39: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	10, // 40: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
-	33, // 41: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
-	31, // 42: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
-	32, // 43: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
-	34, // 44: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
-	7,  // 45: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
-	33, // 46: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
-	32, // 47: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	37, // 48: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	38, // 49: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
-	39, // 50: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
-	36, // 51: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
-	35, // 52: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	29, // 53: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	30, // 54: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
-	40, // 55: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
-	11, // 56: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	13, // 57: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	41, // 58: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	43, // 59: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	45, // 60: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	47, // 61: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	12, // 62: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	14, // 63: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	42, // 64: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	44, // 65: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	46, // 66: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	48, // 67: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	62, // [62:68] is the sub-list for method output_type
-	56, // [56:62] is the sub-list for method input_type
-	56, // [56:56] is the sub-list for extension type_name
-	56, // [56:56] is the sub-list for extension extendee
-	0,  // [0:56] is the sub-list for field type_name
+	17, // 7: api.pola.v1.Srv6Capability.msds:type_name -> api.pola.v1.Msd
+	25, // 8: api.pola.v1.PathSetupTypeCapability.sub_capabilities:type_name -> api.pola.v1.Capability
+	4,  // 9: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
+	15, // 10: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
+	16, // 11: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
+	18, // 12: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
+	19, // 13: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
+	20, // 14: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
+	21, // 15: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
+	22, // 16: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
+	23, // 17: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
+	24, // 18: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
+	28, // 19: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
+	28, // 20: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
+	28, // 21: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
+	28, // 22: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
+	28, // 23: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
+	28, // 24: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
+	28, // 25: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
+	28, // 26: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
+	28, // 27: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
+	28, // 28: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
+	2,  // 29: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
+	25, // 30: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
+	3,  // 31: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
+	25, // 32: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
+	26, // 33: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
+	26, // 34: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
+	27, // 35: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
+	5,  // 36: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
+	6,  // 37: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	29, // 38: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
+	2,  // 39: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
+	6,  // 40: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	10, // 41: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
+	34, // 42: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
+	32, // 43: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	33, // 44: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
+	35, // 45: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
+	7,  // 46: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
+	34, // 47: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
+	33, // 48: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
+	38, // 49: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	39, // 50: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
+	40, // 51: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
+	37, // 52: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
+	36, // 53: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	30, // 54: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	31, // 55: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
+	41, // 56: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
+	11, // 57: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	13, // 58: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	42, // 59: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	44, // 60: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	46, // 61: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	48, // 62: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	12, // 63: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	14, // 64: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	43, // 65: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	45, // 66: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	47, // 67: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	49, // 68: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	63, // [63:69] is the sub-list for method output_type
+	57, // [57:63] is the sub-list for method input_type
+	57, // [57:57] is the sub-list for extension type_name
+	57, // [57:57] is the sub-list for extension extendee
+	0,  // [0:57] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }
@@ -3632,7 +3698,7 @@ func file_api_pola_v1_pola_proto_init() {
 		return
 	}
 	file_api_pola_v1_pola_proto_msgTypes[8].OneofWrappers = []any{}
-	file_api_pola_v1_pola_proto_msgTypes[16].OneofWrappers = []any{
+	file_api_pola_v1_pola_proto_msgTypes[17].OneofWrappers = []any{
 		(*Capability_Stateful)(nil),
 		(*Capability_Sr)(nil),
 		(*Capability_Srv6)(nil),
@@ -3643,15 +3709,15 @@ func file_api_pola_v1_pola_proto_init() {
 		(*Capability_VendorInformation)(nil),
 		(*Capability_Unknown)(nil),
 	}
-	file_api_pola_v1_pola_proto_msgTypes[21].OneofWrappers = []any{}
-	file_api_pola_v1_pola_proto_msgTypes[28].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[22].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[29].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_pola_v1_pola_proto_rawDesc), len(file_api_pola_v1_pola_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   41,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -134,8 +134,14 @@ message SrCapability {
   optional uint32 msd = 3;
 }
 
+message Msd {
+  uint32 type = 1;
+  uint32 value = 2;
+}
+
 message Srv6Capability {
   bool nai_supported = 1;
+  repeated Msd msds = 2;
 }
 
 message PathSetupTypeCapability {

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -27,6 +27,23 @@ func withTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), time.Second)
 }
 
+// Capability tokens.
+const (
+	CapTokenStateful      = "Stateful"
+	CapTokenUpdate        = "Update"
+	CapTokenInstantiation = "Instantiation"
+)
+
+// AssocTypeToken returns the capability token for an association type.
+func AssocTypeToken(assocType uint32) string {
+	return fmt.Sprintf("AssocType:%d", assocType)
+}
+
+// UnknownTLVToken returns the capability token for an unknown TLV type.
+func UnknownTLVToken(tlvType uint32) string {
+	return fmt.Sprintf("unknown_type_%d", tlvType)
+}
+
 // StatefulCapability holds the RFC 8231/8232 Stateful PCE capability flags.
 type StatefulCapability struct {
 	LSPUpdate            bool `json:"LSPUpdate"`
@@ -40,9 +57,9 @@ type StatefulCapability struct {
 
 // Strings returns the human-readable flags for this capability.
 func (c StatefulCapability) Strings() []string {
-	ret := []string{"Stateful"}
+	ret := []string{CapTokenStateful}
 	if c.LSPUpdate {
-		ret = append(ret, "Update")
+		ret = append(ret, CapTokenUpdate)
 	}
 
 	if c.IncludeDBVersion {
@@ -50,7 +67,7 @@ func (c StatefulCapability) Strings() []string {
 	}
 
 	if c.LSPInstantiation {
-		ret = append(ret, "Instantiation")
+		ret = append(ret, CapTokenInstantiation)
 	}
 
 	if c.TriggeredResync {
@@ -97,9 +114,33 @@ func (c SRCapability) Strings() []string {
 	return ret
 }
 
+// MSD is an MSD-Type and MSD-Value pair.
+type MSD struct {
+	Type  uint32 `json:"Type"`
+	Value uint32 `json:"Value"`
+}
+
+// msdTypeNames maps SRv6 MSD types to their IANA names.
+var msdTypeNames = map[uint32]string{
+	41: "SRH-Max-SL",
+	42: "SRH-Max-End-Pop",
+	44: "SRH-Max-H-Encaps",
+	45: "SRH-Max-End-D",
+}
+
+// MSDToken returns a human-readable token for an MSD pair.
+func MSDToken(msdType, value uint32) string {
+	if name, ok := msdTypeNames[msdType]; ok {
+		return fmt.Sprintf("%s=%d", name, value)
+	}
+
+	return fmt.Sprintf("MSD-Type-%d=%d", msdType, value)
+}
+
 // SRv6Capability holds the RFC 9603 SRv6-PCE capability flags.
 type SRv6Capability struct {
-	NAISupported bool `json:"NAISupported"`
+	NAISupported bool  `json:"NAISupported"`
+	MSDs         []MSD `json:"MSDs"`
 }
 
 // Strings returns the human-readable flags for this capability.
@@ -109,11 +150,14 @@ func (c SRv6Capability) Strings() []string {
 		ret = append(ret, "SRv6-NAI-Supported")
 	}
 
+	for _, msd := range c.MSDs {
+		ret = append(ret, MSDToken(msd.Type, msd.Value))
+	}
+
 	return ret
 }
 
-// PathSetupTypeCapability holds the raw PathSetupType values advertised by the peer,
-// along with any per-PST capability sub-TLVs (RFC 8408).
+// PathSetupTypeCapability holds advertised Path Setup Types and their capabilities.
 type PathSetupTypeCapability struct {
 	PathSetupTypes  []uint32     `json:"PathSetupTypes"`
 	SubCapabilities []Capability `json:"SubCapabilities"`
@@ -144,7 +188,7 @@ type AssocTypeListCapability struct {
 func (c AssocTypeListCapability) Strings() []string {
 	ret := make([]string, 0, len(c.AssocTypes))
 	for _, at := range c.AssocTypes {
-		ret = append(ret, fmt.Sprintf("AssocType:%d", at))
+		ret = append(ret, AssocTypeToken(at))
 	}
 
 	return ret
@@ -209,7 +253,7 @@ type UnknownCapability struct {
 
 // Strings returns a human-readable representation of this capability.
 func (c UnknownCapability) Strings() []string {
-	return []string{fmt.Sprintf("unknown_type_%d", c.TLVType)}
+	return []string{UnknownTLVToken(c.TLVType)}
 }
 
 // capabilityDetail is implemented by every typed capability detail above.
@@ -318,7 +362,12 @@ func capabilityFromPB(c *pb.Capability) Capability {
 			MSD:          detail.Sr.Msd,
 		}
 	case *pb.Capability_Srv6:
-		capability.Detail = SRv6Capability{NAISupported: detail.Srv6.GetNaiSupported()}
+		srv6 := SRv6Capability{NAISupported: detail.Srv6.GetNaiSupported()}
+		for _, msd := range detail.Srv6.GetMsds() {
+			srv6.MSDs = append(srv6.MSDs, MSD{Type: msd.GetType(), Value: msd.GetValue()})
+		}
+
+		capability.Detail = srv6
 	case *pb.Capability_PathSetupType:
 		pst := PathSetupTypeCapability{PathSetupTypes: detail.PathSetupType.GetPathSetupTypes()}
 		for _, sub := range detail.PathSetupType.GetSubCapabilities() {

--- a/cmd/pola/grpc/grpc_client_internal_test.go
+++ b/cmd/pola/grpc/grpc_client_internal_test.go
@@ -666,6 +666,11 @@ func TestCapabilityDetail_Strings(t *testing.T) {
 		{name: "SR MSD not advertised", detail: SRCapability{}, want: []string{"SR"}},
 		{name: "SRv6 with NAI support", detail: SRv6Capability{NAISupported: true}, want: []string{"SRv6", "SRv6-NAI-Supported"}},
 		{name: "SRv6 without NAI support", detail: SRv6Capability{}, want: []string{"SRv6"}},
+		{
+			name:   "SRv6 with IANA-named and unassigned MSD types",
+			detail: SRv6Capability{MSDs: []MSD{{Type: 41, Value: 8}, {Type: 42, Value: 4}, {Type: 44, Value: 6}, {Type: 45, Value: 2}, {Type: 43, Value: 1}}},
+			want:   []string{"SRv6", "SRH-Max-SL=8", "SRH-Max-End-Pop=4", "SRH-Max-H-Encaps=6", "SRH-Max-End-D=2", "MSD-Type-43=1"},
+		},
 		{name: "PathSetupType SR-TE (1) and SRv6-TE (3)", detail: PathSetupTypeCapability{PathSetupTypes: []uint32{1, 3}}, want: []string{"SR-TE", "SRv6-TE"}},
 		{name: "PathSetupType unrecognized value is omitted", detail: PathSetupTypeCapability{PathSetupTypes: []uint32{99}}, want: nil},
 		{name: "AssocTypeList", detail: AssocTypeListCapability{AssocTypes: []uint32{6, 7}}, want: []string{"AssocType:6", "AssocType:7"}},
@@ -728,6 +733,13 @@ func TestCapabilityFromPB(t *testing.T) {
 			name:  "SRv6",
 			pbCap: &pb.Capability{Type: pb.CapabilityType_CAPABILITY_TYPE_SRV6, Detail: &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{NaiSupported: true}}},
 			want:  Capability{Type: "SRV6", Detail: SRv6Capability{NAISupported: true}},
+		},
+		{
+			name: "SRv6 with MSDs",
+			pbCap: &pb.Capability{Type: pb.CapabilityType_CAPABILITY_TYPE_SRV6, Detail: &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
+				Msds: []*pb.Msd{{Type: 44, Value: 6}},
+			}}},
+			want: Capability{Type: "SRV6", Detail: SRv6Capability{MSDs: []MSD{{Type: 44, Value: 6}}}},
 		},
 		{
 			name:  "PathSetupType",

--- a/cmd/pola/session_capability.go
+++ b/cmd/pola/session_capability.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/nttcom/pola/cmd/pola/grpc"
@@ -29,17 +28,17 @@ const (
 	capGroupUnknown           = "UNKNOWN"
 )
 
-// assocTypeListLabel is the display header for the ASSOC_TYPE_LIST group.
 const assocTypeListLabel = "ASSOC-TYPE-LIST [RFC8697]"
 
-// capFeature is a comparable capability token.
+// capFeature represents a capability feature with an optional numeric value.
 type capFeature struct {
-	group string
-	token string
+	group  string
+	token  string
+	num    uint32
+	hasNum bool
 }
 
-// capabilitiesFeatures flattens capabilities into deduplicated
-// (group, token) features, preserving first-seen order.
+// capabilitiesFeatures flattens capabilities into deduplicated features.
 func capabilitiesFeatures(caps []grpc.Capability) []capFeature {
 	seen := make(map[capFeature]struct{})
 
@@ -51,11 +50,44 @@ func capabilitiesFeatures(caps []grpc.Capability) []capFeature {
 	return features
 }
 
-// appendCapabilityFeatures adds c's tokens and recursively processes
-// PATH-SETUP-TYPE-CAPABILITY sub-capabilities.
+// capabilityFeatures turns c into its features.
+func capabilityFeatures(c grpc.Capability) []capFeature {
+	switch detail := c.Detail.(type) {
+	case grpc.AssocTypeListCapability:
+		features := make([]capFeature, 0, len(detail.AssocTypes))
+		for _, assocType := range detail.AssocTypes {
+			features = append(features, capFeature{
+				group:  c.Type,
+				token:  grpc.AssocTypeToken(assocType),
+				num:    assocType,
+				hasNum: true,
+			})
+		}
+
+		return features
+
+	case grpc.UnknownCapability:
+		return []capFeature{{
+			group:  c.Type,
+			token:  grpc.UnknownTLVToken(detail.TLVType),
+			num:    detail.TLVType,
+			hasNum: true,
+		}}
+	}
+
+	tokens := c.Strings()
+
+	features := make([]capFeature, 0, len(tokens))
+	for _, token := range tokens {
+		features = append(features, capFeature{group: c.Type, token: token})
+	}
+
+	return features
+}
+
+// appendCapabilityFeatures adds c's features and its sub-capabilities.
 func appendCapabilityFeatures(features []capFeature, seen map[capFeature]struct{}, c grpc.Capability) []capFeature {
-	for _, token := range c.Strings() {
-		f := capFeature{group: c.Type, token: token}
+	for _, f := range capabilityFeatures(c) {
 		if _, ok := seen[f]; ok {
 			continue
 		}
@@ -173,26 +205,13 @@ func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesVi
 	return view
 }
 
-func parseTokenUint32(token, prefix string) (uint32, bool) {
-	if !strings.HasPrefix(token, prefix) {
-		return 0, false
-	}
-
-	n, err := strconv.ParseUint(strings.TrimPrefix(token, prefix), 10, 32)
-	if err != nil {
-		return 0, false
-	}
-
-	return uint32(n), true
-}
-
 func applyStatefulFeature(common *commonCapView, token string) bool {
 	switch token {
-	case "Stateful":
+	case grpc.CapTokenStateful:
 		common.Stateful = true
-	case "Update":
+	case grpc.CapTokenUpdate:
 		common.Update = true
-	case "Instantiation":
+	case grpc.CapTokenInstantiation:
 		common.Instantiation = true
 	default:
 		return false
@@ -210,13 +229,13 @@ func applyCommonFeature(common *commonCapView, f capFeature) bool {
 		common.PathSetupTypes = append(common.PathSetupTypes, f.token)
 		return true
 	case capGroupAssocTypeList:
-		if n, ok := parseTokenUint32(f.token, "AssocType:"); ok {
-			common.AssociationTypes = append(common.AssociationTypes, n)
+		if f.hasNum {
+			common.AssociationTypes = append(common.AssociationTypes, f.num)
 			return true
 		}
 	case capGroupUnknown:
-		if n, ok := parseTokenUint32(f.token, "unknown_type_"); ok {
-			common.UnrecognizedTLVTypes = append(common.UnrecognizedTLVTypes, n)
+		if f.hasNum {
+			common.UnrecognizedTLVTypes = append(common.UnrecognizedTLVTypes, f.num)
 			return true
 		}
 	}
@@ -224,18 +243,17 @@ func applyCommonFeature(common *commonCapView, f capFeature) bool {
 	return false
 }
 
-// capabilityGroups groups features by capability and formats their items
-// according to the capability type.
+// capabilityGroups groups features by capability.
 func capabilityGroups(features []capFeature) []capGroupView {
 	order := make([]string, 0)
 
-	tokensByGroup := make(map[string][]string)
+	byGroup := make(map[string][]capFeature)
 	for _, f := range features {
-		if _, ok := tokensByGroup[f.group]; !ok {
+		if _, ok := byGroup[f.group]; !ok {
 			order = append(order, f.group)
 		}
 
-		tokensByGroup[f.group] = append(tokensByGroup[f.group], f.token)
+		byGroup[f.group] = append(byGroup[f.group], f)
 	}
 
 	slices.SortFunc(order, func(a, b string) int {
@@ -244,29 +262,33 @@ func capabilityGroups(features []capFeature) []capGroupView {
 
 	groups := make([]capGroupView, 0, len(order))
 	for _, group := range order {
-		groups = append(groups, capGroupView{Capability: group, Items: groupItems(group, tokensByGroup[group])})
+		groups = append(groups, capGroupView{Capability: group, Items: groupItems(group, byGroup[group])})
 	}
 
 	return groups
 }
 
-func groupItems(group string, tokens []string) []string {
+func groupItems(group string, features []capFeature) []string {
 	switch group {
 	case capGroupAssocTypeList:
-		return sortedUint32Labels(tokens, "AssocType:", assocTypeLabel)
+		return sortedNumericLabels(features, assocTypeLabel)
 	case capGroupUnknown:
-		return sortedUint32Labels(tokens, "unknown_type_", unrecognizedTLVItem)
+		return sortedNumericLabels(features, unrecognizedTLVItem)
 	default:
-		return tokens
+		items := make([]string, len(features))
+		for i, f := range features {
+			items[i] = f.token
+		}
+
+		return items
 	}
 }
 
-// sortedUint32Labels sorts token values numerically and renders them with label.
-func sortedUint32Labels(tokens []string, prefix string, label func(uint32) string) []string {
-	ns := make([]uint32, 0, len(tokens))
-	for _, token := range tokens {
-		if n, ok := parseTokenUint32(token, prefix); ok {
-			ns = append(ns, n)
+func sortedNumericLabels(features []capFeature, label func(uint32) string) []string {
+	ns := make([]uint32, 0, len(features))
+	for _, f := range features {
+		if f.hasNum {
+			ns = append(ns, f.num)
 		}
 	}
 

--- a/cmd/pola/session_capability_test.go
+++ b/cmd/pola/session_capability_test.go
@@ -211,20 +211,6 @@ func TestUnrecognizedTLVItem_OutOfRange(t *testing.T) {
 	assert.Equal(t, "type=65536: out of TLV registry range, no RFC", unrecognizedTLVItem(0x10000))
 }
 
-func TestParseTokenUint32_NonNumericSuffixReturnsFalse(t *testing.T) {
-	t.Parallel()
-
-	_, ok := parseTokenUint32("MSD=notanumber", "MSD=")
-	assert.False(t, ok)
-}
-
-func TestParseTokenUint32_PrefixMismatchReturnsFalse(t *testing.T) {
-	t.Parallel()
-
-	_, ok := parseTokenUint32("AssocType:6", "MSD=")
-	assert.False(t, ok)
-}
-
 func TestBuildCapabilitiesView_CommonPathSetupTypesAreCollected(t *testing.T) {
 	t.Parallel()
 
@@ -248,9 +234,9 @@ func TestCommonCapabilityLines_GroupsByTLVExceptAssocTypeAndUnknown(t *testing.T
 	common := []capFeature{
 		{group: capGroupStateful, token: "Stateful"},
 		{group: capGroupStateful, token: "Update"},
-		{group: capGroupAssocTypeList, token: "AssocType:6"},
-		{group: capGroupAssocTypeList, token: "AssocType:9"},
-		{group: capGroupUnknown, token: "unknown_type_73"},
+		{group: capGroupAssocTypeList, token: "AssocType:6", num: 6, hasNum: true},
+		{group: capGroupAssocTypeList, token: "AssocType:9", num: 9, hasNum: true},
+		{group: capGroupUnknown, token: "unknown_type_73", num: 73, hasNum: true},
 	}
 
 	lines := capabilityLines(capabilityGroups(common))
@@ -311,7 +297,7 @@ func TestBuildCapabilitiesView_UntypedCommonCapabilitiesLandInOther(t *testing.T
 		{Type: capGroupVendorInformation, Detail: grpc.VendorInformationCapability{EnterpriseNumber: uint32(pcep.EnterpriseNumberJuniper)}},
 		{Type: capGroupMultipath, Detail: grpc.MultipathCapability{MaxMultipaths: 4, Weighted: true}},
 		{Type: capGroupLSPDBVersion, Detail: grpc.LSPDBVersionCapability{VersionNumber: 1}},
-		{Type: capGroupSRv6, Detail: grpc.SRv6Capability{NAISupported: true}},
+		{Type: capGroupSRv6, Detail: grpc.SRv6Capability{NAISupported: true, MSDs: []grpc.MSD{{Type: 44, Value: 6}}}},
 		{Type: capGroupStateful, Detail: grpc.StatefulCapability{TriggeredResync: true}},
 	}
 
@@ -328,6 +314,7 @@ func TestBuildCapabilitiesView_UntypedCommonCapabilitiesLandInOther(t *testing.T
 	assert.Contains(t, otherByGroup[capGroupMultipath], "Weighted")
 	assert.Contains(t, otherByGroup[capGroupLSPDBVersion], "LSP-DB-VERSION")
 	assert.Contains(t, otherByGroup[capGroupSRv6], "SRv6-NAI-Supported")
+	assert.Contains(t, otherByGroup[capGroupSRv6], "SRH-Max-H-Encaps=6")
 	assert.Contains(t, otherByGroup[capGroupStateful], "Triggered-Resync")
 	assert.True(t, view.Common.Stateful)
 	assert.NotContains(t, otherByGroup[capGroupStateful], "Stateful")
@@ -385,7 +372,7 @@ func TestCommonCapabilityLines_SingleAssocTypeStillUsesHeadingForm(t *testing.T)
 	t.Parallel()
 
 	common := []capFeature{
-		{group: capGroupAssocTypeList, token: "AssocType:6"},
+		{group: capGroupAssocTypeList, token: "AssocType:6", num: 6, hasNum: true},
 	}
 
 	lines := capabilityLines(capabilityGroups(common))

--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -458,7 +458,7 @@ type StateReport struct {
 	LSPAObject              *LSPAObject
 	MetricObjects           []*MetricObject
 	BandwidthObjects        []*BandwidthObject
-	AssociationObject       *AssociationObject
+	AssociationObjects      []*AssociationObject
 	VendorInformationObject *VendorInformationObject
 }
 
@@ -471,7 +471,6 @@ func NewStateReport() *StateReport {
 		LSPAObject:              &LSPAObject{},
 		MetricObjects:           []*MetricObject{},
 		BandwidthObjects:        []*BandwidthObject{},
-		AssociationObject:       &AssociationObject{},
 		VendorInformationObject: &VendorInformationObject{},
 	}
 }
@@ -522,7 +521,14 @@ func (r *StateReport) decodeSrpObject(objectType ObjectType, objectBody []uint8)
 }
 
 func (r *StateReport) decodeAssociationObject(objectType ObjectType, objectBody []uint8) error {
-	return r.AssociationObject.DecodeFromBytes(objectType, objectBody)
+	associationObject := &AssociationObject{}
+	if err := associationObject.DecodeFromBytes(objectType, objectBody); err != nil {
+		return err
+	}
+
+	r.AssociationObjects = append(r.AssociationObjects, associationObject)
+
+	return nil
 }
 
 func (r *StateReport) decodeVendorInformationObject(objectType ObjectType, objectBody []uint8) error {

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -507,6 +507,55 @@ func TestPCRptMessage_DecodeFromBytes_MalformedObjectLength(t *testing.T) {
 	}
 }
 
+func TestPCRptMessage_DecodeFromBytes_KeepsEveryAssociationObject(t *testing.T) {
+	t.Parallel()
+
+	srp := &pcep.SrpObject{}
+	srpBytes, err := srp.Serialize()
+	require.NoError(t, err)
+
+	lsp := &pcep.LSPObject{}
+	lspBytes, err := lsp.Serialize()
+	require.NoError(t, err)
+
+	disjoint := &pcep.AssociationObject{
+		ObjectType: pcep.ObjectTypeAssociationIPv4, AssocType: pcep.AssocTypeDisjointAssociation,
+		AssocID: 1, AssocSrc: netip.MustParseAddr("192.0.2.1"),
+	}
+	disjointBytes, err := disjoint.Serialize()
+	require.NoError(t, err)
+
+	srPolicy := &pcep.AssociationObject{
+		ObjectType: pcep.ObjectTypeAssociationIPv4, AssocType: pcep.AssocTypeSRPolicyAssociation,
+		AssocID: 2, AssocSrc: netip.MustParseAddr("192.0.2.2"),
+	}
+	srPolicyBytes, err := srPolicy.Serialize()
+	require.NoError(t, err)
+
+	body := pcep.AppendByteSlices(srpBytes, lspBytes, disjointBytes, srPolicyBytes)
+
+	var m pcep.PCRptMessage
+	require.NoError(t, m.DecodeFromBytes(body))
+	require.Len(t, m.StateReports, 1)
+	assert.Equal(t, []*pcep.AssociationObject{disjoint, srPolicy}, m.StateReports[0].AssociationObjects,
+		"an LSP may join multiple association groups (RFC 8697 §6.4)")
+}
+
+func TestPCRptMessage_DecodeFromBytes_MalformedAssociationObject(t *testing.T) {
+	t.Parallel()
+
+	srp := &pcep.SrpObject{}
+	srpBytes, err := srp.Serialize()
+	require.NoError(t, err)
+
+	body := append([]uint8{}, srpBytes...)
+	body = append(body, pcep.NewCommonObjectHeader(pcep.ObjectClassAssociation, pcep.ObjectTypeAssociationIPv4, 8).Serialize()...)
+	body = append(body, make([]uint8, 4)...) // ASSOCIATION body shorter than the required 8 bytes
+
+	var m pcep.PCRptMessage
+	require.ErrorContains(t, m.DecodeFromBytes(body), "ASSOCIATION")
+}
+
 func TestPCRptMessage_DecodeFromBytes_ObjectBeforeSRPLSP(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -789,6 +789,10 @@ func PathSetupTypeForSegments(segs []table.Segment) (pst Pst, ok bool) {
 		return 0, false
 	}
 
+	if table.HasUnknownSegmentType(segs) || table.HasMixedSegmentTypes(segs) {
+		return 0, false
+	}
+
 	switch segs[0].(type) {
 	case table.SegmentSRMPLS:
 		return PathSetupTypeSRTE, true

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -772,16 +772,31 @@ func NewSrpObject(segs []table.Segment, srpID uint32, isRemove bool) (*SrpObject
 		return o, nil
 	}
 
-	switch segs[0].(type) {
-	case table.SegmentSRMPLS:
-		o.TLVs = append(o.TLVs, &PathSetupType{PathSetupType: PathSetupTypeSRTE})
-	case table.SegmentSRv6:
-		o.TLVs = append(o.TLVs, &PathSetupType{PathSetupType: PathSetupTypeSRv6TE})
-	default:
+	pst, ok := PathSetupTypeForSegments(segs)
+	if !ok {
 		return nil, errors.New("invalid Segment type")
 	}
 
+	o.TLVs = append(o.TLVs, &PathSetupType{PathSetupType: pst})
+
 	return o, nil
+}
+
+// PathSetupTypeForSegments returns the path setup type for the segment list.
+// ok is false for an empty or unknown segment list.
+func PathSetupTypeForSegments(segs []table.Segment) (pst Pst, ok bool) {
+	if len(segs) == 0 {
+		return 0, false
+	}
+
+	switch segs[0].(type) {
+	case table.SegmentSRMPLS:
+		return PathSetupTypeSRTE, true
+	case table.SegmentSRv6:
+		return PathSetupTypeSRv6TE, true
+	}
+
+	return 0, false
 }
 
 // LSP Object (RFC 8281 §5.3.1).

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -1340,6 +1340,31 @@ func TestNewSrpObject(t *testing.T) {
 	}
 }
 
+func TestPathSetupTypeForSegments(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		segs   []table.Segment
+		want   pcep.Pst
+		wantOK bool
+	}{
+		"NoSegments":         {nil, 0, false},
+		"UnknownSegmentType": {[]table.Segment{fakeSegment{}}, 0, false},
+		"SRMPLS":             {[]table.Segment{table.NewSegmentSRMPLS(16001)}, pcep.PathSetupTypeSRTE, true},
+		"SRv6":               {[]table.Segment{table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::"))}, pcep.PathSetupTypeSRv6TE, true},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := pcep.PathSetupTypeForSegments(tt.segs)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestLSPObject_Color(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/packet/pcep/pcep_internal_test.go
+++ b/pkg/packet/pcep/pcep_internal_test.go
@@ -1197,7 +1197,7 @@ func TestPCRptMessage_DecodeFromBytes(t *testing.T) {
 		want.MetricObjects = []*MetricObject{metric1, metric2}
 		want.BandwidthObjects = []*BandwidthObject{{ObjectType: ObjectType(1), Bandwidth: 1000}}
 		want.LSPAObject = lspa
-		want.AssociationObject = assoc
+		want.AssociationObjects = []*AssociationObject{assoc}
 		want.VendorInformationObject = vendorInfo
 
 		assert.Equal(t, []*StateReport{want}, m.StateReports)

--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -842,6 +842,16 @@ func (tlv *SRPCECapability) HasInvalidZeroMSD() bool {
 	return !tlv.HasUnlimitedMaxSIDDepth && tlv.MaximumSidDepth == 0
 }
 
+// MaxSIDs returns the sender's session-wide SID depth limit.
+// ok is false when no limit is enforced.
+func (tlv *SRPCECapability) MaxSIDs() (maxSIDs uint8, ok bool) {
+	if tlv.HasUnlimitedMaxSIDDepth || tlv.MaximumSidDepth == 0 {
+		return 0, false
+	}
+
+	return tlv.MaximumSidDepth, true
+}
+
 // NewSRPCECapability creates an SR-PCE-CAPABILITY TLV.
 func NewSRPCECapability(hasUnlimitedMaxSIDDepth, isNAISupported bool, maximumSidDepth uint8) *SRPCECapability {
 	return &SRPCECapability{
@@ -851,25 +861,42 @@ func NewSRPCECapability(hasUnlimitedMaxSIDDepth, isNAISupported bool, maximumSid
 	}
 }
 
-// SRv6PCECapability represents the SRv6-PCE-CAPABILITY TLV, advertising SRv6
-// path setup support (RFC 9603).
-type SRv6PCECapability struct {
-	IsNAISupported bool
+// MSD is an (MSD-Type, MSD-Value) pair.
+type MSD struct {
+	Type  uint8
+	Value uint8
 }
 
-// SRv6NAISupportedFlag is the SRv6-PCE-CAPABILITY Flags bit indicating NAI
-// support in SRv6-ERO subobjects.
+// MSDPairLength is the size of an MSD pair on the wire.
+const MSDPairLength = 2
+
+// SRv6 MSD types defined in RFC 9352 (Type 43 is unassigned by IANA).
+const (
+	MSDTypeSRHMaxSL      uint8 = 41
+	MSDTypeSRHMaxEndPop  uint8 = 42
+	MSDTypeSRHMaxHEncaps uint8 = 44
+	MSDTypeSRHMaxEndD    uint8 = 45
+)
+
+// SRv6PCECapability represents the SRv6-PCE-CAPABILITY TLV (RFC 9603).
+type SRv6PCECapability struct {
+	IsNAISupported bool
+	MSDs           []MSD
+}
+
+// SRv6NAISupportedFlag indicates NAI resolution support.
 const SRv6NAISupportedFlag uint16 = 0x0002
 
-// Byte offsets of the fields within the SRv6-PCE-CAPABILITY TLV value.
+// Byte offsets of fields within the SRv6-PCE-CAPABILITY TLV value.
 const (
 	SRv6PCECapabilityReservedOffset = 0
 	SRv6PCECapabilityFlagsOffset    = 2
+	SRv6PCECapabilityMSDsOffset     = 4
 )
 
 // DecodeFromBytes implements TLVInterface.
 func (tlv *SRv6PCECapability) DecodeFromBytes(data []byte) error {
-	valueLen, err := decodeTLVLength(data, false)
+	valueLen, err := decodeTLVLength(data, true)
 	if err != nil {
 		return fmt.Errorf("SRv6PCECapability: %w", err)
 	}
@@ -883,13 +910,34 @@ func (tlv *SRv6PCECapability) DecodeFromBytes(data []byte) error {
 	flags := binary.BigEndian.Uint16(value[SRv6PCECapabilityFlagsOffset : SRv6PCECapabilityFlagsOffset+2])
 	tlv.IsNAISupported = (flags & SRv6NAISupportedFlag) != 0
 
+	msdBytes := value[SRv6PCECapabilityMSDsOffset:]
+	if len(msdBytes)%MSDPairLength != 0 {
+		return fmt.Errorf("SRv6PCECapability: value length %d leaves a truncated (MSD-Type, MSD-Value) pair", valueLen)
+	}
+
+	tlv.MSDs = nil
+	for i := 0; i < len(msdBytes); i += MSDPairLength {
+		tlv.MSDs = append(tlv.MSDs, MSD{Type: msdBytes[i], Value: msdBytes[i+1]})
+	}
+
 	return nil
+}
+
+func (tlv *SRv6PCECapability) valueLength() int {
+	return int(TLVSRv6PCECapabilityValueLength) + MSDPairLength*len(tlv.MSDs)
 }
 
 // Serialize implements TLVInterface.
 func (tlv *SRv6PCECapability) Serialize() ([]byte, error) {
-	value := make([]byte, TLVSRv6PCECapabilityValueLength)
-	// value[0:2] reserved, must be zero.
+	valueLenInt := tlv.valueLength()
+
+	valueLen, err := tlvValueLength(valueLenInt)
+	if err != nil {
+		return nil, fmt.Errorf("SRv6PCECapability: %w", err)
+	}
+
+	value := make([]byte, paddedLength(valueLenInt, TLVAlignment))
+
 	var flags uint16
 	if tlv.IsNAISupported {
 		flags |= SRv6NAISupportedFlag
@@ -897,9 +945,16 @@ func (tlv *SRv6PCECapability) Serialize() ([]byte, error) {
 
 	binary.BigEndian.PutUint16(value[SRv6PCECapabilityFlagsOffset:SRv6PCECapabilityFlagsOffset+2], flags)
 
+	offset := SRv6PCECapabilityMSDsOffset
+	for _, msd := range tlv.MSDs {
+		value[offset] = msd.Type
+		value[offset+1] = msd.Value
+		offset += MSDPairLength
+	}
+
 	return AppendByteSlices(
 		Uint16ToByteSlice(tlv.Type()),
-		Uint16ToByteSlice(TLVSRv6PCECapabilityValueLength),
+		Uint16ToByteSlice(valueLen),
 		value,
 	), nil
 }
@@ -911,21 +966,39 @@ func (tlv *SRv6PCECapability) Type() TLVType {
 
 // Len implements TLVInterface.
 func (tlv *SRv6PCECapability) Len() int {
-	return int(TLVValueOffset + TLVSRv6PCECapabilityValueLength)
+	return TLVValueOffset + paddedLength(tlv.valueLength(), TLVAlignment)
 }
 
 func (tlv *SRv6PCECapability) isCapability() {}
 
+// MaxSIDs returns the SID limit from the SRH Max H.Encaps MSD.
+// A zero MSD-Value maps to one SID (RFC 9352 §4.3).
+// ok is false when the MSD is absent.
+func (tlv *SRv6PCECapability) MaxSIDs() (maxSIDs uint8, ok bool) {
+	for _, msd := range tlv.MSDs {
+		if msd.Type != MSDTypeSRHMaxHEncaps {
+			continue
+		}
+
+		if msd.Value == 0 {
+			return 1, true
+		}
+
+		return msd.Value, true
+	}
+
+	return 0, false
+}
+
 // NewSRv6PCECapability creates an SRv6-PCE-CAPABILITY TLV.
-func NewSRv6PCECapability(isNAISupported bool) *SRv6PCECapability {
+func NewSRv6PCECapability(isNAISupported bool, msds ...MSD) *SRv6PCECapability {
 	return &SRv6PCECapability{
 		IsNAISupported: isNAISupported,
+		MSDs:           msds,
 	}
 }
 
-// MultipathCapability represents the MULTIPATH-CAP TLV, advertising the
-// maximum number of paths the speaker can return and its supported multipath
-// attributes (draft-ietf-pce-multipath).
+// MultipathCapability represents the MULTIPATH-CAP TLV (draft-ietf-pce-multipath).
 type MultipathCapability struct {
 	MaxMultipaths            uint16
 	IsWeightedSupported      bool
@@ -934,13 +1007,12 @@ type MultipathCapability struct {
 	IsCompositePathSupported bool
 }
 
-// Flag bits of the MULTIPATH-CAP TLV, as masks against its 16-bit Flags field.
-// 0x0002 is unassigned.
+// Flag bits of the MULTIPATH-CAP TLV.
 const (
-	MultipathFlagW uint16 = 0x0001 // weighted paths
-	MultipathFlagO uint16 = 0x0004 // opposite-direction paths
-	MultipathFlagF uint16 = 0x0008 // forward class
-	MultipathFlagC uint16 = 0x0010 // composite paths
+	MultipathFlagW uint16 = 0x0001
+	MultipathFlagO uint16 = 0x0004
+	MultipathFlagF uint16 = 0x0008
+	MultipathFlagC uint16 = 0x0010
 )
 
 // Byte offsets of the fields within the MULTIPATH-CAP TLV value.
@@ -1431,9 +1503,14 @@ func (tlv *PathSetupTypeCapability) SubCapabilities() []CapabilityInterface {
 	return ret
 }
 
+// PathSetupTypeList returns the advertised PSTs, limited by the PST count.
+func (tlv *PathSetupTypeCapability) PathSetupTypeList() Psts {
+	return tlv.PathSetupTypes[:tlv.pstCount()]
+}
+
 // HasPathSetupType reports whether the receiver advertises the given PST.
 func (tlv *PathSetupTypeCapability) HasPathSetupType(pst Pst) bool {
-	return slices.Contains(tlv.PathSetupTypes[:tlv.pstCount()], pst)
+	return slices.Contains(tlv.PathSetupTypeList(), pst)
 }
 
 // AssocType is an ASSOCIATION object type (RFC 8697).

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -1893,21 +1893,40 @@ var (
 	testSRv6PCECapability            = pcep.NewSRv6PCECapability(true)
 	testSRv6PCECapabilityBytes       = append(tlvHeader(pcep.TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x02)
 	testSRv6PCECapabilityNoNAIBytes  = append(tlvHeader(pcep.TLVSRv6PCECapability, 4), 0x00, 0x00, 0x00, 0x00)
-	testSRv6PCECapabilityExtended    = append(tlvHeader(pcep.TLVSRv6PCECapability, 8), 0x00, 0x00, 0x00, 0x02, 0xde, 0xad, 0xbe, 0xef)
 	testSRv6PCECapabilityShortLength = append(tlvHeader(pcep.TLVSRv6PCECapability, 3), 0x00, 0x00, 0x00)
 	testSRv6PCECapabilityTruncated   = append(tlvHeader(pcep.TLVSRv6PCECapability, 4), 0x00, 0x00)
 	testSRv6PCECapabilityNoNAI       = &pcep.SRv6PCECapability{}
+
+	// Two (MSD-Type, MSD-Value) pairs: SRH Max SL = 10, SRH Max H.encaps = 5.
+	testSRv6PCECapabilityMSDs = pcep.NewSRv6PCECapability(true,
+		pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 10},
+		pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 5},
+	)
+	testSRv6PCECapabilityMSDsBytes = append(tlvHeader(pcep.TLVSRv6PCECapability, 8),
+		0x00, 0x00, 0x00, 0x02, 0x29, 0x0a, 0x2c, 0x05)
+
+	// A single pair requires 4-octet TLV padding.
+	testSRv6PCECapabilityOneMSD = pcep.NewSRv6PCECapability(true,
+		pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 5},
+	)
+	testSRv6PCECapabilityOneMSDBytes = append(tlvHeader(pcep.TLVSRv6PCECapability, 6),
+		0x00, 0x00, 0x00, 0x02, 0x2c, 0x05, 0x00, 0x00)
+
+	testSRv6PCECapabilityOddMSDBytes = append(tlvHeader(pcep.TLVSRv6PCECapability, 7),
+		0x00, 0x00, 0x00, 0x02, 0x2c, 0x05, 0x00)
 )
 
 func TestSRv6PCECapability_DecodeFromBytes(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]TLVTestCase{
-		"ValidSRv6PCECapability":          {testSRv6PCECapabilityBytes, testSRv6PCECapability, false},
-		"ValidSRv6PCECapabilityNoNAI":     {testSRv6PCECapabilityNoNAIBytes, testSRv6PCECapabilityNoNAI, false},
-		"ExtendedLengthSRv6PCECapability": {testSRv6PCECapabilityExtended, testSRv6PCECapability, false},
-		"ShortLengthSRv6PCECapability":    {testSRv6PCECapabilityShortLength, nil, true},
-		"TruncatedSRv6PCECapability":      {testSRv6PCECapabilityTruncated, nil, true},
+		"ValidSRv6PCECapability":       {testSRv6PCECapabilityBytes, testSRv6PCECapability, false},
+		"ValidSRv6PCECapabilityNoNAI":  {testSRv6PCECapabilityNoNAIBytes, testSRv6PCECapabilityNoNAI, false},
+		"SRv6PCECapabilityWithMSDs":    {testSRv6PCECapabilityMSDsBytes, testSRv6PCECapabilityMSDs, false},
+		"SRv6PCECapabilityOneMSD":      {testSRv6PCECapabilityOneMSDBytes, testSRv6PCECapabilityOneMSD, false},
+		"SRv6PCECapabilityOddMSDBytes": {testSRv6PCECapabilityOddMSDBytes, nil, true},
+		"ShortLengthSRv6PCECapability": {testSRv6PCECapabilityShortLength, nil, true},
+		"TruncatedSRv6PCECapability":   {testSRv6PCECapabilityTruncated, nil, true},
 	}
 	runTLVDecodeTests(t, cases, func() pcep.TLVInterface { return &pcep.SRv6PCECapability{} })
 }
@@ -1921,8 +1940,32 @@ func TestSRv6PCECapability_Serialize(t *testing.T) {
 	}{
 		"ValidSRv6PCECapability":      {testSRv6PCECapability, testSRv6PCECapabilityBytes},
 		"ValidSRv6PCECapabilityNoNAI": {testSRv6PCECapabilityNoNAI, testSRv6PCECapabilityNoNAIBytes},
+		"SRv6PCECapabilityWithMSDs":   {testSRv6PCECapabilityMSDs, testSRv6PCECapabilityMSDsBytes},
+		"SRv6PCECapabilityOneMSD":     {testSRv6PCECapabilityOneMSD, testSRv6PCECapabilityOneMSDBytes},
 	}
 	runTLVSerializeTests(t, cases)
+}
+
+func TestSRv6PCECapability_Serialize_LengthBoundary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AtLimit", func(t *testing.T) {
+		t.Parallel()
+
+		tlv := &pcep.SRv6PCECapability{MSDs: make([]pcep.MSD, 32765)}
+		raw, err := tlv.Serialize()
+		require.NoError(t, err)
+		assert.Len(t, raw, tlv.Len(), "Len() must match serialized size")
+		assert.Equal(t, uint16(65534), binary.BigEndian.Uint16(raw[pcep.TLVLengthOffset:pcep.TLVValueOffset]))
+	})
+
+	t.Run("ExceedsLimit", func(t *testing.T) {
+		t.Parallel()
+
+		tlv := &pcep.SRv6PCECapability{MSDs: make([]pcep.MSD, 32766)}
+		_, err := tlv.Serialize()
+		assert.ErrorContains(t, err, "is outside the range")
+	})
 }
 
 func TestSRv6PCECapability_Len(t *testing.T) {
@@ -1933,6 +1976,8 @@ func TestSRv6PCECapability_Len(t *testing.T) {
 		expected uint16
 	}{
 		"ValidSRv6PCECapabilityLength": {testSRv6PCECapability, pcep.TLVValueOffset + pcep.TLVSRv6PCECapabilityValueLength},
+		"WithTwoMSDs":                  {testSRv6PCECapabilityMSDs, pcep.TLVValueOffset + pcep.TLVSRv6PCECapabilityValueLength + 4},
+		"WithOneMSDIsPadded":           {testSRv6PCECapabilityOneMSD, pcep.TLVValueOffset + pcep.TLVSRv6PCECapabilityValueLength + 4},
 	}
 	runTLVLenTests(t, cases)
 }
@@ -2047,6 +2092,73 @@ func TestMultipathCapability_RoundTrip(t *testing.T) {
 			gotData, err := got.Serialize()
 			require.NoError(t, err, "Serialize failed")
 			assert.Equal(t, data, gotData, "re-serialized bytes differ")
+		})
+	}
+}
+
+func TestSRPCECapability_MaxSIDs(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		tlv         *pcep.SRPCECapability
+		wantMaxSIDs uint8
+		wantOK      bool
+	}{
+		"BoundedMSD":   {pcep.NewSRPCECapability(false, false, 10), 10, true},
+		"UnlimitedMSD": {pcep.NewSRPCECapability(true, false, 0), 0, false},
+		"ZeroMSD":      {pcep.NewSRPCECapability(false, false, 0), 0, false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			maxSIDs, ok := tc.tlv.MaxSIDs()
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantMaxSIDs, maxSIDs)
+		})
+	}
+}
+
+func TestSRv6PCECapability_MaxSIDs(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		tlv         *pcep.SRv6PCECapability
+		wantMaxSIDs uint8
+		wantOK      bool
+	}{
+		"NoMSDs": {pcep.NewSRv6PCECapability(true), 0, false},
+		"HEncaps": {
+			pcep.NewSRv6PCECapability(true, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 7}),
+			7, true,
+		},
+		"HEncapsAmongOtherTypes": {
+			pcep.NewSRv6PCECapability(true,
+				pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 3},
+				pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 7},
+				pcep.MSD{Type: pcep.MSDTypeSRHMaxEndD, Value: 2},
+			),
+			7, true,
+		},
+		"OnlyOtherTypes": {
+			pcep.NewSRv6PCECapability(true, pcep.MSD{Type: pcep.MSDTypeSRHMaxEndPop, Value: 4}),
+			0, false,
+		},
+		// A zero H.Encaps MSD still allows one SID (RFC 9352 §4.3).
+		"ZeroHEncaps": {
+			pcep.NewSRv6PCECapability(true, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 0}),
+			1, true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			maxSIDs, ok := tc.tlv.MaxSIDs()
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantMaxSIDs, maxSIDs)
 		})
 	}
 }

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -139,9 +139,12 @@ func buildCapability(capability pcep.CapabilityInterface) *pb.Capability {
 
 		c.Detail = &pb.Capability_Sr{Sr: sr}
 	case *pcep.SRv6PCECapability:
-		c.Detail = &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
-			NaiSupported: tlv.IsNAISupported,
-		}}
+		srv6 := &pb.Srv6Capability{NaiSupported: tlv.IsNAISupported}
+		for _, msd := range tlv.MSDs {
+			srv6.Msds = append(srv6.Msds, &pb.Msd{Type: uint32(msd.Type), Value: uint32(msd.Value)})
+		}
+
+		c.Detail = &pb.Capability_Srv6{Srv6: srv6}
 	case *pcep.PathSetupTypeCapability:
 		psts := make([]uint32, len(tlv.PathSetupTypes))
 		for i, pst := range tlv.PathSetupTypes {

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -2920,6 +2920,20 @@ func TestBuildCapability(t *testing.T) {
 			},
 		},
 		{
+			name: "srv6 with MSDs",
+			cap: &pcep.SRv6PCECapability{IsNAISupported: true, MSDs: []pcep.MSD{
+				{Type: pcep.MSDTypeSRHMaxSL, Value: 8},
+				{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 6},
+			}},
+			want: &pb.Capability{
+				Type: pb.CapabilityType_CAPABILITY_TYPE_SRV6,
+				Detail: &pb.Capability_Srv6{Srv6: &pb.Srv6Capability{
+					NaiSupported: true,
+					Msds:         []*pb.Msd{{Type: 41, Value: 8}, {Type: 44, Value: 6}},
+				}},
+			},
+		},
+		{
 			name: "path setup type",
 			cap:  &pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{1, 3}},
 			want: &pb.Capability{

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -2146,6 +2146,8 @@ func TestCreateSRPolicy(t *testing.T) {
 		peerAddr := netip.MustParseAddr("10.0.255.1")
 		ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 		ss.syncState = SyncStateFinished
+		ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+			[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
 		s := &APIServer{pce: &Server{ted: ted, sessionList: []*Session{ss}}, logger: logger.NewNop()}
 
@@ -2200,6 +2202,8 @@ func TestCreateSRPolicy_SRv6WithoutLocalAddr(t *testing.T) {
 	peerAddr := netip.MustParseAddr("10.0.255.1")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 	ss.syncState = SyncStateFinished
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+		[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE}}})
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
 
@@ -2514,6 +2518,8 @@ func TestDeleteSRPolicy(t *testing.T) {
 		ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 		ss.syncState = SyncStateFinished
 		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: testSRPolicyName, DstAddr: dstAddr, Color: 100, Preference: 100}}
+		ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+			[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
 		s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
 		policy := validPolicy()
@@ -2706,6 +2712,8 @@ func TestSendSRPolicyRequest_CreatesNewPolicy(t *testing.T) {
 	dstAddr := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 	ss.syncState = SyncStateFinished
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+		[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
@@ -2728,6 +2736,8 @@ func TestSendSRPolicyRequest_UpdatesExistingPolicy(t *testing.T) {
 	ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 	ss.syncState = SyncStateFinished
 	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, DstAddr: dstAddr}}
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+		[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -45,8 +45,9 @@ const (
 	localDeadTimerKeepaliveDivisor = 4
 )
 
-// PCEP error codes used during session management (RFC 5440 §7.15).
+// PCEP error codes.
 const (
+	// Session establishment (RFC 5440 §7.15).
 	pcepErrorTypeSessionEstablishmentFailure  uint8 = 1
 	pcepErrorValueInvalidOpenMessage          uint8 = 1
 	pcepErrorValueOpenWaitTimerExpired        uint8 = 2
@@ -59,7 +60,27 @@ const (
 	pcepErrorTypeSecondSessionAttempt         uint8 = 9
 	pcepErrorValueSecondSessionAttempt        uint8 = 1
 	pcepErrorValueUnassigned                  uint8 = 0
+
+	// Reception of an invalid object (RFC 5440 §7.15).
+	pcepErrorTypeInvalidObject    uint8 = 10
+	pcepErrorValueMalformedObject uint8 = 11
+
+	// Invalid traffic engineering path setup type (RFC 8408 §8.3).
+	pcepErrorTypeInvalidPathSetupType     uint8 = 21
+	pcepErrorValueMismatchedPathSetupType uint8 = 2
+
+	// Association Error (RFC 8697 §6.4).
+	pcepErrorTypeAssociationError             uint8 = 26
+	pcepErrorValueAssociationTypeNotSupported uint8 = 1
 )
+
+// acceptedAssocTypes lists Association Types accepted from received messages.
+// Legacy vendor-specific types are accepted for interoperability but not advertised.
+var acceptedAssocTypes = []pcep.AssocType{
+	pcep.AssocTypeSRPolicyAssociation,
+	pcep.AssocTypeSRPolicyAssociationCisco,
+	pcep.AssocTypeSRPolicyAssociationJuniper,
+}
 
 // SessionState represents the PCEP session state (RFC 5440 Appendix A).
 type SessionState uint8
@@ -389,7 +410,6 @@ func NewSession(localOpen OpenParams, peerAddr netip.Addr, tcpConn net.Conn, lg 
 }
 
 // Established runs the PCEP session until it terminates.
-// The returned error indicates the session establishment outcome (RFC 9826).
 func (ss *Session) Established() error {
 	if err := ss.Open(); err != nil {
 		ss.logger.Debug("ERROR! PCEP session establishment failed", logger.Error(err))
@@ -407,7 +427,6 @@ func (ss *Session) Established() error {
 
 	done := make(chan struct{}, 1)
 
-	// Receive PCEP messages in a separate goroutine
 	go func() {
 		if err := ss.ReceivePCEPMessage(); err != nil {
 			ss.logger.Debug("ERROR! Receive PCEP Message", logger.Error(err))
@@ -438,7 +457,6 @@ func (ss *Session) Established() error {
 	}
 }
 
-// sendPCEPMessage serializes and writes a PCEP message.
 func (ss *Session) sendPCEPMessage(message pcep.Message) error {
 	byteMessage, err := message.Serialize()
 	if err != nil {
@@ -461,7 +479,7 @@ func (ss *Session) sendPCEPMessage(message pcep.Message) error {
 const maxLocalOpenRetries = 1
 
 // openNegotiation tracks the Open negotiation state, including the independent
-// RemoteOK and LocalOK conditions from RFC 5440 Appendix A.
+// RemoteOK and LocalOK conditions (RFC 5440 Appendix A).
 type openNegotiation struct {
 	remoteOK          bool
 	localOK           bool
@@ -483,13 +501,11 @@ func (neg *openNegotiation) established() bool {
 	return neg.remoteOK && neg.localOK
 }
 
-// peerOpened reports whether an Open has been received from the peer,
-// acceptable or not.
+// peerOpened reports whether the peer has sent an Open.
 func (neg *openNegotiation) peerOpened() bool {
 	return neg.remoteOK || neg.peerOpensRejected > 0
 }
 
-// state derives the Appendix A state from the negotiation conditions.
 func (neg *openNegotiation) state() SessionState {
 	switch {
 	case neg.established():
@@ -501,7 +517,7 @@ func (neg *openNegotiation) state() SessionState {
 	}
 }
 
-// Open sends Pola's Open and negotiates the PCEP session.
+// Open establishes the PCEP session (RFC 5440 §6.2).
 func (ss *Session) Open() error {
 	if err := ss.SendOpen(); err != nil {
 		return err
@@ -510,8 +526,6 @@ func (ss *Session) Open() error {
 	return ss.negotiateOpen(&openNegotiation{})
 }
 
-// negotiateOpen handles PCEP Open negotiation until both peers have
-// acknowledged each other's Open.
 func (ss *Session) negotiateOpen(neg *openNegotiation) error {
 	ss.restartInitializationTimer(neg)
 
@@ -568,9 +582,7 @@ func (ss *Session) negotiateOpen(neg *openNegotiation) error {
 	}
 }
 
-// applyNegotiationTransition restarts the initialization timer when the
-// negotiation state changed this round, and starts the negotiation Keepalive
-// once the peer's Open has just been accepted.
+// applyNegotiationTransition updates timers and Keepalive state.
 func (ss *Session) applyNegotiationTransition(neg *openNegotiation, before negotiationVars, stopNegotiationKeepalive *func()) {
 	after := neg.vars()
 	if after != before {
@@ -591,8 +603,7 @@ func (ss *Session) restartInitializationTimer(neg *openNegotiation) {
 	neg.deadline = time.Now().Add(timer)
 }
 
-// startNegotiationKeepalive starts the Keepalive timer once RemoteOK is set,
-// while Pola's Open is still awaiting acknowledgment.
+// startNegotiationKeepalive sends Keepalives during Open negotiation.
 func (ss *Session) startNegotiationKeepalive() func() {
 	interval := ss.keepaliveInterval()
 	if interval == 0 {
@@ -627,8 +638,7 @@ func (ss *Session) startNegotiationKeepalive() func() {
 	}
 }
 
-// readNegotiationMessage reads one message under the current initialization
-// timer and handles malformed messages according to session-establishment rules.
+// readNegotiationMessage reads one message before the initialization timer expires.
 func (ss *Session) readNegotiationMessage(neg *openNegotiation) (pcep.MessageType, []uint8, error) {
 	deadline := neg.deadline
 
@@ -664,7 +674,7 @@ func (ss *Session) readNegotiationMessage(neg *openNegotiation) (pcep.MessageTyp
 }
 
 // negotiationTimerExpired reports an initialization timer expiration using
-// the error value corresponding to the current negotiation state.
+// the error value for the current negotiation state.
 func (ss *Session) negotiationTimerExpired(neg *openNegotiation, detail string) error {
 	timer, errorValue := "OpenWait", pcepErrorValueOpenWaitTimerExpired
 	if neg.state() == SessionStateKeepWait {
@@ -676,8 +686,7 @@ func (ss *Session) negotiationTimerExpired(neg *openNegotiation, detail string) 
 	return fmt.Errorf("%s timer expired %s", timer, detail)
 }
 
-// handlePeerOpen processes an Open received during session establishment,
-// accepting it or responding with an appropriate negotiation error.
+// handlePeerOpen processes an Open received during session establishment.
 func (ss *Session) handlePeerOpen(body []uint8, neg *openNegotiation) error {
 	openMessage := &pcep.OpenMessage{}
 	if err := openMessage.DecodeFromBytes(body); err != nil {
@@ -695,6 +704,15 @@ func (ss *Session) handlePeerOpen(body []uint8, neg *openNegotiation) error {
 	}
 
 	peerOpen, pccType, caps := ss.decodePeerOpen(openMessage)
+
+	if err := ss.rejectOnEmptyPathSetupTypeList(caps); err != nil {
+		return err
+	}
+
+	// Refuse the session when the peer has no path setup type in common (RFC 8408 §5).
+	if err := ss.rejectOnPathSetupTypeMismatch(caps); err != nil {
+		return err
+	}
 
 	if ss.acceptableOpen(peerOpen) {
 		ss.commitPeerOpen(peerOpen, pccType, caps)
@@ -732,7 +750,6 @@ func (ss *Session) handlePeerOpen(body []uint8, neg *openNegotiation) error {
 }
 
 // decodePeerOpen decodes the peer's Open without committing it to session state.
-// Capability validation is diagnostic and runs regardless of acceptability.
 func (ss *Session) decodePeerOpen(openMessage *pcep.OpenMessage) (OpenParams, pcep.PccType, []pcep.CapabilityInterface) {
 	receivedCaps := slices.Clone(openMessage.OpenObject.Caps)
 
@@ -763,8 +780,8 @@ func (ss *Session) commitPeerOpen(peerOpen OpenParams, pccType pcep.PccType, cap
 	ss.stateMu.Unlock()
 }
 
-// handleNegotiationPCErr processes a PCErr received during session
-// establishment, continuing negotiation only for Error 1/4.
+// handleNegotiationPCErr processes a PCErr during session establishment.
+// Negotiation continues only for Error 1/4.
 func (ss *Session) handleNegotiationPCErr(body []uint8, neg *openNegotiation) error {
 	pcerrMessage := &pcep.PCErrMessage{}
 	if err := pcerrMessage.DecodeFromBytes(body); err != nil {
@@ -777,7 +794,7 @@ func (ss *Session) handleNegotiationPCErr(body []uint8, neg *openNegotiation) er
 	ss.logger.Debug("Received PCErr while establishing the PCEP session",
 		logger.String("errors", formatPCErrErrors(pcerrMessage.Errors)))
 
-	// A negotiable Error 1/4 may be accompanied by unrelated PCEP-ERROR objects.
+	// Error 1/4 may be accompanied by unrelated PCEP-ERROR objects.
 	negotiable := slices.ContainsFunc(pcerrMessage.Errors, func(errObj *pcep.ErrorObject) bool {
 		return errObj.ErrorType == pcepErrorTypeSessionEstablishmentFailure &&
 			errObj.ErrorValue == pcepErrorValueUnacceptableNegotiable
@@ -798,8 +815,8 @@ func formatPCErrErrors(errObjs []*pcep.ErrorObject) string {
 	return strings.Join(reasons, "; ")
 }
 
-// adoptProposedOpen validates and adopts the peer's proposed session
-// characteristics, then re-sends Pola's Open.
+// adoptProposedOpen adopts the peer's proposed session characteristics and
+// re-sends Pola's Open.
 func (ss *Session) adoptProposedOpen(proposedOpen *pcep.OpenObject, neg *openNegotiation) error {
 	if proposedOpen == nil {
 		ss.sendPCErrBestEffort(pcepErrorValueUnacceptableProposal)
@@ -838,8 +855,6 @@ func (ss *Session) adoptProposedOpen(proposedOpen *pcep.OpenObject, neg *openNeg
 	}
 
 	neg.localOpenRetries++
-
-	// A re-sent Open starts a new negotiation round.
 	neg.localOK = false
 
 	return nil
@@ -859,9 +874,45 @@ func isDeadlineExceeded(err error) bool {
 }
 
 func (ss *Session) sendPCErrBestEffort(errorValue uint8) {
-	if err := ss.SendPCErr(pcepErrorTypeSessionEstablishmentFailure, errorValue); err != nil {
+	ss.sendTypedPCErrBestEffort(pcepErrorTypeSessionEstablishmentFailure, errorValue)
+}
+
+func (ss *Session) sendTypedPCErrBestEffort(errorType, errorValue uint8) {
+	if err := ss.SendPCErr(errorType, errorValue); err != nil {
 		ss.logger.Debug("ERROR! Send PCErr Message", logger.Error(err))
 	}
+}
+
+// rejectOnEmptyPathSetupTypeList rejects an empty PST list (RFC 8408 §3).
+func (ss *Session) rejectOnEmptyPathSetupTypeList(caps []pcep.CapabilityInterface) error {
+	pstCap := firstPathSetupTypeCapability(caps)
+	if pstCap == nil || len(pstCap.PathSetupTypeList()) > 0 {
+		return nil
+	}
+
+	ss.sendTypedPCErrBestEffort(pcepErrorTypeInvalidObject, pcepErrorValueMalformedObject)
+
+	return errors.New("peer advertised a PATH-SETUP-TYPE-CAPABILITY with an empty path setup type list")
+}
+
+// rejectOnPathSetupTypeMismatch rejects when no PST is shared with the peer (RFC 8408 §5).
+// Peers without the capability are accepted for legacy compatibility.
+func (ss *Session) rejectOnPathSetupTypeMismatch(caps []pcep.CapabilityInterface) error {
+	peerCap := firstPathSetupTypeCapability(caps)
+	localCap := firstPathSetupTypeCapability(ss.AdvertisedCapabilities())
+
+	if peerCap == nil || localCap == nil {
+		return nil
+	}
+
+	peerPSTs, localPSTs := peerCap.PathSetupTypeList(), localCap.PathSetupTypeList()
+	if slices.ContainsFunc(localPSTs, func(pst pcep.Pst) bool { return slices.Contains(peerPSTs, pst) }) {
+		return nil
+	}
+
+	ss.sendTypedPCErrBestEffort(pcepErrorTypeInvalidPathSetupType, pcepErrorValueMismatchedPathSetupType)
+
+	return fmt.Errorf("peer advertised no path setup type in common with Pola (peer: %v, Pola: %v)", peerPSTs, localPSTs)
 }
 
 // validateCapabilities validates peer capabilities and logs known RFC deviations.
@@ -918,9 +969,9 @@ func (ss *Session) messageDeadline() time.Time {
 	return deadline
 }
 
-// validTimerRelationship reports whether Keepalive and DeadTimer are
-// mutually consistent. A nonzero DeadTimer is ignored when Keepalive is 0
-// (RFC 5440 §7.3); otherwise DeadTimer must exceed Keepalive (§6.3).
+// validTimerRelationship reports whether Keepalive and DeadTimer are valid.
+// DeadTimer is ignored when Keepalive is 0 (RFC 5440 §7.3); otherwise it
+// must exceed Keepalive (§6.3).
 func validTimerRelationship(open OpenParams) bool {
 	if open.Keepalive == 0 {
 		return true
@@ -929,8 +980,6 @@ func validTimerRelationship(open OpenParams) bool {
 	return open.DeadTimer == 0 || open.DeadTimer > open.Keepalive
 }
 
-// acceptableOpen reports whether the proposed session parameters are
-// acceptable, including a peer's counter-proposal.
 func (ss *Session) acceptableOpen(peerOpen OpenParams) bool {
 	if !validTimerRelationship(peerOpen) {
 		return false
@@ -943,7 +992,6 @@ func (ss *Session) acceptableOpen(peerOpen OpenParams) bool {
 	return peerOpen.Keepalive >= ss.minKeepalive && peerOpen.Keepalive <= ss.maxKeepalive
 }
 
-// proposedTimers returns acceptable Keepalive and DeadTimer values.
 func (ss *Session) proposedTimers(peerOpen OpenParams) (keepalive, deadTimer uint8) {
 	keepalive = peerOpen.Keepalive
 
@@ -965,7 +1013,6 @@ func (ss *Session) proposedTimers(peerOpen OpenParams) (keepalive, deadTimer uin
 	return keepalive, deadTimer
 }
 
-// proposeAcceptableOpen sends a PCErr proposing acceptable session characteristics.
 func (ss *Session) proposeAcceptableOpen(peerOpen OpenParams) error {
 	keepalive, deadTimer := ss.proposedTimers(peerOpen)
 	openObject := pcep.NewOpenObject(peerOpen.SessionID, keepalive, deadTimer, nil)
@@ -1001,7 +1048,7 @@ func (ss *Session) SendKeepalive() error {
 	return nil
 }
 
-// SendClose sends a PCEP Close message to the peer.
+// SendClose sends a PCEP Close message with the given reason.
 func (ss *Session) SendClose(reason pcep.CloseReason) error {
 	closeMessage := pcep.NewCloseMessage(reason)
 
@@ -1018,7 +1065,7 @@ func (ss *Session) SendClose(reason pcep.CloseReason) error {
 	return nil
 }
 
-// SendPCErr sends a PCErr message with the given error type and value.
+// SendPCErr sends a PCEP Error message carrying the given Error-Type and Error-value.
 func (ss *Session) SendPCErr(errorType, errorValue uint8) error {
 	pcerrMessage := pcep.NewPCErrMessage(errorType, errorValue, nil)
 
@@ -1036,13 +1083,13 @@ func (ss *Session) SendPCErr(errorType, errorValue uint8) error {
 	return nil
 }
 
-// ReceivePCEPMessage receives and processes PCEP messages from the peer.
+// ReceivePCEPMessage reads and dispatches PCEP messages until the session ends.
 func (ss *Session) ReceivePCEPMessage() error {
 	for {
 		done, err := ss.receiveOnePCEPMessage()
 		if err != nil {
 			if isDeadlineExceeded(err) {
-				// RFC 5440 Appendix A: DeadTimer expiry terminates the session per §6.8.
+				// DeadTimer expiry terminates the session (RFC 5440 §6.8).
 				if closeErr := ss.SendClose(pcep.CloseReasonDeadTimerExpired); closeErr != nil {
 					ss.logger.Debug("ERROR! Send Close Message", logger.Error(closeErr))
 				}
@@ -1099,7 +1146,7 @@ func (ss *Session) receiveOnePCEPMessage() (done bool, err error) {
 	return false, nil
 }
 
-// countReceived updates the RFC 9826 receive-side counter for a message type.
+// countReceived updates the RFC 9826 receive counter for a message type.
 func (ss *Session) countReceived(mt pcep.MessageType) {
 	switch mt {
 	case pcep.MessageTypeOpen:
@@ -1159,8 +1206,8 @@ func (ss *Session) receiveClose(messageLength uint16, deadline time.Time) error 
 	return nil
 }
 
-// handleUnexpectedOpen rejects an Open received while the session is Up.
-// RFC 5440 Appendix A does not define Open as an event in the Up state.
+// handleUnexpectedOpen rejects Open received in the Up state, which is not
+// defined as an event by RFC 5440 Appendix A.
 func (ss *Session) handleUnexpectedOpen(messageLength uint16, deadline time.Time) error {
 	if _, err := ss.readMessageBody(messageLength, deadline); err != nil {
 		return err
@@ -1220,7 +1267,7 @@ func (ss *Session) readMessageBody(messageLength uint16, deadline time.Time) ([]
 }
 
 // recordUnknownMessage records an unrecognized message and reports whether
-// more than maxUnknownMsgs have arrived within the trailing unknownMsgWindow.
+// the rate limit has been exceeded within unknownMsgWindow.
 func (ss *Session) recordUnknownMessage() bool {
 	ss.unknownMsgMu.Lock()
 	defer ss.unknownMsgMu.Unlock()
@@ -1240,7 +1287,6 @@ func (ss *Session) recordUnknownMessage() bool {
 	return uint32(count) > ss.maxUnknownMsgs
 }
 
-// handlePCErr logs the error and forgets intents for the reported SRP-IDs.
 func (ss *Session) handlePCErr(pcerrMessage *pcep.PCErrMessage) {
 	srpIDs := pcerrMessage.SRPIDs()
 	for _, errObj := range pcerrMessage.Errors {
@@ -1281,6 +1327,10 @@ func (ss *Session) handlePCRpt(length uint16, deadline time.Time) error {
 }
 
 func (ss *Session) handleStateReport(sr *pcep.StateReport, message *pcep.PCRptMessage) error {
+	if err := ss.rejectUnsupportedAssocTypes(sr.AssociationObjects); err != nil {
+		return err
+	}
+
 	if sr.LSPObject.SFlag {
 		return ss.handleSynchronization(sr, message)
 	}
@@ -1296,7 +1346,35 @@ func (ss *Session) handleStateReport(sr *pcep.StateReport, message *pcep.PCRptMe
 	}
 }
 
-// Synchronization (S-Flag).
+// rejectUnsupportedAssocTypes reports unsupported ASSOCIATION types.
+func (ss *Session) rejectUnsupportedAssocTypes(assocs []*pcep.AssociationObject) error {
+	for _, assoc := range assocs {
+		if assoc == nil || slices.Contains(acceptedAssocTypes, assoc.AssocType) {
+			continue
+		}
+
+		ss.logger.Warn("Received unsupported ASSOCIATION type",
+			logger.String("assocType", assoc.AssocType.StringWithReference()))
+
+		if err := ss.SendPCErr(pcepErrorTypeAssociationError, pcepErrorValueAssociationTypeNotSupported); err != nil {
+			return fmt.Errorf("failed to send PCErr for unsupported ASSOCIATION type: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// srPolicyAssociation returns the first accepted ASSOCIATION object.
+func srPolicyAssociation(sr *pcep.StateReport) *pcep.AssociationObject {
+	for _, assoc := range sr.AssociationObjects {
+		if assoc != nil && slices.Contains(acceptedAssocTypes, assoc.AssocType) {
+			return assoc
+		}
+	}
+
+	return nil
+}
+
 func (ss *Session) handleSynchronization(sr *pcep.StateReport, message *pcep.PCRptMessage) error {
 	ss.setSyncState(SyncStateOngoing)
 	ss.logger.Debug("Synchronize SR Policy information", logger.Any("Message", message))
@@ -1309,7 +1387,6 @@ func (ss *Session) handleSynchronization(sr *pcep.StateReport, message *pcep.PCR
 	return nil
 }
 
-// Finish synchronization (PlspID == 0).
 func (ss *Session) handleFinishSynchronization() {
 	ss.logger.Debug("Finish PCRpt state synchronization")
 	ss.setSynced()
@@ -1327,7 +1404,7 @@ func (ss *Session) setSynced() {
 	ss.syncState = SyncStateFinished
 }
 
-// State returns the PCEP session state (RFC 5440 Appendix A).
+// State returns the PCEP session state defined by RFC 5440 Appendix A.
 func (ss *Session) State() SessionState {
 	ss.stateMu.RLock()
 	defer ss.stateMu.RUnlock()
@@ -1440,8 +1517,8 @@ func (ss *Session) keepaliveInterval() uint8 {
 	return effectiveKeepalive(localOpen.Keepalive, localOpen.DeadTimer)
 }
 
-// effectiveKeepalive returns the Keepalive interval Pola uses.
-// It keeps the interval within Pola's advertised DeadTimer.
+// effectiveKeepalive returns the Keepalive interval Pola uses, limited by
+// Pola's advertised DeadTimer.
 func effectiveKeepalive(localKeepalive, localDeadTimer uint8) uint8 {
 	if localKeepalive == 0 || localDeadTimer == 0 {
 		return localKeepalive
@@ -1711,6 +1788,114 @@ func createEroFromSegmentList(segmentList []table.Segment) (*pcep.EroObject, err
 	return eroObject, nil
 }
 
+type sidDepthCapability interface {
+	MaxSIDs() (maxSIDs uint8, ok bool)
+}
+
+// firstSIDDepthCapability returns the first matching capability.
+// Later capabilities are ignored per RFC 8664 §5.1 and RFC 9603 §5.1.
+func firstSIDDepthCapability(caps []pcep.CapabilityInterface, pst pcep.Pst) sidDepthCapability {
+	for _, capability := range caps {
+		switch c := capability.(type) {
+		case *pcep.SRPCECapability:
+			if pst == pcep.PathSetupTypeSRTE {
+				return c
+			}
+		case *pcep.SRv6PCECapability:
+			if pst == pcep.PathSetupTypeSRv6TE {
+				return c
+			}
+		}
+	}
+
+	return nil
+}
+
+// firstPathSetupTypeCapability returns the first PATH-SETUP-TYPE-CAPABILITY.
+// Later instances are ignored per RFC 8408 §3.
+func firstPathSetupTypeCapability(caps []pcep.CapabilityInterface) *pcep.PathSetupTypeCapability {
+	for _, capability := range caps {
+		if pstCap, ok := capability.(*pcep.PathSetupTypeCapability); ok {
+			return pstCap
+		}
+	}
+
+	return nil
+}
+
+// peerSupportsPST reports whether the peer supports the given path setup type.
+// PATH-SETUP-TYPE-CAPABILITY is authoritative (RFC 8408 §5); otherwise,
+// legacy SR-CAPABILITY-TLV implies PSTs 0 and 1 (RFC 8664 Appendix A), and
+// no PST information is treated as permissive for legacy compatibility.
+func peerSupportsPST(caps []pcep.CapabilityInterface, pst pcep.Pst) bool {
+	if pstCap := firstPathSetupTypeCapability(caps); pstCap != nil {
+		return pstCap.HasPathSetupType(pst)
+	}
+
+	if firstSIDDepthCapability(caps, pcep.PathSetupTypeSRTE) != nil {
+		return pst == pcep.PathSetupTypeRSVPTE || pst == pcep.PathSetupTypeSRTE
+	}
+
+	return true
+}
+
+// peerMaxSIDs returns the advertised SID depth for the given path setup type.
+// PATH-SETUP-TYPE-CAPABILITY takes precedence over the legacy top-level
+// capability (RFC 8408 §3, RFC 8664 Appendix A). An unlisted PST is ignored
+// (RFC 8664 §5.1, RFC 9603 §5.1).
+func peerMaxSIDs(caps []pcep.CapabilityInterface, pst pcep.Pst) (maxSIDs uint8, ok bool) {
+	if pstCap := firstPathSetupTypeCapability(caps); pstCap != nil {
+		if !pstCap.HasPathSetupType(pst) {
+			return 0, false
+		}
+
+		if sub := firstSIDDepthCapability(pstCap.SubCapabilities(), pst); sub != nil {
+			return sub.MaxSIDs()
+		}
+
+		return 0, false
+	}
+
+	if topLevel := firstSIDDepthCapability(caps, pst); topLevel != nil {
+		return topLevel.MaxSIDs()
+	}
+
+	return 0, false
+}
+
+// validatePathSetupTypeForPeer rejects segment lists with unsupported path setup types.
+func (ss *Session) validatePathSetupTypeForPeer(segmentList []table.Segment) error {
+	pst, ok := pcep.PathSetupTypeForSegments(segmentList)
+	if !ok {
+		// An empty or unknown segment list is caught when the message is built.
+		return nil
+	}
+
+	if !peerSupportsPST(ss.ReceivedCapabilities(), pst) {
+		return fmt.Errorf("the PCC did not advertise the path setup type this segment list requires: %s", pst)
+	}
+
+	return nil
+}
+
+// validateSegmentListForPeer rejects segment lists unsupported by the peer.
+func (ss *Session) validateSegmentListForPeer(segmentList []table.Segment) error {
+	if err := ss.validatePathSetupTypeForPeer(segmentList); err != nil {
+		return err
+	}
+
+	pst, ok := pcep.PathSetupTypeForSegments(segmentList)
+	if !ok {
+		return nil
+	}
+
+	if maxSIDs, ok := peerMaxSIDs(ss.ReceivedCapabilities(), pst); ok && len(segmentList) > int(maxSIDs) {
+		return fmt.Errorf("segment list has %d SIDs, exceeding the maximum SID depth of %d advertised by the PCC", len(segmentList), maxSIDs)
+	}
+
+	return nil
+}
+
 // RequestAllSRPolicyDeleted requests deletion of all SR Policies for this session.
 func (ss *Session) RequestAllSRPolicyDeleted() error {
 	var srPolicy table.SRPolicy
@@ -1793,6 +1978,16 @@ func (ss *Session) allocateSRPID(polType table.PolicyType, metric table.MetricTy
 
 // SendPCInitiate sends a PCEP PC-Initiate message to request creation or deletion of an SR Policy.
 func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error {
+	// Deletion imposes no SID, so only the path setup type is checked.
+	validate, action := ss.validateSegmentListForPeer, "instantiate"
+	if lspDelete {
+		validate, action = ss.validatePathSetupTypeForPeer, "delete"
+	}
+
+	if err := validate(srPolicy.SegmentList); err != nil {
+		return fmt.Errorf("cannot %s SR policy %q: %w", action, srPolicy.Name, err)
+	}
+
 	srpID, err := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
 	if err != nil {
 		return err
@@ -1824,6 +2019,10 @@ func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error
 
 // SendPCUpdate sends a PCEP PC-Update message to update an existing SR Policy.
 func (ss *Session) SendPCUpdate(srPolicy table.SRPolicy) error {
+	if err := ss.validateSegmentListForPeer(srPolicy.SegmentList); err != nil {
+		return fmt.Errorf("cannot update SR policy %q: %w", srPolicy.Name, err)
+	}
+
 	srpID, err := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
 	if err != nil {
 		return err
@@ -1877,14 +2076,19 @@ func (ss *Session) resolveColorPreference(sr *pcep.StateReport) (color, preferen
 			}
 		}
 
-		// SR Policy Association color takes precedence
-		if c := sr.AssociationObject.Color(); c != 0 {
-			color = c
-		} else if hasColor {
-			color = sr.LSPObject.Color()
+		var assocColor uint32
+		if assoc := srPolicyAssociation(sr); assoc != nil {
+			assocColor = assoc.Color()
+			preference = assoc.Preference()
 		}
 
-		preference = sr.AssociationObject.Preference()
+		// SR Policy Association color takes precedence
+		switch {
+		case assocColor != 0:
+			color = assocColor
+		case hasColor:
+			color = sr.LSPObject.Color()
+		}
 	}
 
 	return color, preference
@@ -1946,9 +2150,11 @@ func (ss *Session) updateOrCreatePolicy(sr *pcep.StateReport, segmentList []tabl
 		return nil
 	}
 
+	assoc := srPolicyAssociation(sr)
+
 	src := sr.LSPObject.SrcAddr
-	if !src.IsValid() {
-		src = sr.AssociationObject.AssocSrc
+	if !src.IsValid() && assoc != nil {
+		src = assoc.AssocSrc
 	}
 
 	if !src.IsValid() {
@@ -1956,8 +2162,8 @@ func (ss *Session) updateOrCreatePolicy(sr *pcep.StateReport, segmentList []tabl
 	}
 
 	dst := sr.LSPObject.DstAddr
-	if !dst.IsValid() {
-		dst = sr.AssociationObject.Endpoint()
+	if !dst.IsValid() && assoc != nil {
+		dst = assoc.Endpoint()
 	}
 
 	if !dst.IsValid() {

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -1824,9 +1824,8 @@ func firstPathSetupTypeCapability(caps []pcep.CapabilityInterface) *pcep.PathSet
 }
 
 // peerSupportsPST reports whether the peer supports the given path setup type.
-// PATH-SETUP-TYPE-CAPABILITY is authoritative (RFC 8408 §5); otherwise,
-// legacy SR-CAPABILITY-TLV implies PSTs 0 and 1 (RFC 8664 Appendix A), and
-// no PST information is treated as permissive for legacy compatibility.
+// PATH-SETUP-TYPE-CAPABILITY takes precedence; otherwise, legacy SR-CAPABILITY-TLV
+// implies PSTs 0 and 1, and its absence implies PST=0 (RFC 8408 §3, RFC 8664 Appendix A).
 func peerSupportsPST(caps []pcep.CapabilityInterface, pst pcep.Pst) bool {
 	if pstCap := firstPathSetupTypeCapability(caps); pstCap != nil {
 		return pstCap.HasPathSetupType(pst)
@@ -1836,13 +1835,13 @@ func peerSupportsPST(caps []pcep.CapabilityInterface, pst pcep.Pst) bool {
 		return pst == pcep.PathSetupTypeRSVPTE || pst == pcep.PathSetupTypeSRTE
 	}
 
-	return true
+	return pst == pcep.PathSetupTypeRSVPTE
 }
 
 // peerMaxSIDs returns the advertised SID depth for the given path setup type.
-// PATH-SETUP-TYPE-CAPABILITY takes precedence over the legacy top-level
-// capability (RFC 8408 §3, RFC 8664 Appendix A). An unlisted PST is ignored
-// (RFC 8664 §5.1, RFC 9603 §5.1).
+// PATH-SETUP-TYPE-CAPABILITY takes precedence; otherwise, the top-level capability
+// is used as a legacy fallback for SRTE (RFC 8408 §3, RFC 8664 Appendix A).
+// An unlisted PST has no advertised SID depth (RFC 8664 §5.1, RFC 9603 §5.1).
 func peerMaxSIDs(caps []pcep.CapabilityInterface, pst pcep.Pst) (maxSIDs uint8, ok bool) {
 	if pstCap := firstPathSetupTypeCapability(caps); pstCap != nil {
 		if !pstCap.HasPathSetupType(pst) {

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -4516,6 +4516,8 @@ func TestHandleSRPolicyWithPLSPID_ComputesPathFromTED(t *testing.T) {
 	})
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), ted, 0)
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+		[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = srcAddr
@@ -5408,7 +5410,7 @@ func TestValidateSegmentListForPeer(t *testing.T) {
 		segmentList []table.Segment
 		wantErr     bool
 	}{
-		"NoCapabilityAdvertised": {nil, srMPLS, false},
+		"NoCapabilityAdvertised": {nil, srMPLS, true},
 		"EmptySegmentList":       {[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 1)}, nil, false},
 		"SRWithinMSD":            {[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 3)}, srMPLS, false},
 		"SRExceedsMSD":           {[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 2)}, srMPLS, true},
@@ -5421,17 +5423,24 @@ func TestValidateSegmentListForPeer(t *testing.T) {
 			}},
 			srv6, false,
 		},
-		"SRv6WithinHEncapsMSD": {
-			[]pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 3})},
-			srv6, false,
-		},
 		"SRv6ExceedsHEncapsMSD": {
-			[]pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 2})},
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE},
+				SubTLVs:        []pcep.TLVInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 2})},
+			}},
 			srv6, true,
 		},
 		"SRv6OtherMSDTypeIsNotALimit": {
-			[]pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 1})},
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE},
+				SubTLVs:        []pcep.TLVInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 1})},
+			}},
 			srv6, false,
+		},
+		// RFC 9603: a top-level SRv6-PCE-CAPABILITY does not imply PST=3 support.
+		"TopLevelSRv6CapAloneDoesNotImplyPSTSupport": {
+			[]pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 3})},
+			srv6, true,
 		},
 		"NestedInPathSetupTypeCapability": {
 			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
@@ -5440,8 +5449,7 @@ func TestValidateSegmentListForPeer(t *testing.T) {
 			}},
 			srMPLS, true,
 		},
-		// RFC 8664 Appendix A: PATH-SETUP-TYPE-CAPABILITY takes precedence over
-		// the top-level SR-CAPABILITY-TLV.
+		// RFC 8664 Appendix A: PATH-SETUP-TYPE-CAPABILITY takes precedence.
 		"SubTLVEnforcedOverPermissiveTopLevelSRCap": {
 			[]pcep.CapabilityInterface{
 				pcep.NewSRPCECapability(true, false, 0),
@@ -5554,8 +5562,8 @@ func TestValidateSegmentListForPeer(t *testing.T) {
 			[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)},
 			srv6, true,
 		},
-		// RFC 8408 §5 leaves the behavior unspecified when no PST list is sent.
-		"NoPSTInformationStaysPermissive": {nil, srv6, false},
+		// RFC 8408 §3: no PATH-SETUP-TYPE-CAPABILITY TLV means only PST=0 (RSVP-TE) is supported.
+		"NoPSTInformationImpliesRSVPTEOnly": {nil, srv6, true},
 	}
 
 	for name, tc := range cases {
@@ -5587,6 +5595,15 @@ func TestPeerMaxSIDs_PSTNotInPathSetupTypeListIsUnbounded(t *testing.T) {
 	}}
 
 	maxSIDs, ok := peerMaxSIDs(caps, pcep.PathSetupTypeSRTE)
+
+	require.False(t, ok)
+	require.Zero(t, maxSIDs)
+}
+
+func TestPeerMaxSIDs_NoCapabilitiesIsUnbounded(t *testing.T) {
+	t.Parallel()
+
+	maxSIDs, ok := peerMaxSIDs([]pcep.CapabilityInterface{}, pcep.PathSetupTypeSRTE)
 
 	require.False(t, ok)
 	require.Zero(t, maxSIDs)

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -131,6 +131,7 @@ func newTestStateReport(t *testing.T, plspID, srpID uint32) *pcep.StateReport {
 	t.Helper()
 
 	sr := pcep.NewStateReport()
+	sr.AssociationObjects = []*pcep.AssociationObject{{AssocType: pcep.AssocTypeSRPolicyAssociation}}
 
 	sr.SrpObject.SrpID = srpID
 	sr.LSPObject.PlspID = plspID
@@ -1199,12 +1200,16 @@ func TestSendOpen_ErrorPropagatesFromSendFailure(t *testing.T) {
 	require.Error(t, ss.SendOpen())
 }
 
-// openMessageBody returns the body of a serialized Open message, ready to be
-// handed to handlePeerOpen.
 func openMessageBody(t *testing.T, sessionID, keepalive, deadTimer uint8) []uint8 {
 	t.Helper()
 
-	full, err := pcep.NewOpenMessage(sessionID, keepalive, deadTimer, nil).Serialize()
+	return openMessageBodyWithCaps(t, sessionID, keepalive, deadTimer, nil)
+}
+
+func openMessageBodyWithCaps(t *testing.T, sessionID, keepalive, deadTimer uint8, caps []pcep.CapabilityInterface) []uint8 {
+	t.Helper()
+
+	full, err := pcep.NewOpenMessage(sessionID, keepalive, deadTimer, caps).Serialize()
 	require.NoError(t, err, "failed to serialize Open message")
 
 	return full[pcep.CommonHeaderLength:]
@@ -1288,6 +1293,93 @@ func TestHandlePeerOpen_RejectedOpenDoesNotOverwriteNegotiatedTimers(t *testing.
 	require.NoError(t, header.DecodeFromBytes(writes[0]))
 	assert.Equal(t, pcep.MessageTypeKeepalive, header.MessageType)
 	assertPCErr(t, writes[1], pcepErrorValueInvalidOpenMessage)
+}
+
+func TestHandlePeerOpen_RejectsPathSetupTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	caps := []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+		PathSetupTypes: pcep.Psts{pcep.PathSetupTypeRSVPTE},
+	}}
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg),
+		"no path setup type in common")
+
+	assert.False(t, neg.remoteOK, "a mismatched Open must not be accepted")
+
+	_, ok := ss.PccOpen()
+	assert.False(t, ok, "a mismatched Open must not be published as the PCC's Open")
+
+	writes := conn.writes()
+	require.Len(t, writes, 1, "RFC 8408 §5 answers a path setup type mismatch with a PCErr, not a Keepalive")
+	assertTypedPCErr(t, writes[0], pcepErrorTypeInvalidPathSetupType, pcepErrorValueMismatchedPathSetupType)
+}
+
+func TestHandlePeerOpen_RejectsEmptyPathSetupTypeList(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	caps := []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{}}
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg),
+		"empty path setup type list")
+
+	assert.False(t, neg.remoteOK)
+
+	writes := conn.writes()
+	require.Len(t, writes, 1, "RFC 8408 §3 requires Num of PSTs > 0 and closes the session otherwise")
+	assertTypedPCErr(t, writes[0], pcepErrorTypeInvalidObject, pcepErrorValueMalformedObject)
+}
+
+func TestHandlePeerOpen_AcceptsPartialPathSetupTypeOverlap(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	caps := []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+		PathSetupTypes: pcep.Psts{pcep.PathSetupTypeRSVPTE, pcep.PathSetupTypeSRTE},
+		SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(true, false, 0)},
+	}}
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg))
+	assert.True(t, neg.remoteOK)
+}
+
+func TestRejectOnPathSetupTypeMismatch_SkippedWhenPolaAdvertisesNoPSTList(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+	ss.advertisedCapabilities = nil
+
+	caps := []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+		PathSetupTypes: pcep.Psts{pcep.PathSetupTypeRSVPTE},
+	}}
+
+	require.NoError(t, ss.rejectOnPathSetupTypeMismatch(caps),
+		"with no PST list of its own, Pola has nothing to compare and must not tear the session down")
+	assert.Empty(t, conn.writes())
+}
+
+func TestHandlePeerOpen_AcceptsPeerWithoutPathSetupTypeCapability(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	// No PST list is accepted for legacy PCC compatibility (RFC 8408 §5).
+	neg := &openNegotiation{}
+	require.NoError(t, ss.handlePeerOpen(openMessageBody(t, 1, 30, 120), neg))
+	assert.True(t, neg.remoteOK)
 }
 
 func TestHandlePeerOpen_RejectedOpenIsNotPublishedAsSessionState(t *testing.T) {
@@ -2444,6 +2536,12 @@ func negotiatingSessionWithLogger(t *testing.T, conn net.Conn, lg *logger.Logger
 func assertPCErr(t *testing.T, write []byte, errorValue uint8) {
 	t.Helper()
 
+	assertTypedPCErr(t, write, pcepErrorTypeSessionEstablishmentFailure, errorValue)
+}
+
+func assertTypedPCErr(t *testing.T, write []byte, errorType, errorValue uint8) {
+	t.Helper()
+
 	var header pcep.CommonHeader
 	require.NoError(t, header.DecodeFromBytes(write))
 	require.Equal(t, pcep.MessageTypeError, header.MessageType, "expected a PCErr message")
@@ -2451,7 +2549,7 @@ func assertPCErr(t *testing.T, write []byte, errorValue uint8) {
 	pcerrMessage := &pcep.PCErrMessage{}
 	require.NoError(t, pcerrMessage.DecodeFromBytes(write[pcep.CommonHeaderLength:]))
 	require.Len(t, pcerrMessage.Errors, 1)
-	assert.Equal(t, pcepErrorTypeSessionEstablishmentFailure, pcerrMessage.Errors[0].ErrorType)
+	assert.Equal(t, errorType, pcerrMessage.Errors[0].ErrorType)
 	assert.Equal(t, errorValue, pcerrMessage.Errors[0].ErrorValue)
 }
 
@@ -4546,8 +4644,8 @@ func TestResolveColorPreference_AssociationColorTakesPrecedence(t *testing.T) {
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.TLVs = append(sr.LSPObject.TLVs, &pcep.Color{Color: 999})
-	sr.AssociationObject.TLVs = append(
-		sr.AssociationObject.TLVs,
+	sr.AssociationObjects[0].TLVs = append(
+		sr.AssociationObjects[0].TLVs,
 		pcep.NewExtendedAssociationID(55, netip.Addr{}),
 		&pcep.SRPolicyCandidatePathPreference{Preference: 33},
 	)
@@ -4606,7 +4704,7 @@ func TestUpdateOrCreatePolicy_SrcAddrFallsBackToAssociationSrc(t *testing.T) {
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = netip.Addr{}
-	sr.AssociationObject.AssocSrc = netip.MustParseAddr("192.0.2.9")
+	sr.AssociationObjects[0].AssocSrc = netip.MustParseAddr("192.0.2.9")
 
 	require.NoError(t, ss.updateOrCreatePolicy(sr, sr.EroObject.ToSegmentList(), 0, 0, table.PolicyUp))
 
@@ -4632,7 +4730,7 @@ func TestUpdateOrCreatePolicy_DstAddrFallsBackToAssociationEndpoint(t *testing.T
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.DstAddr = netip.Addr{}
-	sr.AssociationObject.TLVs = append(sr.AssociationObject.TLVs,
+	sr.AssociationObjects[0].TLVs = append(sr.AssociationObjects[0].TLVs,
 		pcep.NewExtendedAssociationID(0, netip.MustParseAddr("192.0.2.20")))
 
 	require.NoError(t, ss.updateOrCreatePolicy(sr, sr.EroObject.ToSegmentList(), 0, 0, table.PolicyUp))
@@ -5138,4 +5236,422 @@ func TestServer_PeerSetupStats_RecordsOkOnSuccessfulEstablishment(t *testing.T) 
 	ok, fail := s.PeerSetupStats(peerAddr)
 	assert.Equal(t, uint64(1), ok)
 	assert.Equal(t, uint64(0), fail)
+}
+
+func TestHandleStateReport_UnsupportedAssocTypeSendsPCErr(t *testing.T) {
+	t.Parallel()
+
+	server, client := newTCPConnPair(t)
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.AssociationObjects[0].AssocType = pcep.AssocTypeDisjointAssociation
+
+	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
+
+	pcerr := readPCErrMessage(t, client)
+	require.Len(t, pcerr.Errors, 1)
+	assert.Equal(t, pcepErrorTypeAssociationError, pcerr.Errors[0].ErrorType)
+	assert.Equal(t, pcepErrorValueAssociationTypeNotSupported, pcerr.Errors[0].ErrorValue)
+
+	// RFC 8697 §6.4 requires the error without rejecting the report.
+	_, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
+	assert.True(t, found, "the LSP must still be registered")
+}
+
+func TestHandleStateReport_UnsupportedAssocTypeSendPCErrFailureReturnsError(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.AssociationObjects[0].AssocType = pcep.AssocTypeDisjointAssociation
+
+	err := ss.handleStateReport(sr, pcep.NewPCRptMessage())
+	assert.ErrorContains(t, err, "broken pipe",
+		"a failure to send the PCErr reply for an unsupported ASSOCIATION type must be surfaced to the caller")
+}
+
+func TestHandleStateReport_AbsentAssociationObjectSendsNoPCErr(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newTCPConnPair(t)
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.AssociationObjects = nil
+
+	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
+	assert.Equal(t, uint64(0), ss.Stats().PCErrSent)
+}
+
+func TestHandleStateReport_ReservedAssocTypeZeroSendsPCErr(t *testing.T) {
+	t.Parallel()
+
+	server, client := newTCPConnPair(t)
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.AssociationObjects[0].AssocType = 0
+
+	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
+
+	pcerr := readPCErrMessage(t, client)
+	require.Len(t, pcerr.Errors, 1)
+	assert.Equal(t, pcepErrorTypeAssociationError, pcerr.Errors[0].ErrorType)
+	assert.Equal(t, pcepErrorValueAssociationTypeNotSupported, pcerr.Errors[0].ErrorValue)
+}
+
+func TestHandleStateReport_UnsupportedAssocTypeIsIgnoredForSRPolicySemantics(t *testing.T) {
+	t.Parallel()
+
+	server, client := newTCPConnPair(t)
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.LSPObject.SrcAddr = netip.Addr{}
+	sr.LSPObject.DstAddr = netip.Addr{}
+	sr.AssociationObjects = []*pcep.AssociationObject{
+		{
+			AssocType: pcep.AssocTypeDisjointAssociation,
+			AssocSrc:  netip.MustParseAddr("192.0.2.99"),
+			TLVs: []pcep.TLVInterface{
+				pcep.NewExtendedAssociationID(999, netip.MustParseAddr("192.0.2.98")),
+				&pcep.SRPolicyCandidatePathPreference{Preference: 99},
+			},
+		},
+		{
+			AssocType: pcep.AssocTypeSRPolicyAssociation,
+			AssocSrc:  netip.MustParseAddr("192.0.2.1"),
+			TLVs: []pcep.TLVInterface{
+				pcep.NewExtendedAssociationID(55, netip.MustParseAddr("192.0.2.2")),
+				&pcep.SRPolicyCandidatePathPreference{Preference: 33},
+			},
+		},
+	}
+
+	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
+
+	pcerr := readPCErrMessage(t, client)
+	require.Len(t, pcerr.Errors, 1)
+	assert.Equal(t, pcepErrorTypeAssociationError, pcerr.Errors[0].ErrorType)
+
+	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
+	require.True(t, found)
+	assert.Equal(t, uint32(55), policy.Color)
+	assert.Equal(t, uint32(33), policy.Preference)
+	assert.Equal(t, netip.MustParseAddr("192.0.2.1"), policy.SrcAddr)
+	assert.Equal(t, netip.MustParseAddr("192.0.2.2"), policy.DstAddr)
+}
+
+func TestHandleStateReport_EveryUnsupportedAssocTypeIsReported(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newTCPConnPair(t)
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+
+	sr := newTestStateReport(t, 1, 0)
+	sr.AssociationObjects = []*pcep.AssociationObject{
+		{AssocType: pcep.AssocTypeDisjointAssociation},
+		{AssocType: pcep.AssocTypeSRPolicyAssociation},
+		{AssocType: pcep.AssocTypePolicyAssociation},
+	}
+
+	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
+	assert.Equal(t, uint64(2), ss.Stats().PCErrSent)
+}
+
+func TestHandleStateReport_SupportedAssocTypesSendNoPCErr(t *testing.T) {
+	t.Parallel()
+
+	for name, assocType := range map[string]pcep.AssocType{
+		"RFC":     pcep.AssocTypeSRPolicyAssociation,
+		"Cisco":   pcep.AssocTypeSRPolicyAssociationCisco,
+		"Juniper": pcep.AssocTypeSRPolicyAssociationJuniper,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			server, _ := newTCPConnPair(t)
+
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+
+			sr := newTestStateReport(t, 1, 0)
+			sr.AssociationObjects[0].AssocType = assocType
+
+			require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
+			assert.Equal(t, uint64(0), ss.Stats().PCErrSent)
+		})
+	}
+}
+
+func TestValidateSegmentListForPeer(t *testing.T) {
+	t.Parallel()
+
+	srMPLS := []table.Segment{
+		table.NewSegmentSRMPLS(16001),
+		table.NewSegmentSRMPLS(16002),
+		table.NewSegmentSRMPLS(16003),
+	}
+
+	srv6Segment := table.NewSegmentSRv6(netip.MustParseAddr("2001:db8::1"))
+	srv6 := []table.Segment{srv6Segment, srv6Segment, srv6Segment}
+
+	cases := map[string]struct {
+		caps        []pcep.CapabilityInterface
+		segmentList []table.Segment
+		wantErr     bool
+	}{
+		"NoCapabilityAdvertised": {nil, srMPLS, false},
+		"EmptySegmentList":       {[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 1)}, nil, false},
+		"SRWithinMSD":            {[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 3)}, srMPLS, false},
+		"SRExceedsMSD":           {[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 2)}, srMPLS, true},
+		"SRUnlimitedMSD":         {[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)}, srMPLS, false},
+		"SRZeroMSDNotEnforced":   {[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 0)}, srMPLS, false},
+		"SRLimitIgnoredForSRv6": {
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE, pcep.PathSetupTypeSRv6TE},
+				SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(false, false, 1)},
+			}},
+			srv6, false,
+		},
+		"SRv6WithinHEncapsMSD": {
+			[]pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 3})},
+			srv6, false,
+		},
+		"SRv6ExceedsHEncapsMSD": {
+			[]pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 2})},
+			srv6, true,
+		},
+		"SRv6OtherMSDTypeIsNotALimit": {
+			[]pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 1})},
+			srv6, false,
+		},
+		"NestedInPathSetupTypeCapability": {
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+				SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(false, false, 2)},
+			}},
+			srMPLS, true,
+		},
+		// RFC 8664 Appendix A: PATH-SETUP-TYPE-CAPABILITY takes precedence over
+		// the top-level SR-CAPABILITY-TLV.
+		"SubTLVEnforcedOverPermissiveTopLevelSRCap": {
+			[]pcep.CapabilityInterface{
+				pcep.NewSRPCECapability(true, false, 0),
+				&pcep.PathSetupTypeCapability{
+					PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+					SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(false, false, 2)},
+				},
+			},
+			srMPLS, true,
+		},
+		"RestrictiveTopLevelSRCapIgnoredWhenSubTLVPresent": {
+			[]pcep.CapabilityInterface{
+				pcep.NewSRPCECapability(false, false, 2),
+				&pcep.PathSetupTypeCapability{
+					PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+					SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(true, false, 0)},
+				},
+			},
+			srMPLS, false,
+		},
+		"TopLevelSRCapIgnoredWhenPSTCapCarriesNoSubTLV": {
+			[]pcep.CapabilityInterface{
+				pcep.NewSRPCECapability(false, false, 2),
+				&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE}},
+			},
+			srMPLS, false,
+		},
+		// RFC 8664 §5.1 and RFC 9603 §5.1: only the first sub-TLV is processed.
+		"OnlyFirstSRSubTLVProcessed": {
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+				SubTLVs: []pcep.TLVInterface{
+					pcep.NewSRPCECapability(true, false, 0),
+					pcep.NewSRPCECapability(false, false, 2),
+				},
+			}},
+			srMPLS, false,
+		},
+		"OnlyFirstSRv6SubTLVProcessed": {
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE},
+				SubTLVs: []pcep.TLVInterface{
+					pcep.NewSRv6PCECapability(false),
+					pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 2}),
+				},
+			}},
+			srv6, false,
+		},
+		"SRv6SubTLVEnforced": {
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE},
+				SubTLVs:        []pcep.TLVInterface{pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 2})},
+			}},
+			srv6, true,
+		},
+		// RFC 8408 §3: only the first PATH-SETUP-TYPE-CAPABILITY is processed.
+		"SecondPathSetupTypeCapabilityIgnored": {
+			[]pcep.CapabilityInterface{
+				&pcep.PathSetupTypeCapability{
+					PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+					SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(true, false, 0)},
+				},
+				&pcep.PathSetupTypeCapability{
+					PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+					SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(false, false, 2)},
+				},
+			},
+			srMPLS, false,
+		},
+		"SecondPathSetupTypeCapabilityCannotAddPST": {
+			[]pcep.CapabilityInterface{
+				&pcep.PathSetupTypeCapability{
+					PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+					SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(true, false, 0)},
+				},
+				&pcep.PathSetupTypeCapability{
+					PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE},
+					SubTLVs:        []pcep.TLVInterface{pcep.NewSRv6PCECapability(false)},
+				},
+			},
+			srv6, true,
+		},
+		// RFC 8408 §5: only PSTs in the peer's PST list are supported.
+		"UnadvertisedSRTERejected": {
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeRSVPTE},
+			}},
+			srMPLS, true,
+		},
+		"UnadvertisedSRv6TERejected": {
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+				SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(true, false, 0)},
+			}},
+			srv6, true,
+		},
+		// RFC 8664 §5.1 and RFC 9603 §5.1: a sub-TLV for an unlisted PST is ignored.
+		"SubTLVMSDIgnoredWhenPSTOmitted": {
+			[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+				PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+				SubTLVs: []pcep.TLVInterface{
+					pcep.NewSRPCECapability(true, false, 0),
+					pcep.NewSRv6PCECapability(false, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 2}),
+				},
+			}},
+			srMPLS, false,
+		},
+		// RFC 8664 Appendix A: a lone top-level SR-CAPABILITY-TLV implies PSTs 0 and 1.
+		"LegacyTopLevelSRCapRejectsSRv6": {
+			[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)},
+			srv6, true,
+		},
+		// RFC 8408 §5 leaves the behavior unspecified when no PST list is sent.
+		"NoPSTInformationStaysPermissive": {nil, srv6, false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			server, _ := newTCPConnPair(t)
+
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+			ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant, tc.caps)
+
+			err := ss.validateSegmentListForPeer(tc.segmentList)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPeerMaxSIDs_PSTNotInPathSetupTypeListIsUnbounded(t *testing.T) {
+	t.Parallel()
+
+	caps := []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+		PathSetupTypes: pcep.Psts{pcep.PathSetupTypeRSVPTE},
+		SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(false, false, 2)},
+	}}
+
+	maxSIDs, ok := peerMaxSIDs(caps, pcep.PathSetupTypeSRTE)
+
+	require.False(t, ok)
+	require.Zero(t, maxSIDs)
+}
+
+func TestPeerSupportsPST_LegacyTopLevelSRCapAcceptsRSVPTE(t *testing.T) {
+	t.Parallel()
+
+	caps := []pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)}
+
+	assert.True(t, peerSupportsPST(caps, pcep.PathSetupTypeRSVPTE))
+}
+
+func TestSendPCUpdateAndPCInitiate_RejectSegmentListDeeperThanPeerMSD(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newTCPConnPair(t)
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+		[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 1)})
+
+	srPolicy := table.SRPolicy{
+		Name:        "too-deep",
+		SrcAddr:     netip.MustParseAddr("10.255.0.1"),
+		DstAddr:     netip.MustParseAddr("10.255.0.2"),
+		Type:        table.PolicyTypeDynamic,
+		Metric:      table.TEMetric,
+		SegmentList: []table.Segment{table.NewSegmentSRMPLS(16001), table.NewSegmentSRMPLS(16002)},
+	}
+
+	require.ErrorContains(t, ss.SendPCUpdate(srPolicy), "maximum SID depth")
+	require.ErrorContains(t, ss.SendPCInitiate(srPolicy, false), "maximum SID depth")
+
+	// Delete is not subject to the SID depth limit.
+	require.NoError(t, ss.SendPCInitiate(srPolicy, true))
+	assert.Equal(t, uint64(0), ss.Stats().UpdSent)
+}
+
+func TestSendPCUpdateAndPCInitiate_RejectUnadvertisedPathSetupType(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newTCPConnPair(t)
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+		[]pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+			PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE},
+			SubTLVs:        []pcep.TLVInterface{pcep.NewSRPCECapability(true, false, 0)},
+		}})
+
+	srPolicy := table.SRPolicy{
+		Name:        "srv6-to-sr-mpls-only-pcc",
+		SrcAddr:     netip.MustParseAddr("2001:db8::1"),
+		DstAddr:     netip.MustParseAddr("2001:db8::2"),
+		Type:        table.PolicyTypeDynamic,
+		Metric:      table.TEMetric,
+		SegmentList: []table.Segment{table.NewSegmentSRv6(netip.MustParseAddr("2001:db8::100"))},
+	}
+
+	require.ErrorContains(t, ss.SendPCUpdate(srPolicy), "path setup type")
+	require.ErrorContains(t, ss.SendPCInitiate(srPolicy, false), "path setup type")
+
+	// Deletion uses the same PATH-SETUP-TYPE TLV and is rejected too.
+	require.ErrorContains(t, ss.SendPCInitiate(srPolicy, true), "path setup type")
+	assert.Equal(t, uint64(0), ss.Stats().UpdSent)
+	assert.Equal(t, uint64(0), ss.Stats().PCInitiateSent)
 }


### PR DESCRIPTION
## Description

Harden PCEP capability handling and session validation:

* Adding SRv6 MSD support to the gRPC API.
* Enforcing peer SID depth limits and validating PATH-SETUP-TYPE on PC-Initiate requests.
* Preserving all PCRpt ASSOCIATION objects and rejecting unsupported Association Types individually with PCErr.

## Type of change

* [x] Bug fix
* [x] Refactoring

## How was this tested?

* `make ci`
* `make fix`

## Checklist

* [x] `make ci` passes locally
* [x] Tests added or updated if needed
* [ ] Documentation updated if needed