### PR TITLE
Reject unsupported SRv6 MSD types

### DIFF
--- a/pkg/packet/pcep/tlv.go
+++ b/pkg/packet/pcep/tlv.go
@@ -990,6 +990,25 @@ func (tlv *SRv6PCECapability) MaxSIDs() (maxSIDs uint8, ok bool) {
 	return 0, false
 }
 
+// srv6MSDTypes lists the SRv6 MSD types defined in RFC 9352.
+var srv6MSDTypes = map[uint8]struct{}{
+	MSDTypeSRHMaxSL:      {},
+	MSDTypeSRHMaxEndPop:  {},
+	MSDTypeSRHMaxHEncaps: {},
+	MSDTypeSRHMaxEndD:    {},
+}
+
+// UnsupportedMSDType returns the first unrecognized MSD-Type.
+func (tlv *SRv6PCECapability) UnsupportedMSDType() (msdType uint8, ok bool) {
+	for _, msd := range tlv.MSDs {
+		if _, known := srv6MSDTypes[msd.Type]; !known {
+			return msd.Type, true
+		}
+	}
+
+	return 0, false
+}
+
 // NewSRv6PCECapability creates an SRv6-PCE-CAPABILITY TLV.
 func NewSRv6PCECapability(isNAISupported bool, msds ...MSD) *SRv6PCECapability {
 	return &SRv6PCECapability{

--- a/pkg/packet/pcep/tlv_test.go
+++ b/pkg/packet/pcep/tlv_test.go
@@ -2162,3 +2162,53 @@ func TestSRv6PCECapability_MaxSIDs(t *testing.T) {
 		})
 	}
 }
+
+func TestSRv6PCECapability_UnsupportedMSDType(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		tlv      *pcep.SRv6PCECapability
+		wantType uint8
+		wantOK   bool
+	}{
+		"NoMSDs": {pcep.NewSRv6PCECapability(true), 0, false},
+		"AllSRv6Types": {
+			pcep.NewSRv6PCECapability(true,
+				pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 1},
+				pcep.MSD{Type: pcep.MSDTypeSRHMaxEndPop, Value: 1},
+				pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 1},
+				pcep.MSD{Type: pcep.MSDTypeSRHMaxEndD, Value: 1},
+			),
+			0, false,
+		},
+		"UnknownType": {
+			pcep.NewSRv6PCECapability(true, pcep.MSD{Type: 43, Value: 1}),
+			43, true,
+		},
+		"UnknownTypeOne": {
+			pcep.NewSRv6PCECapability(true, pcep.MSD{Type: 1, Value: 1}),
+			1, true,
+		},
+		"KnownTypeThenUnassigned": {
+			pcep.NewSRv6PCECapability(true,
+				pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 1},
+				pcep.MSD{Type: 43, Value: 1},
+			),
+			43, true,
+		},
+		"ZeroValueKnownType": {
+			pcep.NewSRv6PCECapability(true, pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 0}),
+			0, false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			msdType, ok := tc.tlv.UnsupportedMSDType()
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantType, msdType)
+		})
+	}
+}

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -705,6 +705,10 @@ func (ss *Session) handlePeerOpen(body []uint8, neg *openNegotiation) error {
 
 	peerOpen, pccType, caps := ss.decodePeerOpen(openMessage)
 
+	if err := ss.rejectOnUnsupportedSRv6MSDType(caps); err != nil {
+		return err
+	}
+
 	if err := ss.rejectOnEmptyPathSetupTypeList(caps); err != nil {
 		return err
 	}
@@ -913,6 +917,24 @@ func (ss *Session) rejectOnPathSetupTypeMismatch(caps []pcep.CapabilityInterface
 	ss.sendTypedPCErrBestEffort(pcepErrorTypeInvalidPathSetupType, pcepErrorValueMismatchedPathSetupType)
 
 	return fmt.Errorf("peer advertised no path setup type in common with Pola (peer: %v, Pola: %v)", peerPSTs, localPSTs)
+}
+
+// rejectOnUnsupportedSRv6MSDType rejects unsupported SRv6 MSD-Types (RFC 9603 §5.1).
+func (ss *Session) rejectOnUnsupportedSRv6MSDType(caps []pcep.CapabilityInterface) error {
+	for _, capability := range pcep.FlattenCapabilities(caps) {
+		srv6Cap, ok := capability.(*pcep.SRv6PCECapability)
+		if !ok {
+			continue
+		}
+
+		if msdType, unsupported := srv6Cap.UnsupportedMSDType(); unsupported {
+			ss.sendPCErrBestEffort(pcepErrorValueInvalidOpenMessage)
+
+			return fmt.Errorf("peer advertised SRv6-PCE-CAPABILITY with unsupported MSD-Type %d (RFC 9603 §5.1)", msdType)
+		}
+	}
+
+	return nil
 }
 
 // validateCapabilities validates peer capabilities and logs known RFC deviations.

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -1338,6 +1338,84 @@ func TestHandlePeerOpen_RejectsEmptyPathSetupTypeList(t *testing.T) {
 	assertTypedPCErr(t, writes[0], pcepErrorTypeInvalidObject, pcepErrorValueMalformedObject)
 }
 
+func TestHandlePeerOpen_RejectsUnsupportedSRv6MSDType_TopLevel(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	caps := []pcep.CapabilityInterface{
+		pcep.NewSRv6PCECapability(false, pcep.MSD{Type: 43, Value: 1}),
+	}
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg),
+		"unsupported MSD-Type")
+
+	assert.False(t, neg.remoteOK)
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertTypedPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+}
+
+func TestHandlePeerOpen_RejectsUnsupportedSRv6MSDType_NestedInPathSetupTypeCapability(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	caps := []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
+		PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE},
+		SubTLVs: []pcep.TLVInterface{
+			pcep.NewSRv6PCECapability(false, pcep.MSD{Type: 1, Value: 1}),
+		},
+	}}
+
+	neg := &openNegotiation{}
+	require.ErrorContains(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg),
+		"unsupported MSD-Type")
+
+	assert.False(t, neg.remoteOK)
+
+	writes := conn.writes()
+	require.Len(t, writes, 1)
+	assertTypedPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
+}
+
+func TestHandlePeerOpen_AcceptsKnownSRv6MSDTypes(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	caps := []pcep.CapabilityInterface{
+		pcep.NewSRv6PCECapability(false,
+			pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 1},
+			pcep.MSD{Type: pcep.MSDTypeSRHMaxEndPop, Value: 1},
+			pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 1},
+			pcep.MSD{Type: pcep.MSDTypeSRHMaxEndD, Value: 1},
+		),
+	}
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg))
+	assert.True(t, neg.remoteOK)
+}
+
+func TestHandlePeerOpen_AcceptsSRv6PCECapabilityWithoutMSDs(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil)}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	caps := []pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false)}
+
+	neg := &openNegotiation{}
+	require.NoError(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg))
+	assert.True(t, neg.remoteOK)
+}
+
 func TestHandlePeerOpen_AcceptsPartialPathSetupTypeOverlap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description
<!-- What does this PR change, and why is it needed? -->

Reject Open messages containing unsupported SRv6 MSD-Types per RFC 9603 §5.1.

## Type of change
<!-- Check all that apply. -->
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

* Added unit and session tests for supported and unsupported MSD-Types.

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed
