### PR TITLE
Preserve SRv6 SID Structure presence and improve uSID validation

### DIFF
--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -654,28 +654,32 @@ func convertSRPolicy(p *pb.SRPolicy) (table.SRPolicy, error) {
 	}, nil
 }
 
-func sidStructureFromPB(s *pb.SidStructure) (table.SIDStructure, error) {
+func sidStructureFromPB(s *pb.SidStructure) (*table.SIDStructure, error) {
+	if s == nil {
+		return nil, nil
+	}
+
 	localBlock, err := safecast.Uint8(s.GetLocalBlock(), "SID structure LocalBlock")
 	if err != nil {
-		return table.SIDStructure{}, err
+		return nil, err
 	}
 
 	localNode, err := safecast.Uint8(s.GetLocalNode(), "SID structure LocalNode")
 	if err != nil {
-		return table.SIDStructure{}, err
+		return nil, err
 	}
 
 	localFunc, err := safecast.Uint8(s.GetLocalFunc(), "SID structure LocalFunc")
 	if err != nil {
-		return table.SIDStructure{}, err
+		return nil, err
 	}
 
 	localArg, err := safecast.Uint8(s.GetLocalArg(), "SID structure LocalArg")
 	if err != nil {
-		return table.SIDStructure{}, err
+		return nil, err
 	}
 
-	return table.SIDStructure{
+	return &table.SIDStructure{
 		LocalBlock: localBlock,
 		LocalNode:  localNode,
 		LocalFunc:  localFunc,

--- a/cmd/pola/grpc/grpc_client_internal_test.go
+++ b/cmd/pola/grpc/grpc_client_internal_test.go
@@ -948,6 +948,14 @@ func TestConvertSRPolicy(t *testing.T) {
 func TestSidStructureFromPB(t *testing.T) {
 	t.Parallel()
 
+	t.Run("nil input returns nil without error", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := sidStructureFromPB(nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
 	tests := []struct {
 		name string
 		s    *pb.SidStructure
@@ -1149,7 +1157,7 @@ func TestGetTED_Success(t *testing.T) {
 	require.NotNil(t, link0.Srv6EndXSID)
 	assert.Equal(t, table.BehaviorENDX, link0.Srv6EndXSID.EndpointBehavior)
 	assert.Equal(t, []string{"2001:db8:1::"}, link0.Srv6EndXSID.Sids)
-	assert.Equal(t, table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80}, link0.Srv6EndXSID.Srv6SIDStructure)
+	assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80}, link0.Srv6EndXSID.Srv6SIDStructure)
 
 	link1 := a.Links[1]
 	assert.False(t, link1.LocalIP.IsValid())
@@ -1165,7 +1173,7 @@ func TestGetTED_Success(t *testing.T) {
 	assert.Equal(t, []string{"2001:db8:1::"}, sid.Sids)
 	assert.Equal(t, []uint32{1}, sid.MultiTopoIDs)
 	assert.Equal(t, table.EndpointBehavior{Behavior: table.BehaviorEND, Flags: 1, Algorithm: 0}, sid.EndpointBehavior)
-	assert.Equal(t, table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80}, sid.SIDStructure)
+	assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80}, sid.SIDStructure)
 }
 
 func TestGetTED_PropagatesConversionErrors(t *testing.T) {
@@ -1300,7 +1308,7 @@ func TestCreateSrv6EndXSID(t *testing.T) {
 		assert.Equal(t, &table.Srv6EndXSID{
 			EndpointBehavior: table.BehaviorENDX,
 			Sids:             []string{"2001:db8::1:0"},
-			Srv6SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+			Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 		}, got)
 	})
 
@@ -1341,7 +1349,7 @@ func TestCreateSrv6SID(t *testing.T) {
 		want.Sids = []string{"2001:db8:1::"}
 		want.MultiTopoIDs = []uint32{0}
 		want.EndpointBehavior = table.EndpointBehavior{Behavior: table.BehaviorEND}
-		want.SIDStructure = table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0}
+		want.SIDStructure = &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0}
 		assert.Equal(t, want, got)
 	})
 

--- a/cmd/pola/ted_text.go
+++ b/cmd/pola/ted_text.go
@@ -87,6 +87,12 @@ func writeTEDSrv6EndXSIDText(ew *errWriter, sid tedSrv6EndXSIDView) {
 	ew.println("      SRv6 End.X SID:")
 	ew.printf("        EndpointBehavior: %s\n", sid.EndpointBehavior.Name)
 	ew.printf("        SIDs: %v\n", sid.Sids)
+
+	if sid.SidStructure == nil {
+		ew.println("        SID Structure: (not advertised)")
+		return
+	}
+
 	ew.printf("        SID Structure: Block: %d, Node: %d, Func: %d, Arg: %d\n",
 		sid.SidStructure.LocalBlock, sid.SidStructure.LocalNode, sid.SidStructure.LocalFunc, sid.SidStructure.LocalArg)
 }
@@ -101,8 +107,13 @@ func writeTEDNodeSrv6SIDsText(ew *errWriter, node tedNodeView) {
 
 func writeTEDSrv6SIDText(ew *errWriter, sid tedSrv6SIDView) {
 	ew.printf("    SIDs: %v\n", sid.Sids)
-	ew.printf("    Block: %d, Node: %d, Func: %d, Arg: %d\n",
-		sid.SidStructure.LocalBlock, sid.SidStructure.LocalNode, sid.SidStructure.LocalFunc, sid.SidStructure.LocalArg)
+
+	if sid.SidStructure == nil {
+		ew.println("    SID Structure: (not advertised)")
+	} else {
+		ew.printf("    Block: %d, Node: %d, Func: %d, Arg: %d\n",
+			sid.SidStructure.LocalBlock, sid.SidStructure.LocalNode, sid.SidStructure.LocalFunc, sid.SidStructure.LocalArg)
+	}
 
 	var flags, algorithm uint8
 	if sid.EndpointBehavior.Flags != nil {

--- a/cmd/pola/ted_text_test.go
+++ b/cmd/pola/ted_text_test.go
@@ -40,7 +40,7 @@ func fullTEDNodeViewFixture() tedNodeView {
 				Srv6EndXSID: &tedSrv6EndXSIDView{
 					EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
 					Sids:             []string{testSrv6EndXSID},
-					SidStructure:     sidStructureView{LocalBlock: 21, LocalNode: 22, LocalFunc: 23, LocalArg: 24},
+					SidStructure:     &sidStructureView{LocalBlock: 21, LocalNode: 22, LocalFunc: 23, LocalArg: 24},
 				},
 			},
 		},
@@ -48,13 +48,13 @@ func fullTEDNodeViewFixture() tedNodeView {
 			{
 				Sids:             []string{"fc00:0:2:node1::"},
 				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-1"},
-				SidStructure:     sidStructureView{LocalBlock: 31, LocalNode: 32, LocalFunc: 33, LocalArg: 34},
+				SidStructure:     &sidStructureView{LocalBlock: 31, LocalNode: 32, LocalFunc: 33, LocalArg: 34},
 				MultiTopoIDs:     []uint32{1},
 			},
 			{
 				Sids:             []string{"fc00:0:2:node2::"},
 				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-2", Flags: &flags, Algorithm: &algorithm},
-				SidStructure:     sidStructureView{LocalBlock: 41, LocalNode: 42, LocalFunc: 43, LocalArg: 44},
+				SidStructure:     &sidStructureView{LocalBlock: 41, LocalNode: 42, LocalFunc: 43, LocalArg: 44},
 				MultiTopoIDs:     []uint32{2, 3},
 			},
 		},
@@ -74,6 +74,33 @@ func TestWriteTEDText_FullRenderSucceeds(t *testing.T) {
 
 	w := &condFailWriter{}
 	require.NoError(t, writeTEDText(w, []tedNodeView{fullTEDNodeViewFixture()}))
+}
+
+func TestWriteTEDText_SidStructureNotAdvertised(t *testing.T) {
+	t.Parallel()
+
+	node := tedNodeView{
+		RouterID: testRouterID1,
+		Links: []tedLinkView{
+			{
+				RemoteRouterID: testRouterID2,
+				Srv6EndXSID: &tedSrv6EndXSIDView{
+					EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
+					Sids:             []string{testSrv6EndXSID},
+				},
+			},
+		},
+		SRv6SIDs: []tedSrv6SIDView{
+			{
+				Sids:             []string{"fc00:0:2:node1::"},
+				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-1"},
+			},
+		},
+	}
+
+	w := &condFailWriter{}
+	require.NoError(t, writeTEDText(w, []tedNodeView{node}))
+	require.Equal(t, 2, strings.Count(w.buf.String(), "SID Structure: (not advertised)"))
 }
 
 func TestWriteTEDText_PropagatesWriteErrors(t *testing.T) {

--- a/cmd/pola/ted_view.go
+++ b/cmd/pola/ted_view.go
@@ -49,14 +49,14 @@ type tedMetricView struct {
 type tedSrv6SIDView struct {
 	Sids             []string             `json:"sids"`
 	EndpointBehavior endpointBehaviorView `json:"endpointBehavior"`
-	SidStructure     sidStructureView     `json:"sidStructure"`
+	SidStructure     *sidStructureView    `json:"sidStructure,omitempty"`
 	MultiTopoIDs     []uint32             `json:"multiTopoIds"`
 }
 
 type tedSrv6EndXSIDView struct {
 	EndpointBehavior endpointBehaviorView `json:"endpointBehavior"`
 	Sids             []string             `json:"sids"`
-	SidStructure     sidStructureView     `json:"sidStructure"`
+	SidStructure     *sidStructureView    `json:"sidStructure,omitempty"`
 }
 
 // endpointBehaviorView omits Flags and Algorithm for End.X SIDs, which carry only the behavior.
@@ -74,8 +74,7 @@ type sidStructureView struct {
 	LocalArg   uint8 `json:"localArg"`
 }
 
-// newTEDNodeViews derives CLI/JSON views from a TED in router ID order
-// for deterministic output.
+// newTEDNodeViews returns views in router ID order for deterministic output.
 func newTEDNodeViews(nodes map[string]*table.LsNode) []tedNodeView {
 	routerIDs := make([]string, 0, len(nodes))
 	for routerID := range nodes {
@@ -222,8 +221,12 @@ func endpointBehaviorViewFromBehavior(behavior uint16) endpointBehaviorView {
 	}
 }
 
-func sidStructureViewFrom(s table.SIDStructure) sidStructureView {
-	return sidStructureView{
+func sidStructureViewFrom(s *table.SIDStructure) *sidStructureView {
+	if s == nil {
+		return nil
+	}
+
+	return &sidStructureView{
 		LocalBlock: s.LocalBlock,
 		LocalNode:  s.LocalNode,
 		LocalFunc:  s.LocalFunc,

--- a/cmd/pola/ted_view_test.go
+++ b/cmd/pola/ted_view_test.go
@@ -85,7 +85,7 @@ func TestNewTEDLinkView_IncludesSrv6EndXSID(t *testing.T) {
 		Srv6EndXSID: &table.Srv6EndXSID{
 			EndpointBehavior: table.BehaviorENDX,
 			Sids:             []string{testSrv6EndXSID},
-			Srv6SIDStructure: table.SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
+			Srv6SIDStructure: &table.SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
 		},
 	}
 
@@ -113,4 +113,12 @@ func TestNewTEDSrv6SIDViews_SkipsNilEntries(t *testing.T) {
 	views := newTEDSrv6SIDViews([]*table.LsSrv6SID{nil, s})
 	require.Len(t, views, 1)
 	assert.Equal(t, []string{"fc00:0:1::"}, views[0].Sids)
+	assert.Nil(t, views[0].SidStructure, "no SID Structure TLV was advertised")
+}
+
+func TestSidStructureViewFrom_DistinguishesAbsentFromPresentZero(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, sidStructureViewFrom(nil), "absent structure must not render as present-zero")
+	assert.Equal(t, &sidStructureView{}, sidStructureViewFrom(&table.SIDStructure{}), "present-but-zero structure must still render")
 }

--- a/internal/gobgp/interface.go
+++ b/internal/gobgp/interface.go
@@ -646,28 +646,32 @@ func srv6EndXSIDFromAPI(srv6EndXSID *api.LsSrv6EndXSID) (*table.Srv6EndXSID, err
 	}, nil
 }
 
-func srv6SIDStructureFromAPI(s *api.LsSrv6SIDStructure) (table.SIDStructure, error) {
+func srv6SIDStructureFromAPI(s *api.LsSrv6SIDStructure) (*table.SIDStructure, error) {
+	if s == nil {
+		return nil, nil
+	}
+
 	localBlock, err := safecast.Uint8(s.GetLocalBlock(), "SRv6 SID structure LocalBlock")
 	if err != nil {
-		return table.SIDStructure{}, err
+		return nil, err
 	}
 
 	localNode, err := safecast.Uint8(s.GetLocalNode(), "SRv6 SID structure LocalNode")
 	if err != nil {
-		return table.SIDStructure{}, err
+		return nil, err
 	}
 
 	localFunc, err := safecast.Uint8(s.GetLocalFunc(), "SRv6 SID structure LocalFunc")
 	if err != nil {
-		return table.SIDStructure{}, err
+		return nil, err
 	}
 
 	localArg, err := safecast.Uint8(s.GetLocalArg(), "SRv6 SID structure LocalArg")
 	if err != nil {
-		return table.SIDStructure{}, err
+		return nil, err
 	}
 
-	return table.SIDStructure{
+	return &table.SIDStructure{
 		LocalBlock: localBlock,
 		LocalNode:  localNode,
 		LocalFunc:  localFunc,

--- a/internal/gobgp/interface_internal_test.go
+++ b/internal/gobgp/interface_internal_test.go
@@ -445,7 +445,7 @@ func TestGetLsLink(t *testing.T) {
 					Srv6EndXSID: &table.Srv6EndXSID{
 						EndpointBehavior: table.BehaviorENDX,
 						Sids:             []string{testSrv6EndXSID},
-						Srv6SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+						Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 					},
 				},
 			},
@@ -543,7 +543,7 @@ func TestSrv6EndXSIDFromAPI(t *testing.T) {
 		assert.Equal(t, &table.Srv6EndXSID{
 			EndpointBehavior: table.BehaviorENDX,
 			Sids:             []string{testSrv6EndXSID},
-			Srv6SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+			Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 		}, got)
 	})
 
@@ -566,12 +566,50 @@ func TestSrv6EndXSIDFromAPI(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+
+	t.Run("absent SID Structure sub-TLV converts to a nil structure", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := srv6EndXSIDFromAPI(&api.LsSrv6EndXSID{
+			EndpointBehavior: uint32(table.BehaviorENDX),
+			Sids:             []string{testSrv6EndXSID},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, &table.Srv6EndXSID{
+			EndpointBehavior: table.BehaviorENDX,
+			Sids:             []string{testSrv6EndXSID},
+		}, got)
+	})
 }
 
 func TestSrv6SIDStructureFromAPI(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
+	t.Run("nil sub-TLV converts to a nil structure, not a zero-value one", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := srv6SIDStructureFromAPI(nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("sub-TLV present with all-zero fields converts to a non-nil zero-value structure", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := srv6SIDStructureFromAPI(&api.LsSrv6SIDStructure{})
+		require.NoError(t, err)
+		assert.Equal(t, &table.SIDStructure{}, got)
+	})
+
+	t.Run("LIB C-SID shape: LocalBlock and LocalNode zero, LocalFunc set", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := srv6SIDStructureFromAPI(&api.LsSrv6SIDStructure{LocalFunc: 16})
+		require.NoError(t, err)
+		assert.Equal(t, &table.SIDStructure{LocalFunc: 16}, got)
+	})
+
+	errTests := []struct {
 		name string
 		s    *api.LsSrv6SIDStructure
 	}{
@@ -581,7 +619,7 @@ func TestSrv6SIDStructureFromAPI(t *testing.T) {
 		{"LocalArg overflow", &api.LsSrv6SIDStructure{LocalArg: math.MaxUint8 + 1}},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range errTests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -620,9 +658,30 @@ func TestGetLsSrv6SID(t *testing.T) {
 		want := table.NewLsSrv6SID(table.NewLsNode(65000, testRouterID1))
 		want.Sids = []string{testSrv6SID}
 		want.MultiTopoIDs = []uint32{0}
-		want.SIDStructure = table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0}
+		want.SIDStructure = &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0}
 		want.EndpointBehavior = table.EndpointBehavior{Behavior: table.BehaviorEND}
 		assert.Equal(t, want, got)
+	})
+
+	t.Run("absent SID Structure sub-TLV converts to a nil structure, end to end", func(t *testing.T) {
+		t.Parallel()
+
+		nlri := &api.LsAddrPrefix{
+			Nlri: &api.LsAddrPrefix_LsNLRI{
+				Nlri: &api.LsAddrPrefix_LsNLRI_Srv6Sid{
+					Srv6Sid: &api.LsSrv6SIDNLRI{
+						LocalNode:          &api.LsNodeDescriptor{Asn: 65000, IgpRouterId: testRouterID1},
+						Srv6SidInformation: &api.LsSrv6SIDInformation{Sids: []string{testSrv6SID}},
+					},
+				},
+			},
+		}
+
+		got, err := getLsSrv6SID(nlri, &api.LsAttributeSrv6SID{
+			Srv6EndpointBehavior: &api.LsSrv6EndpointBehavior{EndpointBehavior: uint32(table.BehaviorEND)},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.SIDStructure, "no SID Structure sub-TLV was advertised")
 	})
 
 	t.Run("invalid NLRI", func(t *testing.T) {
@@ -712,6 +771,40 @@ func TestGetLsSrv6SID(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestGetLsSrv6SID_LocatorRegistrationEndToEnd verifies BGP-LS to SRv6
+// locator registration, including the valid LocalBlock=32/LocalNode=0 case,
+// where the locator occupies the entire block.
+func TestGetLsSrv6SID_LocatorRegistrationEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	nlri := &api.LsAddrPrefix{
+		Nlri: &api.LsAddrPrefix_LsNLRI{
+			Nlri: &api.LsAddrPrefix_LsNLRI_Srv6Sid{
+				Srv6Sid: &api.LsSrv6SIDNLRI{
+					LocalNode:          &api.LsNodeDescriptor{Asn: 65000, IgpRouterId: testRouterID1},
+					Srv6SidInformation: &api.LsSrv6SIDInformation{Sids: []string{"fc00:1::"}},
+				},
+			},
+		},
+	}
+	attr := &api.LsAttributeSrv6SID{
+		Srv6EndpointBehavior: &api.LsSrv6EndpointBehavior{EndpointBehavior: uint32(table.BehaviorEND)},
+		Srv6SidStructure:     &api.LsSrv6SIDStructure{LocalBlock: 32},
+	}
+
+	lsSrv6SID, err := getLsSrv6SID(nlri, attr)
+	require.NoError(t, err)
+
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+	lsSrv6SID.UpdateTED(ted, 65000)
+
+	idx := table.NewSIDIndex(ted)
+
+	container := table.NewSegmentSRv6(netip.MustParseAddr("fc00:1::99"))
+	container.USid = true
+	assert.True(t, idx.Has(container), "expected the /32 locator to be registered despite LocalNode being 0")
 }
 
 func TestGetLsSrv6SIDList(t *testing.T) {

--- a/pkg/cspf/cspf_internal_test.go
+++ b/pkg/cspf/cspf_internal_test.go
@@ -42,7 +42,7 @@ func cspfInternalTestSRv6Node() *table.LsNode {
 			{
 				Sids:             []string{"2001:db8::a"},
 				EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorEND},
-				SIDStructure:     table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+				SIDStructure:     &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 			},
 		},
 	}
@@ -300,7 +300,7 @@ func TestBuildWaypointSegment(t *testing.T) {
 					{
 						Sids:             []string{"2001:db8::a"},
 						EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorUN},
-						SIDStructure:     table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+						SIDStructure:     &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 					},
 				},
 			},

--- a/pkg/cspf/cspf_test.go
+++ b/pkg/cspf/cspf_test.go
@@ -46,7 +46,7 @@ func srv6Node(routerID, sid string) *table.LsNode {
 			{
 				Sids:             []string{sid},
 				EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorEND},
-				SIDStructure:     table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+				SIDStructure:     &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 			},
 		},
 	}

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -518,12 +518,7 @@ func buildLsSrv6SID(s *table.LsSrv6SID) *pb.LsSrv6SID {
 	pbSID := &pb.LsSrv6SID{
 		Sids:         make([]*pb.SID, 0, len(s.Sids)),
 		MultiTopoIds: make([]*pb.MultiTopoID, 0, len(s.MultiTopoIDs)),
-		SidStructure: &pb.SidStructure{
-			LocalBlock: uint32(s.SIDStructure.LocalBlock),
-			LocalNode:  uint32(s.SIDStructure.LocalNode),
-			LocalFunc:  uint32(s.SIDStructure.LocalFunc),
-			LocalArg:   uint32(s.SIDStructure.LocalArg),
-		},
+		SidStructure: buildSidStructure(s.SIDStructure),
 	}
 
 	for _, sid := range s.Sids {
@@ -547,17 +542,25 @@ func buildLsSrv6SID(s *table.LsSrv6SID) *pb.LsSrv6SID {
 	return pbSID
 }
 
-// convertSrv6EndXSID converts table.Srv6EndXSID to protobuf Srv6EndXSID.
+// buildSidStructure preserves SID Structure presence.
+func buildSidStructure(s *table.SIDStructure) *pb.SidStructure {
+	if s == nil {
+		return nil
+	}
+
+	return &pb.SidStructure{
+		LocalBlock: uint32(s.LocalBlock),
+		LocalNode:  uint32(s.LocalNode),
+		LocalFunc:  uint32(s.LocalFunc),
+		LocalArg:   uint32(s.LocalArg),
+	}
+}
+
 func convertSrv6EndXSID(sid *table.Srv6EndXSID) *pb.Srv6EndXSID {
 	pbSID := &pb.Srv6EndXSID{
 		EndpointBehavior: uint32(sid.EndpointBehavior),
 		Sids:             make([]*pb.SID, 0, len(sid.Sids)),
-		SidStructure: &pb.SidStructure{
-			LocalBlock: uint32(sid.Srv6SIDStructure.LocalBlock),
-			LocalNode:  uint32(sid.Srv6SIDStructure.LocalNode),
-			LocalFunc:  uint32(sid.Srv6SIDStructure.LocalFunc),
-			LocalArg:   uint32(sid.Srv6SIDStructure.LocalArg),
-		},
+		SidStructure:     buildSidStructure(sid.Srv6SIDStructure),
 	}
 
 	for _, s := range sid.Sids {

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -3033,7 +3033,7 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 	link.Srv6EndXSID = &table.Srv6EndXSID{
 		EndpointBehavior: table.BehaviorENDX,
 		Sids:             []string{testSRv6SID1, ""},
-		Srv6SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+		Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 	}
 	node.Links = []*table.LsLink{
 		link,
@@ -3051,7 +3051,7 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 		{
 			Sids:             []string{"2001:db8:1::1", ""},
 			EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorEND, Flags: 0x40, Algorithm: 0},
-			SIDStructure:     table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+			SIDStructure:     &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 			MultiTopoIDs:     []uint32{0, 1},
 		},
 		{Sids: []string{"2001:db8:2::1"}},
@@ -3119,7 +3119,6 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 			{
 				Sids:         []*pb.SID{{Sid: "2001:db8:2::1"}},
 				MultiTopoIds: []*pb.MultiTopoID{},
-				SidStructure: &pb.SidStructure{},
 			},
 		},
 	}

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -206,23 +206,32 @@ func parseSRv6Addrs(sids []string) []netip.Addr {
 }
 
 // Conflicting locator advertisements are merged as unknown/ambiguous
-// instead of letting the latest advertisement win.
-func (idx *SIDIndex) addSRv6(owner string, addrs []netip.Addr, st SIDStructure) {
+// rather than letting the latest advertisement win.
+//
+// A nil SID Structure means it was not advertised, which is distinct
+// from an advertised zero-valued structure.
+func (idx *SIDIndex) addSRv6(owner string, addrs []netip.Addr, st *SIDStructure) {
+	for _, addr := range addrs {
+		idx.srv6SIDs[addr] = struct{}{}
+	}
+
+	if st == nil {
+		return
+	}
+
 	structure := srv6Structure{
 		blockBits: int(st.LocalBlock),
 		nodeBits:  int(st.LocalNode),
 		funcBits:  int(st.LocalFunc),
 	}
 	locBits := structure.locatorBits()
+	structureBits := locBits + structure.funcBits + int(st.LocalArg)
+
+	if locBits <= 0 || structureBits > SRv6SIDBitLength {
+		return
+	}
 
 	for _, addr := range addrs {
-		idx.srv6SIDs[addr] = struct{}{}
-
-		// RFC 9800 allows a zero-length Locator-Node, which this index does not decompose.
-		if structure.nodeBits <= 0 || locBits > SRv6SIDBitLength {
-			continue
-		}
-
 		p, err := addr.Prefix(locBits)
 		if err != nil {
 			continue
@@ -272,7 +281,7 @@ func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
 		return false
 	}
 
-	declaredLocBits := 0
+	declaredLocBits := -1
 	if len(s.Structure) == 4 {
 		declaredLocBits = int(s.Structure[0]) + int(s.Structure[1])
 	}
@@ -282,9 +291,7 @@ func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
 	return found
 }
 
-// lookupSRv6Locator returns the most specific locator containing addr,
-// restricted to locators no more specific than maxBits.
-// maxBits <= 0 means unrestricted.
+// maxBits < 0 means unrestricted; maxBits == 0 only matches /0 locators.
 func (idx *SIDIndex) lookupSRv6Locator(addr netip.Addr, maxBits int) (srv6LocatorInfo, bool) {
 	var (
 		best  netip.Prefix
@@ -297,7 +304,7 @@ func (idx *SIDIndex) lookupSRv6Locator(addr netip.Addr, maxBits int) (srv6Locato
 			continue
 		}
 
-		if maxBits > 0 && p.Bits() > maxBits {
+		if maxBits >= 0 && p.Bits() > maxBits {
 			continue
 		}
 
@@ -452,7 +459,7 @@ func usidSetBit(b *[16]byte, pos int, v bool) {
 // When matched is true, ownerUnknown means the container is known but its
 // terminating owner cannot be determined unambiguously.
 func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bool) {
-	declaredLocBits := 0
+	declaredLocBits := -1
 	hasDeclared := len(s.Structure) == 4
 
 	if hasDeclared {
@@ -489,7 +496,6 @@ func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bo
 
 	resolved := ownerUnknown
 
-	// Resolve each micro-segment independently to support nested locators.
 	for _, seg := range segments {
 		segInfo, ok := idx.srv6Locators[seg]
 		if !ok {

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -42,11 +42,26 @@ type SIDIndex struct {
 	srv6AdjSIDNextHop map[adjKeySRv6]string
 }
 
-// srv6LocatorInfo describes an SRv6 locator advertised into the TED.
-type srv6LocatorInfo struct {
-	owner     string // ownerUnknown when advertised by multiple nodes
+// srv6Structure is the [Locator-Block, Locator-Node, Function] bit-length
+// split of an SRv6 SID.
+type srv6Structure struct {
 	blockBits int
 	nodeBits  int
+	funcBits  int
+}
+
+// locatorBits returns the node-identifying locator width (LBL + LNL).
+func (s srv6Structure) locatorBits() int { return s.blockBits + s.nodeBits }
+
+// stride returns the width of one micro-segment slot (LNL + FL).
+func (s srv6Structure) stride() int { return s.nodeBits + s.funcBits }
+
+// srv6LocatorInfo describes an SRv6 locator advertised into the TED.
+// Conflicting advertisements make owner/structure explicitly unknown.
+type srv6LocatorInfo struct {
+	owner          string // ownerUnknown when owners conflict
+	structure      srv6Structure
+	structureKnown bool // false when SID Structures conflict
 }
 
 // MissingSegment identifies a rejected segment.
@@ -101,7 +116,7 @@ func (idx *SIDIndex) addNodePrefixSIDs(node *LsNode) {
 
 		if label, ok := srgbLabel(node, p.SidIndex); ok {
 			idx.mplsSIDs[label] = struct{}{}
-			idx.mplsNodeSIDOwner[label] = node.RouterID
+			mergeSIDOwner(idx.mplsNodeSIDOwner, label, node.RouterID)
 		}
 	}
 }
@@ -171,7 +186,7 @@ func (idx *SIDIndex) addSRv6NodeSIDs(node *LsNode) {
 			idx.addSRv6(node.RouterID, addrs, s.SIDStructure)
 
 			for _, addr := range addrs {
-				idx.srv6NodeSIDOwner[addr] = node.RouterID
+				mergeSIDOwner(idx.srv6NodeSIDOwner, addr, node.RouterID)
 			}
 		}
 	}
@@ -190,16 +205,21 @@ func parseSRv6Addrs(sids []string) []netip.Addr {
 	return addrs
 }
 
-// addSRv6 registers SIDs and their locator prefixes.
-// Conflicting locator owners are recorded as ownerUnknown.
+// Conflicting locator advertisements are merged as unknown/ambiguous
+// instead of letting the latest advertisement win.
 func (idx *SIDIndex) addSRv6(owner string, addrs []netip.Addr, st SIDStructure) {
-	blockBits, nodeBits := int(st.LocalBlock), int(st.LocalNode)
-	locBits := blockBits + nodeBits
+	structure := srv6Structure{
+		blockBits: int(st.LocalBlock),
+		nodeBits:  int(st.LocalNode),
+		funcBits:  int(st.LocalFunc),
+	}
+	locBits := structure.locatorBits()
 
 	for _, addr := range addrs {
 		idx.srv6SIDs[addr] = struct{}{}
 
-		if nodeBits <= 0 || locBits > SRv6SIDBitLength {
+		// RFC 9800 allows a zero-length Locator-Node, which this index does not decompose.
+		if structure.nodeBits <= 0 || locBits > SRv6SIDBitLength {
 			continue
 		}
 
@@ -208,13 +228,26 @@ func (idx *SIDIndex) addSRv6(owner string, addrs []netip.Addr, st SIDStructure) 
 			continue
 		}
 
-		info := srv6LocatorInfo{owner: owner, blockBits: blockBits, nodeBits: nodeBits}
-		if existing, ok := idx.srv6Locators[p]; ok && existing.owner != owner {
-			info.owner = ownerUnknown
-		}
-
-		idx.srv6Locators[p] = info
+		idx.mergeSRv6Locator(p, owner, structure)
 	}
+}
+
+// mergeSRv6Locator merges a locator advertisement for prefix p.
+// Owner and structure conflicts are tracked independently.
+func (idx *SIDIndex) mergeSRv6Locator(p netip.Prefix, owner string, structure srv6Structure) {
+	existing, ok := idx.srv6Locators[p]
+	if !ok {
+		idx.srv6Locators[p] = srv6LocatorInfo{owner: owner, structure: structure, structureKnown: true}
+		return
+	}
+
+	if existing.owner != owner {
+		existing.owner = ownerUnknown
+	}
+
+	existing.structureKnown = existing.structureKnown && existing.structure == structure
+
+	idx.srv6Locators[p] = existing
 }
 
 // Has reports whether the TED knows about seg.
@@ -231,7 +264,6 @@ func (idx *SIDIndex) Has(seg Segment) bool {
 }
 
 func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
-	// End / End.X SIDs are advertised verbatim, so prefer the exact match.
 	if _, ok := idx.srv6SIDs[s.Sid]; ok {
 		return true
 	}
@@ -239,31 +271,46 @@ func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
 	if !s.USid {
 		return false
 	}
-	// Fall back to locator containment for uSID containers.
-	locBits := 0
+
+	declaredLocBits := 0
 	if len(s.Structure) == 4 {
-		locBits = int(s.Structure[0]) + int(s.Structure[1])
+		declaredLocBits = int(s.Structure[0]) + int(s.Structure[1])
 	}
 
-	for loc := range idx.srv6Locators {
-		if !loc.Contains(s.Sid) {
-			continue
-		}
-		// Reject a request whose declared locator is shorter than the TED's.
-		if locBits > 0 && loc.Bits() > locBits {
+	_, found := idx.lookupSRv6Locator(s.Sid, declaredLocBits)
+
+	return found
+}
+
+// lookupSRv6Locator returns the most specific locator containing addr,
+// restricted to locators no more specific than maxBits.
+// maxBits <= 0 means unrestricted.
+func (idx *SIDIndex) lookupSRv6Locator(addr netip.Addr, maxBits int) (srv6LocatorInfo, bool) {
+	var (
+		best  netip.Prefix
+		info  srv6LocatorInfo
+		found bool
+	)
+
+	for p, i := range idx.srv6Locators {
+		if !p.Contains(addr) {
 			continue
 		}
 
-		return true
+		if maxBits > 0 && p.Bits() > maxBits {
+			continue
+		}
+
+		if !found || p.Bits() > best.Bits() {
+			best, info, found = p, i, true
+		}
 	}
 
-	return false
+	return info, found
 }
 
 // NextHop returns the next-hop router ID after traversing seg from owner.
-// For node SIDs it returns the SID's owning router ID (valid from any owner).
-// For adjacency SIDs it verifies the SID is local to owner, then returns the remote router ID.
-// Returns an error if the SID is unknown or does not belong to owner.
+// Node SIDs resolve to their owning router; adjacency SIDs must belong to owner.
 func (idx *SIDIndex) NextHop(owner string, seg Segment) (string, error) {
 	switch s := seg.(type) {
 	case SegmentSRMPLS:
@@ -278,8 +325,17 @@ func (idx *SIDIndex) NextHop(owner string, seg Segment) (string, error) {
 // ownerUnknown indicates that the current router is unknown.
 const ownerUnknown = ""
 
+// Multiple owners for the same SID make ownership ambiguous.
+func mergeSIDOwner[K comparable](owners map[K]string, sid K, owner string) {
+	if existing, ok := owners[sid]; ok && existing != owner {
+		owners[sid] = ownerUnknown
+		return
+	}
+
+	owners[sid] = owner
+}
+
 func (idx *SIDIndex) nextHopMPLS(owner string, s SegmentSRMPLS) (string, error) {
-	// Node SID (prefix SID)?
 	if next, ok := idx.mplsNodeSIDOwner[s.Sid]; ok {
 		return next, nil
 	}
@@ -291,7 +347,7 @@ func (idx *SIDIndex) nextHopMPLS(owner string, s SegmentSRMPLS) (string, error) 
 
 		return "", fmt.Errorf("SID %s not found in TED", s.SidString())
 	}
-	// Adjacency SID — must be on owner.
+
 	if next, ok := idx.mplsAdjSIDNextHop[adjKeyMPLS{owner, s.Sid}]; ok {
 		return next, nil
 	}
@@ -334,27 +390,28 @@ func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
 	return "", fmt.Errorf("SID %s not found in TED", s.SidString())
 }
 
-// uSIDMicroSegmentPrefixes returns the locator prefixes of a uSID container.
-// An all-zero micro-segment marks the end of the container (RFC 9800 §5).
-func uSIDMicroSegmentPrefixes(sid netip.Addr, blockBits, nodeBits int) []netip.Prefix {
-	if nodeBits <= 0 || blockBits < 0 || blockBits+nodeBits > SRv6SIDBitLength {
+// uSIDMicroSegmentPrefixes returns the locator prefix for each micro-segment.
+// Each slot is stride() bits wide, but only its nodeBits identify the node.
+func uSIDMicroSegmentPrefixes(sid netip.Addr, s srv6Structure) []netip.Prefix {
+	if s.nodeBits <= 0 || s.blockBits < 0 || s.funcBits < 0 || s.locatorBits() > SRv6SIDBitLength {
 		return nil
 	}
 
+	stride := s.stride()
 	src := sid.As16()
 
 	var prefixes []netip.Prefix
 
-	for start := blockBits; start+nodeBits <= SRv6SIDBitLength; start += nodeBits {
-		if usidBitsAllZero(&src, start, nodeBits) {
+	for start := s.blockBits; start+stride <= SRv6SIDBitLength; start += stride {
+		if usidBitsAllZero(&src, start, stride) {
 			break
 		}
 
 		var dst [16]byte
-		usidCopyBits(&dst, &src, 0, 0, blockBits)
-		usidCopyBits(&dst, &src, start, blockBits, nodeBits)
+		usidCopyBits(&dst, &src, 0, 0, s.blockBits)
+		usidCopyBits(&dst, &src, start, s.blockBits, s.nodeBits)
 
-		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom16(dst), blockBits+nodeBits))
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom16(dst), s.locatorBits()))
 	}
 
 	return prefixes
@@ -389,48 +446,64 @@ func usidSetBit(b *[16]byte, pos int, v bool) {
 	}
 }
 
-// usidContainerOwner resolves the owner of a uSID container.
-// matched is false when the container is outside all known locators.
+// usidContainerOwner resolves the owner of a uSID/C-SID container.
+//
+// matched is false when the SID has no compatible known locator.
+// When matched is true, ownerUnknown means the container is known but its
+// terminating owner cannot be determined unambiguously.
 func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bool) {
 	declaredLocBits := 0
-	if len(s.Structure) == 4 {
+	hasDeclared := len(s.Structure) == 4
+
+	if hasDeclared {
 		declaredLocBits = int(s.Structure[0]) + int(s.Structure[1])
 	}
 
-	for loc, info := range idx.srv6Locators {
-		if !loc.Contains(s.Sid) {
-			continue
-		}
-		// Reject a request whose declared locator is shorter than the TED's.
-		if declaredLocBits > 0 && loc.Bits() > declaredLocBits {
-			continue
-		}
+	locInfo, found := idx.lookupSRv6Locator(s.Sid, declaredLocBits)
+	if !found {
+		return ownerUnknown, false
+	}
 
-		blockBits, nodeBits := info.blockBits, info.nodeBits
-		if len(s.Structure) == 4 {
-			blockBits, nodeBits = int(s.Structure[0]), int(s.Structure[1])
-		}
+	structure := locInfo.structure
 
-		segments := uSIDMicroSegmentPrefixes(s.Sid, blockBits, nodeBits)
-		if len(segments) == 0 {
+	switch {
+	case hasDeclared:
+		// The SID's declared structure takes precedence over the locator's.
+		structure = srv6Structure{
+			blockBits: int(s.Structure[0]),
+			nodeBits:  int(s.Structure[1]),
+			funcBits:  int(s.Structure[2]),
+		}
+	case !locInfo.structureKnown:
+		return ownerUnknown, true
+	}
+
+	if structure.nodeBits <= 0 {
+		return ownerUnknown, false
+	}
+
+	segments := uSIDMicroSegmentPrefixes(s.Sid, structure)
+	if len(segments) == 0 {
+		return ownerUnknown, true
+	}
+
+	resolved := ownerUnknown
+
+	// Resolve each micro-segment independently to support nested locators.
+	for _, seg := range segments {
+		segInfo, ok := idx.srv6Locators[seg]
+		if !ok {
 			return ownerUnknown, true
 		}
 
-		resolved := ownerUnknown
-
-		for _, seg := range segments {
-			segInfo, ok := idx.srv6Locators[seg]
-			if !ok {
-				return ownerUnknown, true
-			}
-
-			resolved = segInfo.owner
+		if !hasDeclared && (!segInfo.structureKnown || segInfo.structure != structure) {
+			return ownerUnknown, true
 		}
 
-		return resolved, true
+		resolved = segInfo.owner
 	}
 
-	return "", false
+	return resolved, true
 }
 
 // ValidateExplicitPath validates an explicit segment list from srcRouterID.

--- a/pkg/table/sid_validate_internal_test.go
+++ b/pkg/table/sid_validate_internal_test.go
@@ -215,7 +215,6 @@ func TestUSIDMicroSegmentPrefixes(t *testing.T) {
 	})
 
 	t.Run("FL>0 non-byte-aligned: stride and locator width are independent", func(t *testing.T) {
-
 		t.Parallel()
 
 		sid := netip.AddrFrom16([16]byte{0xA1, 0x23, 0xF4, 0x56, 0x00})
@@ -264,11 +263,9 @@ func TestSRv6LocatorLookup(t *testing.T) {
 
 		addr := netip.MustParseAddr("2001:db8:1::1")
 
-		for range 100 {
-			info, found := idx.lookupSRv6Locator(addr, 0)
-			require.True(t, found)
-			assert.Equal(t, "specific", info.owner)
-		}
+		info, found := idx.lookupSRv6Locator(addr, -1)
+		require.True(t, found)
+		assert.Equal(t, "specific", info.owner)
 	})
 
 	t.Run("maxBits excludes a too-specific locator, falling back to the broader one", func(t *testing.T) {
@@ -293,7 +290,7 @@ func TestSRv6LocatorLookup(t *testing.T) {
 			netip.MustParsePrefix("2001:db8::/32"): {owner: "broad", structureKnown: true},
 		}}
 
-		_, found := idx.lookupSRv6Locator(netip.MustParseAddr("fd00::1"), 0)
+		_, found := idx.lookupSRv6Locator(netip.MustParseAddr("fd00::1"), -1)
 		assert.False(t, found)
 	})
 }
@@ -305,12 +302,12 @@ func TestSRv6LocatorMerge(t *testing.T) {
 		t.Parallel()
 
 		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
-			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 32}},
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: &SIDStructure{LocalBlock: 16, LocalNode: 32}},
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
 
-		info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), 0)
+		info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), -1)
 		require.True(t, found)
 		assert.Equal(t, "X", info.owner)
 		assert.False(t, info.structureKnown, "conflicting structures for the same prefix must not be resolved by last-write-wins")
@@ -320,36 +317,87 @@ func TestSRv6LocatorMerge(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16}},
 		}}
 		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16}},
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
 
-		for range 100 {
-			info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), 0)
-			require.True(t, found)
-			assert.Equal(t, ownerUnknown, info.owner)
-			assert.True(t, info.structureKnown, "an owner collision must not also mark the agreed-upon structure as unknown")
-		}
+		info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), -1)
+		require.True(t, found)
+		assert.Equal(t, ownerUnknown, info.owner)
+		assert.True(t, info.structureKnown, "an owner collision must not also mark the agreed-upon structure as unknown")
 	})
 
 	t.Run("conflicting owners and conflicting structure: both unknown", func(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16}},
 		}}
 		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 32}},
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: &SIDStructure{LocalBlock: 16, LocalNode: 32}},
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
 
-		info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), 0)
+		info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), -1)
 		require.True(t, found)
 		assert.Equal(t, ownerUnknown, info.owner)
 		assert.False(t, info.structureKnown)
+	})
+}
+
+func TestAddSRv6_StructurePresence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absent structure registers the exact SID but no locator", func(t *testing.T) {
+		t.Parallel()
+
+		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fc00:1::1"}, SIDStructure: nil},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
+
+		assert.Empty(t, idx.srv6Locators, "no structure was advertised, so no locator can be derived")
+		assert.True(t, idx.Has(NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))))
+	})
+
+	t.Run("LocalNode zero with LocalBlock set registers a locator, not skipped as if absent", func(t *testing.T) {
+		t.Parallel()
+
+		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fc00:1::1"}, SIDStructure: &SIDStructure{LocalBlock: 32}},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
+
+		info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fc00:1::1"), -1)
+		require.True(t, found, "expected a /32 locator despite LocalNode being 0")
+		assert.Equal(t, "X", info.owner)
+	})
+
+	t.Run("LIB C-SID shape (LocalBlock=0, LocalNode=0, LocalFunc>0) registers the exact SID but no locator", func(t *testing.T) {
+		t.Parallel()
+
+		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fc00::1"}, SIDStructure: &SIDStructure{LocalFunc: 16}},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
+
+		assert.True(t, idx.Has(NewSegmentSRv6(netip.MustParseAddr("fc00::1"))), "expected the exact SID to still be registered")
+		assert.Empty(t, idx.srv6Locators, "a zero-width locator carries no usable per-node prefix, present or not")
+	})
+
+	t.Run("absent and present-but-zero structures both skip the locator, but neither drops the exact SID", func(t *testing.T) {
+		t.Parallel()
+
+		nodeAbsent := &LsNode{RouterID: "absent", SRv6SIDs: []*LsSrv6SID{{Sids: []string{"fc00::1"}}}}
+		nodePresentZero := &LsNode{RouterID: "zero", SRv6SIDs: []*LsSrv6SID{{Sids: []string{"fc00::2"}, SIDStructure: &SIDStructure{}}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeAbsent, nodePresentZero))
+
+		assert.Empty(t, idx.srv6Locators)
+		assert.True(t, idx.Has(NewSegmentSRv6(netip.MustParseAddr("fc00::1"))))
+		assert.True(t, idx.Has(NewSegmentSRv6(netip.MustParseAddr("fc00::2"))))
 	})
 }
 
@@ -360,13 +408,13 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0200::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0200::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		nodeZ := &LsNode{RouterID: "Z", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0300::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0300::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY, nodeZ))
 
@@ -383,10 +431,10 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0200::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0200::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
 
@@ -404,7 +452,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
 
@@ -421,10 +469,10 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		nodeZ := &LsNode{RouterID: "Z", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0300::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0300::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeZ))
 
@@ -441,7 +489,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
 
@@ -457,7 +505,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0000::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0000::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
 
@@ -475,10 +523,10 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{{
-			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
 
@@ -495,8 +543,8 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
-			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 32}},
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: &SIDStructure{LocalBlock: 16, LocalNode: 32}},
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
 
@@ -512,8 +560,8 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Parallel()
 
 		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
-			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 32}},
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: &SIDStructure{LocalBlock: 16, LocalNode: 32}},
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
 
@@ -526,24 +574,41 @@ func TestUSIDContainerOwner(t *testing.T) {
 		assert.Equal(t, "X", owner)
 	})
 
+	t.Run("no declared structure and a later micro-segment's locator structure disagrees", func(t *testing.T) {
+		t.Parallel()
+
+		nodeA := &LsNode{RouterID: "A", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		nodeB := &LsNode{RouterID: "B", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0200::"}, SIDStructure: &SIDStructure{LocalBlock: 16, LocalNode: 32},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeA, nodeB))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200::"))
+		seg.USid = true
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, ownerUnknown, owner, "the second micro-segment's own locator disagrees with the container's structure")
+	})
+
 	t.Run("nested locators: no declared structure selects the most specific locator", func(t *testing.T) {
 		t.Parallel()
 
 		nodeBroad := &LsNode{RouterID: "broad", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"1234::"}, SIDStructure: SIDStructure{LocalBlock: 8, LocalNode: 8}},
+			{Sids: []string{"1234::"}, SIDStructure: &SIDStructure{LocalBlock: 8, LocalNode: 8}},
 		}}
 		nodeSpecific := &LsNode{RouterID: "specific", SRv6SIDs: []*LsSrv6SID{
-			{Sids: []string{"1234:5678::"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 16}},
+			{Sids: []string{"1234:5678::"}, SIDStructure: &SIDStructure{LocalBlock: 16, LocalNode: 16}},
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeBroad, nodeSpecific))
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("1234:5678::"))
 		seg.USid = true
 
-		for range 100 {
-			owner, matched := idx.usidContainerOwner(seg)
-			require.True(t, matched)
-			assert.Equal(t, "specific", owner)
-		}
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, "specific", owner)
 	})
 }

--- a/pkg/table/sid_validate_internal_test.go
+++ b/pkg/table/sid_validate_internal_test.go
@@ -71,6 +71,50 @@ func TestSIDIndexNextHop_OwnerUnknownBranches(t *testing.T) {
 	})
 }
 
+func TestSIDIndexNextHop_ConflictingExactOwnerIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("two nodes advertising the same SRv6 node SID resolve to owner unknown", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{Sids: []string{"2001:db8::1"}}}}
+		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{{Sids: []string{"2001:db8::1"}}}}
+
+		for range 20 {
+			idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
+
+			next, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(netip.MustParseAddr("2001:db8::1")))
+			require.NoError(t, err)
+			assert.Equal(t, ownerUnknown, next, "conflicting owners must never resolve to whichever node was visited last")
+		}
+	})
+
+	t.Run("two nodes advertising the same MPLS prefix SID label resolve to owner unknown", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{
+			RouterID:  "X",
+			SrgbBegin: 16000,
+			SrgbEnd:   17000,
+			Prefixes:  []*LsPrefix{{HasSidIndex: true, SidIndex: 1}},
+		}
+		nodeY := &LsNode{
+			RouterID:  "Y",
+			SrgbBegin: 16000,
+			SrgbEnd:   17000,
+			Prefixes:  []*LsPrefix{{HasSidIndex: true, SidIndex: 1}},
+		}
+
+		for range 20 {
+			idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
+
+			next, err := idx.NextHop(ownerUnknown, NewSegmentSRMPLS(16001))
+			require.NoError(t, err)
+			assert.Equal(t, ownerUnknown, next, "conflicting owners must never resolve to whichever node was visited last")
+		}
+	})
+}
+
 func TestUSIDMicroSegmentPrefixes(t *testing.T) {
 	t.Parallel()
 
@@ -78,7 +122,7 @@ func TestUSIDMicroSegmentPrefixes(t *testing.T) {
 		t.Parallel()
 
 		sid := netip.MustParseAddr("fcbb:bb00:0100:0200:0300::")
-		got := uSIDMicroSegmentPrefixes(sid, 32, 16)
+		got := uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 32, nodeBits: 16})
 		want := []netip.Prefix{
 			netip.MustParsePrefix("fcbb:bb00:0100::/48"),
 			netip.MustParsePrefix("fcbb:bb00:0200::/48"),
@@ -91,7 +135,7 @@ func TestUSIDMicroSegmentPrefixes(t *testing.T) {
 		t.Parallel()
 
 		sid := netip.MustParseAddr("fcbb:bb00:0100:0000:0300::")
-		got := uSIDMicroSegmentPrefixes(sid, 32, 16)
+		got := uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 32, nodeBits: 16})
 		want := []netip.Prefix{
 			netip.MustParsePrefix("fcbb:bb00:0100::/48"),
 		}
@@ -102,21 +146,35 @@ func TestUSIDMicroSegmentPrefixes(t *testing.T) {
 		t.Parallel()
 
 		sid := netip.MustParseAddr("fcbb:bb00:0100::")
-		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, 32, 0))
+		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 32, nodeBits: 0}))
+	})
+
+	t.Run("nodeBits zero with function bits set still returns nil (LIB CSID is not decomposed)", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("fcbb:bb00:0100::")
+		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 32, nodeBits: 0, funcBits: 16}))
 	})
 
 	t.Run("blockBits negative returns nil", func(t *testing.T) {
 		t.Parallel()
 
 		sid := netip.MustParseAddr("fcbb:bb00:0100::")
-		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, -1, 16))
+		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: -1, nodeBits: 16}))
+	})
+
+	t.Run("funcBits negative returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("fcbb:bb00:0100::")
+		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 32, nodeBits: 16, funcBits: -1}))
 	})
 
 	t.Run("blockBits plus nodeBits exceeds 128 returns nil", func(t *testing.T) {
 		t.Parallel()
 
 		sid := netip.MustParseAddr("fcbb:bb00:0100::")
-		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, 120, 16))
+		assert.Nil(t, uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 120, nodeBits: 16}))
 	})
 
 	t.Run("non-byte-aligned nodeBits extracts bits correctly", func(t *testing.T) {
@@ -124,7 +182,7 @@ func TestUSIDMicroSegmentPrefixes(t *testing.T) {
 
 		// block=0xA, segments=0x123 and 0x456 (12 bits each).
 		sid := netip.AddrFrom16([16]byte{0xA1, 0x23, 0x45, 0x60})
-		got := uSIDMicroSegmentPrefixes(sid, 4, 12)
+		got := uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 4, nodeBits: 12})
 		want := []netip.Prefix{
 			netip.PrefixFrom(netip.AddrFrom16([16]byte{0xA1, 0x23}), 16),
 			netip.PrefixFrom(netip.AddrFrom16([16]byte{0xA4, 0x56}), 16),
@@ -136,12 +194,162 @@ func TestUSIDMicroSegmentPrefixes(t *testing.T) {
 		t.Parallel()
 
 		sid := netip.MustParseAddr("2001:db8:0:0:1:2:3:4")
-		got := uSIDMicroSegmentPrefixes(sid, 64, 32)
+		got := uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 64, nodeBits: 32})
 		want := []netip.Prefix{
 			netip.MustParsePrefix("2001:db8:0:0:1:2::/96"),
 			netip.MustParsePrefix("2001:db8:0:0:3:4::/96"),
 		}
 		assert.Equal(t, want, got)
+	})
+
+	t.Run("FL>0: stride includes function bits, locator prefix excludes them", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.AddrFrom16([16]byte{0xAA, 0xBB, 0xCC, 0xEE, 0xFF})
+		got := uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 8, nodeBits: 8, funcBits: 8})
+		want := []netip.Prefix{
+			netip.PrefixFrom(netip.AddrFrom16([16]byte{0xAA, 0xBB}), 16),
+			netip.PrefixFrom(netip.AddrFrom16([16]byte{0xAA, 0xEE}), 16),
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("FL>0 non-byte-aligned: stride and locator width are independent", func(t *testing.T) {
+
+		t.Parallel()
+
+		sid := netip.AddrFrom16([16]byte{0xA1, 0x23, 0xF4, 0x56, 0x00})
+		got := uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 4, nodeBits: 12, funcBits: 4})
+		want := []netip.Prefix{
+			netip.PrefixFrom(netip.AddrFrom16([16]byte{0xA1, 0x23}), 16),
+			netip.PrefixFrom(netip.AddrFrom16([16]byte{0xA4, 0x56}), 16),
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("128 bits used exactly with FL padding included in stride", func(t *testing.T) {
+		t.Parallel()
+
+		// blockBits=32, nodeBits=16, funcBits=16 -> stride=32; exactly 3 hops fit in 128 bits.
+		structure := srv6Structure{blockBits: 32, nodeBits: 16, funcBits: 16}
+		raw := [16]byte{0xFC, 0xBB, 0xBB, 0x00, 0x01, 0x00, 0xFF, 0xFF, 0x02, 0x00, 0xAA, 0xAA, 0x03, 0x00, 0xBB, 0xBB}
+		got := uSIDMicroSegmentPrefixes(netip.AddrFrom16(raw), structure)
+		want := []netip.Prefix{
+			netip.MustParsePrefix("fcbb:bb00:0100::/48"),
+			netip.MustParsePrefix("fcbb:bb00:0200::/48"),
+			netip.MustParsePrefix("fcbb:bb00:0300::/48"),
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("does not emit a partial slot when function bits exceed the SID", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("2001:db8::1")
+		got := uSIDMicroSegmentPrefixes(sid, srv6Structure{blockBits: 32, nodeBits: 16, funcBits: 81})
+		assert.Empty(t, got)
+	})
+}
+
+func TestSRv6LocatorLookup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("longest prefix match: nested locators pick the most specific", func(t *testing.T) {
+		t.Parallel()
+
+		idx := &SIDIndex{srv6Locators: map[netip.Prefix]srv6LocatorInfo{
+			netip.MustParsePrefix("2001:db8::/32"):   {owner: "broad", structure: srv6Structure{blockBits: 16, nodeBits: 16}, structureKnown: true},
+			netip.MustParsePrefix("2001:db8:1::/48"): {owner: "specific", structure: srv6Structure{blockBits: 32, nodeBits: 16}, structureKnown: true},
+		}}
+
+		addr := netip.MustParseAddr("2001:db8:1::1")
+
+		for range 100 {
+			info, found := idx.lookupSRv6Locator(addr, 0)
+			require.True(t, found)
+			assert.Equal(t, "specific", info.owner)
+		}
+	})
+
+	t.Run("maxBits excludes a too-specific locator, falling back to the broader one", func(t *testing.T) {
+		t.Parallel()
+
+		idx := &SIDIndex{srv6Locators: map[netip.Prefix]srv6LocatorInfo{
+			netip.MustParsePrefix("2001:db8::/32"):   {owner: "broad", structureKnown: true},
+			netip.MustParsePrefix("2001:db8:1::/48"): {owner: "specific", structureKnown: true},
+		}}
+
+		addr := netip.MustParseAddr("2001:db8:1::1")
+
+		info, found := idx.lookupSRv6Locator(addr, 32)
+		require.True(t, found)
+		assert.Equal(t, "broad", info.owner)
+	})
+
+	t.Run("no containing locator", func(t *testing.T) {
+		t.Parallel()
+
+		idx := &SIDIndex{srv6Locators: map[netip.Prefix]srv6LocatorInfo{
+			netip.MustParsePrefix("2001:db8::/32"): {owner: "broad", structureKnown: true},
+		}}
+
+		_, found := idx.lookupSRv6Locator(netip.MustParseAddr("fd00::1"), 0)
+		assert.False(t, found)
+	})
+}
+
+func TestSRv6LocatorMerge(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same owner, conflicting structure: owner known, structure unknown", func(t *testing.T) {
+		t.Parallel()
+
+		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 32}},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
+
+		info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), 0)
+		require.True(t, found)
+		assert.Equal(t, "X", info.owner)
+		assert.False(t, info.structureKnown, "conflicting structures for the same prefix must not be resolved by last-write-wins")
+	})
+
+	t.Run("conflicting owners, same structure: structure known, owner unknown", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+		}}
+		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
+
+		for range 100 {
+			info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), 0)
+			require.True(t, found)
+			assert.Equal(t, ownerUnknown, info.owner)
+			assert.True(t, info.structureKnown, "an owner collision must not also mark the agreed-upon structure as unknown")
+		}
+	})
+
+	t.Run("conflicting owners and conflicting structure: both unknown", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+		}}
+		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 32}},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
+
+		info, found := idx.lookupSRv6Locator(netip.MustParseAddr("fcbb:bb00:0100::"), 0)
+		require.True(t, found)
+		assert.Equal(t, ownerUnknown, info.owner)
+		assert.False(t, info.structureKnown)
 	})
 }
 
@@ -164,11 +372,49 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
 		assert.Equal(t, "Z", owner)
+	})
+
+	t.Run("resolved owner is the last micro-segment's, not the first's", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0200::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200::"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, "Y", owner)
+		assert.NotEqual(t, "X", owner)
+	})
+
+	t.Run("single micro-segment container resolves to its sole owner", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, "X", owner)
 	})
 
 	t.Run("partially resolved degrades to owner unknown", func(t *testing.T) {
@@ -184,7 +430,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -201,7 +447,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fd00:bb00:0100:0200:0300::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
 
 		_, matched := idx.usidContainerOwner(seg)
 		assert.False(t, matched)
@@ -218,7 +464,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		// The first micro-segment is all zero, marking the container end (RFC 9800 §5).
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0000::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -238,10 +484,66 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 16, 0}
+		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
 		assert.Equal(t, ownerUnknown, owner)
+	})
+
+	t.Run("locator structure conflict with no declared structure degrades to owner unknown", func(t *testing.T) {
+		t.Parallel()
+
+		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 32}},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
+		seg.USid = true
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched, "the container is still within a known locator")
+		assert.Equal(t, ownerUnknown, owner, "ambiguous locator structure must not be guessed")
+	})
+
+	t.Run("declared structure overrides an ambiguous locator structure", func(t *testing.T) {
+		t.Parallel()
+
+		node := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: SIDStructure{LocalBlock: 32, LocalNode: 16}},
+			{Sids: []string{"fcbb:bb00:0100::1"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 32}},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, "X", owner)
+	})
+
+	t.Run("nested locators: no declared structure selects the most specific locator", func(t *testing.T) {
+		t.Parallel()
+
+		nodeBroad := &LsNode{RouterID: "broad", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"1234::"}, SIDStructure: SIDStructure{LocalBlock: 8, LocalNode: 8}},
+		}}
+		nodeSpecific := &LsNode{RouterID: "specific", SRv6SIDs: []*LsSrv6SID{
+			{Sids: []string{"1234:5678::"}, SIDStructure: SIDStructure{LocalBlock: 16, LocalNode: 16}},
+		}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeBroad, nodeSpecific))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("1234:5678::"))
+		seg.USid = true
+
+		for range 100 {
+			owner, matched := idx.usidContainerOwner(seg)
+			require.True(t, matched)
+			assert.Equal(t, "specific", owner)
+		}
 	})
 }

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -258,7 +258,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 		SRv6SIDs: []*table.LsSrv6SID{
 			{
 				Sids:         []string{"fcbb:bb00:0100::"},
-				SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
+				SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16},
 			},
 		},
 	}
@@ -271,7 +271,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 
 		seg := table.NewSegmentSRv6(container)
 		seg.USid = true
-		seg.Structure = []uint8{32, 16, 16, 0}
+		seg.Structure = []uint8{32, 16, 0, 0}
 		assert.True(t, table.NewSIDIndex(ted).Has(seg), "expected uSID container to be accepted via locator containment")
 	})
 
@@ -828,7 +828,7 @@ func usidLocatorNode(routerID, sid string, remote *table.LsNode, endXSid string)
 		RouterID: routerID,
 		SRv6SIDs: []*table.LsSrv6SID{{
 			Sids:         []string{sid},
-			SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
+			SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}},
 	}
 	if remote != nil {
@@ -863,7 +863,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
 		})
 		require.NoError(t, err)
@@ -877,7 +877,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg("fcbb:bb00:0100::", []uint8{32, 16, 16, 0}),
+			usidContainerSeg("fcbb:bb00:0100::", []uint8{32, 16, 0, 0}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
 		})
 		require.NoError(t, err)
@@ -893,7 +893,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX, nodeY, nodeZ)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW3)),
 		})
 		require.NoError(t, err)
@@ -909,7 +909,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX, nodeY, nodeZ)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
 		})
 		require.Error(t, err)
@@ -926,7 +926,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX, nodeZ)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW3)),
 		})
 		require.NoError(t, err)
@@ -940,7 +940,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeX, nodeZ)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 16, 0}),
+			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
 			table.NewSegmentSRv6(netip.MustParseAddr("fd00::dead:beef")),
 		})
 		require.Error(t, err)
@@ -954,7 +954,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg("fd00:bb00:0100:0200:0300::", []uint8{32, 16, 16, 0}),
+			usidContainerSeg("fd00:bb00:0100:0200:0300::", []uint8{32, 16, 0, 0}),
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in TED")

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -217,13 +217,13 @@ func TestSIDIndexHas_SRv6Exact(t *testing.T) {
 	node := &table.LsNode{
 		RouterID: testRouterID1,
 		SRv6SIDs: []*table.LsSrv6SID{
-			{Sids: []string{testSRv6ExactSID}, SIDStructure: table.SIDStructure{}},
+			{Sids: []string{testSRv6ExactSID}, SIDStructure: &table.SIDStructure{}},
 		},
 		Links: []*table.LsLink{
 			{
 				Srv6EndXSID: &table.Srv6EndXSID{
 					Sids:             []string{"2001:db8:1::1"},
-					Srv6SIDStructure: table.SIDStructure{},
+					Srv6SIDStructure: &table.SIDStructure{},
 				},
 			},
 		},
@@ -258,7 +258,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 		SRv6SIDs: []*table.LsSrv6SID{
 			{
 				Sids:         []string{"fcbb:bb00:0100::"},
-				SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16},
+				SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16},
 			},
 		},
 	}
@@ -292,6 +292,15 @@ func TestSIDIndexHas_USID(t *testing.T) {
 		// the TED actually advertises.
 		seg.Structure = []uint8{24, 8, 16, 0}
 		assert.False(t, table.NewSIDIndex(ted).Has(seg), "expected mismatch when declared locator is shorter than TED advertised")
+	})
+
+	t.Run("declared zero-width locator does not match an unrelated enclosing TED locator", func(t *testing.T) {
+		t.Parallel()
+
+		seg := table.NewSegmentSRv6(container)
+		seg.USid = true
+		seg.Structure = []uint8{0, 0, 48, 0}
+		assert.False(t, table.NewSIDIndex(ted).Has(seg), "expected declared zero-width locator not to match an unrelated enclosing TED locator")
 	})
 
 	t.Run("outside any known locator", func(t *testing.T) {
@@ -374,7 +383,7 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 		sid := netip.MustParseAddr("fc00:0:1::")
 		node := &table.LsNode{
 			RouterID: testRouterID1,
-			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{sid.String()}, SIDStructure: table.SIDStructure{}}},
+			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{sid.String()}, SIDStructure: &table.SIDStructure{}}},
 		}
 		idx := table.NewSIDIndex(newTestTED(node))
 		assert.True(t, idx.Has(table.NewSegmentSRv6(sid)), "expected exact match regardless of locator length")
@@ -390,7 +399,7 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 		sid := netip.MustParseAddr("fc00:0:1::")
 		node := &table.LsNode{
 			RouterID: testRouterID1,
-			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{sid.String()}, SIDStructure: table.SIDStructure{LocalBlock: 200, LocalNode: 200}}},
+			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{sid.String()}, SIDStructure: &table.SIDStructure{LocalBlock: 200, LocalNode: 200}}},
 		}
 		idx := table.NewSIDIndex(newTestTED(node))
 		assert.True(t, idx.Has(table.NewSegmentSRv6(sid)), "expected exact match regardless of locator length")
@@ -398,6 +407,30 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 		other := table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::1234"))
 		other.USid = true
 		assert.False(t, idx.Has(other), "expected no locator fallback registered when LocalBlock+LocalNode exceeds 128 bits")
+	})
+
+	t.Run("total structure width exceeds 128 bits is not registered", func(t *testing.T) {
+		t.Parallel()
+
+		sid := netip.MustParseAddr("fc00:0:1::")
+		node := &table.LsNode{
+			RouterID: testRouterID1,
+			SRv6SIDs: []*table.LsSrv6SID{{
+				Sids: []string{sid.String()},
+				SIDStructure: &table.SIDStructure{
+					LocalBlock: 32,
+					LocalNode:  16,
+					LocalFunc:  50,
+					LocalArg:   31,
+				},
+			}},
+		}
+		idx := table.NewSIDIndex(newTestTED(node))
+		assert.True(t, idx.Has(table.NewSegmentSRv6(sid)), "expected exact match regardless of total width")
+
+		other := table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::1234"))
+		other.USid = true
+		assert.False(t, idx.Has(other), "expected no locator fallback registered when LocalBlock+LocalNode+LocalFunc+LocalArg exceeds 128 bits")
 	})
 
 	t.Run("non-IPv6 node SID is not reachable via NextHop either", func(t *testing.T) {
@@ -828,7 +861,7 @@ func usidLocatorNode(routerID, sid string, remote *table.LsNode, endXSid string)
 		RouterID: routerID,
 		SRv6SIDs: []*table.LsSrv6SID{{
 			Sids:         []string{sid},
-			SIDStructure: table.SIDStructure{LocalBlock: 32, LocalNode: 16},
+			SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16},
 		}},
 	}
 	if remote != nil {
@@ -1020,14 +1053,15 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found in TED")
 	})
 
