### PR TITLE
Fix integer conversion in SidString

### DIFF
--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -293,7 +293,7 @@ type SegmentSRMPLS struct {
 
 // SidString returns the SR-MPLS SID as a string.
 func (seg SegmentSRMPLS) SidString() string {
-	return strconv.Itoa(int(seg.Sid))
+	return strconv.FormatUint(uint64(seg.Sid), 10)
 }
 
 // HasMPLSStackEntryAttrs reports whether the SR-MPLS segment has any MPLS stack entry attributes set.


### PR DESCRIPTION
## Description
<!-- What does this PR change, and why is it needed? -->

Fix SidString() to correctly format the unsigned SID without converting it to int.



## Type of change
<!-- Check all that apply. -->
- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Build / CI

## How was this tested?
<!-- Commands run (e.g. `make test`, `make test-scenario`), and/or
example topologies verified.
-->

make ci

## Checklist

- [x] `make ci` passes locally
- [ ] Tests added or updated if needed
- [ ] Documentation updated if needed
