### PR TITLE
Refactor Association Types and Capability Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and a PCEP Library in Go.
 
 ## Features
 
-* Support for SRv6(full-SID/uSID) and SR-MPLS
+* Support for SRv6 (full-SID/uSID) and SR-MPLS
 * Implementation of active stateful PCE functionality (PCInitiate, PCUpdate, etc.)
 * Dynamic and explicit SR policy definition using YAML
   * Dynamic path: Utilizes CSPF with GoBGP BGP-LS TED
@@ -63,7 +63,4 @@ Your contributions are highly appreciated.
 
 ## Licensing
 
-Pola PCE is licensed under the
-[MIT license](https://en.wikipedia.org/wiki/MIT_License).  
-For the full license text, see
-[LICENSE](https://github.com/nttcom/pola/blob/master/LICENSE).
+Pola PCE is licensed under the [MIT License](LICENSE).

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-### From Go Package
+### From Go
 
 ```bash
 go install github.com/nttcom/pola/cmd/pola@latest
@@ -10,15 +10,8 @@ go install github.com/nttcom/pola/cmd/pola@latest
 
 ### From Source
 
-#### Getting the Source
-
 ```bash
 git clone https://github.com/nttcom/pola.git
-```
-
-#### Build & install
-
-```bash
 cd pola
 go install ./cmd/pola
 
@@ -36,9 +29,7 @@ Displays PCEP sessions, sorted by peer address.
 - `detail` includes additional session information and message statistics.
 - `-j` outputs JSON.
 
-Without arguments, all sessions are shown in summary form.
-
-Text formatted response (`pola session detail`)
+Text output (`pola session detail`)
 
 ```text
 Session #0: 192.0.2.1
@@ -57,14 +48,16 @@ Session #0: 192.0.2.1
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update, Instantiation
       SR-PCE-CAPABILITY [RFC8664]: SR, SR-NAI-Supported
       ASSOC-TYPE-LIST [RFC8697]:
-        6 SR Policy Association
+        SR Policy Association (0x0006) [RFC9862]
+      Unrecognized TLVs:
+        type=73: SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11) [sub-TLV of PATH-SETUP-TYPE-CAPABILITY]
     Local only:
       SR-PCE-CAPABILITY [RFC8664]: MSD=10
     Peer only:
       STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Color
       SR-PCE-CAPABILITY [RFC8664]: MSD=16
       ASSOC-TYPE-LIST [RFC8697]:
-        9 P2MP SR Policy Association (draft)
+        P2MP SR Policy Association (0x0009) [draft-ietf-pce-sr-p2mp-policy-11]
   Session Creation:  2026-08-19T09:30:05Z
   Initiator:         remote
   Stats:
@@ -84,7 +77,7 @@ Session #0: 192.0.2.1
     Session Setup:     ok=1, fail=0
 ```
 
-JSON formatted response (`pola session detail -j`)
+JSON output (`pola session detail -j`)
 
 ```json
 [
@@ -107,14 +100,25 @@ JSON formatted response (`pola session detail -j`)
         "instantiation": true,
         "pathSetupTypes": [],
         "associationTypes": [6],
-        "unrecognizedTlvTypes": [],
+        "unrecognizedTlvTypes": [73],
+        "capabilities": [
+          { "capability": "STATEFUL", "items": ["Stateful", "Update", "Instantiation"] },
+          { "capability": "SR", "items": ["SR", "SR-NAI-Supported"] },
+          { "capability": "ASSOC_TYPE_LIST", "items": ["SR Policy Association (0x0006) [RFC9862]"] },
+          {
+            "capability": "UNKNOWN",
+            "items": [
+              "type=73: SR-P2MP-POLICY-CAPABILITY (draft-ietf-pce-sr-p2mp-policy-11) [sub-TLV of PATH-SETUP-TYPE-CAPABILITY]"
+            ]
+          }
+        ],
         "other": []
       },
       "localOnly": [{ "capability": "SR", "items": ["MSD=10"] }],
       "peerOnly": [
         { "capability": "STATEFUL", "items": ["Color"] },
         { "capability": "SR", "items": ["MSD=16"] },
-        { "capability": "ASSOC_TYPE_LIST", "items": ["9 P2MP SR Policy Association (draft)"] }
+        { "capability": "ASSOC_TYPE_LIST", "items": ["P2MP SR Policy Association (0x0009) [draft-ietf-pce-sr-p2mp-policy-11]"] }
       ]
     },
     "sessionCreation": "2026-08-19T09:30:05Z",
@@ -138,20 +142,23 @@ JSON formatted response (`pola session detail -j`)
 ]
 ```
 
-Field reference:
+Fields:
 
-- `sessionId.local`/`peer` are omitted until the corresponding Open
-  message has been exchanged.
-- `lspDbSync` indicates the LSP-DB synchronization state and uses the
-  same vocabulary as `pola sr-policy list`.
-- `stats` contains RFC 9826 message counters. Session setup counters
-  persist across reconnects.
+- `lspDbSync` indicates the LSP-DB synchronization state, using the same
+  vocabulary as `pola sr-policy list`.
+- `stats` contains RFC 9826 message counters.
+- `capabilities.common.capabilities` lists all capabilities shared by
+  both sides, grouped by TLV. Other fields provide views of commonly used
+  capabilities. `other` is deprecated and retained for backward compatibility.
+- `[sub-TLV of PATH-SETUP-TYPE-CAPABILITY]` indicates a capability
+  advertised only as a PATH-SETUP-TYPE-CAPABILITY sub-TLV and included
+  in `unrecognizedTlvTypes`.
 
 ### pola session delete *Address* [-j]
 
 Deletes the session with the specified peer address.
 
-JSON formatted response
+JSON output
 
 ```json
 {
@@ -164,11 +171,10 @@ JSON formatted response
 Displays SR Policies managed by polad, grouped by PCEP peer and sorted by
 peer address. `--peer` filters by peer address.
 
-All connected sessions are included. Use `lspDbSync` to distinguish an
-unsynchronized session (`pending` or `ongoing`) from a synced session
-(`finished`) with no SR Policies.
+All connected sessions are included. `lspDbSync` indicates whether the
+session is synchronized (`finished`) or not (`pending` or `ongoing`).
 
-Text formatted response
+Text output
 
 ```text
 Session: 192.0.2.2 (State: up, LSP-DB Sync: finished)
@@ -187,7 +193,7 @@ Session: 2001:db8::1 (State: keep-wait, LSP-DB Sync: pending)
   No SR Policies: session is not established.
 ```
 
-JSON formatted response
+JSON output
 
 ```json
 [
@@ -230,12 +236,11 @@ Notes:
 - Policies appear after the first PCRpt is received.
 - `lspId` is omitted when zero.
 - `srcRouterId`/`dstRouterId` are resolved from TED.
-- `type` and `metric` are available for policies created by
-  `pola sr-policy add`.
+- `metric` is included for policies created with `type: dynamic`.
 
 ### pola sr-policy add -f `filepath`
 
-Create a new SR Policy **using TED**.
+Creates a new SR Policy.
 
 #### Dynamic path
 
@@ -255,7 +260,7 @@ srPolicy:
 
 `metric` can be `igp`, `te`, or `delay`.
 
-JSON formatted response
+JSON output
 
 ```json
 {
@@ -264,8 +269,6 @@ JSON formatted response
 ```
 
 #### Explicit path
-
-Each SID may include address information for the NAI.
 
 YAML input format
 
@@ -284,7 +287,7 @@ srPolicy:
     - sid: 16004
 ```
 
-JSON formatted response
+JSON output
 
 ```json
 {
@@ -302,8 +305,7 @@ segment list verbatim.
 Each SID is still validated against the TED, so with `ted.enable: false` this
 form additionally requires `--no-sid-validate`.
 
-For each SID, specify the address information required to construct the NAI.
-`localAddr` is required for SRv6 SIDs but optional for SR-MPLS labels.
+`localAddr` is required for SRv6 SIDs and optional for SR-MPLS labels.
 
 See [JSON schema](../../docs/schemas/cli/policy.json) for input details.
 
@@ -326,7 +328,7 @@ srPolicy:
       sidStructure: "32,16,0,80"
 ```
 
-JSON formatted response
+JSON output
 
 ```json
 {
@@ -338,18 +340,13 @@ JSON formatted response
 
 Skips validation of explicit SIDs against the TED.
 
-> [!NOTE]
-> SID validation depends on the asynchronously populated BGP-LS TED and may
-> not reflect the current network topology. Use this option for SIDs that
-> cannot be represented in the TED.
-
 ### pola ted [-j]
 
 Displays the TED managed by polad, sorted by router ID. If TED is disabled by
 polad, the command returns a non-zero exit status with an error message on
 stderr, in both text and `-j` mode.
 
-Text formatted response
+Text output
 
 ```text
 Node #0: 0000.0aff.0001
@@ -388,9 +385,9 @@ Node #1: 0000.0aff.0002
   SRv6 SIDs:
 ```
 
-JSON formatted response. The top level is an array of nodes, matching the
-other commands' output; there is no wrapping `ted` object. A link's `localIp`/`remoteIp` is omitted when the BGP-LS descriptor
-does not contain an interface address.
+JSON output. The top level is an array of nodes; there is no wrapping
+`ted` object. `localIp`/`remoteIp` are omitted when no interface address
+is present in the BGP-LS descriptor.
 
 ```json
 [

--- a/cmd/pola/session_capability.go
+++ b/cmd/pola/session_capability.go
@@ -38,16 +38,32 @@ type capFeature struct {
 	hasNum bool
 }
 
-// capabilitiesFeatures flattens capabilities into deduplicated features.
-func capabilitiesFeatures(caps []grpc.Capability) []capFeature {
+// capabilitiesFeatures flattens capabilities and identifies nested-only features.
+func capabilitiesFeatures(caps []grpc.Capability) (features []capFeature, nestedOnly map[capFeature]struct{}) {
 	seen := make(map[capFeature]struct{})
 
-	features := make([]capFeature, 0, len(caps))
+	features = make([]capFeature, 0, len(caps))
 	for _, c := range caps {
 		features = appendCapabilityFeatures(features, seen, c)
 	}
 
-	return features
+	topLevel := make(map[capFeature]struct{}, len(features))
+
+	for _, c := range caps {
+		for _, f := range capabilityFeatures(c) {
+			topLevel[f] = struct{}{}
+		}
+	}
+
+	nestedOnly = make(map[capFeature]struct{})
+
+	for _, f := range features {
+		if _, ok := topLevel[f]; !ok {
+			nestedOnly[f] = struct{}{}
+		}
+	}
+
+	return features, nestedOnly
 }
 
 // capabilityFeatures turns c into its features.
@@ -106,14 +122,17 @@ func appendCapabilityFeatures(features []capFeature, seen map[capFeature]struct{
 }
 
 type capabilitySets struct {
-	common    []capFeature
-	localOnly []capFeature
-	peerOnly  []capFeature
+	common          []capFeature
+	localOnly       []capFeature
+	peerOnly        []capFeature
+	commonNested    map[capFeature]struct{}
+	localOnlyNested map[capFeature]struct{}
+	peerOnlyNested  map[capFeature]struct{}
 }
 
 func splitCapabilities(localCaps, peerCaps []grpc.Capability) capabilitySets {
-	local := capabilitiesFeatures(localCaps)
-	peer := capabilitiesFeatures(peerCaps)
+	local, localNested := capabilitiesFeatures(localCaps)
+	peer, peerNested := capabilitiesFeatures(peerCaps)
 
 	peerSet := make(map[capFeature]struct{}, len(peer))
 	for _, f := range peer {
@@ -125,19 +144,38 @@ func splitCapabilities(localCaps, peerCaps []grpc.Capability) capabilitySets {
 		localSet[f] = struct{}{}
 	}
 
-	var sets capabilitySets
+	sets := capabilitySets{
+		commonNested:    make(map[capFeature]struct{}),
+		localOnlyNested: make(map[capFeature]struct{}),
+		peerOnlyNested:  make(map[capFeature]struct{}),
+	}
 
 	for _, f := range local {
 		if _, ok := peerSet[f]; ok {
 			sets.common = append(sets.common, f)
+
+			_, localSaysNested := localNested[f]
+			_, peerSaysNested := peerNested[f]
+
+			if localSaysNested && peerSaysNested {
+				sets.commonNested[f] = struct{}{}
+			}
 		} else {
 			sets.localOnly = append(sets.localOnly, f)
+
+			if _, ok := localNested[f]; ok {
+				sets.localOnlyNested[f] = struct{}{}
+			}
 		}
 	}
 
 	for _, f := range peer {
 		if _, ok := localSet[f]; !ok {
 			sets.peerOnly = append(sets.peerOnly, f)
+
+			if _, ok := peerNested[f]; ok {
+				sets.peerOnlyNested[f] = struct{}{}
+			}
 		}
 	}
 
@@ -154,13 +192,10 @@ type capabilitiesView struct {
 	Common    commonCapView  `json:"common"`
 	LocalOnly []capGroupView `json:"localOnly"`
 	PeerOnly  []capGroupView `json:"peerOnly"`
-
-	// commonGroups holds grouped common capabilities for text output.
-	commonGroups []capGroupView
 }
 
 func (c capabilitiesView) commonLines() []capDisplayLine {
-	return capabilityLines(c.commonGroups)
+	return capabilityLines(c.Common.Capabilities)
 }
 
 // commonCapView exposes capabilities shared by both sides.
@@ -171,6 +206,7 @@ type commonCapView struct {
 	PathSetupTypes       []string       `json:"pathSetupTypes"`
 	AssociationTypes     []uint32       `json:"associationTypes"`
 	UnrecognizedTLVTypes []uint32       `json:"unrecognizedTlvTypes"`
+	Capabilities         []capGroupView `json:"capabilities"`
 	Other                []capGroupView `json:"other"`
 }
 
@@ -182,10 +218,10 @@ func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesVi
 			PathSetupTypes:       []string{},
 			AssociationTypes:     []uint32{},
 			UnrecognizedTLVTypes: []uint32{},
+			Capabilities:         capabilityGroups(sets.common, sets.commonNested),
 		},
-		LocalOnly:    capabilityGroups(sets.localOnly),
-		PeerOnly:     capabilityGroups(sets.peerOnly),
-		commonGroups: capabilityGroups(sets.common),
+		LocalOnly: capabilityGroups(sets.localOnly, sets.localOnlyNested),
+		PeerOnly:  capabilityGroups(sets.peerOnly, sets.peerOnlyNested),
 	}
 
 	var otherFeatures []capFeature
@@ -196,7 +232,7 @@ func buildCapabilitiesView(localCaps, peerCaps []grpc.Capability) capabilitiesVi
 		}
 	}
 
-	view.Common.Other = capabilityGroups(otherFeatures)
+	view.Common.Other = capabilityGroups(otherFeatures, sets.commonNested)
 
 	slices.Sort(view.Common.PathSetupTypes)
 	slices.Sort(view.Common.AssociationTypes)
@@ -243,8 +279,7 @@ func applyCommonFeature(common *commonCapView, f capFeature) bool {
 	return false
 }
 
-// capabilityGroups groups features by capability.
-func capabilityGroups(features []capFeature) []capGroupView {
+func capabilityGroups(features []capFeature, nestedOnly map[capFeature]struct{}) []capGroupView {
 	order := make([]string, 0)
 
 	byGroup := make(map[string][]capFeature)
@@ -262,18 +297,20 @@ func capabilityGroups(features []capFeature) []capGroupView {
 
 	groups := make([]capGroupView, 0, len(order))
 	for _, group := range order {
-		groups = append(groups, capGroupView{Capability: group, Items: groupItems(group, byGroup[group])})
+		groups = append(groups, capGroupView{Capability: group, Items: groupItems(group, byGroup[group], nestedOnly)})
 	}
 
 	return groups
 }
 
-func groupItems(group string, features []capFeature) []string {
+const nestedSubTLVSuffix = " [sub-TLV of PATH-SETUP-TYPE-CAPABILITY]"
+
+func groupItems(group string, features []capFeature, nestedOnly map[capFeature]struct{}) []string {
 	switch group {
 	case capGroupAssocTypeList:
-		return sortedNumericLabels(features, assocTypeLabel)
+		return sortedNumericLabels(features, assocTypeLabel, nil)
 	case capGroupUnknown:
-		return sortedNumericLabels(features, unrecognizedTLVItem)
+		return sortedNumericLabels(features, unrecognizedTLVItem, nestedOnly)
 	default:
 		items := make([]string, len(features))
 		for i, f := range features {
@@ -284,19 +321,26 @@ func groupItems(group string, features []capFeature) []string {
 	}
 }
 
-func sortedNumericLabels(features []capFeature, label func(uint32) string) []string {
-	ns := make([]uint32, 0, len(features))
+func sortedNumericLabels(features []capFeature, label func(uint32) string, nestedOnly map[capFeature]struct{}) []string {
+	numbered := make([]capFeature, 0, len(features))
 	for _, f := range features {
 		if f.hasNum {
-			ns = append(ns, f.num)
+			numbered = append(numbered, f)
 		}
 	}
 
-	slices.Sort(ns)
+	slices.SortFunc(numbered, func(a, b capFeature) int {
+		return cmp.Compare(a.num, b.num)
+	})
 
-	items := make([]string, len(ns))
-	for i, n := range ns {
-		items[i] = label(n)
+	items := make([]string, len(numbered))
+	for i, f := range numbered {
+		item := label(f.num)
+		if _, ok := nestedOnly[f]; ok {
+			item += nestedSubTLVSuffix
+		}
+
+		items[i] = item
 	}
 
 	return items

--- a/cmd/pola/session_capability_test.go
+++ b/cmd/pola/session_capability_test.go
@@ -147,7 +147,7 @@ func TestCapabilitiesFeatures_DeduplicatesByGroupAndToken(t *testing.T) {
 		{Type: "SR", Detail: grpc.SRCapability{UnlimitedMSD: true}},
 	}
 
-	got := capabilitiesFeatures(caps)
+	got, _ := capabilitiesFeatures(caps)
 	assert.Equal(t, []capFeature{{group: "SR", token: "SR"}, {group: "SR", token: "Unlimited-SID-Depth"}}, got)
 }
 
@@ -239,7 +239,7 @@ func TestCommonCapabilityLines_GroupsByTLVExceptAssocTypeAndUnknown(t *testing.T
 		{group: capGroupUnknown, token: "unknown_type_73", num: 73, hasNum: true},
 	}
 
-	lines := capabilityLines(capabilityGroups(common))
+	lines := capabilityLines(capabilityGroups(common, nil))
 	assert.Equal(t, []capDisplayLine{
 		{Header: "STATEFUL-PCE-CAPABILITY [RFC8231/8281]: Stateful, Update"},
 		{Header: assocTypeListLabel, Items: []string{
@@ -262,7 +262,7 @@ func TestCommonCapabilityLines_OrdersByTLVTypeRegardlessOfInputOrder(t *testing.
 		{group: capGroupStateful, token: "Stateful"},
 	}
 
-	lines := capabilityLines(capabilityGroups(common))
+	lines := capabilityLines(capabilityGroups(common, nil))
 
 	headers := make([]string, 0, len(lines))
 	for _, line := range lines {
@@ -285,7 +285,7 @@ func TestCommonCapabilityLines_UnknownGroupSortsLast(t *testing.T) {
 		{group: capGroupMultipath, token: "Multipath"},
 	}
 
-	lines := capabilityLines(capabilityGroups(common))
+	lines := capabilityLines(capabilityGroups(common, nil))
 	assert.Equal(t, "MULTIPATH-CAP [draft-ietf-pce-multipath]: Multipath", lines[0].Header)
 	assert.Equal(t, "Unrecognized TLVs", lines[1].Header)
 }
@@ -375,7 +375,7 @@ func TestCommonCapabilityLines_SingleAssocTypeStillUsesHeadingForm(t *testing.T)
 		{group: capGroupAssocTypeList, token: "AssocType:6", num: 6, hasNum: true},
 	}
 
-	lines := capabilityLines(capabilityGroups(common))
+	lines := capabilityLines(capabilityGroups(common, nil))
 	assert.Equal(t, []capDisplayLine{
 		{Header: assocTypeListLabel, Items: []string{"SR Policy Association (0x0006) [RFC9862]"}},
 	}, lines)
@@ -409,6 +409,134 @@ func TestBuildCapabilitiesView_LocalOnlyAssocTypeUsesRegistryLabel(t *testing.T)
 		Capability: capGroupAssocTypeList,
 		Items:      []string{"SR Policy Association (0x0006) [RFC9862]"},
 	}}, view.LocalOnly)
+}
+
+func unrecognizedTLVGroup(view capabilitiesView) (capGroupView, bool) {
+	for _, g := range view.Common.Capabilities {
+		if g.Capability == capGroupUnknown {
+			return g, true
+		}
+	}
+
+	return capGroupView{}, false
+}
+
+func TestBuildCapabilitiesView_UnknownSubTLVProvenanceSuffix(t *testing.T) {
+	t.Parallel()
+
+	pstWith := func(sub grpc.Capability) grpc.Capability {
+		return grpc.Capability{Type: capGroupPathSetupType, Detail: grpc.PathSetupTypeCapability{
+			PathSetupTypes:  []uint32{1},
+			SubCapabilities: []grpc.Capability{sub},
+		}}
+	}
+	topLevelUnknown := grpc.Capability{Type: capGroupUnknown, Detail: grpc.UnknownCapability{TLVType: 73}}
+	nestedUnknown := grpc.Capability{Type: capGroupUnknown, Detail: grpc.UnknownCapability{TLVType: 73}}
+
+	nestedOnlyCaps := []grpc.Capability{pstWith(nestedUnknown)}
+	topLevelOnlyCaps := []grpc.Capability{topLevelUnknown}
+	bothCaps := []grpc.Capability{topLevelUnknown, pstWith(nestedUnknown)}
+
+	nestedOnlyView := buildCapabilitiesView(nestedOnlyCaps, nestedOnlyCaps)
+	topLevelOnlyView := buildCapabilitiesView(topLevelOnlyCaps, topLevelOnlyCaps)
+	bothView := buildCapabilitiesView(bothCaps, bothCaps)
+
+	nestedGroup, ok := unrecognizedTLVGroup(nestedOnlyView)
+	require.True(t, ok)
+	require.Len(t, nestedGroup.Items, 1)
+	assert.Contains(t, nestedGroup.Items[0], nestedSubTLVSuffix, "a sub-TLV-only unknown type must be annotated")
+
+	topLevelGroup, ok := unrecognizedTLVGroup(topLevelOnlyView)
+	require.True(t, ok)
+	require.Len(t, topLevelGroup.Items, 1)
+	assert.NotContains(t, topLevelGroup.Items[0], nestedSubTLVSuffix, "a top-level-only unknown type must not be annotated")
+
+	bothGroup, ok := unrecognizedTLVGroup(bothView)
+	require.True(t, ok)
+	require.Len(t, bothGroup.Items, 1)
+	assert.NotContains(t, bothGroup.Items[0], nestedSubTLVSuffix, "a type seen both top-level and nested must not be annotated")
+
+	assert.Equal(t, []uint32{73}, nestedOnlyView.Common.UnrecognizedTLVTypes)
+	assert.Equal(t, nestedOnlyView.Common.UnrecognizedTLVTypes, topLevelOnlyView.Common.UnrecognizedTLVTypes)
+	assert.Equal(t, nestedOnlyView.Common.UnrecognizedTLVTypes, bothView.Common.UnrecognizedTLVTypes)
+}
+
+func TestBuildCapabilitiesView_CapabilitiesIsCanonicalAndIncludesOther(t *testing.T) {
+	t.Parallel()
+
+	caps := []grpc.Capability{
+		{Type: capGroupStateful, Detail: grpc.StatefulCapability{LSPUpdate: true}},
+		{Type: capGroupMultipath, Detail: grpc.MultipathCapability{MaxMultipaths: 4}},
+	}
+
+	view := buildCapabilitiesView(caps, caps)
+
+	byGroup := make(map[string]capGroupView, len(view.Common.Capabilities))
+	for _, g := range view.Common.Capabilities {
+		byGroup[g.Capability] = g
+	}
+
+	for _, g := range view.Common.Other {
+		assert.Equal(t, g, byGroup[g.Capability], "Other group %q must also appear in Capabilities", g.Capability)
+	}
+
+	require.Contains(t, byGroup, capGroupStateful, "a typed-field-consumed group must still appear in Capabilities")
+	assert.NotContains(t, view.Common.Other, capGroupView{Capability: capGroupStateful})
+}
+
+func TestBuildCapabilitiesView_CapabilitiesMatchesCommonLinesOutput(t *testing.T) {
+	t.Parallel()
+
+	caps := []grpc.Capability{
+		{Type: capGroupStateful, Detail: grpc.StatefulCapability{LSPUpdate: true}},
+		{Type: capGroupAssocTypeList, Detail: grpc.AssocTypeListCapability{AssocTypes: []uint32{6}}},
+		{Type: capGroupUnknown, Detail: grpc.UnknownCapability{TLVType: 73}},
+	}
+
+	view := buildCapabilitiesView(caps, caps)
+
+	assert.Equal(t, capabilityLines(view.Common.Capabilities), view.commonLines(),
+		"text and JSON output must read from the same canonical data")
+}
+
+func TestBuildCapabilitiesView_EmptyBothSidesCapabilitiesIsEmptyNotNil(t *testing.T) {
+	t.Parallel()
+
+	view := buildCapabilitiesView(nil, nil)
+
+	assert.NotNil(t, view.Common.Capabilities)
+	assert.Empty(t, view.Common.Capabilities)
+}
+
+func TestBuildCapabilitiesView_PeerOnlyNestedUnknownGetsSuffix(t *testing.T) {
+	t.Parallel()
+
+	peer := []grpc.Capability{
+		{Type: capGroupPathSetupType, Detail: grpc.PathSetupTypeCapability{
+			PathSetupTypes: []uint32{1},
+			SubCapabilities: []grpc.Capability{
+				{Type: capGroupUnknown, Detail: grpc.UnknownCapability{TLVType: 73}},
+			},
+		}},
+	}
+
+	view := buildCapabilitiesView(nil, peer)
+
+	var unknownGroup capGroupView
+
+	found := false
+
+	for _, g := range view.PeerOnly {
+		if g.Capability == capGroupUnknown {
+			unknownGroup = g
+			found = true
+		}
+	}
+
+	require.True(t, found, "peer-only unknown TLV must appear in PeerOnly")
+	require.Len(t, unknownGroup.Items, 1)
+	assert.Contains(t, unknownGroup.Items[0], nestedSubTLVSuffix,
+		"a peer-only unknown TLV seen only as a PATH-SETUP-TYPE-CAPABILITY sub-capability must be annotated")
 }
 
 func TestBuildCapabilitiesView_VendorInformationTokenIsNotLowercased(t *testing.T) {

--- a/cmd/pola/session_text_test.go
+++ b/cmd/pola/session_text_test.go
@@ -34,10 +34,10 @@ func fullSessionViewFixture() sessionView {
 			Common: commonCapView{
 				Stateful: true, Update: true,
 				PathSetupTypes: []string{}, AssociationTypes: []uint32{}, UnrecognizedTLVTypes: []uint32{},
+				Capabilities: []capGroupView{{Capability: capGroupStateful, Items: []string{"Stateful", "Update"}}},
 			},
-			LocalOnly:    []capGroupView{{Capability: "SR", Items: []string{"MSD=10"}}},
-			PeerOnly:     []capGroupView{{Capability: "SR", Items: []string{"MSD=16"}}},
-			commonGroups: []capGroupView{{Capability: capGroupStateful, Items: []string{"Stateful", "Update"}}},
+			LocalOnly: []capGroupView{{Capability: "SR", Items: []string{"MSD=10"}}},
+			PeerOnly:  []capGroupView{{Capability: "SR", Items: []string{"MSD=16"}}},
 		},
 		SessionCreation: "2026-08-19T09:30:00Z",
 		Initiator:       "remote",
@@ -151,7 +151,9 @@ func TestWriteCapabilityGroupSection_PropagatesGroupedLineWriteError(t *testing.
 	t.Parallel()
 
 	c := capabilitiesView{
-		commonGroups: []capGroupView{{Capability: capGroupAssocTypeList, Items: []string{"SR Policy Association (0x0006) [RFC9862]"}}},
+		Common: commonCapView{
+			Capabilities: []capGroupView{{Capability: capGroupAssocTypeList, Items: []string{"SR Policy Association (0x0006) [RFC9862]"}}},
+		},
 	}
 
 	w := &condFailWriter{fail: containsFail("ASSOC-TYPE-LIST")}

--- a/docs/sources/getting-started.md
+++ b/docs/sources/getting-started.md
@@ -4,7 +4,7 @@ This page explains how to use Pola PCE.
 
 ## Installation
 
-### From Go Package
+### From Go
 
 ```bash
 go install github.com/nttcom/pola/cmd/polad@latest
@@ -12,20 +12,13 @@ go install github.com/nttcom/pola/cmd/polad@latest
 
 ### From Source
 
-#### Getting the Source
-
 ```bash
 git clone https://github.com/nttcom/pola.git
-```
-
-#### Build & install
-
-```bash
-$ cd pola
-$ go install ./cmd/polad
+cd pola
+go install ./cmd/polad
 
 # or, install with cli command
-$ go install ./...
+go install ./...
 ```
 
 ### From Container Image
@@ -34,7 +27,7 @@ See the [Docker page](../../build/package/README.md).
 
 ## Configuration
 
-Specify the IP address and port number for each PCEP and gRPC.
+Configure the IP address and port for PCEP and gRPC.
 `address` must be a literal IPv4 or IPv6 address; hostnames are not resolved.
 See [JSON schema](../schemas/server/polad_config.json) for config details.
 
@@ -103,7 +96,7 @@ global:
 To manage SR Policy using TED, enable TED as follows.
 This also enables dynamic path calculation.
 
-A specific tool for updating TED is required to use this feature.
+TED updates require a supported BGP-LS source.
 Currently, only GoBGP is supported.
 
 **Not currently available for IPv6 underlay (IPv6 SR-MPLS / SRv6).**
@@ -148,7 +141,7 @@ neighbors:
       afi-safi-name: ls
 ```
 
-## Run Pola PCE using polad
+## Run Polad
 
 Start polad. Specify the created configuration file with the -f option.
 
@@ -158,5 +151,5 @@ $ sudo polad -f polad.yaml
 2022-06-05T22:57:59.823Z        info    PCEP listen     {"listenInfo": "192.0.2.254:4189"}
 ```
 
-After Polad is running, use [pola cmd](../../cmd/pola/README.md) or the
-[gRPC client](../../api/grpc/) for daemon operations
+After Polad is running, use the [pola CLI](../../cmd/pola/README.md) or
+[gRPC client](../../api/grpc/) to manage the daemon.

--- a/pkg/packet/pcep/capability.go
+++ b/pkg/packet/pcep/capability.go
@@ -53,6 +53,13 @@ func polaAssocTypeList() *AssocTypeList {
 	}
 }
 
+// PolaAssocTypes returns the Association Types Pola advertises in its OPEN.
+func PolaAssocTypes() []AssocType {
+	types := polaAssocTypeList().AssocTypes
+
+	return append([]AssocType(nil), types...)
+}
+
 // polaMultipathCapability advertises support for a single path per request.
 func polaMultipathCapability() *MultipathCapability {
 	return NewMultipathCapability(1, false, false, false, false)

--- a/pkg/packet/pcep/capability_test.go
+++ b/pkg/packet/pcep/capability_test.go
@@ -14,6 +14,20 @@ import (
 	"github.com/nttcom/pola/pkg/packet/pcep"
 )
 
+func findAssocTypeList(t *testing.T, caps []pcep.CapabilityInterface) *pcep.AssocTypeList {
+	t.Helper()
+
+	for _, cap := range caps {
+		if v, ok := cap.(*pcep.AssocTypeList); ok {
+			return v
+		}
+	}
+
+	require.Fail(t, "expected DefaultCapabilities to include an AssocTypeList")
+
+	return nil
+}
+
 func TestDefaultCapabilities(t *testing.T) {
 	t.Parallel()
 
@@ -57,6 +71,21 @@ func TestDefaultCapabilities(t *testing.T) {
 	assert.False(t, multipathCap.IsOppositeDirSupported)
 	assert.False(t, multipathCap.IsForwardClassSupported)
 	assert.False(t, multipathCap.IsCompositePathSupported)
+}
+
+func TestPolaAssocTypes(t *testing.T) {
+	t.Parallel()
+
+	assocCap := findAssocTypeList(t, pcep.DefaultCapabilities())
+
+	assert.Equal(t, assocCap.AssocTypes, pcep.PolaAssocTypes())
+
+	// Ensure the returned slice is a copy and cannot mutate the defaults.
+	got := pcep.PolaAssocTypes()
+	got[0] = pcep.AssocTypeSRPolicyAssociationCisco
+
+	rebuiltAssocCap := findAssocTypeList(t, pcep.DefaultCapabilities())
+	assert.Equal(t, []pcep.AssocType{pcep.AssocTypeSRPolicyAssociation}, rebuiltAssocCap.AssocTypes)
 }
 
 func TestFlattenCapabilities(t *testing.T) {

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -74,13 +74,14 @@ const (
 	pcepErrorValueAssociationTypeNotSupported uint8 = 1
 )
 
-// acceptedAssocTypes lists Association Types accepted from received messages.
-// Legacy vendor-specific types are accepted for interoperability but not advertised.
-var acceptedAssocTypes = []pcep.AssocType{
-	pcep.AssocTypeSRPolicyAssociation,
+// legacyAcceptedAssocTypes lists vendor-specific Association Types that are
+// accepted but not advertised.
+var legacyAcceptedAssocTypes = []pcep.AssocType{
 	pcep.AssocTypeSRPolicyAssociationCisco,
 	pcep.AssocTypeSRPolicyAssociationJuniper,
 }
+
+var acceptedAssocTypes = append(pcep.PolaAssocTypes(), legacyAcceptedAssocTypes...)
 
 // SessionState represents the PCEP session state (RFC 5440 Appendix A).
 type SessionState uint8

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -1108,98 +1108,6 @@ func writeMessage(t *testing.T, w io.Writer, message pcep.Message) {
 	require.NoError(t, err, "failed to write message")
 }
 
-func readOpenMessage(t *testing.T, r io.Reader) *pcep.OpenMessage {
-	t.Helper()
-
-	headerBytes := make([]byte, pcep.CommonHeaderLength)
-	_, err := io.ReadFull(r, headerBytes)
-	require.NoError(t, err, "failed to read common header")
-
-	var header pcep.CommonHeader
-	require.NoError(t, header.DecodeFromBytes(headerBytes))
-	require.Equal(t, pcep.MessageTypeOpen, header.MessageType)
-
-	body := make([]byte, int(header.MessageLength)-int(pcep.CommonHeaderLength))
-	_, err = io.ReadFull(r, body)
-	require.NoError(t, err, "failed to read message body")
-
-	openMessage := &pcep.OpenMessage{}
-	require.NoError(t, openMessage.DecodeFromBytes(body))
-
-	return openMessage
-}
-
-func TestSendOpen_StoresWireValuesAsLocalOpen(t *testing.T) {
-	t.Parallel()
-
-	server, client := newTCPConnPair(t)
-	t.Cleanup(func() {
-		assert.NoError(t, client.Close(), "failed to close client connection")
-	})
-	t.Cleanup(func() {
-		assert.NoError(t, server.Close(), "failed to close server connection")
-	})
-
-	ss := NewSession(testLocalOpen(7), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
-	_, ok := ss.LocalOpen()
-	require.False(t, ok, "nothing is advertised before the Open message is sent")
-
-	require.NoError(t, ss.SendOpen())
-
-	sent := readOpenMessage(t, client)
-	localOpen, ok := ss.LocalOpen()
-	require.True(t, ok)
-	assert.Equal(t, sent.OpenObject.Sid, localOpen.SessionID, "local SID must match the value actually sent")
-	assert.Equal(t, sent.OpenObject.Keepalive, localOpen.Keepalive, "local Keepalive must match the value actually sent")
-	assert.Equal(t, sent.OpenObject.Deadtime, localOpen.DeadTimer, "local DeadTimer must match the value actually sent")
-	assert.Equal(t, uint8(7), localOpen.SessionID)
-	assert.Equal(t, defaultLocalKeepalive, localOpen.Keepalive)
-	assert.Equal(t, pcep.DeadTimerFor(defaultLocalKeepalive), localOpen.DeadTimer)
-}
-
-func TestSendOpen_AdvertisesConfiguredTimers(t *testing.T) {
-	t.Parallel()
-
-	server, client := newTCPConnPair(t)
-	t.Cleanup(func() { assert.NoError(t, client.Close()) })
-	t.Cleanup(func() { assert.NoError(t, server.Close()) })
-
-	// RFC 5440 §8.1: the local Keepalive and DeadTimer are configurable.
-	local := OpenParams{SessionID: 1, Keepalive: 5, DeadTimer: 60}
-	ss := NewSession(local, netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
-	require.NoError(t, ss.SendOpen())
-
-	sent := readOpenMessage(t, client)
-	assert.Equal(t, uint8(5), sent.OpenObject.Keepalive)
-	assert.Equal(t, uint8(60), sent.OpenObject.Deadtime)
-}
-
-func TestSendOpen_AdvertisesFullCapabilitySetOnTheWire(t *testing.T) {
-	t.Parallel()
-
-	server, client := newTCPConnPair(t)
-	t.Cleanup(func() { assert.NoError(t, client.Close()) })
-	t.Cleanup(func() { assert.NoError(t, server.Close()) })
-
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
-	require.NoError(t, ss.SendOpen())
-
-	sent := readOpenMessage(t, client)
-	assert.Equal(t, pcep.DefaultCapabilities(), sent.OpenObject.Caps,
-		"the wire-level Open must carry Pola's complete capability set, not a partial default")
-	assert.Equal(t, pcep.DefaultCapabilities(), ss.AdvertisedCapabilities(),
-		"AdvertisedCapabilities must match what was actually sent on the wire")
-}
-
-func TestSendOpen_ErrorPropagatesFromSendFailure(t *testing.T) {
-	t.Parallel()
-
-	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
-
-	require.Error(t, ss.SendOpen())
-}
-
 func openMessageBody(t *testing.T, sessionID, keepalive, deadTimer uint8) []uint8 {
 	t.Helper()
 
@@ -1338,82 +1246,13 @@ func TestHandlePeerOpen_RejectsEmptyPathSetupTypeList(t *testing.T) {
 	assertTypedPCErr(t, writes[0], pcepErrorTypeInvalidObject, pcepErrorValueMalformedObject)
 }
 
-func TestHandlePeerOpen_RejectsUnsupportedSRv6MSDType_TopLevel(t *testing.T) {
+func TestAcceptedAssocTypes_IncludesEveryAdvertisedType(t *testing.T) {
 	t.Parallel()
 
-	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
-
-	caps := []pcep.CapabilityInterface{
-		pcep.NewSRv6PCECapability(false, pcep.MSD{Type: 43, Value: 1}),
+	for _, advertised := range pcep.PolaAssocTypes() {
+		assert.Contains(t, acceptedAssocTypes, advertised,
+			"an Association Type Pola advertises must also be accepted, or Pola would PCErr its own advertised type")
 	}
-
-	neg := &openNegotiation{}
-	require.ErrorContains(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg),
-		"unsupported MSD-Type")
-
-	assert.False(t, neg.remoteOK)
-
-	writes := conn.writes()
-	require.Len(t, writes, 1)
-	assertTypedPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
-}
-
-func TestHandlePeerOpen_RejectsUnsupportedSRv6MSDType_NestedInPathSetupTypeCapability(t *testing.T) {
-	t.Parallel()
-
-	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
-
-	caps := []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{
-		PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE},
-		SubTLVs: []pcep.TLVInterface{
-			pcep.NewSRv6PCECapability(false, pcep.MSD{Type: 1, Value: 1}),
-		},
-	}}
-
-	neg := &openNegotiation{}
-	require.ErrorContains(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg),
-		"unsupported MSD-Type")
-
-	assert.False(t, neg.remoteOK)
-
-	writes := conn.writes()
-	require.Len(t, writes, 1)
-	assertTypedPCErr(t, writes[0], pcepErrorTypeSessionEstablishmentFailure, pcepErrorValueInvalidOpenMessage)
-}
-
-func TestHandlePeerOpen_AcceptsKnownSRv6MSDTypes(t *testing.T) {
-	t.Parallel()
-
-	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
-
-	caps := []pcep.CapabilityInterface{
-		pcep.NewSRv6PCECapability(false,
-			pcep.MSD{Type: pcep.MSDTypeSRHMaxSL, Value: 1},
-			pcep.MSD{Type: pcep.MSDTypeSRHMaxEndPop, Value: 1},
-			pcep.MSD{Type: pcep.MSDTypeSRHMaxHEncaps, Value: 1},
-			pcep.MSD{Type: pcep.MSDTypeSRHMaxEndD, Value: 1},
-		),
-	}
-
-	neg := &openNegotiation{}
-	require.NoError(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg))
-	assert.True(t, neg.remoteOK)
-}
-
-func TestHandlePeerOpen_AcceptsSRv6PCECapabilityWithoutMSDs(t *testing.T) {
-	t.Parallel()
-
-	conn := &fakeConn{r: bytes.NewReader(nil)}
-	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
-
-	caps := []pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false)}
-
-	neg := &openNegotiation{}
-	require.NoError(t, ss.handlePeerOpen(openMessageBodyWithCaps(t, 1, 30, 120, caps), neg))
-	assert.True(t, neg.remoteOK)
 }
 
 func TestHandlePeerOpen_AcceptsPartialPathSetupTypeOverlap(t *testing.T) {
@@ -1474,6 +1313,98 @@ func TestHandlePeerOpen_RejectedOpenIsNotPublishedAsSessionState(t *testing.T) {
 	assert.False(t, ok, "an unacceptable-but-negotiable Open must not be published as the PCC's Open")
 	assert.Equal(t, pcep.RFCCompliant, ss.PccType(), "PccType must stay at its default until an Open is accepted")
 	assert.Empty(t, ss.ReceivedCapabilities())
+}
+
+func readOpenMessage(t *testing.T, r io.Reader) *pcep.OpenMessage {
+	t.Helper()
+
+	headerBytes := make([]byte, pcep.CommonHeaderLength)
+	_, err := io.ReadFull(r, headerBytes)
+	require.NoError(t, err, "failed to read common header")
+
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(headerBytes))
+	require.Equal(t, pcep.MessageTypeOpen, header.MessageType)
+
+	body := make([]byte, int(header.MessageLength)-int(pcep.CommonHeaderLength))
+	_, err = io.ReadFull(r, body)
+	require.NoError(t, err, "failed to read message body")
+
+	openMessage := &pcep.OpenMessage{}
+	require.NoError(t, openMessage.DecodeFromBytes(body))
+
+	return openMessage
+}
+
+func TestSendOpen_StoresWireValuesAsLocalOpen(t *testing.T) {
+	t.Parallel()
+
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(), "failed to close client connection")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close(), "failed to close server connection")
+	})
+
+	ss := NewSession(testLocalOpen(7), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+	_, ok := ss.LocalOpen()
+	require.False(t, ok, "nothing is advertised before the Open message is sent")
+
+	require.NoError(t, ss.SendOpen())
+
+	sent := readOpenMessage(t, client)
+	localOpen, ok := ss.LocalOpen()
+	require.True(t, ok)
+	assert.Equal(t, sent.OpenObject.Sid, localOpen.SessionID, "local SID must match the value actually sent")
+	assert.Equal(t, sent.OpenObject.Keepalive, localOpen.Keepalive, "local Keepalive must match the value actually sent")
+	assert.Equal(t, sent.OpenObject.Deadtime, localOpen.DeadTimer, "local DeadTimer must match the value actually sent")
+	assert.Equal(t, uint8(7), localOpen.SessionID)
+	assert.Equal(t, defaultLocalKeepalive, localOpen.Keepalive)
+	assert.Equal(t, pcep.DeadTimerFor(defaultLocalKeepalive), localOpen.DeadTimer)
+}
+
+func TestSendOpen_AdvertisesConfiguredTimers(t *testing.T) {
+	t.Parallel()
+
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+	t.Cleanup(func() { assert.NoError(t, server.Close()) })
+
+	// RFC 5440 §8.1: the local Keepalive and DeadTimer are configurable.
+	local := OpenParams{SessionID: 1, Keepalive: 5, DeadTimer: 60}
+	ss := NewSession(local, netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+	require.NoError(t, ss.SendOpen())
+
+	sent := readOpenMessage(t, client)
+	assert.Equal(t, uint8(5), sent.OpenObject.Keepalive)
+	assert.Equal(t, uint8(60), sent.OpenObject.Deadtime)
+}
+
+func TestSendOpen_AdvertisesFullCapabilitySetOnTheWire(t *testing.T) {
+	t.Parallel()
+
+	server, client := newTCPConnPair(t)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+	t.Cleanup(func() { assert.NoError(t, server.Close()) })
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+	require.NoError(t, ss.SendOpen())
+
+	sent := readOpenMessage(t, client)
+	assert.Equal(t, pcep.DefaultCapabilities(), sent.OpenObject.Caps,
+		"the wire-level Open must carry Pola's complete capability set, not a partial default")
+	assert.Equal(t, pcep.DefaultCapabilities(), ss.AdvertisedCapabilities(),
+		"AdvertisedCapabilities must match what was actually sent on the wire")
+}
+
+func TestSendOpen_ErrorPropagatesFromSendFailure(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeConn{r: bytes.NewReader(nil), writeErr: errors.New("write: broken pipe")}
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), conn, logger.NewNop(), nil, 0)
+
+	require.Error(t, ss.SendOpen())
 }
 
 func TestAcceptableOpen(t *testing.T) {


### PR DESCRIPTION
## Description

Refactor Association Type handling and capability display, including nested capability information in session output.

## Type of change
<!-- Check all that apply. -->
- [ ] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

Added and updated unit tests for Association Types and capability display.

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
