### PR TITLE
Reject non-IPv6 addresses from SRv6 SID index

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -280,6 +280,7 @@ type resolvedPath struct {
 	SegmentList []table.Segment
 	SrcAddr     netip.Addr
 	DstAddr     netip.Addr
+	SrcRouterID string
 	Metric      table.MetricType
 }
 
@@ -331,7 +332,13 @@ func resolvePathViaTED(s *APIServer, input *pb.CreateSRPolicyRequest) (resolvedP
 		return resolvedPath{}, err
 	}
 
-	return resolvedPath{SegmentList: segmentList, SrcAddr: srcAddr, DstAddr: dstAddr, Metric: metricType}, nil
+	return resolvedPath{
+		SegmentList: segmentList,
+		SrcAddr:     srcAddr,
+		DstAddr:     dstAddr,
+		SrcRouterID: inputSRPolicy.GetSrcRouterId(),
+		Metric:      metricType,
+	}, nil
 }
 
 // resolvePathFromRequest takes the SR Policy path directly from the request,
@@ -440,7 +447,7 @@ func (s *APIServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyRequ
 		return nil, wrapStatusError(err, "failed to resolve SR policy path")
 	}
 
-	if err := s.validateSIDs(req, path.SegmentList); err != nil {
+	if err := s.validateSIDs(req, path); err != nil {
 		return nil, err
 	}
 
@@ -451,8 +458,9 @@ func (s *APIServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyRequ
 	return &pb.CreateSRPolicyResponse{}, nil
 }
 
-func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []table.Segment) error {
+func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, path resolvedPath) error {
 	policy := req.GetSrPolicy()
+	segmentList := path.SegmentList
 
 	// Reject out-of-range labels before the validation skip paths.
 	if invalid := table.OutOfRangeSRMPLSLabels(segmentList); len(invalid) > 0 {
@@ -500,21 +508,16 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, segmentList []ta
 	}
 
 	// Resolve source router ID for path traversal.
-	var srcRouterID string
+	srcRouterID := path.SrcRouterID
 
 	if req.GetDisablePathCompute() {
-		srcAddr, ok := netip.AddrFromSlice(req.GetSrPolicy().GetSrcAddr())
-		if !ok {
-			return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid source address in request")
-		}
+		var ok bool
 
-		srcRouterID, ok = ted.FindRouterIDByLoopback(srcAddr)
+		srcRouterID, ok = ted.FindRouterIDByLoopback(path.SrcAddr)
 		if !ok {
 			return newStatus(codes.InvalidArgument, ReasonInvalidRequest,
-				"source address %s not found in TED", srcAddr)
+				"source address %s not found in TED", path.SrcAddr)
 		}
-	} else {
-		srcRouterID = req.GetSrPolicy().GetSrcRouterId()
 	}
 
 	if err := table.ValidateExplicitPath(ted, srcRouterID, segmentList); err != nil {

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -255,7 +255,7 @@ func TestValidateSIDs_NoSidValidateSkipsCheck(t *testing.T) {
 	req := explicitPolicyRequest(true, "16099")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList})
 	assert.NoError(t, err, "expected no_sid_validate to skip the check even with no TED")
 }
 
@@ -266,7 +266,7 @@ func TestValidateSIDs_DynamicPathSkipsCheck(t *testing.T) {
 	req := dynamicPolicyRequest()
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList})
 	assert.NoError(t, err, "expected a dynamic path to skip the check")
 }
 
@@ -290,7 +290,7 @@ func TestValidateSIDs_DynamicWithDisablePathComputeIsStillValidated(t *testing.T
 	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.0.0.1")})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
@@ -303,7 +303,7 @@ func TestValidateSIDs_NoTED(t *testing.T) {
 	req := explicitPolicyRequest(false, "16003")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcRouterID: testRouterID1})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
@@ -317,7 +317,7 @@ func TestValidateSIDs_TEDEmpty(t *testing.T) {
 	req := explicitPolicyRequest(false, "16003")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcRouterID: testRouterID1})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
@@ -340,7 +340,7 @@ func TestValidateSIDs_MissingSID(t *testing.T) {
 	req := explicitPolicyRequest(false, "16099")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcRouterID: testRouterID1})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
@@ -366,37 +366,11 @@ func TestValidateSIDs_EndpointFormIsStillValidated(t *testing.T) {
 	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.0.0.1")})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
 	assert.Contains(t, st.Message(), "hop 1", "expected the missing hop to be listed")
-}
-
-func TestValidateSIDs_DisablePathComputeInvalidSourceAddress(t *testing.T) {
-	t.Parallel()
-
-	node := &table.LsNode{
-		RouterID:  testRouterID1,
-		SrgbBegin: 16000,
-		Prefixes: []*table.LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
-		},
-	}
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
-	s := newTestAPIServer(ted)
-
-	req := explicitPolicyRequest(false, "16003")
-	req.DisablePathCompute = true
-	req.SrPolicy.SrcAddr = []byte{1, 2, 3}
-	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
-	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
-
-	err := s.validateSIDs(req, segmentList)
-	st, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, st.Code())
-	assert.Contains(t, st.Message(), "invalid source address in request")
 }
 
 func TestValidateSIDs_DisablePathComputeSourceAddressNotFound(t *testing.T) {
@@ -418,7 +392,7 @@ func TestValidateSIDs_DisablePathComputeSourceAddressNotFound(t *testing.T) {
 	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.0.0.9")})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
@@ -432,7 +406,7 @@ func TestValidateSIDs_LabelOutOfRangeIsRejectedEvenWithNoSidValidate(t *testing.
 	req := explicitPolicyRequest(true, "1048576")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(1048576)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
@@ -449,7 +423,7 @@ func TestValidateSIDs_LabelBoundsAreAccepted(t *testing.T) {
 		req := explicitPolicyRequest(true, strconv.FormatUint(uint64(label), 10))
 		segmentList := []table.Segment{table.NewSegmentSRMPLS(label)}
 
-		assert.NoErrorf(t, s.validateSIDs(req, segmentList), "expected label %d to be in range", label)
+		assert.NoErrorf(t, s.validateSIDs(req, resolvedPath{SegmentList: segmentList}), "expected label %d to be in range", label)
 	}
 }
 
@@ -469,7 +443,7 @@ func TestValidateSIDs_AllKnownSucceeds(t *testing.T) {
 	req := explicitPolicyRequest(false, "16003")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcRouterID: testRouterID1})
 	assert.NoError(t, err)
 }
 
@@ -480,7 +454,7 @@ func TestValidateSIDs_UnknownSegmentTypeIsRejected(t *testing.T) {
 	req := explicitPolicyRequest(true, "16099")
 	segmentList := []table.Segment{unknownSegment{}}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
@@ -497,7 +471,7 @@ func TestValidateSIDs_MixedSegmentTypesAreRejected(t *testing.T) {
 		table.SegmentSRv6{Sid: netip.MustParseAddr("2001:db8::1")},
 	}
 
-	err := s.validateSIDs(req, segmentList)
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -145,16 +145,15 @@ func (idx *SIDIndex) addEndXSID(node *LsNode, l *LsLink) {
 		return
 	}
 
-	idx.addSRv6(l.Srv6EndXSID.Sids, l.Srv6EndXSID.Srv6SIDStructure)
+	addrs := parseSRv6Addrs(l.Srv6EndXSID.Sids)
+	idx.addSRv6(addrs, l.Srv6EndXSID.Srv6SIDStructure)
 
 	if l.RemoteNode == nil {
 		return
 	}
 
-	for _, s := range l.Srv6EndXSID.Sids {
-		if addr, err := netip.ParseAddr(s); err == nil {
-			idx.srv6AdjSIDNextHop[adjKeySRv6{node.RouterID, addr}] = l.RemoteNode.RouterID
-		}
+	for _, addr := range addrs {
+		idx.srv6AdjSIDNextHop[adjKeySRv6{node.RouterID, addr}] = l.RemoteNode.RouterID
 	}
 }
 
@@ -162,27 +161,34 @@ func (idx *SIDIndex) addEndXSID(node *LsNode, l *LsLink) {
 func (idx *SIDIndex) addSRv6NodeSIDs(node *LsNode) {
 	for _, s := range node.SRv6SIDs {
 		if s != nil {
-			idx.addSRv6(s.Sids, s.SIDStructure)
+			addrs := parseSRv6Addrs(s.Sids)
+			idx.addSRv6(addrs, s.SIDStructure)
 
-			for _, sidStr := range s.Sids {
-				if addr, err := netip.ParseAddr(sidStr); err == nil {
-					idx.srv6NodeSIDOwner[addr] = node.RouterID
-				}
+			for _, addr := range addrs {
+				idx.srv6NodeSIDOwner[addr] = node.RouterID
 			}
 		}
 	}
 }
 
-// addSRv6 registers exact SIDs and their locator prefixes.
-func (idx *SIDIndex) addSRv6(sids []string, st SIDStructure) {
+// parseSRv6Addrs keeps only valid IPv6 addresses.
+func parseSRv6Addrs(sids []string) []netip.Addr {
+	addrs := make([]netip.Addr, 0, len(sids))
+
+	for _, sid := range sids {
+		if addr, err := netip.ParseAddr(sid); err == nil && addr.Is6() {
+			addrs = append(addrs, addr)
+		}
+	}
+
+	return addrs
+}
+
+// addSRv6 registers SIDs and their locator prefixes.
+func (idx *SIDIndex) addSRv6(addrs []netip.Addr, st SIDStructure) {
 	locBits := int(st.LocalBlock) + int(st.LocalNode)
 
-	for _, s := range sids {
-		addr, err := netip.ParseAddr(s)
-		if err != nil || !addr.Is6() {
-			continue
-		}
-
+	for _, addr := range addrs {
 		idx.srv6SIDs[addr] = struct{}{}
 
 		if locBits <= 0 || locBits > SRv6SIDBitLength {

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -399,6 +399,39 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 		other.USid = true
 		assert.False(t, idx.Has(other), "expected no locator fallback registered when LocalBlock+LocalNode exceeds 128 bits")
 	})
+
+	t.Run("non-IPv6 node SID is not reachable via NextHop either", func(t *testing.T) {
+		t.Parallel()
+
+		node := &table.LsNode{
+			RouterID: testRouterID1,
+			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{"10.0.0.1"}}},
+		}
+		idx := table.NewSIDIndex(newTestTED(node))
+
+		seg := table.NewSegmentSRv6(netip.MustParseAddr("10.0.0.1"))
+		assert.False(t, idx.Has(seg))
+		_, err := idx.NextHop(testRouterID1, seg)
+		assert.Error(t, err, "expected NextHop to agree with Has() for a non-IPv6 advertised SID")
+	})
+
+	t.Run("non-IPv6 End.X SID is not reachable via NextHop either", func(t *testing.T) {
+		t.Parallel()
+
+		nodeA := &table.LsNode{RouterID: testRouterIDA}
+		nodeB := &table.LsNode{RouterID: testRouterIDB}
+		nodeA.Links = []*table.LsLink{{
+			LocalNode:   nodeA,
+			RemoteNode:  nodeB,
+			Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"10.0.0.1"}},
+		}}
+		idx := table.NewSIDIndex(newTestTED(nodeA, nodeB))
+
+		seg := table.NewSegmentSRv6(netip.MustParseAddr("10.0.0.1"))
+		assert.False(t, idx.Has(seg))
+		_, err := idx.NextHop(testRouterIDA, seg)
+		assert.Error(t, err, "expected NextHop to agree with Has() for a non-IPv6 advertised End.X SID")
+	})
 }
 
 func TestSIDIndexHas_EmptyTED(t *testing.T) {


### PR DESCRIPTION
## Description
Fix SRv6 SID index inconsistency by ignoring non-IPv6 addresses when registering SIDs.

## Type of change
- [x] Bug fix

## How was this tested?
- `make fix`
- `make test scenario-parallel`

## Checklist
- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed