### PR TITLE
Resolve uSID container ownership for zero-node locators

### DIFF
--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -485,8 +485,9 @@ func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bo
 		return ownerUnknown, true
 	}
 
+	// A node-bits=0 locator cannot encode further hops (LIB C-SID semantics).
 	if structure.nodeBits <= 0 {
-		return ownerUnknown, false
+		return locInfo.owner, true
 	}
 
 	segments := uSIDMicroSegmentPrefixes(s.Sid, structure)

--- a/pkg/table/sid_validate_internal_test.go
+++ b/pkg/table/sid_validate_internal_test.go
@@ -611,4 +611,93 @@ func TestUSIDContainerOwner(t *testing.T) {
 		require.True(t, matched)
 		assert.Equal(t, "specific", owner)
 	})
+
+	t.Run("node-bits=0 locator resolves directly to its sole owner, not decomposed", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fc00:1::1"}, SIDStructure: &SIDStructure{LocalBlock: 32},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))
+		seg.USid = true
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched, "a node-bits=0 locator is a known, if non-decomposable, match")
+		assert.Equal(t, "X", owner)
+	})
+
+	t.Run("node-bits=0 locator advertised by two nodes degrades to owner unknown", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fc00:1::1"}, SIDStructure: &SIDStructure{LocalBlock: 32},
+		}}}
+		nodeY := &LsNode{RouterID: "Y", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fc00:1::2"}, SIDStructure: &SIDStructure{LocalBlock: 32},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))
+		seg.USid = true
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, ownerUnknown, owner, "conflicting owners for the same node-bits=0 locator must not be guessed")
+	})
+
+	t.Run("declared structure with node-bits=0 resolves to the matched locator's owner", func(t *testing.T) {
+		t.Parallel()
+
+		nodeX := &LsNode{RouterID: "X", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fc00:1::1"}, SIDStructure: &SIDStructure{LocalBlock: 32},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
+
+		seg := NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))
+		seg.USid = true
+		seg.Structure = SIDStructureBytes{32, 0, 16, 0}
+
+		owner, matched := idx.usidContainerOwner(seg)
+		require.True(t, matched)
+		assert.Equal(t, "X", owner)
+	})
+
+	t.Run("nested locator: a node-bits=0 umbrella and a more specific node-bits>0 locator resolve independently", func(t *testing.T) {
+		t.Parallel()
+
+		nodeUmbrella := &LsNode{RouterID: "umbrella", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb::1"}, SIDStructure: &SIDStructure{LocalBlock: 16},
+		}}}
+		nodeA := &LsNode{RouterID: "A", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0100::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		nodeB := &LsNode{RouterID: "B", SRv6SIDs: []*LsSrv6SID{{
+			Sids: []string{"fcbb:bb00:0200::"}, SIDStructure: &SIDStructure{LocalBlock: 32, LocalNode: 16},
+		}}}
+		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeUmbrella, nodeA, nodeB))
+
+		t.Run("address outside the nested locator falls back to the flat umbrella owner", func(t *testing.T) {
+			t.Parallel()
+
+			seg := NewSegmentSRv6(netip.MustParseAddr("fcbb::1"))
+			seg.USid = true
+
+			owner, matched := idx.usidContainerOwner(seg)
+			require.True(t, matched)
+			assert.Equal(t, "umbrella", owner)
+		})
+
+		t.Run("address within the nested locator still decomposes through the uSID chain", func(t *testing.T) {
+			t.Parallel()
+
+			seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200::"))
+			seg.USid = true
+
+			owner, matched := idx.usidContainerOwner(seg)
+			require.True(t, matched)
+			assert.Equal(t, "B", owner)
+		})
+	})
 }

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -1071,13 +1071,11 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		nodeA.Links = []*table.LsLink{{LocalNode: nodeA, RemoteNode: nodeB, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"fc00::a:b"}}}}
 		ted := newTestTED(nodeA, nodeB)
 
-		// A /32 locator has no node bits, so uSID matching is not authoritative.
-		// Fall back to exact-SID ownership.
+		// A /32 locator has no node bits and resolves directly to its owner.
 		err := table.ValidateExplicitPath(ted, testRouterIDB, []table.Segment{
 			usidContainerSeg("fc00::a:b", nil),
 		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "does not have adjacency SID")
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
## Description
<!-- What does this PR change, and why is it needed? -->

Fix uSID container ownership resolution for zero-node locators.

## Type of change
<!-- Check all that apply. -->
- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?
<!-- Commands run (e.g. `make test`, `make test-scenario`), and/or
example topologies verified.
-->

 `make ci`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed
