### PR TITLE
Resolve uSID container owners from micro-segments

### DIFF
--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -29,9 +29,9 @@ const MPLSLabelMax uint32 = 0xFFFFF
 
 // SIDIndex is a lookup structure over the SIDs advertised by the TED.
 type SIDIndex struct {
-	mplsSIDs     map[uint32]struct{}       // prefix SIDs and adjacency SIDs
-	srv6SIDs     map[netip.Addr]struct{}   // End / End.X SIDs, matched exactly
-	srv6Locators map[netip.Prefix]struct{} // locator prefixes derived from SID structures
+	mplsSIDs     map[uint32]struct{}              // prefix SIDs and adjacency SIDs
+	srv6SIDs     map[netip.Addr]struct{}          // End / End.X SIDs, matched exactly
+	srv6Locators map[netip.Prefix]srv6LocatorInfo // locator prefixes derived from SID structures
 
 	// path-aware: node SID → owning router ID
 	mplsNodeSIDOwner map[uint32]string
@@ -42,8 +42,14 @@ type SIDIndex struct {
 	srv6AdjSIDNextHop map[adjKeySRv6]string
 }
 
-// MissingSegment identifies one rejected segment by its position in the
-// segment list and its SID.
+// srv6LocatorInfo describes an SRv6 locator advertised into the TED.
+type srv6LocatorInfo struct {
+	owner     string // ownerUnknown when advertised by multiple nodes
+	blockBits int
+	nodeBits  int
+}
+
+// MissingSegment identifies a rejected segment.
 type MissingSegment struct {
 	Hop int // 1-origin position in the segment list
 	SID string
@@ -58,7 +64,7 @@ func NewSIDIndex(ted *LsTED) *SIDIndex {
 	idx := &SIDIndex{
 		mplsSIDs:          map[uint32]struct{}{},
 		srv6SIDs:          map[netip.Addr]struct{}{},
-		srv6Locators:      map[netip.Prefix]struct{}{},
+		srv6Locators:      map[netip.Prefix]srv6LocatorInfo{},
 		mplsNodeSIDOwner:  map[uint32]string{},
 		srv6NodeSIDOwner:  map[netip.Addr]string{},
 		mplsAdjSIDNextHop: map[adjKeyMPLS]string{},
@@ -146,7 +152,7 @@ func (idx *SIDIndex) addEndXSID(node *LsNode, l *LsLink) {
 	}
 
 	addrs := parseSRv6Addrs(l.Srv6EndXSID.Sids)
-	idx.addSRv6(addrs, l.Srv6EndXSID.Srv6SIDStructure)
+	idx.addSRv6(node.RouterID, addrs, l.Srv6EndXSID.Srv6SIDStructure)
 
 	if l.RemoteNode == nil {
 		return
@@ -162,7 +168,7 @@ func (idx *SIDIndex) addSRv6NodeSIDs(node *LsNode) {
 	for _, s := range node.SRv6SIDs {
 		if s != nil {
 			addrs := parseSRv6Addrs(s.Sids)
-			idx.addSRv6(addrs, s.SIDStructure)
+			idx.addSRv6(node.RouterID, addrs, s.SIDStructure)
 
 			for _, addr := range addrs {
 				idx.srv6NodeSIDOwner[addr] = node.RouterID
@@ -185,19 +191,29 @@ func parseSRv6Addrs(sids []string) []netip.Addr {
 }
 
 // addSRv6 registers SIDs and their locator prefixes.
-func (idx *SIDIndex) addSRv6(addrs []netip.Addr, st SIDStructure) {
-	locBits := int(st.LocalBlock) + int(st.LocalNode)
+// Conflicting locator owners are recorded as ownerUnknown.
+func (idx *SIDIndex) addSRv6(owner string, addrs []netip.Addr, st SIDStructure) {
+	blockBits, nodeBits := int(st.LocalBlock), int(st.LocalNode)
+	locBits := blockBits + nodeBits
 
 	for _, addr := range addrs {
 		idx.srv6SIDs[addr] = struct{}{}
 
-		if locBits <= 0 || locBits > SRv6SIDBitLength {
+		if nodeBits <= 0 || locBits > SRv6SIDBitLength {
 			continue
 		}
 
-		if p, err := addr.Prefix(locBits); err == nil {
-			idx.srv6Locators[p] = struct{}{}
+		p, err := addr.Prefix(locBits)
+		if err != nil {
+			continue
 		}
+
+		info := srv6LocatorInfo{owner: owner, blockBits: blockBits, nodeBits: nodeBits}
+		if existing, ok := idx.srv6Locators[p]; ok && existing.owner != owner {
+			info.owner = ownerUnknown
+		}
+
+		idx.srv6Locators[p] = info
 	}
 }
 
@@ -288,7 +304,6 @@ func (idx *SIDIndex) nextHopMPLS(owner string, s SegmentSRMPLS) (string, error) 
 }
 
 func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
-	// Node SID (End SID)?
 	if next, ok := idx.srv6NodeSIDOwner[s.Sid]; ok {
 		return next, nil
 	}
@@ -300,22 +315,126 @@ func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
 
 		return "", fmt.Errorf("SID %s not found in TED", s.SidString())
 	}
-	// Adjacency SID (End.X) — must be on owner.
+
 	if next, ok := idx.srv6AdjSIDNextHop[adjKeySRv6{owner, s.Sid}]; ok {
 		return next, nil
 	}
 
-	if idx.hasSRv6(s) {
+	// uSID containers are matched by their micro-segments against TED locators.
+	if s.USid {
+		if next, matched := idx.usidContainerOwner(s); matched {
+			return next, nil
+		}
+	}
+
+	if _, ok := idx.srv6SIDs[s.Sid]; ok {
 		return "", fmt.Errorf("%s does not have adjacency SID %s", owner, s.SidString())
 	}
 
 	return "", fmt.Errorf("SID %s not found in TED", s.SidString())
 }
 
-// ValidateExplicitPath performs path-aware SID validation on an explicit segment list.
-// Starting from srcRouterID, it verifies each SID via SIDIndex.NextHop:
-//   - Node SIDs are valid from any owner; the owner advances to that node.
-//   - Adjacency SIDs must be local to the current owner; owner advances to the link's remote node.
+// uSIDMicroSegmentPrefixes returns the locator prefixes of a uSID container.
+// An all-zero micro-segment marks the end of the container (RFC 9800 §5).
+func uSIDMicroSegmentPrefixes(sid netip.Addr, blockBits, nodeBits int) []netip.Prefix {
+	if nodeBits <= 0 || blockBits < 0 || blockBits+nodeBits > SRv6SIDBitLength {
+		return nil
+	}
+
+	src := sid.As16()
+
+	var prefixes []netip.Prefix
+
+	for start := blockBits; start+nodeBits <= SRv6SIDBitLength; start += nodeBits {
+		if usidBitsAllZero(&src, start, nodeBits) {
+			break
+		}
+
+		var dst [16]byte
+		usidCopyBits(&dst, &src, 0, 0, blockBits)
+		usidCopyBits(&dst, &src, start, blockBits, nodeBits)
+
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom16(dst), blockBits+nodeBits))
+	}
+
+	return prefixes
+}
+
+func usidBitsAllZero(b *[16]byte, offset, length int) bool {
+	for i := range length {
+		if usidGetBit(b, offset+i) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func usidCopyBits(dst, src *[16]byte, srcOffset, dstOffset, length int) {
+	for i := range length {
+		usidSetBit(dst, dstOffset+i, usidGetBit(src, srcOffset+i))
+	}
+}
+
+func usidGetBit(b *[16]byte, pos int) bool {
+	return b[pos/8]&(1<<(7-pos%8)) != 0
+}
+
+func usidSetBit(b *[16]byte, pos int, v bool) {
+	mask := byte(1 << (7 - pos%8))
+	if v {
+		b[pos/8] |= mask
+	} else {
+		b[pos/8] &^= mask
+	}
+}
+
+// usidContainerOwner resolves the owner of a uSID container.
+// matched is false when the container is outside all known locators.
+func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bool) {
+	declaredLocBits := 0
+	if len(s.Structure) == 4 {
+		declaredLocBits = int(s.Structure[0]) + int(s.Structure[1])
+	}
+
+	for loc, info := range idx.srv6Locators {
+		if !loc.Contains(s.Sid) {
+			continue
+		}
+		// Reject a request whose declared locator is shorter than the TED's.
+		if declaredLocBits > 0 && loc.Bits() > declaredLocBits {
+			continue
+		}
+
+		blockBits, nodeBits := info.blockBits, info.nodeBits
+		if len(s.Structure) == 4 {
+			blockBits, nodeBits = int(s.Structure[0]), int(s.Structure[1])
+		}
+
+		segments := uSIDMicroSegmentPrefixes(s.Sid, blockBits, nodeBits)
+		if len(segments) == 0 {
+			return ownerUnknown, true
+		}
+
+		resolved := ownerUnknown
+
+		for _, seg := range segments {
+			segInfo, ok := idx.srv6Locators[seg]
+			if !ok {
+				return ownerUnknown, true
+			}
+
+			resolved = segInfo.owner
+		}
+
+		return resolved, true
+	}
+
+	return "", false
+}
+
+// ValidateExplicitPath validates an explicit segment list from srcRouterID.
+// Each segment must be a valid next hop from the current owner.
 func ValidateExplicitPath(ted *LsTED, srcRouterID string, segmentList []Segment) error {
 	if ted == nil {
 		return errors.New("TED is nil")

--- a/pkg/table/sid_validate_internal_test.go
+++ b/pkg/table/sid_validate_internal_test.go
@@ -70,3 +70,178 @@ func TestSIDIndexNextHop_OwnerUnknownBranches(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found in TED")
 	})
 }
+
+func TestUSIDMicroSegmentPrefixes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("block 32 node 16, three micro-segments", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("fcbb:bb00:0100:0200:0300::")
+		got := uSIDMicroSegmentPrefixes(sid, 32, 16)
+		want := []netip.Prefix{
+			netip.MustParsePrefix("fcbb:bb00:0100::/48"),
+			netip.MustParsePrefix("fcbb:bb00:0200::/48"),
+			netip.MustParsePrefix("fcbb:bb00:0300::/48"),
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("stops at zero micro-segment", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("fcbb:bb00:0100:0000:0300::")
+		got := uSIDMicroSegmentPrefixes(sid, 32, 16)
+		want := []netip.Prefix{
+			netip.MustParsePrefix("fcbb:bb00:0100::/48"),
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("nodeBits zero returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("fcbb:bb00:0100::")
+		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, 32, 0))
+	})
+
+	t.Run("blockBits negative returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("fcbb:bb00:0100::")
+		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, -1, 16))
+	})
+
+	t.Run("blockBits plus nodeBits exceeds 128 returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("fcbb:bb00:0100::")
+		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, 120, 16))
+	})
+
+	t.Run("non-byte-aligned nodeBits extracts bits correctly", func(t *testing.T) {
+		t.Parallel()
+
+		// block=0xA, segments=0x123 and 0x456 (12 bits each).
+		sid := netip.AddrFrom16([16]byte{0xA1, 0x23, 0x45, 0x60})
+		got := uSIDMicroSegmentPrefixes(sid, 4, 12)
+		want := []netip.Prefix{
+			netip.PrefixFrom(netip.AddrFrom16([16]byte{0xA1, 0x23}), 16),
+			netip.PrefixFrom(netip.AddrFrom16([16]byte{0xA4, 0x56}), 16),
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("128 bits used exactly with no padding", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("2001:db8:0:0:1:2:3:4")
+		got := uSIDMicroSegmentPrefixes(sid, 64, 32)
+		want := []netip.Prefix{
+			netip.MustParsePrefix("2001:db8:0:0:1:2::/96"),
+			netip.MustParsePrefix("2001:db8:0:0:3:4::/96"),
+		}
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestUSIDContainerOwner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fully resolved returns last micro-segment owner", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0200::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		nodeZ := &LsNode{RouterID: "Z", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0300::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY, nodeZ))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, "Z", owner)
+	})
+
+	t.Run("partially resolved degrades to owner unknown", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		nodeZ := &LsNode{RouterID: "Z", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0300::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeZ))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, ownerUnknown, owner)
+	})
+
+	t.Run("not within any known locator", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fd00:bb00:0100:0200:0300::"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+
+		_, matched := idx.usidContainerOwner(seg)
+		assert.False(t, matched)
+	})
+
+	t.Run("container has no micro-segments beyond the locator returns owner unknown but matched", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0000::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
+
+		// The first micro-segment is all zero, marking the container end (RFC 9800 §5).
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0000::"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, ownerUnknown, owner)
+	})
+
+	t.Run("same locator advertised by two nodes degrades to owner unknown", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, ownerUnknown, owner)
+	})
+}

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -822,6 +822,229 @@ func TestValidateExplicitPathSRv6(t *testing.T) {
 	}
 }
 
+// usidLocatorNode builds a node advertising an SRv6 locator and optional End.X SID.
+func usidLocatorNode(routerID, sid string, remote *table.LsNode, endXSid string) *table.LsNode {
+	node := &table.LsNode{
+		RouterID: routerID,
+		SRv6SIDs: []*table.LsSrv6SID{{
+			Sids:         []string{sid},
+			SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
+		}},
+	}
+	if remote != nil {
+		node.Links = []*table.LsLink{{RemoteNode: remote, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{endXSid}}}}
+	}
+
+	return node
+}
+
+func usidContainerSeg(addr string, structure []uint8) table.Segment {
+	seg := table.NewSegmentSRv6(netip.MustParseAddr(addr))
+	seg.USid = true
+	seg.Structure = structure
+
+	return seg
+}
+
+func TestValidateExplicitPathUSID(t *testing.T) {
+	t.Parallel()
+
+	const (
+		container = "fcbb:bb00:0100:0200:0300::"
+		endXToW1  = "fc00::1:2" // owned by the node advertising locator ::0100::
+		endXToW3  = "fc00::3:4" // owned by the node advertising locator ::0300::
+	)
+
+	t.Run("regression: single-locator container from existing fixture, one hop", func(t *testing.T) {
+		t.Parallel()
+
+		nodeW := &table.LsNode{RouterID: "W"}
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nodeW, endXToW1)
+		ted := newTestTED(nodeW, nodeX)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("single micro-segment container equal to locator, then owner's End.X", func(t *testing.T) {
+		t.Parallel()
+
+		nodeW := &table.LsNode{RouterID: "W"}
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nodeW, endXToW1)
+		ted := newTestTED(nodeW, nodeX)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg("fcbb:bb00:0100::", []uint8{32, 16, 16, 0}),
+			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("all micro-segments resolve, then last micro-segment owner's End.X", func(t *testing.T) {
+		t.Parallel()
+
+		nodeW := &table.LsNode{RouterID: "W"}
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nil, "")
+		nodeY := usidLocatorNode("Y", "fcbb:bb00:0200::", nil, "")
+		nodeZ := usidLocatorNode("Z", "fcbb:bb00:0300::", nodeW, endXToW3)
+		ted := newTestTED(nodeW, nodeX, nodeY, nodeZ)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			table.NewSegmentSRv6(netip.MustParseAddr(endXToW3)),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("all micro-segments resolve, then first micro-segment owner's End.X fails", func(t *testing.T) {
+		t.Parallel()
+
+		nodeW := &table.LsNode{RouterID: "W"}
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nodeW, endXToW1)
+		nodeY := usidLocatorNode("Y", "fcbb:bb00:0200::", nil, "")
+		nodeZ := usidLocatorNode("Z", "fcbb:bb00:0300::", nil, "")
+		ted := newTestTED(nodeW, nodeX, nodeY, nodeZ)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not have adjacency SID")
+	})
+
+	t.Run("unresolved micro-segment degrades to owner unknown, known End.X still validates", func(t *testing.T) {
+		t.Parallel()
+
+		nodeW := &table.LsNode{RouterID: "W"}
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nil, "")
+		nodeZ := usidLocatorNode("Z", "fcbb:bb00:0300::", nodeW, endXToW3)
+		// Y's locator is intentionally absent from the TED.
+		ted := newTestTED(nodeW, nodeX, nodeZ)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			table.NewSegmentSRv6(netip.MustParseAddr(endXToW3)),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("unresolved micro-segment degrades to owner unknown, unknown SID after still fails", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nil, "")
+		nodeZ := usidLocatorNode("Z", "fcbb:bb00:0300::", nil, "")
+		ted := newTestTED(nodeX, nodeZ)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			table.NewSegmentSRv6(netip.MustParseAddr("fd00::dead:beef")),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in TED")
+	})
+
+	t.Run("container outside any known locator", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nil, "")
+		ted := newTestTED(nodeX)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg("fd00:bb00:0100:0200:0300::", []uint8{32, 16, 16, 0}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in TED")
+	})
+
+	t.Run("declared locator shorter than TED's", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nil, "")
+		ted := newTestTED(nodeX)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg(container, []uint8{24, 8, 16, 0}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in TED")
+	})
+
+	t.Run("uSID false is not treated as a container", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nil, "")
+		ted := newTestTED(nodeX)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			table.NewSegmentSRv6(netip.MustParseAddr(container)),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in TED")
+	})
+
+	t.Run("exact End.X SID from wrong owner still errors with uSID enabled", func(t *testing.T) {
+		t.Parallel()
+
+		nodeA := &table.LsNode{
+			RouterID: testRouterIDA,
+			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{"fc00::a:1"}}},
+		}
+		nodeB := &table.LsNode{
+			RouterID: testRouterIDB,
+			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{"fc00::b:1"}}},
+		}
+		nodeA.Links = []*table.LsLink{{LocalNode: nodeA, RemoteNode: nodeB, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"fc00::a:b"}}}}
+		ted := newTestTED(nodeA, nodeB)
+
+		err := table.ValidateExplicitPath(ted, testRouterIDB, []table.Segment{
+			usidContainerSeg("fc00::a:b", nil),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not have adjacency SID")
+	})
+
+	t.Run("nodeBits zero does not hang and falls back to not found", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := usidLocatorNode("X", "fcbb:bb00:0100::", nil, "")
+		ted := newTestTED(nodeX)
+
+		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
+			usidContainerSeg("fd00:bb00:0100::", []uint8{32, 0, 16, 0}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in TED")
+	})
+
+	t.Run("LocalNode unset does not bypass owner validation", func(t *testing.T) {
+		t.Parallel()
+
+		nodeA := &table.LsNode{
+			RouterID: testRouterIDA,
+			SRv6SIDs: []*table.LsSrv6SID{{
+				Sids:         []string{"fc00::a:1"},
+				SIDStructure: table.SIDStructure{LocalBlock: 32},
+			}},
+		}
+		nodeB := &table.LsNode{
+			RouterID: testRouterIDB,
+			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{"fc00::b:1"}}},
+		}
+		nodeA.Links = []*table.LsLink{{LocalNode: nodeA, RemoteNode: nodeB, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"fc00::a:b"}}}}
+		ted := newTestTED(nodeA, nodeB)
+
+		err := table.ValidateExplicitPath(ted, testRouterIDB, []table.Segment{
+			usidContainerSeg("fc00::a:b", nil),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not have adjacency SID")
+	})
+}
+
 func TestSIDIndexNextHop_UnknownSegmentFamily(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Resolve the owner of uSID containers from advertised SRv6 locators to validate subsequent segments correctly.

## Type of change
<!-- Check all that apply. -->
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

* Added unit and path validation tests for uSID container owner resolution.


## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed
