### PR TITLE
Unify SID Structure representations

### DIFF
--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"strconv"
 	"strings"
 	"time"
 
@@ -746,14 +745,12 @@ func segmentFromPB(s *pb.Segment) (table.Segment, error) {
 			return nil, err
 		}
 
-		structure, err := parseSidStructure(s.GetSidStructure())
+		structure, err := table.ParseSIDStructure(s.GetSidStructure())
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid SID structure for SID %q: %w", s.GetSid(), err)
 		}
 
-		if structure != nil {
-			v.Structure = table.SIDStructureBytes(structure)
-		}
+		v.Structure = structure
 
 		return v, nil
 	case table.SegmentSRMPLS:
@@ -787,35 +784,6 @@ func parseOptionalAddr(field, s string) (netip.Addr, error) {
 	}
 
 	return addr, nil
-}
-
-// parseSidStructure parses a comma-separated SID structure string and treats an empty string as unset.
-func parseSidStructure(s string) ([]uint8, error) {
-	if s == "" {
-		return nil, nil
-	}
-
-	parts := strings.Split(s, ",")
-	if len(parts) != 4 {
-		return nil, fmt.Errorf("expected 4 comma-separated values, got %d", len(parts))
-	}
-
-	result := make([]uint8, 4)
-
-	for i, p := range parts {
-		v, err := strconv.ParseUint(strings.TrimSpace(p), 10, 8)
-		if err != nil {
-			return nil, fmt.Errorf("part %d: %w", i, err)
-		}
-
-		result[i] = uint8(v)
-	}
-
-	if err := table.SIDStructureBytes(result).Validate(); err != nil {
-		return nil, fmt.Errorf("invalid SID structure %q: %w", s, err)
-	}
-
-	return result, nil
 }
 
 // CreateSRPolicy sends a create SR policy request to the PCE server.

--- a/cmd/pola/grpc/grpc_client_internal_test.go
+++ b/cmd/pola/grpc/grpc_client_internal_test.go
@@ -211,7 +211,7 @@ func TestSegmentFromPB_SRv6(t *testing.T) {
 	assert.Equal(t, "2001:db8:1005::", srv6Seg.SidString())
 	assert.Equal(t, "2001:db8::5", srv6Seg.LocalAddr.String())
 	assert.Equal(t, "2001:db8::6", srv6Seg.RemoteAddr.String())
-	assert.Equal(t, table.SIDStructureBytes{32, 16, 0, 80}, srv6Seg.Structure)
+	assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}, srv6Seg.Structure)
 }
 
 func TestSegmentFromPB_InvalidSID(t *testing.T) {
@@ -252,39 +252,6 @@ func TestSegmentFromPB_InvalidAddr(t *testing.T) {
 
 			_, err := segmentFromPB(tt.segment)
 			require.Error(t, err)
-		})
-	}
-}
-
-func TestParseSidStructure(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		in      string
-		want    []uint8
-		wantErr bool
-	}{
-		{name: "empty returns nil", in: "", want: nil},
-		{name: "valid", in: "32,16,0,80", want: []uint8{32, 16, 0, 80}},
-		{name: "wrong part count", in: "32,16,0", wantErr: true},
-		{name: "non-numeric part", in: "32,16,0,xx", wantErr: true},
-		{name: "value out of uint8 range", in: "32,16,0,256", wantErr: true},
-		{name: "sum exceeds 128 bits", in: "128,128,0,0", wantErr: true},
-		{name: "whitespace around parts is trimmed", in: " 32 , 16 , 0 , 80 ", want: []uint8{32, 16, 0, 80}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, err := parseSidStructure(tt.in)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/cmd/pola/ted_text_test.go
+++ b/cmd/pola/ted_text_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/nttcom/pola/pkg/table"
 )
 
 // fullTEDNodeViewFixture exercises the rendering branches in ted_text.go.
@@ -40,7 +42,7 @@ func fullTEDNodeViewFixture() tedNodeView {
 				Srv6EndXSID: &tedSrv6EndXSIDView{
 					EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
 					Sids:             []string{testSrv6EndXSID},
-					SidStructure:     &sidStructureView{LocalBlock: 21, LocalNode: 22, LocalFunc: 23, LocalArg: 24},
+					SidStructure:     &table.SIDStructure{LocalBlock: 21, LocalNode: 22, LocalFunc: 23, LocalArg: 24},
 				},
 			},
 		},
@@ -48,13 +50,13 @@ func fullTEDNodeViewFixture() tedNodeView {
 			{
 				Sids:             []string{"fc00:0:2:node1::"},
 				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-1"},
-				SidStructure:     &sidStructureView{LocalBlock: 31, LocalNode: 32, LocalFunc: 33, LocalArg: 34},
+				SidStructure:     &table.SIDStructure{LocalBlock: 31, LocalNode: 32, LocalFunc: 33, LocalArg: 34},
 				MultiTopoIDs:     []uint32{1},
 			},
 			{
 				Sids:             []string{"fc00:0:2:node2::"},
 				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-2", Flags: &flags, Algorithm: &algorithm},
-				SidStructure:     &sidStructureView{LocalBlock: 41, LocalNode: 42, LocalFunc: 43, LocalArg: 44},
+				SidStructure:     &table.SIDStructure{LocalBlock: 41, LocalNode: 42, LocalFunc: 43, LocalArg: 44},
 				MultiTopoIDs:     []uint32{2, 3},
 			},
 		},

--- a/cmd/pola/ted_view.go
+++ b/cmd/pola/ted_view.go
@@ -49,14 +49,14 @@ type tedMetricView struct {
 type tedSrv6SIDView struct {
 	Sids             []string             `json:"sids"`
 	EndpointBehavior endpointBehaviorView `json:"endpointBehavior"`
-	SidStructure     *sidStructureView    `json:"sidStructure,omitempty"`
+	SidStructure     *table.SIDStructure  `json:"sidStructure,omitempty"`
 	MultiTopoIDs     []uint32             `json:"multiTopoIds"`
 }
 
 type tedSrv6EndXSIDView struct {
 	EndpointBehavior endpointBehaviorView `json:"endpointBehavior"`
 	Sids             []string             `json:"sids"`
-	SidStructure     *sidStructureView    `json:"sidStructure,omitempty"`
+	SidStructure     *table.SIDStructure  `json:"sidStructure,omitempty"`
 }
 
 // endpointBehaviorView omits Flags and Algorithm for End.X SIDs, which carry only the behavior.
@@ -65,13 +65,6 @@ type endpointBehaviorView struct {
 	Name      string `json:"name"` // table.BehaviorToString
 	Flags     *uint8 `json:"flags,omitempty"`
 	Algorithm *uint8 `json:"algorithm,omitempty"`
-}
-
-type sidStructureView struct {
-	LocalBlock uint8 `json:"localBlock"`
-	LocalNode  uint8 `json:"localNode"`
-	LocalFunc  uint8 `json:"localFunc"`
-	LocalArg   uint8 `json:"localArg"`
 }
 
 // newTEDNodeViews returns views in router ID order for deterministic output.
@@ -186,7 +179,7 @@ func newTEDSrv6SIDViews(sids []*table.LsSrv6SID) []tedSrv6SIDView {
 		views = append(views, tedSrv6SIDView{
 			Sids:             s.Sids,
 			EndpointBehavior: endpointBehaviorViewFrom(s.EndpointBehavior),
-			SidStructure:     sidStructureViewFrom(s.SIDStructure),
+			SidStructure:     s.SIDStructure,
 			MultiTopoIDs:     s.MultiTopoIDs,
 		})
 	}
@@ -198,7 +191,7 @@ func newTEDSrv6EndXSIDView(s *table.Srv6EndXSID) tedSrv6EndXSIDView {
 	return tedSrv6EndXSIDView{
 		EndpointBehavior: endpointBehaviorViewFromBehavior(s.EndpointBehavior),
 		Sids:             s.Sids,
-		SidStructure:     sidStructureViewFrom(s.Srv6SIDStructure),
+		SidStructure:     s.Srv6SIDStructure,
 	}
 }
 
@@ -218,18 +211,5 @@ func endpointBehaviorViewFromBehavior(behavior uint16) endpointBehaviorView {
 	return endpointBehaviorView{
 		Behavior: behavior,
 		Name:     table.BehaviorToString(behavior),
-	}
-}
-
-func sidStructureViewFrom(s *table.SIDStructure) *sidStructureView {
-	if s == nil {
-		return nil
-	}
-
-	return &sidStructureView{
-		LocalBlock: s.LocalBlock,
-		LocalNode:  s.LocalNode,
-		LocalFunc:  s.LocalFunc,
-		LocalArg:   s.LocalArg,
 	}
 }

--- a/cmd/pola/ted_view_test.go
+++ b/cmd/pola/ted_view_test.go
@@ -116,9 +116,14 @@ func TestNewTEDSrv6SIDViews_SkipsNilEntries(t *testing.T) {
 	assert.Nil(t, views[0].SidStructure, "no SID Structure TLV was advertised")
 }
 
-func TestSidStructureViewFrom_DistinguishesAbsentFromPresentZero(t *testing.T) {
+func TestNewTEDSrv6SIDViews_DistinguishesAbsentFromPresentZero(t *testing.T) {
 	t.Parallel()
 
-	assert.Nil(t, sidStructureViewFrom(nil), "absent structure must not render as present-zero")
-	assert.Equal(t, &sidStructureView{}, sidStructureViewFrom(&table.SIDStructure{}), "present-but-zero structure must still render")
+	views := newTEDSrv6SIDViews([]*table.LsSrv6SID{
+		{Sids: []string{"fc00:0:1::"}},
+		{Sids: []string{"fc00:0:2::"}, SIDStructure: &table.SIDStructure{}},
+	})
+	require.Len(t, views, 2)
+	assert.Nil(t, views[0].SidStructure, "absent structure must not render as present-zero")
+	assert.Equal(t, &table.SIDStructure{}, views[1].SidStructure, "present-but-zero structure must still render")
 }

--- a/pkg/cspf/cspf_internal_test.go
+++ b/pkg/cspf/cspf_internal_test.go
@@ -54,7 +54,7 @@ func cspfInternalTestSRv6DefaultSeg(sid string) table.SegmentSRv6 {
 	return table.SegmentSRv6{
 		Sid:       addr,
 		LocalAddr: addr,
-		Structure: table.SIDStructureBytes{32, 16, 16, 0},
+		Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 	}
 }
 
@@ -288,7 +288,7 @@ func TestBuildWaypointSegment(t *testing.T) {
 			want: table.SegmentSRv6{
 				Sid:       netip.MustParseAddr(cspfInternalTestOverrideSID),
 				LocalAddr: netip.MustParseAddr("2001:db8::a"),
-				Structure: table.SIDStructureBytes{32, 16, 16, 0},
+				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 			},
 		},
 		{
@@ -308,7 +308,7 @@ func TestBuildWaypointSegment(t *testing.T) {
 			want: table.SegmentSRv6{
 				Sid:       netip.MustParseAddr(cspfInternalTestOverrideSID),
 				LocalAddr: netip.MustParseAddr("2001:db8::a"),
-				Structure: table.SIDStructureBytes{32, 16, 16, 0},
+				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 				USid:      true,
 			},
 		},

--- a/pkg/cspf/cspf_test.go
+++ b/pkg/cspf/cspf_test.go
@@ -58,7 +58,7 @@ func srv6DefaultSeg(sid string) table.SegmentSRv6 {
 	return table.SegmentSRv6{
 		Sid:       addr,
 		LocalAddr: addr,
-		Structure: table.SIDStructureBytes{32, 16, 16, 0},
+		Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 	}
 }
 
@@ -387,7 +387,7 @@ func TestWithLooseSourceRouting(t *testing.T) {
 			table.SegmentSRv6{
 				Sid:       netip.MustParseAddr("2001:db8::2ff"),
 				LocalAddr: netip.MustParseAddr("2001:db8::2"),
-				Structure: table.SIDStructureBytes{32, 16, 16, 0},
+				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 			},
 			srv6DefaultSeg("2001:db8::3"),
 		}

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1617,15 +1617,17 @@ func (o *SRv6EroSubobject) DecodeFromBytes(subobject []uint8) error {
 			return errors.New("SRv6EroSubobject: truncated SID-Structure")
 		}
 
-		o.Segment.Structure = []uint8{
-			subobject[off+0],
-			subobject[off+1],
-			subobject[off+2],
-			subobject[off+3],
+		structure := &table.SIDStructure{
+			LocalBlock: subobject[off+0],
+			LocalNode:  subobject[off+1],
+			LocalFunc:  subobject[off+2],
+			LocalArg:   subobject[off+3],
 		}
-		if err := o.Segment.Structure.Validate(); err != nil {
+		if err := structure.Validate(); err != nil {
 			return fmt.Errorf("SRv6EroSubobject: invalid SID structure: %w", err)
 		}
+
+		o.Segment.Structure = structure
 
 		off += 8
 	}
@@ -1731,8 +1733,8 @@ func (o *SRv6EroSubobject) Serialize() ([]uint8, error) {
 	}
 
 	byteSidStructure := []uint8{}
-	if o.Segment.Structure != nil {
-		byteSidStructure = append(byteSidStructure, o.Segment.Structure...)
+	if s := o.Segment.Structure; s != nil {
+		byteSidStructure = append(byteSidStructure, s.LocalBlock, s.LocalNode, s.LocalFunc, s.LocalArg)
 		byteSidStructure = append(byteSidStructure, make([]uint8, 4)...)
 	}
 
@@ -1786,11 +1788,7 @@ func NewSRv6EroSubobject(seg table.SegmentSRv6) (*SRv6EroSubobject, error) {
 		return nil, fmt.Errorf("SegmentSRv6: invalid SID structure: %w", err)
 	}
 
-	if len(seg.Structure) == 0 {
-		subo.Segment.Structure = nil
-	}
-
-	subo.TFlag = len(subo.Segment.Structure) > 0
+	subo.TFlag = subo.Segment.Structure != nil
 
 	local, remote := seg.LocalAddr.Unmap(), seg.RemoteAddr.Unmap()
 	switch {

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -485,7 +485,7 @@ func TestSRv6EroSubobject_RoundTrip(t *testing.T) {
 			TFlag:         true,
 			Segment: table.SegmentSRv6{
 				Sid: sid, LocalAddr: local, USid: true,
-				Structure: []uint8{32, 16, 16, 0},
+				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 			},
 		},
 		"LFlag_IPv6Node": {
@@ -2094,7 +2094,7 @@ func TestNewSRv6EroSubobject_NAIFromSegment(t *testing.T) {
 			wantNAIType: pcep.NAITypeSRv6IPv6AdjacencyGlobal,
 		},
 		"WithStructure": {
-			seg:         table.SegmentSRv6{Sid: sid, LocalAddr: local, Structure: []uint8{32, 16, 16, 0}},
+			seg:         table.SegmentSRv6{Sid: sid, LocalAddr: local, Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16}},
 			wantNAIType: pcep.NAITypeSRv6IPv6Node, wantTFlag: true,
 		},
 	}
@@ -2169,18 +2169,18 @@ func TestNewSRv6EroSubobject_StructureValidation(t *testing.T) {
 	sid := netip.MustParseAddr("fc00:0:1::")
 	local := netip.MustParseAddr(testIPv6Addr1)
 
-	t.Run("EmptyStructureIsAbsent", func(t *testing.T) {
+	t.Run("NilStructureIsAbsent", func(t *testing.T) {
 		t.Parallel()
 
-		subo, err := pcep.NewSRv6EroSubobject(table.SegmentSRv6{Sid: sid, LocalAddr: local, Structure: []uint8{}})
+		subo, err := pcep.NewSRv6EroSubobject(table.SegmentSRv6{Sid: sid, LocalAddr: local})
 		require.NoError(t, err)
 		assert.False(t, subo.TFlag)
 	})
 
-	t.Run("InvalidLengthRejected", func(t *testing.T) {
+	t.Run("SumExceeding128BitsRejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := pcep.NewSRv6EroSubobject(table.SegmentSRv6{Sid: sid, LocalAddr: local, Structure: []uint8{32, 16, 16}})
+		_, err := pcep.NewSRv6EroSubobject(table.SegmentSRv6{Sid: sid, LocalAddr: local, Structure: &table.SIDStructure{LocalBlock: 64, LocalNode: 64, LocalFunc: 1}})
 		assert.Error(t, err)
 	})
 }

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -371,8 +371,8 @@ func convertSegment(seg table.Segment) *pb.Segment {
 			pbSeg.RemoteAddr = v.RemoteAddr.String()
 		}
 
-		if len(v.Structure) == 4 {
-			pbSeg.SidStructure = fmt.Sprintf("%d,%d,%d,%d", v.Structure[0], v.Structure[1], v.Structure[2], v.Structure[3])
+		if s := v.Structure; s != nil {
+			pbSeg.SidStructure = fmt.Sprintf("%d,%d,%d,%d", s.LocalBlock, s.LocalNode, s.LocalFunc, s.LocalArg)
 		}
 	case table.SegmentSRMPLS:
 		if v.LocalAddr.IsValid() {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -155,32 +155,13 @@ func validateCreateSRPolicy(req *pb.CreateSRPolicyRequest, disablePathCompute bo
 
 // parseSidStructure parses a comma-separated SID structure (e.g. "32,16,0,80").
 // It returns nil for empty input.
-func parseSidStructure(s string) ([]uint8, error) {
-	if s == "" {
-		return nil, nil
+func parseSidStructure(s string) (*table.SIDStructure, error) {
+	structure, err := table.ParseSIDStructure(s)
+	if err != nil {
+		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "%s", err.Error())
 	}
 
-	parts := strings.Split(s, ",")
-	if len(parts) != 4 {
-		return nil, fmt.Errorf("invalid SID structure %q", s)
-	}
-
-	result := make([]uint8, 4)
-
-	for i, p := range parts {
-		v, err := strconv.ParseUint(strings.TrimSpace(p), 10, 8)
-		if err != nil {
-			return nil, fmt.Errorf("invalid SID structure %q: %w", s, err)
-		}
-
-		result[i] = uint8(v)
-	}
-
-	if err := table.SIDStructureBytes(result).Validate(); err != nil {
-		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid SID structure %q: %s", s, err.Error())
-	}
-
-	return result, nil
+	return structure, nil
 }
 
 // enrichSRv6Segment applies gRPC overrides to an SRv6 segment.
@@ -192,7 +173,7 @@ func enrichSRv6Segment(srv6Seg table.SegmentSRv6, segment *pb.Segment, usidMode 
 	if structure, err := parseSidStructure(segment.GetSidStructure()); err != nil {
 		return srv6Seg, err
 	} else if structure != nil {
-		srv6Seg.Structure = table.SIDStructureBytes(structure)
+		srv6Seg.Structure = structure
 	}
 
 	if s := segment.GetLocalAddr(); s != "" {

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -177,7 +177,7 @@ func TestNewEnrichedSegmentSRv6(t *testing.T) {
 		assert.Equal(t, "2001:db8:1005::", srv6Seg.Sid.String(), "Sid")
 		assert.Equal(t, "2001:db8::5", addrString(srv6Seg.LocalAddr), "LocalAddr")
 		assert.Equal(t, "2001:db8::6", addrString(srv6Seg.RemoteAddr), "RemoteAddr")
-		assert.Equal(t, table.SIDStructureBytes{32, 16, 0, 80}, srv6Seg.Structure, "Structure")
+		assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}, srv6Seg.Structure, "Structure")
 		assert.Equalf(t, usidMode, srv6Seg.USid, "USid with usidMode=%v", usidMode)
 	}
 }
@@ -1121,7 +1121,7 @@ func TestConvertSegment_CarriesSRv6NAIAndStructure(t *testing.T) {
 		Sid:        sid,
 		LocalAddr:  netip.MustParseAddr("2001:db8::5"),
 		RemoteAddr: netip.MustParseAddr("2001:db8::6"),
-		Structure:  table.SIDStructureBytes{32, 16, 0, 80},
+		Structure:  &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80},
 	}
 
 	pbSeg := convertSegment(seg)
@@ -1774,11 +1774,11 @@ func TestParseSidStructure(t *testing.T) {
 	tests := []struct {
 		name    string
 		in      string
-		want    []uint8
+		want    *table.SIDStructure
 		wantErr bool
 	}{
 		{name: "empty string", in: "", want: nil},
-		{name: "valid", in: "32,16,0,80", want: []uint8{32, 16, 0, 80}},
+		{name: "valid", in: "32,16,0,80", want: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}},
 		{name: "wrong part count", in: "1,2,3", wantErr: true},
 		{name: "non-numeric part", in: "1,2,3,x", wantErr: true},
 		{name: "value out of uint8 range", in: "1,2,3,256", wantErr: true},

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -2267,7 +2267,7 @@ func (ss *Session) SRPolicies() []*table.SRPolicy {
 		clone.SegmentList = slices.Clone(p.SegmentList)
 		for j, seg := range clone.SegmentList {
 			if srv6, ok := seg.(table.SegmentSRv6); ok {
-				srv6.Structure = slices.Clone(srv6.Structure)
+				srv6.Structure = srv6.Structure.Clone()
 				clone.SegmentList[j] = srv6
 			}
 		}

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -191,7 +191,7 @@ func TestSRPolicies_SnapshotSRv6StructureIsIndependent(t *testing.T) {
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 
 	srv6Seg := table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1005::"))
-	srv6Seg.Structure = table.SIDStructureBytes{32, 16, 0, 80}
+	srv6Seg.Structure = &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}
 	ss.srPolicies = append(ss.srPolicies, table.NewSRPolicy(1, "pe01-policy1", []table.Segment{srv6Seg}, netip.MustParseAddr("10.255.0.1"), netip.MustParseAddr("10.255.0.2"), 0, 0, 0, table.PolicyUp))
 
 	policies := ss.SRPolicies()
@@ -201,14 +201,14 @@ func TestSRPolicies_SnapshotSRv6StructureIsIndependent(t *testing.T) {
 	snapshotSeg, ok := policies[0].SegmentList[0].(table.SegmentSRv6)
 	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRv6", policies[0].SegmentList[0])
 
-	snapshotSeg.Structure[0] = 99
+	snapshotSeg.Structure.LocalBlock = 99
 
 	got, found := ss.SearchSRPolicy(1)
 	require.True(t, found, "SR Policy was not registered")
 
 	gotSeg, ok := got.SegmentList[0].(table.SegmentSRv6)
 	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRv6", got.SegmentList[0])
-	assert.Equal(t, table.SIDStructureBytes{32, 16, 0, 80}, gotSeg.Structure,
+	assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}, gotSeg.Structure,
 		"mutating the snapshot's SegmentSRv6.Structure changed the session's SR Policy")
 }
 

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -282,8 +282,8 @@ func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
 	}
 
 	declaredLocBits := -1
-	if len(s.Structure) == 4 {
-		declaredLocBits = int(s.Structure[0]) + int(s.Structure[1])
+	if s.Structure != nil {
+		declaredLocBits = int(s.Structure.LocalBlock) + int(s.Structure.LocalNode)
 	}
 
 	_, found := idx.lookupSRv6Locator(s.Sid, declaredLocBits)
@@ -460,10 +460,10 @@ func usidSetBit(b *[16]byte, pos int, v bool) {
 // terminating owner cannot be determined unambiguously.
 func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bool) {
 	declaredLocBits := -1
-	hasDeclared := len(s.Structure) == 4
+	hasDeclared := s.Structure != nil
 
 	if hasDeclared {
-		declaredLocBits = int(s.Structure[0]) + int(s.Structure[1])
+		declaredLocBits = int(s.Structure.LocalBlock) + int(s.Structure.LocalNode)
 	}
 
 	locInfo, found := idx.lookupSRv6Locator(s.Sid, declaredLocBits)
@@ -477,9 +477,9 @@ func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bo
 	case hasDeclared:
 		// The SID's declared structure takes precedence over the locator's.
 		structure = srv6Structure{
-			blockBits: int(s.Structure[0]),
-			nodeBits:  int(s.Structure[1]),
-			funcBits:  int(s.Structure[2]),
+			blockBits: int(s.Structure.LocalBlock),
+			nodeBits:  int(s.Structure.LocalNode),
+			funcBits:  int(s.Structure.LocalFunc),
 		}
 	case !locInfo.structureKnown:
 		return ownerUnknown, true

--- a/pkg/table/sid_validate_internal_test.go
+++ b/pkg/table/sid_validate_internal_test.go
@@ -420,7 +420,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -440,7 +440,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -458,7 +458,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -478,7 +478,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -495,7 +495,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fd00:bb00:0100:0200:0300::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
 		_, matched := idx.usidContainerOwner(seg)
 		assert.False(t, matched)
@@ -512,7 +512,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		// The first micro-segment is all zero, marking the container end (RFC 9800 §5).
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0000::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -532,7 +532,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -567,7 +567,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 16, 0, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)
@@ -657,7 +657,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 
 		seg := NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))
 		seg.USid = true
-		seg.Structure = SIDStructureBytes{32, 0, 16, 0}
+		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 0, LocalFunc: 16, LocalArg: 0}
 
 		owner, matched := idx.usidContainerOwner(seg)
 		require.True(t, matched)

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -271,7 +271,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 
 		seg := table.NewSegmentSRv6(container)
 		seg.USid = true
-		seg.Structure = []uint8{32, 16, 0, 0}
+		seg.Structure = &table.SIDStructure{LocalBlock: 32, LocalNode: 16}
 		assert.True(t, table.NewSIDIndex(ted).Has(seg), "expected uSID container to be accepted via locator containment")
 	})
 
@@ -290,7 +290,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 		seg.USid = true
 		// Declares a /32 locator (block=24,node=8), which contradicts the /48
 		// the TED actually advertises.
-		seg.Structure = []uint8{24, 8, 16, 0}
+		seg.Structure = &table.SIDStructure{LocalBlock: 24, LocalNode: 8, LocalFunc: 16}
 		assert.False(t, table.NewSIDIndex(ted).Has(seg), "expected mismatch when declared locator is shorter than TED advertised")
 	})
 
@@ -299,7 +299,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 
 		seg := table.NewSegmentSRv6(container)
 		seg.USid = true
-		seg.Structure = []uint8{0, 0, 48, 0}
+		seg.Structure = &table.SIDStructure{LocalFunc: 48}
 		assert.False(t, table.NewSIDIndex(ted).Has(seg), "expected declared zero-width locator not to match an unrelated enclosing TED locator")
 	})
 
@@ -871,7 +871,7 @@ func usidLocatorNode(routerID, sid string, remote *table.LsNode, endXSid string)
 	return node
 }
 
-func usidContainerSeg(addr string, structure []uint8) table.Segment {
+func usidContainerSeg(addr string, structure *table.SIDStructure) table.Segment {
 	seg := table.NewSegmentSRv6(netip.MustParseAddr(addr))
 	seg.USid = true
 	seg.Structure = structure
@@ -896,7 +896,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
+			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
 		})
 		require.NoError(t, err)
@@ -910,7 +910,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg("fcbb:bb00:0100::", []uint8{32, 16, 0, 0}),
+			usidContainerSeg("fcbb:bb00:0100::", &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
 		})
 		require.NoError(t, err)
@@ -926,7 +926,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX, nodeY, nodeZ)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
+			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW3)),
 		})
 		require.NoError(t, err)
@@ -942,7 +942,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX, nodeY, nodeZ)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
+			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
 		})
 		require.Error(t, err)
@@ -959,7 +959,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeW, nodeX, nodeZ)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
+			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
 			table.NewSegmentSRv6(netip.MustParseAddr(endXToW3)),
 		})
 		require.NoError(t, err)
@@ -973,7 +973,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeX, nodeZ)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{32, 16, 0, 0}),
+			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
 			table.NewSegmentSRv6(netip.MustParseAddr("fd00::dead:beef")),
 		})
 		require.Error(t, err)
@@ -987,7 +987,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg("fd00:bb00:0100:0200:0300::", []uint8{32, 16, 0, 0}),
+			usidContainerSeg("fd00:bb00:0100:0200:0300::", &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in TED")
@@ -1000,7 +1000,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg(container, []uint8{24, 8, 16, 0}),
+			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 24, LocalNode: 8, LocalFunc: 16}),
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in TED")
@@ -1047,7 +1047,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			usidContainerSeg("fd00:bb00:0100::", []uint8{32, 0, 16, 0}),
+			usidContainerSeg("fd00:bb00:0100::", &table.SIDStructure{LocalBlock: 32, LocalFunc: 16}),
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in TED")

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -6,13 +6,10 @@
 package table
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/netip"
-	"slices"
 	"strconv"
-	"strings"
 )
 
 // PolicyState represents the state of an SR Policy.
@@ -201,49 +198,13 @@ func BehaviorToString(behavior uint16) string {
 // FirstSIDIndex is the index for the first SID in the SRv6 SID array.
 const FirstSIDIndex = 0
 
-// SIDStructureBytes is the [LocalBlock, LocalNode, LocalFunc, LocalArg] length split of an SRv6 SID.
-// It marshals as a comma-separated string (e.g. "32,16,0,80").
-type SIDStructureBytes []uint8
-
-// MarshalJSON returns the JSON representation of SIDStructureBytes as a comma-separated string.
-func (s SIDStructureBytes) MarshalJSON() ([]byte, error) {
-	if len(s) == 0 {
-		return json.Marshal(nil)
-	}
-
-	parts := make([]string, len(s))
-	for i, v := range s {
-		parts[i] = strconv.Itoa(int(v))
-	}
-
-	return json.Marshal(strings.Join(parts, ","))
-}
-
-// Validate checks the SID structure lengths.
-func (s SIDStructureBytes) Validate() error {
-	if len(s) == 0 {
-		return nil
-	}
-
-	if len(s) != 4 {
-		return fmt.Errorf("SID structure must have 4 elements, got %d", len(s))
-	}
-
-	sum := int(s[0]) + int(s[1]) + int(s[2]) + int(s[3])
-	if sum > SRv6SIDBitLength {
-		return fmt.Errorf("SID structure sum %d exceeds %d bits", sum, SRv6SIDBitLength)
-	}
-
-	return nil
-}
-
 // SegmentSRv6 represents an SRv6 segment.
 type SegmentSRv6 struct {
-	Sid        netip.Addr        `json:"sid"`
-	LocalAddr  netip.Addr        `json:"localAddr,omitzero"`
-	RemoteAddr netip.Addr        `json:"remoteAddr,omitzero"`
-	Structure  SIDStructureBytes `json:"sidStructure,omitempty"`
-	USid       bool              `json:"uSid,omitempty"`
+	Sid        netip.Addr    `json:"sid"`
+	LocalAddr  netip.Addr    `json:"localAddr,omitzero"`
+	RemoteAddr netip.Addr    `json:"remoteAddr,omitzero"`
+	Structure  *SIDStructure `json:"sidStructure,omitempty"`
+	USid       bool          `json:"uSid,omitempty"`
 }
 
 // SidString returns the SRv6 SID as a string.
@@ -299,14 +260,7 @@ func NewSegmentSRv6WithNodeInfo(sid netip.Addr, n *LsNode) (SegmentSRv6, error) 
 
 		seg.LocalAddr = addr
 
-		if srv6SID.SIDStructure != nil {
-			seg.Structure = SIDStructureBytes{
-				srv6SID.SIDStructure.LocalBlock,
-				srv6SID.SIDStructure.LocalNode,
-				srv6SID.SIDStructure.LocalFunc,
-				srv6SID.SIDStructure.LocalArg,
-			}
-		}
+		seg.Structure = srv6SID.SIDStructure.Clone()
 
 		if IsUSidBehavior(srv6SID.EndpointBehavior.Behavior) {
 			seg.USid = true
@@ -360,7 +314,7 @@ func (seg SegmentSRv6) Equal(other SegmentSRv6) bool {
 		seg.LocalAddr == other.LocalAddr &&
 		seg.RemoteAddr == other.RemoteAddr &&
 		seg.USid == other.USid &&
-		slices.Equal(seg.Structure, other.Structure)
+		seg.Structure.Equal(other.Structure)
 }
 
 // Equal reports whether this SR-MPLS segment is equal to another.

--- a/pkg/table/sr_policy_test.go
+++ b/pkg/table/sr_policy_test.go
@@ -6,6 +6,7 @@
 package table_test
 
 import (
+	"encoding/json"
 	"net/netip"
 	"testing"
 
@@ -122,13 +123,13 @@ func TestSegmentsEqual(t *testing.T) {
 			name: "SRv6 same SID with different Structure",
 			a: func() table.SegmentSRv6 {
 				s := newTestSegmentSRv6("", "")
-				s.Structure = table.SIDStructureBytes{1, 2, 3, 4}
+				s.Structure = &table.SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4}
 
 				return s
 			}(),
 			b: func() table.SegmentSRv6 {
 				s := newTestSegmentSRv6("", "")
-				s.Structure = table.SIDStructureBytes{5, 6, 7, 8}
+				s.Structure = &table.SIDStructure{LocalBlock: 5, LocalNode: 6, LocalFunc: 7, LocalArg: 8}
 
 				return s
 			}(),
@@ -284,25 +285,33 @@ func TestBehaviorToString(t *testing.T) {
 	}
 }
 
-func TestSIDStructureBytesMarshalJSON(t *testing.T) {
+func TestSegmentSRv6_StructureMarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name string
-		s    table.SIDStructureBytes
+		s    *table.SIDStructure
 		want string
 	}{
-		{"nil structure", nil, "null"},
-		{"empty structure", table.SIDStructureBytes{}, "null"},
-		{"populated structure", table.SIDStructureBytes{32, 16, 0, 80}, `"32,16,0,80"`},
+		{"not declared", nil, ""},
+		{"declared, all zero", &table.SIDStructure{}, `{"localBlock":0,"localNode":0,"localFunc":0,"localArg":0}`},
+		{"declared", &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}, `{"localBlock":32,"localNode":16,"localFunc":0,"localArg":80}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			b, err := tt.s.MarshalJSON()
+			seg := newTestSegmentSRv6(testSRv6Addr, "")
+			seg.Structure = tt.s
+
+			b, err := json.Marshal(seg)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, string(b))
+
+			var got struct {
+				SidStructure json.RawMessage `json:"sidStructure"`
+			}
+			require.NoError(t, json.Unmarshal(b, &got))
+			assert.Equal(t, tt.want, string(got.SidStructure))
 		})
 	}
 }
@@ -386,18 +395,17 @@ func TestIsUSidBehavior(t *testing.T) {
 	}
 }
 
-func TestSIDStructureBytes_Validate(t *testing.T) {
+func TestSIDStructure_Validate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name    string
-		s       table.SIDStructureBytes
+		s       *table.SIDStructure
 		wantErr bool
 	}{
-		{name: "nil structure", s: nil},
-		{name: "sum is 128", s: table.SIDStructureBytes{32, 32, 32, 32}},
-		{name: "sum exceeds 128", s: table.SIDStructureBytes{32, 32, 32, 33}, wantErr: true},
-		{name: "wrong element count", s: table.SIDStructureBytes{32, 32, 32}, wantErr: true},
+		{name: "nil (not advertised/declared)", s: nil},
+		{name: "sum is 128", s: &table.SIDStructure{LocalBlock: 32, LocalNode: 32, LocalFunc: 32, LocalArg: 32}},
+		{name: "sum exceeds 128", s: &table.SIDStructure{LocalBlock: 32, LocalNode: 32, LocalFunc: 32, LocalArg: 33}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -437,7 +445,7 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 			want: table.SegmentSRv6{
 				Sid:       netip.MustParseAddr("2001:db8::1"),
 				LocalAddr: netip.MustParseAddr(testSRv6Addr),
-				Structure: table.SIDStructureBytes{32, 16, 16, 0},
+				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 				USid:      false,
 			},
 		},
@@ -455,7 +463,7 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 			want: table.SegmentSRv6{
 				Sid:       netip.MustParseAddr("2001:db8::1"),
 				LocalAddr: netip.MustParseAddr("fcbb:bb00:0100::"),
-				Structure: table.SIDStructureBytes{32, 16, 0, 0},
+				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16},
 				USid:      true,
 			},
 		},

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
+	"strconv"
+	"strings"
 )
 
 // LsTED represents a Traffic Engineering Database built from BGP-LS data.
@@ -466,12 +468,81 @@ func (lp *LsPrefix) UpdateTED(ted *LsTED, cfgASN uint32) {
 	localNode.Prefixes = append(localNode.Prefixes, lp)
 }
 
-// SIDStructure represents the structure breakdown of an SRv6 SID.
+// SIDStructure is the LocalBlock, LocalNode, LocalFunc, LocalArg length split
+// of an SRv6 SID (RFC 9603 §4.1).
+//
+// A nil value indicates that no structure was advertised or declared;
+// an all-zero value is a valid, explicitly declared structure.
 type SIDStructure struct {
-	LocalBlock uint8
-	LocalNode  uint8
-	LocalFunc  uint8
-	LocalArg   uint8
+	LocalBlock uint8 `json:"localBlock"`
+	LocalNode  uint8 `json:"localNode"`
+	LocalFunc  uint8 `json:"localFunc"`
+	LocalArg   uint8 `json:"localArg"`
+}
+
+// Validate checks that the structure fits within an SRv6 SID.
+func (s *SIDStructure) Validate() error {
+	if s == nil {
+		return nil
+	}
+
+	if sum := int(s.LocalBlock) + int(s.LocalNode) + int(s.LocalFunc) + int(s.LocalArg); sum > SRv6SIDBitLength {
+		return fmt.Errorf("SID structure sum %d exceeds %d bits", sum, SRv6SIDBitLength)
+	}
+
+	return nil
+}
+
+// Clone returns a copy of s.
+func (s *SIDStructure) Clone() *SIDStructure {
+	if s == nil {
+		return nil
+	}
+
+	c := *s
+
+	return &c
+}
+
+// Equal reports whether s and other represent the same SID structure.
+// A nil value is distinct from a zero-valued structure.
+func (s *SIDStructure) Equal(other *SIDStructure) bool {
+	if s == nil || other == nil {
+		return s == other
+	}
+
+	return *s == *other
+}
+
+// ParseSIDStructure parses a comma-separated SID structure
+// (e.g. "32,16,0,80"). An empty string returns nil.
+func ParseSIDStructure(s string) (*SIDStructure, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(s, ",")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("SID structure %q must have 4 comma-separated elements, got %d", s, len(parts))
+	}
+
+	var vals [4]uint8
+
+	for i, p := range parts {
+		v, err := strconv.ParseUint(strings.TrimSpace(p), 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid SID structure %q: %w", s, err)
+		}
+
+		vals[i] = uint8(v)
+	}
+
+	st := &SIDStructure{LocalBlock: vals[0], LocalNode: vals[1], LocalFunc: vals[2], LocalArg: vals[3]}
+	if err := st.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid SID structure %q: %w", s, err)
+	}
+
+	return st, nil
 }
 
 // EndpointBehavior represents the endpoint behavior attributes of an SRv6 SID.
@@ -575,8 +646,7 @@ func (m MetricType) String() string {
 	}
 }
 
-// DisplayString renders the metric as a short lowercase token (e.g. "igp"), used
-// for human-facing CLI output (unlike String()'s "METRIC_TYPE_..." form).
+// DisplayString returns the metric type as a lowercase string for display.
 func (m MetricType) DisplayString() string {
 	switch m {
 	case IGPMetric:
@@ -592,8 +662,7 @@ func (m MetricType) DisplayString() string {
 	}
 }
 
-// MarshalJSON renders the metric as a short lowercase token (e.g. "igp"), consistent
-// with the other lowercase enum-like fields on SRPolicy (e.g. State).
+// MarshalJSON returns the metric type as a lowercase JSON string.
 func (m MetricType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.DisplayString())
 }

--- a/pkg/table/ted_test.go
+++ b/pkg/table/ted_test.go
@@ -738,3 +738,54 @@ type errorWriter struct{}
 func (errorWriter) Write([]byte) (int, error) {
 	return 0, assert.AnError
 }
+
+func TestParseSIDStructure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		want    *table.SIDStructure
+		wantErr bool
+	}{
+		{name: "empty string means not declared", in: "", want: nil},
+		{name: "valid", in: "32,16,0,80", want: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}},
+		{name: "wrong part count", in: "32,16,0", wantErr: true},
+		{name: "non-numeric part", in: "32,16,0,xx", wantErr: true},
+		{name: "value out of uint8 range", in: "32,16,0,256", wantErr: true},
+		{name: "sum exceeds 128 bits", in: "128,128,0,0", wantErr: true},
+		{name: "whitespace around parts is trimmed", in: " 32 , 16 , 0 , 80 ", want: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := table.ParseSIDStructure(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSIDStructure_CloneAndEqual(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, (*table.SIDStructure)(nil).Clone())
+
+	st := &table.SIDStructure{LocalBlock: 32, LocalNode: 16}
+	clone := st.Clone()
+	require.NotNil(t, clone)
+	assert.NotSame(t, st, clone)
+	assert.Equal(t, st, clone)
+
+	assert.True(t, st.Equal(clone))
+	assert.False(t, st.Equal(nil))
+	assert.False(t, (*table.SIDStructure)(nil).Equal(st))
+	assert.True(t, (*table.SIDStructure)(nil).Equal(nil))
+	assert.False(t, st.Equal(&table.SIDStructure{LocalBlock: 1}))
+}


### PR DESCRIPTION
## Description
Unify SRv6 SID Structure handling around `*SIDStructure.`

- Replace `SIDStructureBytes` with `*SIDStructure`
- Centralize parsing and validation in `pkg/table`
- Preserve nil vs. explicitly declared zero-value semantics
- Clone SID structures when creating independent snapshots/segments

## Type of change
<!-- Check all that apply. -->
- [ ] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?
<!-- Commands run (e.g. `make test`, `make test-scenario`), and/or
example topologies verified.
-->

`make test-scenario-parallel`

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [ ] Documentation updated if needed