-	t.Run("LocalNode unset does not bypass owner validation", func(t *testing.T) {
+	t.Run("LocalNode unset registers a real locator, not a wildcard match", func(t *testing.T) {
 		t.Parallel()
 
+		// LocalBlock=32, LocalNode=0 is a valid structure with no node bits.
 		nodeA := &table.LsNode{
 			RouterID: testRouterIDA,
 			SRv6SIDs: []*table.LsSrv6SID{{
 				Sids:         []string{"fc00::a:1"},
-				SIDStructure: table.SIDStructure{LocalBlock: 32},
+				SIDStructure: &table.SIDStructure{LocalBlock: 32},
 			}},
 		}
 		nodeB := &table.LsNode{
@@ -1037,6 +1071,8 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		nodeA.Links = []*table.LsLink{{LocalNode: nodeA, RemoteNode: nodeB, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"fc00::a:b"}}}}
 		ted := newTestTED(nodeA, nodeB)
 
+		// A /32 locator has no node bits, so uSID matching is not authoritative.
+		// Fall back to exact-SID ownership.
 		err := table.ValidateExplicitPath(ted, testRouterIDB, []table.Segment{
 			usidContainerSeg("fc00::a:b", nil),
 		})

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -299,12 +299,15 @@ func NewSegmentSRv6WithNodeInfo(sid netip.Addr, n *LsNode) (SegmentSRv6, error) 
 
 		seg.LocalAddr = addr
 
-		seg.Structure = SIDStructureBytes{
-			srv6SID.SIDStructure.LocalBlock,
-			srv6SID.SIDStructure.LocalNode,
-			srv6SID.SIDStructure.LocalFunc,
-			srv6SID.SIDStructure.LocalArg,
+		if srv6SID.SIDStructure != nil {
+			seg.Structure = SIDStructureBytes{
+				srv6SID.SIDStructure.LocalBlock,
+				srv6SID.SIDStructure.LocalNode,
+				srv6SID.SIDStructure.LocalFunc,
+				srv6SID.SIDStructure.LocalArg,
+			}
 		}
+
 		if IsUSidBehavior(srv6SID.EndpointBehavior.Behavior) {
 			seg.USid = true
 		}

--- a/pkg/table/sr_policy_test.go
+++ b/pkg/table/sr_policy_test.go
@@ -429,7 +429,7 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 				SRv6SIDs: []*table.LsSrv6SID{
 					{
 						Sids:             []string{testSRv6Addr},
-						SIDStructure:     table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+						SIDStructure:     &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 						EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorEND},
 					},
 				},
@@ -447,7 +447,7 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 				SRv6SIDs: []*table.LsSrv6SID{
 					{
 						Sids:             []string{"fcbb:bb00:0100::"},
-						SIDStructure:     table.SIDStructure{LocalBlock: 32, LocalNode: 16},
+						SIDStructure:     &table.SIDStructure{LocalBlock: 32, LocalNode: 16},
 						EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorUN},
 					},
 				},
@@ -470,7 +470,6 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 			want: table.SegmentSRv6{
 				Sid:       netip.MustParseAddr("2001:db8::1"),
 				LocalAddr: netip.MustParseAddr(testSRv6Addr),
-				Structure: table.SIDStructureBytes{0, 0, 0, 0},
 			},
 		},
 		{
@@ -484,7 +483,6 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 			want: table.SegmentSRv6{
 				Sid:       netip.MustParseAddr("2001:db8::1"),
 				LocalAddr: netip.MustParseAddr(testSRv6Addr),
-				Structure: table.SIDStructureBytes{0, 0, 0, 0},
 			},
 		},
 		{

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -217,12 +217,19 @@ func printLink(ew *errWriter, link *LsLink) {
 		ew.println("      SRv6 End.X SID:")
 		ew.printf("        EndpointBehavior: %s\n", BehaviorToString(link.Srv6EndXSID.EndpointBehavior))
 		ew.printf("        SIDs: %v\n", link.Srv6EndXSID.Sids)
-		ew.printf("        SID Structure: Block: %d, Node: %d, Func: %d, Arg: %d\n",
-			link.Srv6EndXSID.Srv6SIDStructure.LocalBlock,
-			link.Srv6EndXSID.Srv6SIDStructure.LocalNode,
-			link.Srv6EndXSID.Srv6SIDStructure.LocalFunc,
-			link.Srv6EndXSID.Srv6SIDStructure.LocalArg)
+		printSIDStructure(ew, "        ", link.Srv6EndXSID.Srv6SIDStructure)
 	}
+}
+
+// printSIDStructure prints an SID Structure or "(not advertised)".
+func printSIDStructure(ew *errWriter, indent string, s *SIDStructure) {
+	if s == nil {
+		ew.printf("%sSID Structure: (not advertised)\n", indent)
+		return
+	}
+
+	ew.printf("%sSID Structure: Block: %d, Node: %d, Func: %d, Arg: %d\n",
+		indent, s.LocalBlock, s.LocalNode, s.LocalFunc, s.LocalArg)
 }
 
 // printNodeSRv6SIDs prints the SRv6 SIDs associated with a node.
@@ -239,11 +246,17 @@ func printNodeSRv6SIDs(ew *errWriter, node *LsNode) {
 		}
 
 		ew.printf("    SIDs: %v\n", srv6SID.Sids)
-		ew.printf("    Block: %d, Node: %d, Func: %d, Arg: %d\n",
-			srv6SID.SIDStructure.LocalBlock,
-			srv6SID.SIDStructure.LocalNode,
-			srv6SID.SIDStructure.LocalFunc,
-			srv6SID.SIDStructure.LocalArg)
+
+		if srv6SID.SIDStructure == nil {
+			ew.println("    SID Structure: (not advertised)")
+		} else {
+			ew.printf("    Block: %d, Node: %d, Func: %d, Arg: %d\n",
+				srv6SID.SIDStructure.LocalBlock,
+				srv6SID.SIDStructure.LocalNode,
+				srv6SID.SIDStructure.LocalFunc,
+				srv6SID.SIDStructure.LocalArg)
+		}
+
 		ew.printf("    EndpointBehavior: %s, Flags: %d, Algorithm: %d\n",
 			BehaviorToString(srv6SID.EndpointBehavior.Behavior),
 			srv6SID.EndpointBehavior.Flags,
@@ -473,7 +486,7 @@ type LsSrv6SID struct {
 	LocalNode        *LsNode          // primary key, in MP_REACH_NLRI Attr
 	Sids             []string         // in LsSrv6SID Attr
 	EndpointBehavior EndpointBehavior // in BGP-LS Attr
-	SIDStructure     SIDStructure     // in BGP-LS Attr
+	SIDStructure     *SIDStructure    // nil when the SID Structure TLV was not advertised
 	MultiTopoIDs     []uint32         // in LsSrv6SID Attr
 }
 
@@ -589,5 +602,5 @@ func (m MetricType) MarshalJSON() ([]byte, error) {
 type Srv6EndXSID struct {
 	EndpointBehavior uint16
 	Sids             []string
-	Srv6SIDStructure SIDStructure
+	Srv6SIDStructure *SIDStructure // nil when the SID Structure TLV was not advertised
 }

--- a/pkg/table/ted_internal_test.go
+++ b/pkg/table/ted_internal_test.go
@@ -63,7 +63,7 @@ func TestPrintLink(t *testing.T) {
 			Srv6EndXSID: &Srv6EndXSID{
 				EndpointBehavior: 5,
 				Sids:             []string{tedInternalTestSRv6SID1},
-				Srv6SIDStructure: SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
+				Srv6SIDStructure: &SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
 			},
 		}
 
@@ -164,7 +164,7 @@ func TestPrintNodeSRv6SIDs(t *testing.T) {
 			SRv6SIDs: []*LsSrv6SID{
 				{
 					Sids:             []string{tedInternalTestSRv6SID1},
-					SIDStructure:     SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
+					SIDStructure:     &SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
 					EndpointBehavior: EndpointBehavior{Behavior: 5, Flags: 6, Algorithm: 7},
 					MultiTopoIDs:     []uint32{0, 1},
 				},

--- a/pkg/table/ted_test.go
+++ b/pkg/table/ted_test.go
@@ -695,6 +695,28 @@ func TestLsTEDPrint(t *testing.T) {
 		assert.Contains(t, buf.String(), "router1")
 	})
 
+	t.Run("SRv6 End.X SID structure not advertised", func(t *testing.T) {
+		t.Parallel()
+
+		ted := &table.LsTED{Nodes: map[string]*table.LsNode{
+			"R1": {
+				RouterID: "R1",
+				Links: []*table.LsLink{
+					{
+						RemoteNode: &table.LsNode{RouterID: "R2"},
+						Srv6EndXSID: &table.Srv6EndXSID{
+							Sids: []string{"fcbb:bb00:0100::"},
+						},
+					},
+				},
+			},
+		}}
+
+		var buf bytes.Buffer
+		require.NoError(t, ted.Print(&buf))
+		assert.Contains(t, buf.String(), "SID Structure: (not advertised)")
+	})
+
 	t.Run("print returns error when writer fails", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Description

Preserve whether the SRv6 SID Structure TLV was advertised, distinguishing absent structures from present zero-valued structures. 
Also make uSID locator validation deterministic by handling structure/owner conflicts and using the correct micro-segment stride.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?

- Added/updated unit and end-to-end tests.
- `make ci` passes locally.

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed
