### PR TITLE
Support IPv6 and IPv4/IPv6 dual-stack underlay

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,12 +97,11 @@ diff coverage: 99.3% (2371/2388 changed instrumented lines covered since 318d86a
 
 Then use `make test-coverage-html` to see those lines in context.
 
-Notes:
-
-* Comparison starts at the merge base of your branch and `DIFF_BASE` (default `origin/develop`) — the same changes a PR shows under "Files changed".
-* Coverage is measured against your working tree, not `HEAD`, so uncommitted changes to tracked files are included. Untracked files must be staged with `git add` to be included.
-* Only instrumented lines count (Go skips declarations, comments, blanks, closing braces).
-* Threshold is `DIFF_COVER_MIN` (default `90`). Override with `make test-coverage-diff DIFF_BASE=origin/develop DIFF_COVER_MIN=85`.
+> [!NOTE]
+> * Comparison starts at the merge base of your branch and `DIFF_BASE` (default `origin/develop`) — the same changes a PR shows under "Files changed".
+> * Coverage is measured against your working tree, not `HEAD`, so uncommitted changes to tracked files are included. Untracked files must be staged with `git add` to be included.
+> * Only instrumented lines count (Go skips declarations, comments, blanks, closing braces).
+> * Threshold is `DIFF_COVER_MIN` (default `90`). Override with `make test-coverage-diff DIFF_BASE=origin/develop DIFF_COVER_MIN=85`.
 
 For untestable lines, mention it in the PR rather than working around the check.
 
@@ -136,5 +135,6 @@ make clean
 
 ### Notes
 
-* The authoritative list of targets and behavior is in [Makefile](Makefile).
-* Docker image runtime examples are documented in [build/package/README.md](build/package/README.md).
+> [!NOTE]
+> * The authoritative list of targets and behavior is in [Makefile](Makefile).
+> * Docker image runtime examples are documented in [build/package/README.md](build/package/README.md).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and a PCEP Library in Go.
 ## Features
 
 * Support for SRv6 (full-SID/uSID) and SR-MPLS
+* IPv4 / IPv6 underlay support, including dual-stack topologies
 * Implementation of active stateful PCE functionality (PCInitiate, PCUpdate, etc.)
 * Dynamic and explicit SR policy definition using YAML
   * Dynamic path: Utilizes CSPF with GoBGP BGP-LS TED

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -124,55 +124,6 @@ func (DataPlane) EnumDescriptor() ([]byte, []int) {
 	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{1}
 }
 
-type SRPolicyType int32
-
-const (
-	SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED SRPolicyType = 0
-	SRPolicyType_SR_POLICY_TYPE_EXPLICIT    SRPolicyType = 1
-	SRPolicyType_SR_POLICY_TYPE_DYNAMIC     SRPolicyType = 2
-)
-
-// Enum value maps for SRPolicyType.
-var (
-	SRPolicyType_name = map[int32]string{
-		0: "SR_POLICY_TYPE_UNSPECIFIED",
-		1: "SR_POLICY_TYPE_EXPLICIT",
-		2: "SR_POLICY_TYPE_DYNAMIC",
-	}
-	SRPolicyType_value = map[string]int32{
-		"SR_POLICY_TYPE_UNSPECIFIED": 0,
-		"SR_POLICY_TYPE_EXPLICIT":    1,
-		"SR_POLICY_TYPE_DYNAMIC":     2,
-	}
-)
-
-func (x SRPolicyType) Enum() *SRPolicyType {
-	p := new(SRPolicyType)
-	*p = x
-	return p
-}
-
-func (x SRPolicyType) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (SRPolicyType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[2].Descriptor()
-}
-
-func (SRPolicyType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[2]
-}
-
-func (x SRPolicyType) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use SRPolicyType.Descriptor instead.
-func (SRPolicyType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
-}
-
 type SRPolicyState int32
 
 const (
@@ -212,11 +163,11 @@ func (x SRPolicyState) String() string {
 }
 
 func (SRPolicyState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[3].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[2].Descriptor()
 }
 
 func (SRPolicyState) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[3]
+	return &file_api_pola_v1_pola_proto_enumTypes[2]
 }
 
 func (x SRPolicyState) Number() protoreflect.EnumNumber {
@@ -225,7 +176,7 @@ func (x SRPolicyState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SRPolicyState.Descriptor instead.
 func (SRPolicyState) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
 }
 
 type SessionState int32
@@ -267,11 +218,11 @@ func (x SessionState) String() string {
 }
 
 func (SessionState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[4].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[3].Descriptor()
 }
 
 func (SessionState) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[4]
+	return &file_api_pola_v1_pola_proto_enumTypes[3]
 }
 
 func (x SessionState) Number() protoreflect.EnumNumber {
@@ -280,7 +231,7 @@ func (x SessionState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SessionState.Descriptor instead.
 func (SessionState) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
 }
 
 type PccType int32
@@ -319,11 +270,11 @@ func (x PccType) String() string {
 }
 
 func (PccType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[5].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[4].Descriptor()
 }
 
 func (PccType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[5]
+	return &file_api_pola_v1_pola_proto_enumTypes[4]
 }
 
 func (x PccType) Number() protoreflect.EnumNumber {
@@ -332,7 +283,7 @@ func (x PccType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PccType.Descriptor instead.
 func (PccType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
 }
 
 type CapabilityType int32
@@ -389,11 +340,11 @@ func (x CapabilityType) String() string {
 }
 
 func (CapabilityType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[6].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[5].Descriptor()
 }
 
 func (CapabilityType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[6]
+	return &file_api_pola_v1_pola_proto_enumTypes[5]
 }
 
 func (x CapabilityType) Number() protoreflect.EnumNumber {
@@ -402,7 +353,7 @@ func (x CapabilityType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CapabilityType.Descriptor instead.
 func (CapabilityType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{6}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
 }
 
 // RFC 9826 ietf-pcep: /pcep/entity/peers/peer/sessions/session/initiator
@@ -439,11 +390,11 @@ func (x SessionInitiator) String() string {
 }
 
 func (SessionInitiator) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[7].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[6].Descriptor()
 }
 
 func (SessionInitiator) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[7]
+	return &file_api_pola_v1_pola_proto_enumTypes[6]
 }
 
 func (x SessionInitiator) Number() protoreflect.EnumNumber {
@@ -452,7 +403,7 @@ func (x SessionInitiator) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SessionInitiator.Descriptor instead.
 func (SessionInitiator) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{6}
 }
 
 // LSP-DB synchronization state defined by RFC 8231 and exposed by RFC 9826.
@@ -492,11 +443,11 @@ func (x LspDbSyncState) String() string {
 }
 
 func (LspDbSyncState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[8].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[7].Descriptor()
 }
 
 func (LspDbSyncState) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[8]
+	return &file_api_pola_v1_pola_proto_enumTypes[7]
 }
 
 func (x LspDbSyncState) Number() protoreflect.EnumNumber {
@@ -505,7 +456,7 @@ func (x LspDbSyncState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use LspDbSyncState.Descriptor instead.
 func (LspDbSyncState) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{8}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
 }
 
 type MetricType int32
@@ -547,11 +498,11 @@ func (x MetricType) String() string {
 }
 
 func (MetricType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[9].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[8].Descriptor()
 }
 
 func (MetricType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[9]
+	return &file_api_pola_v1_pola_proto_enumTypes[8]
 }
 
 func (x MetricType) Number() protoreflect.EnumNumber {
@@ -560,7 +511,7 @@ func (x MetricType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use MetricType.Descriptor instead.
 func (MetricType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{9}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{8}
 }
 
 type Segment struct {
@@ -668,7 +619,7 @@ func (x *Segment) GetRemoteIfaceId() uint32 {
 type Waypoint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RouterId      string                 `protobuf:"bytes,1,opt,name=router_id,json=routerId,proto3" json:"router_id,omitempty"`
-	Sid           string                 `protobuf:"bytes,2,opt,name=sid,proto3" json:"sid,omitempty"` // Optional: explicit SID override
+	Sid           string                 `protobuf:"bytes,2,opt,name=sid,proto3" json:"sid,omitempty"` // Optional explicit SID override.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -717,34 +668,241 @@ func (x *Waypoint) GetSid() string {
 	return ""
 }
 
-type SRPolicy struct {
-	state       protoimpl.MessageState `protogen:"open.v1"`
-	PeerAddr    []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
-	SrcAddr     []byte                 `protobuf:"bytes,2,opt,name=src_addr,json=srcAddr,proto3" json:"src_addr,omitempty"`
-	DstAddr     []byte                 `protobuf:"bytes,3,opt,name=dst_addr,json=dstAddr,proto3" json:"dst_addr,omitempty"`
-	SrcRouterId string                 `protobuf:"bytes,4,opt,name=src_router_id,json=srcRouterId,proto3" json:"src_router_id,omitempty"`
-	DstRouterId string                 `protobuf:"bytes,5,opt,name=dst_router_id,json=dstRouterId,proto3" json:"dst_router_id,omitempty"`
-	Color       uint32                 `protobuf:"varint,6,opt,name=color,proto3" json:"color,omitempty"`
-	Preference  uint32                 `protobuf:"varint,7,opt,name=preference,proto3" json:"preference,omitempty"`
-	PolicyName  string                 `protobuf:"bytes,8,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
-	Type        SRPolicyType           `protobuf:"varint,9,opt,name=type,proto3,enum=api.pola.v1.SRPolicyType" json:"type,omitempty"`
-	SegmentList []*Segment             `protobuf:"bytes,10,rep,name=segment_list,json=segmentList,proto3" json:"segment_list,omitempty"`
-	Metric      MetricType             `protobuf:"varint,11,opt,name=metric,proto3,enum=api.pola.v1.MetricType" json:"metric,omitempty"`
-	Waypoints   []*Waypoint            `protobuf:"bytes,12,rep,name=waypoints,proto3" json:"waypoints,omitempty"`
-	PlspId      uint32                 `protobuf:"varint,13,opt,name=plsp_id,json=plspId,proto3" json:"plsp_id,omitempty"`
-	LspId       uint32                 `protobuf:"varint,14,opt,name=lsp_id,json=lspId,proto3" json:"lsp_id,omitempty"`
-	State       SRPolicyState          `protobuf:"varint,15,opt,name=state,proto3,enum=api.pola.v1.SRPolicyState" json:"state,omitempty"`
-	// Underlay plane for dynamic path computation.
-	// Unspecified uses the TED node's unique viable plane and is rejected if ambiguous.
-	UnderlayFamily AddressFamily `protobuf:"varint,16,opt,name=underlay_family,json=underlayFamily,proto3,enum=api.pola.v1.AddressFamily" json:"underlay_family,omitempty"`
-	DataPlane      DataPlane     `protobuf:"varint,17,opt,name=data_plane,json=dataPlane,proto3,enum=api.pola.v1.DataPlane" json:"data_plane,omitempty"`
+type DynamicPath struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Metric MetricType             `protobuf:"varint,1,opt,name=metric,proto3,enum=api.pola.v1.MetricType" json:"metric,omitempty"`
+	// Unspecified uses the unique viable data plane; rejected if ambiguous.
+	DataPlane DataPlane `protobuf:"varint,2,opt,name=data_plane,json=dataPlane,proto3,enum=api.pola.v1.DataPlane" json:"data_plane,omitempty"`
+	// Unspecified uses the unique viable family; rejected if ambiguous.
+	// Pola extension; no IETF counterpart.
+	UnderlayFamily AddressFamily `protobuf:"varint,3,opt,name=underlay_family,json=underlayFamily,proto3,enum=api.pola.v1.AddressFamily" json:"underlay_family,omitempty"`
+	Waypoints      []*Waypoint   `protobuf:"bytes,4,rep,name=waypoints,proto3" json:"waypoints,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
+func (x *DynamicPath) Reset() {
+	*x = DynamicPath{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DynamicPath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DynamicPath) ProtoMessage() {}
+
+func (x *DynamicPath) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DynamicPath.ProtoReflect.Descriptor instead.
+func (*DynamicPath) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *DynamicPath) GetMetric() MetricType {
+	if x != nil {
+		return x.Metric
+	}
+	return MetricType_METRIC_TYPE_UNSPECIFIED
+}
+
+func (x *DynamicPath) GetDataPlane() DataPlane {
+	if x != nil {
+		return x.DataPlane
+	}
+	return DataPlane_DATA_PLANE_UNSPECIFIED
+}
+
+func (x *DynamicPath) GetUnderlayFamily() AddressFamily {
+	if x != nil {
+		return x.UnderlayFamily
+	}
+	return AddressFamily_ADDRESS_FAMILY_UNSPECIFIED
+}
+
+func (x *DynamicPath) GetWaypoints() []*Waypoint {
+	if x != nil {
+		return x.Waypoints
+	}
+	return nil
+}
+
+type ExplicitPath struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SegmentList   []*Segment             `protobuf:"bytes,1,rep,name=segment_list,json=segmentList,proto3" json:"segment_list,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExplicitPath) Reset() {
+	*x = ExplicitPath{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExplicitPath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExplicitPath) ProtoMessage() {}
+
+func (x *ExplicitPath) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExplicitPath.ProtoReflect.Descriptor instead.
+func (*ExplicitPath) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ExplicitPath) GetSegmentList() []*Segment {
+	if x != nil {
+		return x.SegmentList
+	}
+	return nil
+}
+
+type CandidatePath struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Zero means "not set" in proto3 and is normalized server-side to
+	// table.DefaultPreference (100) (RFC 9256 §2.7).
+	Preference uint32 `protobuf:"varint,1,opt,name=preference,proto3" json:"preference,omitempty"`
+	// Types that are valid to be assigned to Path:
+	//
+	//	*CandidatePath_Dynamic
+	//	*CandidatePath_Explicit
+	Path          isCandidatePath_Path `protobuf_oneof:"path"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CandidatePath) Reset() {
+	*x = CandidatePath{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CandidatePath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CandidatePath) ProtoMessage() {}
+
+func (x *CandidatePath) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CandidatePath.ProtoReflect.Descriptor instead.
+func (*CandidatePath) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *CandidatePath) GetPreference() uint32 {
+	if x != nil {
+		return x.Preference
+	}
+	return 0
+}
+
+func (x *CandidatePath) GetPath() isCandidatePath_Path {
+	if x != nil {
+		return x.Path
+	}
+	return nil
+}
+
+func (x *CandidatePath) GetDynamic() *DynamicPath {
+	if x != nil {
+		if x, ok := x.Path.(*CandidatePath_Dynamic); ok {
+			return x.Dynamic
+		}
+	}
+	return nil
+}
+
+func (x *CandidatePath) GetExplicit() *ExplicitPath {
+	if x != nil {
+		if x, ok := x.Path.(*CandidatePath_Explicit); ok {
+			return x.Explicit
+		}
+	}
+	return nil
+}
+
+type isCandidatePath_Path interface {
+	isCandidatePath_Path()
+}
+
+type CandidatePath_Dynamic struct {
+	Dynamic *DynamicPath `protobuf:"bytes,2,opt,name=dynamic,proto3,oneof"`
+}
+
+type CandidatePath_Explicit struct {
+	Explicit *ExplicitPath `protobuf:"bytes,3,opt,name=explicit,proto3,oneof"`
+}
+
+func (*CandidatePath_Dynamic) isCandidatePath_Path() {}
+
+func (*CandidatePath_Explicit) isCandidatePath_Path() {}
+
+type SRPolicy struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	PeerAddr []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
+	// Policy identity addresses (RFC 9256 §2.1). Mutually exclusive with
+	// headend_router_id / endpoint_router_id.
+	Headend  []byte `protobuf:"bytes,2,opt,name=headend,proto3" json:"headend,omitempty"`
+	Endpoint []byte `protobuf:"bytes,3,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
+	// Router ID form for TED resolution. Mutually exclusive with headend / endpoint.
+	HeadendRouterId  string `protobuf:"bytes,4,opt,name=headend_router_id,json=headendRouterId,proto3" json:"headend_router_id,omitempty"`
+	EndpointRouterId string `protobuf:"bytes,5,opt,name=endpoint_router_id,json=endpointRouterId,proto3" json:"endpoint_router_id,omitempty"`
+	// Address family used to resolve endpoints from router IDs.
+	// Unspecified follows the underlay family; valid only with the router ID form.
+	EndpointFamily AddressFamily  `protobuf:"varint,18,opt,name=endpoint_family,json=endpointFamily,proto3,enum=api.pola.v1.AddressFamily" json:"endpoint_family,omitempty"`
+	Color          uint32         `protobuf:"varint,6,opt,name=color,proto3" json:"color,omitempty"`
+	PolicyName     string         `protobuf:"bytes,8,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
+	CandidatePath  *CandidatePath `protobuf:"bytes,19,opt,name=candidate_path,json=candidatePath,proto3" json:"candidate_path,omitempty"`
+	PlspId         uint32         `protobuf:"varint,13,opt,name=plsp_id,json=plspId,proto3" json:"plsp_id,omitempty"`
+	LspId          uint32         `protobuf:"varint,14,opt,name=lsp_id,json=lspId,proto3" json:"lsp_id,omitempty"`
+	State          SRPolicyState  `protobuf:"varint,15,opt,name=state,proto3,enum=api.pola.v1.SRPolicyState" json:"state,omitempty"`
+	// Currently signaled segment list reported by the PCE, not request input.
+	SegmentList   []*Segment `protobuf:"bytes,20,rep,name=segment_list,json=segmentList,proto3" json:"segment_list,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
 func (x *SRPolicy) Reset() {
 	*x = SRPolicy{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[2]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -756,7 +914,7 @@ func (x *SRPolicy) String() string {
 func (*SRPolicy) ProtoMessage() {}
 
 func (x *SRPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[2]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -769,7 +927,7 @@ func (x *SRPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRPolicy.ProtoReflect.Descriptor instead.
 func (*SRPolicy) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SRPolicy) GetPeerAddr() []byte {
@@ -779,44 +937,44 @@ func (x *SRPolicy) GetPeerAddr() []byte {
 	return nil
 }
 
-func (x *SRPolicy) GetSrcAddr() []byte {
+func (x *SRPolicy) GetHeadend() []byte {
 	if x != nil {
-		return x.SrcAddr
+		return x.Headend
 	}
 	return nil
 }
 
-func (x *SRPolicy) GetDstAddr() []byte {
+func (x *SRPolicy) GetEndpoint() []byte {
 	if x != nil {
-		return x.DstAddr
+		return x.Endpoint
 	}
 	return nil
 }
 
-func (x *SRPolicy) GetSrcRouterId() string {
+func (x *SRPolicy) GetHeadendRouterId() string {
 	if x != nil {
-		return x.SrcRouterId
+		return x.HeadendRouterId
 	}
 	return ""
 }
 
-func (x *SRPolicy) GetDstRouterId() string {
+func (x *SRPolicy) GetEndpointRouterId() string {
 	if x != nil {
-		return x.DstRouterId
+		return x.EndpointRouterId
 	}
 	return ""
+}
+
+func (x *SRPolicy) GetEndpointFamily() AddressFamily {
+	if x != nil {
+		return x.EndpointFamily
+	}
+	return AddressFamily_ADDRESS_FAMILY_UNSPECIFIED
 }
 
 func (x *SRPolicy) GetColor() uint32 {
 	if x != nil {
 		return x.Color
-	}
-	return 0
-}
-
-func (x *SRPolicy) GetPreference() uint32 {
-	if x != nil {
-		return x.Preference
 	}
 	return 0
 }
@@ -828,30 +986,9 @@ func (x *SRPolicy) GetPolicyName() string {
 	return ""
 }
 
-func (x *SRPolicy) GetType() SRPolicyType {
+func (x *SRPolicy) GetCandidatePath() *CandidatePath {
 	if x != nil {
-		return x.Type
-	}
-	return SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED
-}
-
-func (x *SRPolicy) GetSegmentList() []*Segment {
-	if x != nil {
-		return x.SegmentList
-	}
-	return nil
-}
-
-func (x *SRPolicy) GetMetric() MetricType {
-	if x != nil {
-		return x.Metric
-	}
-	return MetricType_METRIC_TYPE_UNSPECIFIED
-}
-
-func (x *SRPolicy) GetWaypoints() []*Waypoint {
-	if x != nil {
-		return x.Waypoints
+		return x.CandidatePath
 	}
 	return nil
 }
@@ -877,33 +1014,25 @@ func (x *SRPolicy) GetState() SRPolicyState {
 	return SRPolicyState_SR_POLICY_STATE_UNSPECIFIED
 }
 
-func (x *SRPolicy) GetUnderlayFamily() AddressFamily {
+func (x *SRPolicy) GetSegmentList() []*Segment {
 	if x != nil {
-		return x.UnderlayFamily
+		return x.SegmentList
 	}
-	return AddressFamily_ADDRESS_FAMILY_UNSPECIFIED
-}
-
-func (x *SRPolicy) GetDataPlane() DataPlane {
-	if x != nil {
-		return x.DataPlane
-	}
-	return DataPlane_DATA_PLANE_UNSPECIFIED
+	return nil
 }
 
 type CreateSRPolicyRequest struct {
-	state              protoimpl.MessageState `protogen:"open.v1"`
-	SrPolicy           *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
-	Asn                uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
-	DisablePathCompute bool                   `protobuf:"varint,4,opt,name=disable_path_compute,json=disablePathCompute,proto3" json:"disable_path_compute,omitempty"`
-	NoSidValidate      bool                   `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SrPolicy      *SRPolicy              `protobuf:"bytes,1,opt,name=sr_policy,json=srPolicy,proto3" json:"sr_policy,omitempty"`
+	Asn           uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
+	NoSidValidate bool                   `protobuf:"varint,5,opt,name=no_sid_validate,json=noSidValidate,proto3" json:"no_sid_validate,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateSRPolicyRequest) Reset() {
 	*x = CreateSRPolicyRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[3]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -915,7 +1044,7 @@ func (x *CreateSRPolicyRequest) String() string {
 func (*CreateSRPolicyRequest) ProtoMessage() {}
 
 func (x *CreateSRPolicyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[3]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -928,7 +1057,7 @@ func (x *CreateSRPolicyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSRPolicyRequest.ProtoReflect.Descriptor instead.
 func (*CreateSRPolicyRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CreateSRPolicyRequest) GetSrPolicy() *SRPolicy {
@@ -943,13 +1072,6 @@ func (x *CreateSRPolicyRequest) GetAsn() uint32 {
 		return x.Asn
 	}
 	return 0
-}
-
-func (x *CreateSRPolicyRequest) GetDisablePathCompute() bool {
-	if x != nil {
-		return x.DisablePathCompute
-	}
-	return false
 }
 
 func (x *CreateSRPolicyRequest) GetNoSidValidate() bool {
@@ -967,7 +1089,7 @@ type CreateSRPolicyResponse struct {
 
 func (x *CreateSRPolicyResponse) Reset() {
 	*x = CreateSRPolicyResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[4]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -979,7 +1101,7 @@ func (x *CreateSRPolicyResponse) String() string {
 func (*CreateSRPolicyResponse) ProtoMessage() {}
 
 func (x *CreateSRPolicyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[4]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -992,7 +1114,7 @@ func (x *CreateSRPolicyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSRPolicyResponse.ProtoReflect.Descriptor instead.
 func (*CreateSRPolicyResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
 }
 
 type DeleteSRPolicyRequest struct {
@@ -1005,7 +1127,7 @@ type DeleteSRPolicyRequest struct {
 
 func (x *DeleteSRPolicyRequest) Reset() {
 	*x = DeleteSRPolicyRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[5]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1017,7 +1139,7 @@ func (x *DeleteSRPolicyRequest) String() string {
 func (*DeleteSRPolicyRequest) ProtoMessage() {}
 
 func (x *DeleteSRPolicyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[5]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1030,7 +1152,7 @@ func (x *DeleteSRPolicyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSRPolicyRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSRPolicyRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *DeleteSRPolicyRequest) GetSrPolicy() *SRPolicy {
@@ -1055,7 +1177,7 @@ type DeleteSRPolicyResponse struct {
 
 func (x *DeleteSRPolicyResponse) Reset() {
 	*x = DeleteSRPolicyResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[6]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1067,7 +1189,7 @@ func (x *DeleteSRPolicyResponse) String() string {
 func (*DeleteSRPolicyResponse) ProtoMessage() {}
 
 func (x *DeleteSRPolicyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[6]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1080,7 +1202,7 @@ func (x *DeleteSRPolicyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSRPolicyResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSRPolicyResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{6}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{9}
 }
 
 type StatefulCapability struct {
@@ -1098,7 +1220,7 @@ type StatefulCapability struct {
 
 func (x *StatefulCapability) Reset() {
 	*x = StatefulCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[7]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1110,7 +1232,7 @@ func (x *StatefulCapability) String() string {
 func (*StatefulCapability) ProtoMessage() {}
 
 func (x *StatefulCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[7]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1123,7 +1245,7 @@ func (x *StatefulCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatefulCapability.ProtoReflect.Descriptor instead.
 func (*StatefulCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *StatefulCapability) GetLspUpdate() bool {
@@ -1187,7 +1309,7 @@ type SrCapability struct {
 
 func (x *SrCapability) Reset() {
 	*x = SrCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[8]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1199,7 +1321,7 @@ func (x *SrCapability) String() string {
 func (*SrCapability) ProtoMessage() {}
 
 func (x *SrCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[8]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1212,7 +1334,7 @@ func (x *SrCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SrCapability.ProtoReflect.Descriptor instead.
 func (*SrCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{8}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *SrCapability) GetUnlimitedMsd() bool {
@@ -1246,7 +1368,7 @@ type Msd struct {
 
 func (x *Msd) Reset() {
 	*x = Msd{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1258,7 +1380,7 @@ func (x *Msd) String() string {
 func (*Msd) ProtoMessage() {}
 
 func (x *Msd) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[9]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1271,7 +1393,7 @@ func (x *Msd) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Msd.ProtoReflect.Descriptor instead.
 func (*Msd) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{9}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *Msd) GetType() uint32 {
@@ -1298,7 +1420,7 @@ type Srv6Capability struct {
 
 func (x *Srv6Capability) Reset() {
 	*x = Srv6Capability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1310,7 +1432,7 @@ func (x *Srv6Capability) String() string {
 func (*Srv6Capability) ProtoMessage() {}
 
 func (x *Srv6Capability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[10]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1323,7 +1445,7 @@ func (x *Srv6Capability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Srv6Capability.ProtoReflect.Descriptor instead.
 func (*Srv6Capability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{10}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Srv6Capability) GetNaiSupported() bool {
@@ -1351,7 +1473,7 @@ type PathSetupTypeCapability struct {
 
 func (x *PathSetupTypeCapability) Reset() {
 	*x = PathSetupTypeCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1363,7 +1485,7 @@ func (x *PathSetupTypeCapability) String() string {
 func (*PathSetupTypeCapability) ProtoMessage() {}
 
 func (x *PathSetupTypeCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[11]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1376,7 +1498,7 @@ func (x *PathSetupTypeCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PathSetupTypeCapability.ProtoReflect.Descriptor instead.
 func (*PathSetupTypeCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{11}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PathSetupTypeCapability) GetPathSetupTypes() []uint32 {
@@ -1402,7 +1524,7 @@ type AssocTypeListCapability struct {
 
 func (x *AssocTypeListCapability) Reset() {
 	*x = AssocTypeListCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1414,7 +1536,7 @@ func (x *AssocTypeListCapability) String() string {
 func (*AssocTypeListCapability) ProtoMessage() {}
 
 func (x *AssocTypeListCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[12]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1427,7 +1549,7 @@ func (x *AssocTypeListCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssocTypeListCapability.ProtoReflect.Descriptor instead.
 func (*AssocTypeListCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{12}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *AssocTypeListCapability) GetAssocTypes() []uint32 {
@@ -1446,7 +1568,7 @@ type LspDbVersionCapability struct {
 
 func (x *LspDbVersionCapability) Reset() {
 	*x = LspDbVersionCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1458,7 +1580,7 @@ func (x *LspDbVersionCapability) String() string {
 func (*LspDbVersionCapability) ProtoMessage() {}
 
 func (x *LspDbVersionCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[13]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1471,7 +1593,7 @@ func (x *LspDbVersionCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LspDbVersionCapability.ProtoReflect.Descriptor instead.
 func (*LspDbVersionCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{13}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LspDbVersionCapability) GetVersionNumber() uint64 {
@@ -1494,7 +1616,7 @@ type MultipathCapability struct {
 
 func (x *MultipathCapability) Reset() {
 	*x = MultipathCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1506,7 +1628,7 @@ func (x *MultipathCapability) String() string {
 func (*MultipathCapability) ProtoMessage() {}
 
 func (x *MultipathCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[14]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1519,7 +1641,7 @@ func (x *MultipathCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultipathCapability.ProtoReflect.Descriptor instead.
 func (*MultipathCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{14}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *MultipathCapability) GetMaxMultipaths() uint32 {
@@ -1566,7 +1688,7 @@ type VendorInformationCapability struct {
 
 func (x *VendorInformationCapability) Reset() {
 	*x = VendorInformationCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1578,7 +1700,7 @@ func (x *VendorInformationCapability) String() string {
 func (*VendorInformationCapability) ProtoMessage() {}
 
 func (x *VendorInformationCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[15]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1591,7 +1713,7 @@ func (x *VendorInformationCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VendorInformationCapability.ProtoReflect.Descriptor instead.
 func (*VendorInformationCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{15}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *VendorInformationCapability) GetEnterpriseNumber() uint32 {
@@ -1610,7 +1732,7 @@ type UnknownCapability struct {
 
 func (x *UnknownCapability) Reset() {
 	*x = UnknownCapability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1622,7 +1744,7 @@ func (x *UnknownCapability) String() string {
 func (*UnknownCapability) ProtoMessage() {}
 
 func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[16]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1635,7 +1757,7 @@ func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnknownCapability.ProtoReflect.Descriptor instead.
 func (*UnknownCapability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{16}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *UnknownCapability) GetTlvType() uint32 {
@@ -1666,7 +1788,7 @@ type Capability struct {
 
 func (x *Capability) Reset() {
 	*x = Capability{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1678,7 +1800,7 @@ func (x *Capability) String() string {
 func (*Capability) ProtoMessage() {}
 
 func (x *Capability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[17]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1691,7 +1813,7 @@ func (x *Capability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Capability.ProtoReflect.Descriptor instead.
 func (*Capability) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{17}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *Capability) GetType() CapabilityType {
@@ -1857,7 +1979,7 @@ type SessionTimers struct {
 
 func (x *SessionTimers) Reset() {
 	*x = SessionTimers{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1869,7 +1991,7 @@ func (x *SessionTimers) String() string {
 func (*SessionTimers) ProtoMessage() {}
 
 func (x *SessionTimers) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[18]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1882,7 +2004,7 @@ func (x *SessionTimers) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionTimers.ProtoReflect.Descriptor instead.
 func (*SessionTimers) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{18}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SessionTimers) GetKeepalive() uint32 {
@@ -1909,7 +2031,7 @@ type EffectiveTimers struct {
 
 func (x *EffectiveTimers) Reset() {
 	*x = EffectiveTimers{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1921,7 +2043,7 @@ func (x *EffectiveTimers) String() string {
 func (*EffectiveTimers) ProtoMessage() {}
 
 func (x *EffectiveTimers) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[19]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1934,7 +2056,7 @@ func (x *EffectiveTimers) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EffectiveTimers.ProtoReflect.Descriptor instead.
 func (*EffectiveTimers) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{19}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *EffectiveTimers) GetKeepalive() uint32 {
@@ -1962,7 +2084,7 @@ type MessageCounter struct {
 
 func (x *MessageCounter) Reset() {
 	*x = MessageCounter{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1974,7 +2096,7 @@ func (x *MessageCounter) String() string {
 func (*MessageCounter) ProtoMessage() {}
 
 func (x *MessageCounter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[20]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1987,7 +2109,7 @@ func (x *MessageCounter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageCounter.ProtoReflect.Descriptor instead.
 func (*MessageCounter) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{20}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *MessageCounter) GetSent() uint64 {
@@ -2004,8 +2126,6 @@ func (x *MessageCounter) GetRcvd() uint64 {
 	return 0
 }
 
-// SessionStats contains per-session PCEP message counters.
-// Open and close are Pola-specific additions.
 type SessionStats struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Keepalive        *MessageCounter        `protobuf:"bytes,1,opt,name=keepalive,proto3" json:"keepalive,omitempty"`                                        // keepalive-sent / keepalive-rcvd (RFC 9826)
@@ -2028,7 +2148,7 @@ type SessionStats struct {
 
 func (x *SessionStats) Reset() {
 	*x = SessionStats{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2040,7 +2160,7 @@ func (x *SessionStats) String() string {
 func (*SessionStats) ProtoMessage() {}
 
 func (x *SessionStats) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[21]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2053,7 +2173,7 @@ func (x *SessionStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionStats.ProtoReflect.Descriptor instead.
 func (*SessionStats) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{21}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SessionStats) GetKeepalive() *MessageCounter {
@@ -2180,7 +2300,7 @@ type Session struct {
 
 func (x *Session) Reset() {
 	*x = Session{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2192,7 +2312,7 @@ func (x *Session) String() string {
 func (*Session) ProtoMessage() {}
 
 func (x *Session) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[22]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2205,7 +2325,7 @@ func (x *Session) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Session.ProtoReflect.Descriptor instead.
 func (*Session) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{22}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Session) GetPeerAddr() []byte {
@@ -2332,7 +2452,7 @@ type SRPolicySession struct {
 
 func (x *SRPolicySession) Reset() {
 	*x = SRPolicySession{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2344,7 +2464,7 @@ func (x *SRPolicySession) String() string {
 func (*SRPolicySession) ProtoMessage() {}
 
 func (x *SRPolicySession) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[23]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2357,7 +2477,7 @@ func (x *SRPolicySession) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRPolicySession.ProtoReflect.Descriptor instead.
 func (*SRPolicySession) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{23}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SRPolicySession) GetPeerAddr() []byte {
@@ -2399,7 +2519,7 @@ type EndpointBehavior struct {
 
 func (x *EndpointBehavior) Reset() {
 	*x = EndpointBehavior{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2411,7 +2531,7 @@ func (x *EndpointBehavior) String() string {
 func (*EndpointBehavior) ProtoMessage() {}
 
 func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[24]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2424,7 +2544,7 @@ func (x *EndpointBehavior) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointBehavior.ProtoReflect.Descriptor instead.
 func (*EndpointBehavior) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{24}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *EndpointBehavior) GetBehavior() uint32 {
@@ -2460,7 +2580,7 @@ type SidStructure struct {
 
 func (x *SidStructure) Reset() {
 	*x = SidStructure{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2472,7 +2592,7 @@ func (x *SidStructure) String() string {
 func (*SidStructure) ProtoMessage() {}
 
 func (x *SidStructure) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[25]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2485,7 +2605,7 @@ func (x *SidStructure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidStructure.ProtoReflect.Descriptor instead.
 func (*SidStructure) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{25}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SidStructure) GetLocalBlock() uint32 {
@@ -2525,7 +2645,7 @@ type SID struct {
 
 func (x *SID) Reset() {
 	*x = SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2537,7 +2657,7 @@ func (x *SID) String() string {
 func (*SID) ProtoMessage() {}
 
 func (x *SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[26]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2550,7 +2670,7 @@ func (x *SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SID.ProtoReflect.Descriptor instead.
 func (*SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{26}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SID) GetSid() string {
@@ -2569,7 +2689,7 @@ type MultiTopoID struct {
 
 func (x *MultiTopoID) Reset() {
 	*x = MultiTopoID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2581,7 +2701,7 @@ func (x *MultiTopoID) String() string {
 func (*MultiTopoID) ProtoMessage() {}
 
 func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[27]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2594,7 +2714,7 @@ func (x *MultiTopoID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultiTopoID.ProtoReflect.Descriptor instead.
 func (*MultiTopoID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{27}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *MultiTopoID) GetMultiTopoId() uint32 {
@@ -2616,7 +2736,7 @@ type LsSrv6SID struct {
 
 func (x *LsSrv6SID) Reset() {
 	*x = LsSrv6SID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2628,7 +2748,7 @@ func (x *LsSrv6SID) String() string {
 func (*LsSrv6SID) ProtoMessage() {}
 
 func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[28]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2641,7 +2761,7 @@ func (x *LsSrv6SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6SID.ProtoReflect.Descriptor instead.
 func (*LsSrv6SID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{28}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *LsSrv6SID) GetSids() []*SID {
@@ -2682,7 +2802,7 @@ type LsPrefix struct {
 
 func (x *LsPrefix) Reset() {
 	*x = LsPrefix{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2694,7 +2814,7 @@ func (x *LsPrefix) String() string {
 func (*LsPrefix) ProtoMessage() {}
 
 func (x *LsPrefix) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[29]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2707,7 +2827,7 @@ func (x *LsPrefix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsPrefix.ProtoReflect.Descriptor instead.
 func (*LsPrefix) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{29}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LsPrefix) GetPrefix() string {
@@ -2734,7 +2854,7 @@ type Metric struct {
 
 func (x *Metric) Reset() {
 	*x = Metric{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2746,7 +2866,7 @@ func (x *Metric) String() string {
 func (*Metric) ProtoMessage() {}
 
 func (x *Metric) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[30]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2759,7 +2879,7 @@ func (x *Metric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metric.ProtoReflect.Descriptor instead.
 func (*Metric) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{30}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Metric) GetType() MetricType {
@@ -2787,7 +2907,7 @@ type Srv6EndXSID struct {
 
 func (x *Srv6EndXSID) Reset() {
 	*x = Srv6EndXSID{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2799,7 +2919,7 @@ func (x *Srv6EndXSID) String() string {
 func (*Srv6EndXSID) ProtoMessage() {}
 
 func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[31]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2812,7 +2932,7 @@ func (x *Srv6EndXSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Srv6EndXSID.ProtoReflect.Descriptor instead.
 func (*Srv6EndXSID) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{31}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Srv6EndXSID) GetEndpointBehavior() uint32 {
@@ -2850,7 +2970,7 @@ type LsLinkEndpoint struct {
 
 func (x *LsLinkEndpoint) Reset() {
 	*x = LsLinkEndpoint{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2862,7 +2982,7 @@ func (x *LsLinkEndpoint) String() string {
 func (*LsLinkEndpoint) ProtoMessage() {}
 
 func (x *LsLinkEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2875,7 +2995,7 @@ func (x *LsLinkEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsLinkEndpoint.ProtoReflect.Descriptor instead.
 func (*LsLinkEndpoint) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *LsLinkEndpoint) GetRouterId() string {
@@ -2924,7 +3044,7 @@ type AdjSid struct {
 
 func (x *AdjSid) Reset() {
 	*x = AdjSid{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2936,7 +3056,7 @@ func (x *AdjSid) String() string {
 func (*AdjSid) ProtoMessage() {}
 
 func (x *AdjSid) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2949,7 +3069,7 @@ func (x *AdjSid) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdjSid.ProtoReflect.Descriptor instead.
 func (*AdjSid) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *AdjSid) GetFamily() AddressFamily {
@@ -2979,7 +3099,7 @@ type LsLink struct {
 
 func (x *LsLink) Reset() {
 	*x = LsLink{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2991,7 +3111,7 @@ func (x *LsLink) String() string {
 func (*LsLink) ProtoMessage() {}
 
 func (x *LsLink) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3004,7 +3124,7 @@ func (x *LsLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsLink.ProtoReflect.Descriptor instead.
 func (*LsLink) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *LsLink) GetLocal() *LsLinkEndpoint {
@@ -3059,7 +3179,7 @@ type LsNode struct {
 
 func (x *LsNode) Reset() {
 	*x = LsNode{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3071,7 +3191,7 @@ func (x *LsNode) String() string {
 func (*LsNode) ProtoMessage() {}
 
 func (x *LsNode) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3084,7 +3204,7 @@ func (x *LsNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsNode.ProtoReflect.Descriptor instead.
 func (*LsNode) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *LsNode) GetAsn() uint32 {
@@ -3160,7 +3280,7 @@ type GetSessionListRequest struct {
 
 func (x *GetSessionListRequest) Reset() {
 	*x = GetSessionListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3172,7 +3292,7 @@ func (x *GetSessionListRequest) String() string {
 func (*GetSessionListRequest) ProtoMessage() {}
 
 func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3185,7 +3305,7 @@ func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListRequest.ProtoReflect.Descriptor instead.
 func (*GetSessionListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetSessionListRequest) GetPeerAddr() []byte {
@@ -3211,7 +3331,7 @@ type GetSessionListResponse struct {
 
 func (x *GetSessionListResponse) Reset() {
 	*x = GetSessionListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3223,7 +3343,7 @@ func (x *GetSessionListResponse) String() string {
 func (*GetSessionListResponse) ProtoMessage() {}
 
 func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3236,7 +3356,7 @@ func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListResponse.ProtoReflect.Descriptor instead.
 func (*GetSessionListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetSessionListResponse) GetSessions() []*Session {
@@ -3255,7 +3375,7 @@ type GetSRPolicyListRequest struct {
 
 func (x *GetSRPolicyListRequest) Reset() {
 	*x = GetSRPolicyListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3267,7 +3387,7 @@ func (x *GetSRPolicyListRequest) String() string {
 func (*GetSRPolicyListRequest) ProtoMessage() {}
 
 func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3280,7 +3400,7 @@ func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListRequest.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetSRPolicyListRequest) GetPeerAddr() []byte {
@@ -3299,7 +3419,7 @@ type GetSRPolicyListResponse struct {
 
 func (x *GetSRPolicyListResponse) Reset() {
 	*x = GetSRPolicyListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3311,7 +3431,7 @@ func (x *GetSRPolicyListResponse) String() string {
 func (*GetSRPolicyListResponse) ProtoMessage() {}
 
 func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3324,7 +3444,7 @@ func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListResponse.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{39}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *GetSRPolicyListResponse) GetSessions() []*SRPolicySession {
@@ -3342,7 +3462,7 @@ type GetTEDRequest struct {
 
 func (x *GetTEDRequest) Reset() {
 	*x = GetTEDRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3354,7 +3474,7 @@ func (x *GetTEDRequest) String() string {
 func (*GetTEDRequest) ProtoMessage() {}
 
 func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3367,7 +3487,7 @@ func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDRequest.ProtoReflect.Descriptor instead.
 func (*GetTEDRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{40}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{43}
 }
 
 type GetTEDResponse struct {
@@ -3380,7 +3500,7 @@ type GetTEDResponse struct {
 
 func (x *GetTEDResponse) Reset() {
 	*x = GetTEDResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3392,7 +3512,7 @@ func (x *GetTEDResponse) String() string {
 func (*GetTEDResponse) ProtoMessage() {}
 
 func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3405,7 +3525,7 @@ func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDResponse.ProtoReflect.Descriptor instead.
 func (*GetTEDResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{41}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *GetTEDResponse) GetEnabled() bool {
@@ -3431,7 +3551,7 @@ type DeleteSessionRequest struct {
 
 func (x *DeleteSessionRequest) Reset() {
 	*x = DeleteSessionRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[42]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3443,7 +3563,7 @@ func (x *DeleteSessionRequest) String() string {
 func (*DeleteSessionRequest) ProtoMessage() {}
 
 func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[42]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3456,7 +3576,7 @@ func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{42}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *DeleteSessionRequest) GetPeerAddr() []byte {
@@ -3474,7 +3594,7 @@ type DeleteSessionResponse struct {
 
 func (x *DeleteSessionResponse) Reset() {
 	*x = DeleteSessionResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[43]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3486,7 +3606,7 @@ func (x *DeleteSessionResponse) String() string {
 func (*DeleteSessionResponse) ProtoMessage() {}
 
 func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[43]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3499,7 +3619,7 @@ func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{43}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{46}
 }
 
 var File_api_pola_v1_pola_proto protoreflect.FileDescriptor
@@ -3523,35 +3643,45 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x10_remote_iface_id\"9\n" +
 	"\bWaypoint\x12\x1b\n" +
 	"\trouter_id\x18\x01 \x01(\tR\brouterId\x12\x10\n" +
-	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xa8\x05\n" +
-	"\bSRPolicy\x12\x1b\n" +
-	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12\x19\n" +
-	"\bsrc_addr\x18\x02 \x01(\fR\asrcAddr\x12\x19\n" +
-	"\bdst_addr\x18\x03 \x01(\fR\adstAddr\x12\"\n" +
-	"\rsrc_router_id\x18\x04 \x01(\tR\vsrcRouterId\x12\"\n" +
-	"\rdst_router_id\x18\x05 \x01(\tR\vdstRouterId\x12\x14\n" +
-	"\x05color\x18\x06 \x01(\rR\x05color\x12\x1e\n" +
+	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xef\x01\n" +
+	"\vDynamicPath\x12/\n" +
+	"\x06metric\x18\x01 \x01(\x0e2\x17.api.pola.v1.MetricTypeR\x06metric\x125\n" +
 	"\n" +
-	"preference\x18\a \x01(\rR\n" +
-	"preference\x12\x1f\n" +
+	"data_plane\x18\x02 \x01(\x0e2\x16.api.pola.v1.DataPlaneR\tdataPlane\x12C\n" +
+	"\x0funderlay_family\x18\x03 \x01(\x0e2\x1a.api.pola.v1.AddressFamilyR\x0eunderlayFamily\x123\n" +
+	"\twaypoints\x18\x04 \x03(\v2\x15.api.pola.v1.WaypointR\twaypoints\"G\n" +
+	"\fExplicitPath\x127\n" +
+	"\fsegment_list\x18\x01 \x03(\v2\x14.api.pola.v1.SegmentR\vsegmentList\"\xa6\x01\n" +
+	"\rCandidatePath\x12\x1e\n" +
+	"\n" +
+	"preference\x18\x01 \x01(\rR\n" +
+	"preference\x124\n" +
+	"\adynamic\x18\x02 \x01(\v2\x18.api.pola.v1.DynamicPathH\x00R\adynamic\x127\n" +
+	"\bexplicit\x18\x03 \x01(\v2\x19.api.pola.v1.ExplicitPathH\x00R\bexplicitB\x06\n" +
+	"\x04path\"\xfd\x04\n" +
+	"\bSRPolicy\x12\x1b\n" +
+	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12\x18\n" +
+	"\aheadend\x18\x02 \x01(\fR\aheadend\x12\x1a\n" +
+	"\bendpoint\x18\x03 \x01(\fR\bendpoint\x12*\n" +
+	"\x11headend_router_id\x18\x04 \x01(\tR\x0fheadendRouterId\x12,\n" +
+	"\x12endpoint_router_id\x18\x05 \x01(\tR\x10endpointRouterId\x12C\n" +
+	"\x0fendpoint_family\x18\x12 \x01(\x0e2\x1a.api.pola.v1.AddressFamilyR\x0eendpointFamily\x12\x14\n" +
+	"\x05color\x18\x06 \x01(\rR\x05color\x12\x1f\n" +
 	"\vpolicy_name\x18\b \x01(\tR\n" +
-	"policyName\x12-\n" +
-	"\x04type\x18\t \x01(\x0e2\x19.api.pola.v1.SRPolicyTypeR\x04type\x127\n" +
-	"\fsegment_list\x18\n" +
-	" \x03(\v2\x14.api.pola.v1.SegmentR\vsegmentList\x12/\n" +
-	"\x06metric\x18\v \x01(\x0e2\x17.api.pola.v1.MetricTypeR\x06metric\x123\n" +
-	"\twaypoints\x18\f \x03(\v2\x15.api.pola.v1.WaypointR\twaypoints\x12\x17\n" +
+	"policyName\x12A\n" +
+	"\x0ecandidate_path\x18\x13 \x01(\v2\x1a.api.pola.v1.CandidatePathR\rcandidatePath\x12\x17\n" +
 	"\aplsp_id\x18\r \x01(\rR\x06plspId\x12\x15\n" +
 	"\x06lsp_id\x18\x0e \x01(\rR\x05lspId\x120\n" +
-	"\x05state\x18\x0f \x01(\x0e2\x1a.api.pola.v1.SRPolicyStateR\x05state\x12C\n" +
-	"\x0funderlay_family\x18\x10 \x01(\x0e2\x1a.api.pola.v1.AddressFamilyR\x0eunderlayFamily\x125\n" +
-	"\n" +
-	"data_plane\x18\x11 \x01(\x0e2\x16.api.pola.v1.DataPlaneR\tdataPlane\"\xcb\x01\n" +
+	"\x05state\x18\x0f \x01(\x0e2\x1a.api.pola.v1.SRPolicyStateR\x05state\x127\n" +
+	"\fsegment_list\x18\x14 \x03(\v2\x14.api.pola.v1.SegmentR\vsegmentListJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
+	"J\x04\b\n" +
+	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x10\x10\x11J\x04\b\x11\x10\x12R\n" +
+	"preferenceR\x04typeR\x06metricR\twaypointsR\x0funderlay_familyR\n" +
+	"data_plane\"\xb5\x01\n" +
 	"\x15CreateSRPolicyRequest\x122\n" +
 	"\tsr_policy\x18\x01 \x01(\v2\x15.api.pola.v1.SRPolicyR\bsrPolicy\x12\x10\n" +
-	"\x03asn\x18\x02 \x01(\rR\x03asn\x120\n" +
-	"\x14disable_path_compute\x18\x04 \x01(\bR\x12disablePathCompute\x12&\n" +
-	"\x0fno_sid_validate\x18\x05 \x01(\bR\rnoSidValidateJ\x04\b\x03\x10\x04R\fsid_validate\"*\n" +
+	"\x03asn\x18\x02 \x01(\rR\x03asn\x12&\n" +
+	"\x0fno_sid_validate\x18\x05 \x01(\bR\rnoSidValidateJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05R\fsid_validateR\x14disable_path_compute\"*\n" +
 	"\x16CreateSRPolicyResponseJ\x04\b\x01\x10\x02R\n" +
 	"is_success\"]\n" +
 	"\x15DeleteSRPolicyRequest\x122\n" +
@@ -3754,11 +3884,7 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\tDataPlane\x12\x1a\n" +
 	"\x16DATA_PLANE_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12DATA_PLANE_SR_MPLS\x10\x01\x12\x13\n" +
-	"\x0fDATA_PLANE_SRV6\x10\x02*g\n" +
-	"\fSRPolicyType\x12\x1e\n" +
-	"\x1aSR_POLICY_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n" +
-	"\x17SR_POLICY_TYPE_EXPLICIT\x10\x01\x12\x1a\n" +
-	"\x16SR_POLICY_TYPE_DYNAMIC\x10\x02*\x9b\x01\n" +
+	"\x0fDATA_PLANE_SRV6\x10\x02*\x9b\x01\n" +
 	"\rSRPolicyState\x12\x1f\n" +
 	"\x1bSR_POLICY_STATE_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14SR_POLICY_STATE_DOWN\x10\x01\x12\x16\n" +
@@ -3824,145 +3950,151 @@ func file_api_pola_v1_pola_proto_rawDescGZIP() []byte {
 	return file_api_pola_v1_pola_proto_rawDescData
 }
 
-var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
+var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
+var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_api_pola_v1_pola_proto_goTypes = []any{
 	(AddressFamily)(0),                  // 0: api.pola.v1.AddressFamily
 	(DataPlane)(0),                      // 1: api.pola.v1.DataPlane
-	(SRPolicyType)(0),                   // 2: api.pola.v1.SRPolicyType
-	(SRPolicyState)(0),                  // 3: api.pola.v1.SRPolicyState
-	(SessionState)(0),                   // 4: api.pola.v1.SessionState
-	(PccType)(0),                        // 5: api.pola.v1.PccType
-	(CapabilityType)(0),                 // 6: api.pola.v1.CapabilityType
-	(SessionInitiator)(0),               // 7: api.pola.v1.SessionInitiator
-	(LspDbSyncState)(0),                 // 8: api.pola.v1.LspDbSyncState
-	(MetricType)(0),                     // 9: api.pola.v1.MetricType
-	(*Segment)(nil),                     // 10: api.pola.v1.Segment
-	(*Waypoint)(nil),                    // 11: api.pola.v1.Waypoint
-	(*SRPolicy)(nil),                    // 12: api.pola.v1.SRPolicy
-	(*CreateSRPolicyRequest)(nil),       // 13: api.pola.v1.CreateSRPolicyRequest
-	(*CreateSRPolicyResponse)(nil),      // 14: api.pola.v1.CreateSRPolicyResponse
-	(*DeleteSRPolicyRequest)(nil),       // 15: api.pola.v1.DeleteSRPolicyRequest
-	(*DeleteSRPolicyResponse)(nil),      // 16: api.pola.v1.DeleteSRPolicyResponse
-	(*StatefulCapability)(nil),          // 17: api.pola.v1.StatefulCapability
-	(*SrCapability)(nil),                // 18: api.pola.v1.SrCapability
-	(*Msd)(nil),                         // 19: api.pola.v1.Msd
-	(*Srv6Capability)(nil),              // 20: api.pola.v1.Srv6Capability
-	(*PathSetupTypeCapability)(nil),     // 21: api.pola.v1.PathSetupTypeCapability
-	(*AssocTypeListCapability)(nil),     // 22: api.pola.v1.AssocTypeListCapability
-	(*LspDbVersionCapability)(nil),      // 23: api.pola.v1.LspDbVersionCapability
-	(*MultipathCapability)(nil),         // 24: api.pola.v1.MultipathCapability
-	(*VendorInformationCapability)(nil), // 25: api.pola.v1.VendorInformationCapability
-	(*UnknownCapability)(nil),           // 26: api.pola.v1.UnknownCapability
-	(*Capability)(nil),                  // 27: api.pola.v1.Capability
-	(*SessionTimers)(nil),               // 28: api.pola.v1.SessionTimers
-	(*EffectiveTimers)(nil),             // 29: api.pola.v1.EffectiveTimers
-	(*MessageCounter)(nil),              // 30: api.pola.v1.MessageCounter
-	(*SessionStats)(nil),                // 31: api.pola.v1.SessionStats
-	(*Session)(nil),                     // 32: api.pola.v1.Session
-	(*SRPolicySession)(nil),             // 33: api.pola.v1.SRPolicySession
-	(*EndpointBehavior)(nil),            // 34: api.pola.v1.EndpointBehavior
-	(*SidStructure)(nil),                // 35: api.pola.v1.SidStructure
-	(*SID)(nil),                         // 36: api.pola.v1.SID
-	(*MultiTopoID)(nil),                 // 37: api.pola.v1.MultiTopoID
-	(*LsSrv6SID)(nil),                   // 38: api.pola.v1.LsSrv6SID
-	(*LsPrefix)(nil),                    // 39: api.pola.v1.LsPrefix
-	(*Metric)(nil),                      // 40: api.pola.v1.Metric
-	(*Srv6EndXSID)(nil),                 // 41: api.pola.v1.Srv6EndXSID
-	(*LsLinkEndpoint)(nil),              // 42: api.pola.v1.LsLinkEndpoint
-	(*AdjSid)(nil),                      // 43: api.pola.v1.AdjSid
-	(*LsLink)(nil),                      // 44: api.pola.v1.LsLink
-	(*LsNode)(nil),                      // 45: api.pola.v1.LsNode
-	(*GetSessionListRequest)(nil),       // 46: api.pola.v1.GetSessionListRequest
-	(*GetSessionListResponse)(nil),      // 47: api.pola.v1.GetSessionListResponse
-	(*GetSRPolicyListRequest)(nil),      // 48: api.pola.v1.GetSRPolicyListRequest
-	(*GetSRPolicyListResponse)(nil),     // 49: api.pola.v1.GetSRPolicyListResponse
-	(*GetTEDRequest)(nil),               // 50: api.pola.v1.GetTEDRequest
-	(*GetTEDResponse)(nil),              // 51: api.pola.v1.GetTEDResponse
-	(*DeleteSessionRequest)(nil),        // 52: api.pola.v1.DeleteSessionRequest
-	(*DeleteSessionResponse)(nil),       // 53: api.pola.v1.DeleteSessionResponse
+	(SRPolicyState)(0),                  // 2: api.pola.v1.SRPolicyState
+	(SessionState)(0),                   // 3: api.pola.v1.SessionState
+	(PccType)(0),                        // 4: api.pola.v1.PccType
+	(CapabilityType)(0),                 // 5: api.pola.v1.CapabilityType
+	(SessionInitiator)(0),               // 6: api.pola.v1.SessionInitiator
+	(LspDbSyncState)(0),                 // 7: api.pola.v1.LspDbSyncState
+	(MetricType)(0),                     // 8: api.pola.v1.MetricType
+	(*Segment)(nil),                     // 9: api.pola.v1.Segment
+	(*Waypoint)(nil),                    // 10: api.pola.v1.Waypoint
+	(*DynamicPath)(nil),                 // 11: api.pola.v1.DynamicPath
+	(*ExplicitPath)(nil),                // 12: api.pola.v1.ExplicitPath
+	(*CandidatePath)(nil),               // 13: api.pola.v1.CandidatePath
+	(*SRPolicy)(nil),                    // 14: api.pola.v1.SRPolicy
+	(*CreateSRPolicyRequest)(nil),       // 15: api.pola.v1.CreateSRPolicyRequest
+	(*CreateSRPolicyResponse)(nil),      // 16: api.pola.v1.CreateSRPolicyResponse
+	(*DeleteSRPolicyRequest)(nil),       // 17: api.pola.v1.DeleteSRPolicyRequest
+	(*DeleteSRPolicyResponse)(nil),      // 18: api.pola.v1.DeleteSRPolicyResponse
+	(*StatefulCapability)(nil),          // 19: api.pola.v1.StatefulCapability
+	(*SrCapability)(nil),                // 20: api.pola.v1.SrCapability
+	(*Msd)(nil),                         // 21: api.pola.v1.Msd
+	(*Srv6Capability)(nil),              // 22: api.pola.v1.Srv6Capability
+	(*PathSetupTypeCapability)(nil),     // 23: api.pola.v1.PathSetupTypeCapability
+	(*AssocTypeListCapability)(nil),     // 24: api.pola.v1.AssocTypeListCapability
+	(*LspDbVersionCapability)(nil),      // 25: api.pola.v1.LspDbVersionCapability
+	(*MultipathCapability)(nil),         // 26: api.pola.v1.MultipathCapability
+	(*VendorInformationCapability)(nil), // 27: api.pola.v1.VendorInformationCapability
+	(*UnknownCapability)(nil),           // 28: api.pola.v1.UnknownCapability
+	(*Capability)(nil),                  // 29: api.pola.v1.Capability
+	(*SessionTimers)(nil),               // 30: api.pola.v1.SessionTimers
+	(*EffectiveTimers)(nil),             // 31: api.pola.v1.EffectiveTimers
+	(*MessageCounter)(nil),              // 32: api.pola.v1.MessageCounter
+	(*SessionStats)(nil),                // 33: api.pola.v1.SessionStats
+	(*Session)(nil),                     // 34: api.pola.v1.Session
+	(*SRPolicySession)(nil),             // 35: api.pola.v1.SRPolicySession
+	(*EndpointBehavior)(nil),            // 36: api.pola.v1.EndpointBehavior
+	(*SidStructure)(nil),                // 37: api.pola.v1.SidStructure
+	(*SID)(nil),                         // 38: api.pola.v1.SID
+	(*MultiTopoID)(nil),                 // 39: api.pola.v1.MultiTopoID
+	(*LsSrv6SID)(nil),                   // 40: api.pola.v1.LsSrv6SID
+	(*LsPrefix)(nil),                    // 41: api.pola.v1.LsPrefix
+	(*Metric)(nil),                      // 42: api.pola.v1.Metric
+	(*Srv6EndXSID)(nil),                 // 43: api.pola.v1.Srv6EndXSID
+	(*LsLinkEndpoint)(nil),              // 44: api.pola.v1.LsLinkEndpoint
+	(*AdjSid)(nil),                      // 45: api.pola.v1.AdjSid
+	(*LsLink)(nil),                      // 46: api.pola.v1.LsLink
+	(*LsNode)(nil),                      // 47: api.pola.v1.LsNode
+	(*GetSessionListRequest)(nil),       // 48: api.pola.v1.GetSessionListRequest
+	(*GetSessionListResponse)(nil),      // 49: api.pola.v1.GetSessionListResponse
+	(*GetSRPolicyListRequest)(nil),      // 50: api.pola.v1.GetSRPolicyListRequest
+	(*GetSRPolicyListResponse)(nil),     // 51: api.pola.v1.GetSRPolicyListResponse
+	(*GetTEDRequest)(nil),               // 52: api.pola.v1.GetTEDRequest
+	(*GetTEDResponse)(nil),              // 53: api.pola.v1.GetTEDResponse
+	(*DeleteSessionRequest)(nil),        // 54: api.pola.v1.DeleteSessionRequest
+	(*DeleteSessionResponse)(nil),       // 55: api.pola.v1.DeleteSessionResponse
 }
 var file_api_pola_v1_pola_proto_depIdxs = []int32{
-	2,  // 0: api.pola.v1.SRPolicy.type:type_name -> api.pola.v1.SRPolicyType
-	10, // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
-	9,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
-	11, // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
-	3,  // 4: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
-	0,  // 5: api.pola.v1.SRPolicy.underlay_family:type_name -> api.pola.v1.AddressFamily
-	1,  // 6: api.pola.v1.SRPolicy.data_plane:type_name -> api.pola.v1.DataPlane
-	12, // 7: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	12, // 8: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	19, // 9: api.pola.v1.Srv6Capability.msds:type_name -> api.pola.v1.Msd
-	27, // 10: api.pola.v1.PathSetupTypeCapability.sub_capabilities:type_name -> api.pola.v1.Capability
-	6,  // 11: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
-	17, // 12: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
-	18, // 13: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
-	20, // 14: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
-	21, // 15: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
-	22, // 16: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
-	23, // 17: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
-	24, // 18: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
-	25, // 19: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
-	26, // 20: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
-	30, // 21: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
-	30, // 22: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
-	30, // 23: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
-	30, // 24: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
-	30, // 25: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
-	30, // 26: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
-	30, // 27: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
-	30, // 28: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
-	30, // 29: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
-	30, // 30: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
-	4,  // 31: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
-	27, // 32: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
-	5,  // 33: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
-	27, // 34: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
-	28, // 35: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
-	28, // 36: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
-	29, // 37: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
-	7,  // 38: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
-	8,  // 39: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	31, // 40: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
-	4,  // 41: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
-	8,  // 42: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	12, // 43: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
-	36, // 44: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
-	34, // 45: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
-	35, // 46: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
-	37, // 47: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
-	9,  // 48: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
-	36, // 49: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
-	35, // 50: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	0,  // 51: api.pola.v1.AdjSid.family:type_name -> api.pola.v1.AddressFamily
-	42, // 52: api.pola.v1.LsLink.local:type_name -> api.pola.v1.LsLinkEndpoint
-	42, // 53: api.pola.v1.LsLink.remote:type_name -> api.pola.v1.LsLinkEndpoint
-	40, // 54: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	43, // 55: api.pola.v1.LsLink.adj_sids:type_name -> api.pola.v1.AdjSid
-	41, // 56: api.pola.v1.LsLink.srv6_end_x_sids:type_name -> api.pola.v1.Srv6EndXSID
-	44, // 57: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
-	39, // 58: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
-	38, // 59: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	32, // 60: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	33, // 61: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
-	45, // 62: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
-	13, // 63: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	15, // 64: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	46, // 65: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	48, // 66: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	50, // 67: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	52, // 68: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	14, // 69: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	16, // 70: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	47, // 71: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	49, // 72: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	51, // 73: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	53, // 74: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	69, // [69:75] is the sub-list for method output_type
-	63, // [63:69] is the sub-list for method input_type
-	63, // [63:63] is the sub-list for extension type_name
-	63, // [63:63] is the sub-list for extension extendee
-	0,  // [0:63] is the sub-list for field type_name
+	8,  // 0: api.pola.v1.DynamicPath.metric:type_name -> api.pola.v1.MetricType
+	1,  // 1: api.pola.v1.DynamicPath.data_plane:type_name -> api.pola.v1.DataPlane
+	0,  // 2: api.pola.v1.DynamicPath.underlay_family:type_name -> api.pola.v1.AddressFamily
+	10, // 3: api.pola.v1.DynamicPath.waypoints:type_name -> api.pola.v1.Waypoint
+	9,  // 4: api.pola.v1.ExplicitPath.segment_list:type_name -> api.pola.v1.Segment
+	11, // 5: api.pola.v1.CandidatePath.dynamic:type_name -> api.pola.v1.DynamicPath
+	12, // 6: api.pola.v1.CandidatePath.explicit:type_name -> api.pola.v1.ExplicitPath
+	0,  // 7: api.pola.v1.SRPolicy.endpoint_family:type_name -> api.pola.v1.AddressFamily
+	13, // 8: api.pola.v1.SRPolicy.candidate_path:type_name -> api.pola.v1.CandidatePath
+	2,  // 9: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
+	9,  // 10: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
+	14, // 11: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	14, // 12: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	21, // 13: api.pola.v1.Srv6Capability.msds:type_name -> api.pola.v1.Msd
+	29, // 14: api.pola.v1.PathSetupTypeCapability.sub_capabilities:type_name -> api.pola.v1.Capability
+	5,  // 15: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
+	19, // 16: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
+	20, // 17: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
+	22, // 18: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
+	23, // 19: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
+	24, // 20: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
+	25, // 21: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
+	26, // 22: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
+	27, // 23: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
+	28, // 24: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
+	32, // 25: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
+	32, // 26: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
+	32, // 27: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
+	32, // 28: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
+	32, // 29: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
+	32, // 30: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
+	32, // 31: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
+	32, // 32: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
+	32, // 33: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
+	32, // 34: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
+	3,  // 35: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
+	29, // 36: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
+	4,  // 37: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
+	29, // 38: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
+	30, // 39: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
+	30, // 40: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
+	31, // 41: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
+	6,  // 42: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
+	7,  // 43: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	33, // 44: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
+	3,  // 45: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
+	7,  // 46: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	14, // 47: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
+	38, // 48: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
+	36, // 49: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	37, // 50: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
+	39, // 51: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
+	8,  // 52: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
+	38, // 53: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
+	37, // 54: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
+	0,  // 55: api.pola.v1.AdjSid.family:type_name -> api.pola.v1.AddressFamily
+	44, // 56: api.pola.v1.LsLink.local:type_name -> api.pola.v1.LsLinkEndpoint
+	44, // 57: api.pola.v1.LsLink.remote:type_name -> api.pola.v1.LsLinkEndpoint
+	42, // 58: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	45, // 59: api.pola.v1.LsLink.adj_sids:type_name -> api.pola.v1.AdjSid
+	43, // 60: api.pola.v1.LsLink.srv6_end_x_sids:type_name -> api.pola.v1.Srv6EndXSID
+	46, // 61: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
+	41, // 62: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
+	40, // 63: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	34, // 64: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	35, // 65: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
+	47, // 66: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
+	15, // 67: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	17, // 68: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	48, // 69: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	50, // 70: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	52, // 71: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	54, // 72: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	16, // 73: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	18, // 74: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	49, // 75: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	51, // 76: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	53, // 77: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	55, // 78: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	73, // [73:79] is the sub-list for method output_type
+	67, // [67:73] is the sub-list for method input_type
+	67, // [67:67] is the sub-list for extension type_name
+	67, // [67:67] is the sub-list for extension extendee
+	0,  // [0:67] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }
@@ -3971,8 +4103,12 @@ func file_api_pola_v1_pola_proto_init() {
 		return
 	}
 	file_api_pola_v1_pola_proto_msgTypes[0].OneofWrappers = []any{}
-	file_api_pola_v1_pola_proto_msgTypes[8].OneofWrappers = []any{}
-	file_api_pola_v1_pola_proto_msgTypes[17].OneofWrappers = []any{
+	file_api_pola_v1_pola_proto_msgTypes[4].OneofWrappers = []any{
+		(*CandidatePath_Dynamic)(nil),
+		(*CandidatePath_Explicit)(nil),
+	}
+	file_api_pola_v1_pola_proto_msgTypes[11].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[20].OneofWrappers = []any{
 		(*Capability_Stateful)(nil),
 		(*Capability_Sr)(nil),
 		(*Capability_Srv6)(nil),
@@ -3983,16 +4119,16 @@ func file_api_pola_v1_pola_proto_init() {
 		(*Capability_VendorInformation)(nil),
 		(*Capability_Unknown)(nil),
 	}
-	file_api_pola_v1_pola_proto_msgTypes[22].OneofWrappers = []any{}
-	file_api_pola_v1_pola_proto_msgTypes[29].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[25].OneofWrappers = []any{}
 	file_api_pola_v1_pola_proto_msgTypes[32].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[35].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_pola_v1_pola_proto_rawDesc), len(file_api_pola_v1_pola_proto_rawDesc)),
-			NumEnums:      10,
-			NumMessages:   44,
+			NumEnums:      9,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -26,6 +26,104 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type AddressFamily int32
+
+const (
+	AddressFamily_ADDRESS_FAMILY_UNSPECIFIED AddressFamily = 0
+	AddressFamily_ADDRESS_FAMILY_IPV4        AddressFamily = 1
+	AddressFamily_ADDRESS_FAMILY_IPV6        AddressFamily = 2
+)
+
+// Enum value maps for AddressFamily.
+var (
+	AddressFamily_name = map[int32]string{
+		0: "ADDRESS_FAMILY_UNSPECIFIED",
+		1: "ADDRESS_FAMILY_IPV4",
+		2: "ADDRESS_FAMILY_IPV6",
+	}
+	AddressFamily_value = map[string]int32{
+		"ADDRESS_FAMILY_UNSPECIFIED": 0,
+		"ADDRESS_FAMILY_IPV4":        1,
+		"ADDRESS_FAMILY_IPV6":        2,
+	}
+)
+
+func (x AddressFamily) Enum() *AddressFamily {
+	p := new(AddressFamily)
+	*p = x
+	return p
+}
+
+func (x AddressFamily) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AddressFamily) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_pola_v1_pola_proto_enumTypes[0].Descriptor()
+}
+
+func (AddressFamily) Type() protoreflect.EnumType {
+	return &file_api_pola_v1_pola_proto_enumTypes[0]
+}
+
+func (x AddressFamily) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AddressFamily.Descriptor instead.
+func (AddressFamily) EnumDescriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{0}
+}
+
+type DataPlane int32
+
+const (
+	DataPlane_DATA_PLANE_UNSPECIFIED DataPlane = 0
+	DataPlane_DATA_PLANE_SR_MPLS     DataPlane = 1
+	DataPlane_DATA_PLANE_SRV6        DataPlane = 2
+)
+
+// Enum value maps for DataPlane.
+var (
+	DataPlane_name = map[int32]string{
+		0: "DATA_PLANE_UNSPECIFIED",
+		1: "DATA_PLANE_SR_MPLS",
+		2: "DATA_PLANE_SRV6",
+	}
+	DataPlane_value = map[string]int32{
+		"DATA_PLANE_UNSPECIFIED": 0,
+		"DATA_PLANE_SR_MPLS":     1,
+		"DATA_PLANE_SRV6":        2,
+	}
+)
+
+func (x DataPlane) Enum() *DataPlane {
+	p := new(DataPlane)
+	*p = x
+	return p
+}
+
+func (x DataPlane) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DataPlane) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_pola_v1_pola_proto_enumTypes[1].Descriptor()
+}
+
+func (DataPlane) Type() protoreflect.EnumType {
+	return &file_api_pola_v1_pola_proto_enumTypes[1]
+}
+
+func (x DataPlane) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DataPlane.Descriptor instead.
+func (DataPlane) EnumDescriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{1}
+}
+
 type SRPolicyType int32
 
 const (
@@ -59,11 +157,11 @@ func (x SRPolicyType) String() string {
 }
 
 func (SRPolicyType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[0].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[2].Descriptor()
 }
 
 func (SRPolicyType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[0]
+	return &file_api_pola_v1_pola_proto_enumTypes[2]
 }
 
 func (x SRPolicyType) Number() protoreflect.EnumNumber {
@@ -72,7 +170,7 @@ func (x SRPolicyType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SRPolicyType.Descriptor instead.
 func (SRPolicyType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{0}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
 }
 
 type SRPolicyState int32
@@ -114,11 +212,11 @@ func (x SRPolicyState) String() string {
 }
 
 func (SRPolicyState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[1].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[3].Descriptor()
 }
 
 func (SRPolicyState) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[1]
+	return &file_api_pola_v1_pola_proto_enumTypes[3]
 }
 
 func (x SRPolicyState) Number() protoreflect.EnumNumber {
@@ -127,7 +225,7 @@ func (x SRPolicyState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SRPolicyState.Descriptor instead.
 func (SRPolicyState) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{1}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
 }
 
 type SessionState int32
@@ -169,11 +267,11 @@ func (x SessionState) String() string {
 }
 
 func (SessionState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[2].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[4].Descriptor()
 }
 
 func (SessionState) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[2]
+	return &file_api_pola_v1_pola_proto_enumTypes[4]
 }
 
 func (x SessionState) Number() protoreflect.EnumNumber {
@@ -182,7 +280,7 @@ func (x SessionState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SessionState.Descriptor instead.
 func (SessionState) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{2}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
 }
 
 type PccType int32
@@ -221,11 +319,11 @@ func (x PccType) String() string {
 }
 
 func (PccType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[3].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[5].Descriptor()
 }
 
 func (PccType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[3]
+	return &file_api_pola_v1_pola_proto_enumTypes[5]
 }
 
 func (x PccType) Number() protoreflect.EnumNumber {
@@ -234,7 +332,7 @@ func (x PccType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PccType.Descriptor instead.
 func (PccType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{3}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
 }
 
 type CapabilityType int32
@@ -291,11 +389,11 @@ func (x CapabilityType) String() string {
 }
 
 func (CapabilityType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[4].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[6].Descriptor()
 }
 
 func (CapabilityType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[4]
+	return &file_api_pola_v1_pola_proto_enumTypes[6]
 }
 
 func (x CapabilityType) Number() protoreflect.EnumNumber {
@@ -304,7 +402,7 @@ func (x CapabilityType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CapabilityType.Descriptor instead.
 func (CapabilityType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{4}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{6}
 }
 
 // RFC 9826 ietf-pcep: /pcep/entity/peers/peer/sessions/session/initiator
@@ -341,11 +439,11 @@ func (x SessionInitiator) String() string {
 }
 
 func (SessionInitiator) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[5].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[7].Descriptor()
 }
 
 func (SessionInitiator) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[5]
+	return &file_api_pola_v1_pola_proto_enumTypes[7]
 }
 
 func (x SessionInitiator) Number() protoreflect.EnumNumber {
@@ -354,7 +452,7 @@ func (x SessionInitiator) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SessionInitiator.Descriptor instead.
 func (SessionInitiator) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{5}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
 }
 
 // LSP-DB synchronization state defined by RFC 8231 and exposed by RFC 9826.
@@ -394,11 +492,11 @@ func (x LspDbSyncState) String() string {
 }
 
 func (LspDbSyncState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[6].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[8].Descriptor()
 }
 
 func (LspDbSyncState) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[6]
+	return &file_api_pola_v1_pola_proto_enumTypes[8]
 }
 
 func (x LspDbSyncState) Number() protoreflect.EnumNumber {
@@ -407,7 +505,7 @@ func (x LspDbSyncState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use LspDbSyncState.Descriptor instead.
 func (LspDbSyncState) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{6}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{8}
 }
 
 type MetricType int32
@@ -449,11 +547,11 @@ func (x MetricType) String() string {
 }
 
 func (MetricType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_pola_v1_pola_proto_enumTypes[7].Descriptor()
+	return file_api_pola_v1_pola_proto_enumTypes[9].Descriptor()
 }
 
 func (MetricType) Type() protoreflect.EnumType {
-	return &file_api_pola_v1_pola_proto_enumTypes[7]
+	return &file_api_pola_v1_pola_proto_enumTypes[9]
 }
 
 func (x MetricType) Number() protoreflect.EnumNumber {
@@ -462,16 +560,21 @@ func (x MetricType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use MetricType.Descriptor instead.
 func (MetricType) EnumDescriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{7}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{9}
 }
 
 type Segment struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Sid           string                 `protobuf:"bytes,1,opt,name=sid,proto3" json:"sid,omitempty"`
-	SidStructure  string                 `protobuf:"bytes,2,opt,name=sid_structure,json=sidStructure,proto3" json:"sid_structure,omitempty"`
-	LocalAddr     string                 `protobuf:"bytes,3,opt,name=local_addr,json=localAddr,proto3" json:"local_addr,omitempty"`
-	RemoteAddr    string                 `protobuf:"bytes,4,opt,name=remote_addr,json=remoteAddr,proto3" json:"remote_addr,omitempty"`
-	SidAbsent     bool                   `protobuf:"varint,5,opt,name=sid_absent,json=sidAbsent,proto3" json:"sid_absent,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Sid          string                 `protobuf:"bytes,1,opt,name=sid,proto3" json:"sid,omitempty"`
+	SidStructure string                 `protobuf:"bytes,2,opt,name=sid_structure,json=sidStructure,proto3" json:"sid_structure,omitempty"`
+	LocalAddr    string                 `protobuf:"bytes,3,opt,name=local_addr,json=localAddr,proto3" json:"local_addr,omitempty"`
+	RemoteAddr   string                 `protobuf:"bytes,4,opt,name=remote_addr,json=remoteAddr,proto3" json:"remote_addr,omitempty"`
+	SidAbsent    bool                   `protobuf:"varint,5,opt,name=sid_absent,json=sidAbsent,proto3" json:"sid_absent,omitempty"`
+	// SRv6 endpoint behavior advertised by the TED (RFC 9603 §4.3.1).
+	Behavior uint32 `protobuf:"varint,6,opt,name=behavior,proto3" json:"behavior,omitempty"`
+	// Interface ID for link-local NAI scoping (RFC 8664/9603 §4.3.1).
+	LocalIfaceId  *uint32 `protobuf:"varint,7,opt,name=local_iface_id,json=localIfaceId,proto3,oneof" json:"local_iface_id,omitempty"`
+	RemoteIfaceId *uint32 `protobuf:"varint,8,opt,name=remote_iface_id,json=remoteIfaceId,proto3,oneof" json:"remote_iface_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -541,6 +644,27 @@ func (x *Segment) GetSidAbsent() bool {
 	return false
 }
 
+func (x *Segment) GetBehavior() uint32 {
+	if x != nil {
+		return x.Behavior
+	}
+	return 0
+}
+
+func (x *Segment) GetLocalIfaceId() uint32 {
+	if x != nil && x.LocalIfaceId != nil {
+		return *x.LocalIfaceId
+	}
+	return 0
+}
+
+func (x *Segment) GetRemoteIfaceId() uint32 {
+	if x != nil && x.RemoteIfaceId != nil {
+		return *x.RemoteIfaceId
+	}
+	return 0
+}
+
 type Waypoint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RouterId      string                 `protobuf:"bytes,1,opt,name=router_id,json=routerId,proto3" json:"router_id,omitempty"`
@@ -594,24 +718,28 @@ func (x *Waypoint) GetSid() string {
 }
 
 type SRPolicy struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PeerAddr      []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
-	SrcAddr       []byte                 `protobuf:"bytes,2,opt,name=src_addr,json=srcAddr,proto3" json:"src_addr,omitempty"`
-	DstAddr       []byte                 `protobuf:"bytes,3,opt,name=dst_addr,json=dstAddr,proto3" json:"dst_addr,omitempty"`
-	SrcRouterId   string                 `protobuf:"bytes,4,opt,name=src_router_id,json=srcRouterId,proto3" json:"src_router_id,omitempty"`
-	DstRouterId   string                 `protobuf:"bytes,5,opt,name=dst_router_id,json=dstRouterId,proto3" json:"dst_router_id,omitempty"`
-	Color         uint32                 `protobuf:"varint,6,opt,name=color,proto3" json:"color,omitempty"`
-	Preference    uint32                 `protobuf:"varint,7,opt,name=preference,proto3" json:"preference,omitempty"`
-	PolicyName    string                 `protobuf:"bytes,8,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
-	Type          SRPolicyType           `protobuf:"varint,9,opt,name=type,proto3,enum=api.pola.v1.SRPolicyType" json:"type,omitempty"`
-	SegmentList   []*Segment             `protobuf:"bytes,10,rep,name=segment_list,json=segmentList,proto3" json:"segment_list,omitempty"`
-	Metric        MetricType             `protobuf:"varint,11,opt,name=metric,proto3,enum=api.pola.v1.MetricType" json:"metric,omitempty"`
-	Waypoints     []*Waypoint            `protobuf:"bytes,12,rep,name=waypoints,proto3" json:"waypoints,omitempty"`
-	PlspId        uint32                 `protobuf:"varint,13,opt,name=plsp_id,json=plspId,proto3" json:"plsp_id,omitempty"`
-	LspId         uint32                 `protobuf:"varint,14,opt,name=lsp_id,json=lspId,proto3" json:"lsp_id,omitempty"`
-	State         SRPolicyState          `protobuf:"varint,15,opt,name=state,proto3,enum=api.pola.v1.SRPolicyState" json:"state,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	PeerAddr    []byte                 `protobuf:"bytes,1,opt,name=peer_addr,json=peerAddr,proto3" json:"peer_addr,omitempty"`
+	SrcAddr     []byte                 `protobuf:"bytes,2,opt,name=src_addr,json=srcAddr,proto3" json:"src_addr,omitempty"`
+	DstAddr     []byte                 `protobuf:"bytes,3,opt,name=dst_addr,json=dstAddr,proto3" json:"dst_addr,omitempty"`
+	SrcRouterId string                 `protobuf:"bytes,4,opt,name=src_router_id,json=srcRouterId,proto3" json:"src_router_id,omitempty"`
+	DstRouterId string                 `protobuf:"bytes,5,opt,name=dst_router_id,json=dstRouterId,proto3" json:"dst_router_id,omitempty"`
+	Color       uint32                 `protobuf:"varint,6,opt,name=color,proto3" json:"color,omitempty"`
+	Preference  uint32                 `protobuf:"varint,7,opt,name=preference,proto3" json:"preference,omitempty"`
+	PolicyName  string                 `protobuf:"bytes,8,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
+	Type        SRPolicyType           `protobuf:"varint,9,opt,name=type,proto3,enum=api.pola.v1.SRPolicyType" json:"type,omitempty"`
+	SegmentList []*Segment             `protobuf:"bytes,10,rep,name=segment_list,json=segmentList,proto3" json:"segment_list,omitempty"`
+	Metric      MetricType             `protobuf:"varint,11,opt,name=metric,proto3,enum=api.pola.v1.MetricType" json:"metric,omitempty"`
+	Waypoints   []*Waypoint            `protobuf:"bytes,12,rep,name=waypoints,proto3" json:"waypoints,omitempty"`
+	PlspId      uint32                 `protobuf:"varint,13,opt,name=plsp_id,json=plspId,proto3" json:"plsp_id,omitempty"`
+	LspId       uint32                 `protobuf:"varint,14,opt,name=lsp_id,json=lspId,proto3" json:"lsp_id,omitempty"`
+	State       SRPolicyState          `protobuf:"varint,15,opt,name=state,proto3,enum=api.pola.v1.SRPolicyState" json:"state,omitempty"`
+	// Underlay plane for dynamic path computation.
+	// Unspecified uses the TED node's unique viable plane and is rejected if ambiguous.
+	UnderlayFamily AddressFamily `protobuf:"varint,16,opt,name=underlay_family,json=underlayFamily,proto3,enum=api.pola.v1.AddressFamily" json:"underlay_family,omitempty"`
+	DataPlane      DataPlane     `protobuf:"varint,17,opt,name=data_plane,json=dataPlane,proto3,enum=api.pola.v1.DataPlane" json:"data_plane,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SRPolicy) Reset() {
@@ -747,6 +875,20 @@ func (x *SRPolicy) GetState() SRPolicyState {
 		return x.State
 	}
 	return SRPolicyState_SR_POLICY_STATE_UNSPECIFIED
+}
+
+func (x *SRPolicy) GetUnderlayFamily() AddressFamily {
+	if x != nil {
+		return x.UnderlayFamily
+	}
+	return AddressFamily_ADDRESS_FAMILY_UNSPECIFIED
+}
+
+func (x *SRPolicy) GetDataPlane() DataPlane {
+	if x != nil {
+		return x.DataPlane
+	}
+	return DataPlane_DATA_PLANE_UNSPECIFIED
 }
 
 type CreateSRPolicyRequest struct {
@@ -2694,24 +2836,150 @@ func (x *Srv6EndXSID) GetSidStructure() *SidStructure {
 	return nil
 }
 
+type LsLinkEndpoint struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	RouterId string                 `protobuf:"bytes,1,opt,name=router_id,json=routerId,proto3" json:"router_id,omitempty"`
+	Asn      uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
+	// Interface ID (BGP-LS TLV 258/259) for link-local IPv6 address scoping.
+	InterfaceId   *uint32 `protobuf:"varint,3,opt,name=interface_id,json=interfaceId,proto3,oneof" json:"interface_id,omitempty"`
+	Ipv4          string  `protobuf:"bytes,4,opt,name=ipv4,proto3" json:"ipv4,omitempty"`
+	Ipv6          string  `protobuf:"bytes,5,opt,name=ipv6,proto3" json:"ipv6,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LsLinkEndpoint) Reset() {
+	*x = LsLinkEndpoint{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsLinkEndpoint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsLinkEndpoint) ProtoMessage() {}
+
+func (x *LsLinkEndpoint) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsLinkEndpoint.ProtoReflect.Descriptor instead.
+func (*LsLinkEndpoint) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *LsLinkEndpoint) GetRouterId() string {
+	if x != nil {
+		return x.RouterId
+	}
+	return ""
+}
+
+func (x *LsLinkEndpoint) GetAsn() uint32 {
+	if x != nil {
+		return x.Asn
+	}
+	return 0
+}
+
+func (x *LsLinkEndpoint) GetInterfaceId() uint32 {
+	if x != nil && x.InterfaceId != nil {
+		return *x.InterfaceId
+	}
+	return 0
+}
+
+func (x *LsLinkEndpoint) GetIpv4() string {
+	if x != nil {
+		return x.Ipv4
+	}
+	return ""
+}
+
+func (x *LsLinkEndpoint) GetIpv6() string {
+	if x != nil {
+		return x.Ipv6
+	}
+	return ""
+}
+
+type AdjSid struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unspecified when GoBGP cannot distinguish IPv4 and IPv6 Adjacency-SIDs.
+	Family        AddressFamily `protobuf:"varint,1,opt,name=family,proto3,enum=api.pola.v1.AddressFamily" json:"family,omitempty"`
+	Sid           uint32        `protobuf:"varint,2,opt,name=sid,proto3" json:"sid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdjSid) Reset() {
+	*x = AdjSid{}
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdjSid) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdjSid) ProtoMessage() {}
+
+func (x *AdjSid) ProtoReflect() protoreflect.Message {
+	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdjSid.ProtoReflect.Descriptor instead.
+func (*AdjSid) Descriptor() ([]byte, []int) {
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *AdjSid) GetFamily() AddressFamily {
+	if x != nil {
+		return x.Family
+	}
+	return AddressFamily_ADDRESS_FAMILY_UNSPECIFIED
+}
+
+func (x *AdjSid) GetSid() uint32 {
+	if x != nil {
+		return x.Sid
+	}
+	return 0
+}
+
 type LsLink struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	LocalRouterId  string                 `protobuf:"bytes,1,opt,name=local_router_id,json=localRouterId,proto3" json:"local_router_id,omitempty"`
-	LocalAsn       uint32                 `protobuf:"varint,2,opt,name=local_asn,json=localAsn,proto3" json:"local_asn,omitempty"`
-	LocalIp        string                 `protobuf:"bytes,3,opt,name=local_ip,json=localIp,proto3" json:"local_ip,omitempty"`
-	RemoteRouterId string                 `protobuf:"bytes,4,opt,name=remote_router_id,json=remoteRouterId,proto3" json:"remote_router_id,omitempty"`
-	RemoteAsn      uint32                 `protobuf:"varint,5,opt,name=remote_asn,json=remoteAsn,proto3" json:"remote_asn,omitempty"`
-	RemoteIp       string                 `protobuf:"bytes,6,opt,name=remote_ip,json=remoteIp,proto3" json:"remote_ip,omitempty"`
-	Metrics        []*Metric              `protobuf:"bytes,7,rep,name=metrics,proto3" json:"metrics,omitempty"`
-	AdjSid         uint32                 `protobuf:"varint,8,opt,name=adj_sid,json=adjSid,proto3" json:"adj_sid,omitempty"`
-	Srv6EndXSid    *Srv6EndXSID           `protobuf:"bytes,9,opt,name=srv6_end_x_sid,json=srv6EndXSid,proto3" json:"srv6_end_x_sid,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Local         *LsLinkEndpoint        `protobuf:"bytes,1,opt,name=local,proto3" json:"local,omitempty"`
+	Remote        *LsLinkEndpoint        `protobuf:"bytes,2,opt,name=remote,proto3" json:"remote,omitempty"`
+	Metrics       []*Metric              `protobuf:"bytes,3,rep,name=metrics,proto3" json:"metrics,omitempty"`
+	AdjSids       []*AdjSid              `protobuf:"bytes,4,rep,name=adj_sids,json=adjSids,proto3" json:"adj_sids,omitempty"`
+	Srv6EndXSids  []*Srv6EndXSID         `protobuf:"bytes,5,rep,name=srv6_end_x_sids,json=srv6EndXSids,proto3" json:"srv6_end_x_sids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *LsLink) Reset() {
 	*x = LsLink{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2723,7 +2991,7 @@ func (x *LsLink) String() string {
 func (*LsLink) ProtoMessage() {}
 
 func (x *LsLink) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[32]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2736,49 +3004,21 @@ func (x *LsLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsLink.ProtoReflect.Descriptor instead.
 func (*LsLink) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{32}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
 }
 
-func (x *LsLink) GetLocalRouterId() string {
+func (x *LsLink) GetLocal() *LsLinkEndpoint {
 	if x != nil {
-		return x.LocalRouterId
+		return x.Local
 	}
-	return ""
+	return nil
 }
 
-func (x *LsLink) GetLocalAsn() uint32 {
+func (x *LsLink) GetRemote() *LsLinkEndpoint {
 	if x != nil {
-		return x.LocalAsn
+		return x.Remote
 	}
-	return 0
-}
-
-func (x *LsLink) GetLocalIp() string {
-	if x != nil {
-		return x.LocalIp
-	}
-	return ""
-}
-
-func (x *LsLink) GetRemoteRouterId() string {
-	if x != nil {
-		return x.RemoteRouterId
-	}
-	return ""
-}
-
-func (x *LsLink) GetRemoteAsn() uint32 {
-	if x != nil {
-		return x.RemoteAsn
-	}
-	return 0
-}
-
-func (x *LsLink) GetRemoteIp() string {
-	if x != nil {
-		return x.RemoteIp
-	}
-	return ""
+	return nil
 }
 
 func (x *LsLink) GetMetrics() []*Metric {
@@ -2788,16 +3028,16 @@ func (x *LsLink) GetMetrics() []*Metric {
 	return nil
 }
 
-func (x *LsLink) GetAdjSid() uint32 {
+func (x *LsLink) GetAdjSids() []*AdjSid {
 	if x != nil {
-		return x.AdjSid
+		return x.AdjSids
 	}
-	return 0
+	return nil
 }
 
-func (x *LsLink) GetSrv6EndXSid() *Srv6EndXSID {
+func (x *LsLink) GetSrv6EndXSids() []*Srv6EndXSID {
 	if x != nil {
-		return x.Srv6EndXSid
+		return x.Srv6EndXSids
 	}
 	return nil
 }
@@ -2819,7 +3059,7 @@ type LsNode struct {
 
 func (x *LsNode) Reset() {
 	*x = LsNode{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2831,7 +3071,7 @@ func (x *LsNode) String() string {
 func (*LsNode) ProtoMessage() {}
 
 func (x *LsNode) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[33]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2844,7 +3084,7 @@ func (x *LsNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsNode.ProtoReflect.Descriptor instead.
 func (*LsNode) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{33}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *LsNode) GetAsn() uint32 {
@@ -2920,7 +3160,7 @@ type GetSessionListRequest struct {
 
 func (x *GetSessionListRequest) Reset() {
 	*x = GetSessionListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2932,7 +3172,7 @@ func (x *GetSessionListRequest) String() string {
 func (*GetSessionListRequest) ProtoMessage() {}
 
 func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[34]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2945,7 +3185,7 @@ func (x *GetSessionListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListRequest.ProtoReflect.Descriptor instead.
 func (*GetSessionListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetSessionListRequest) GetPeerAddr() []byte {
@@ -2971,7 +3211,7 @@ type GetSessionListResponse struct {
 
 func (x *GetSessionListResponse) Reset() {
 	*x = GetSessionListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2983,7 +3223,7 @@ func (x *GetSessionListResponse) String() string {
 func (*GetSessionListResponse) ProtoMessage() {}
 
 func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[35]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2996,7 +3236,7 @@ func (x *GetSessionListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionListResponse.ProtoReflect.Descriptor instead.
 func (*GetSessionListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{35}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetSessionListResponse) GetSessions() []*Session {
@@ -3015,7 +3255,7 @@ type GetSRPolicyListRequest struct {
 
 func (x *GetSRPolicyListRequest) Reset() {
 	*x = GetSRPolicyListRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3027,7 +3267,7 @@ func (x *GetSRPolicyListRequest) String() string {
 func (*GetSRPolicyListRequest) ProtoMessage() {}
 
 func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[36]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3040,7 +3280,7 @@ func (x *GetSRPolicyListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListRequest.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{36}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetSRPolicyListRequest) GetPeerAddr() []byte {
@@ -3059,7 +3299,7 @@ type GetSRPolicyListResponse struct {
 
 func (x *GetSRPolicyListResponse) Reset() {
 	*x = GetSRPolicyListResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3071,7 +3311,7 @@ func (x *GetSRPolicyListResponse) String() string {
 func (*GetSRPolicyListResponse) ProtoMessage() {}
 
 func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[37]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3084,7 +3324,7 @@ func (x *GetSRPolicyListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSRPolicyListResponse.ProtoReflect.Descriptor instead.
 func (*GetSRPolicyListResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{37}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetSRPolicyListResponse) GetSessions() []*SRPolicySession {
@@ -3102,7 +3342,7 @@ type GetTEDRequest struct {
 
 func (x *GetTEDRequest) Reset() {
 	*x = GetTEDRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3114,7 +3354,7 @@ func (x *GetTEDRequest) String() string {
 func (*GetTEDRequest) ProtoMessage() {}
 
 func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[38]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3127,7 +3367,7 @@ func (x *GetTEDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDRequest.ProtoReflect.Descriptor instead.
 func (*GetTEDRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{38}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{40}
 }
 
 type GetTEDResponse struct {
@@ -3140,7 +3380,7 @@ type GetTEDResponse struct {
 
 func (x *GetTEDResponse) Reset() {
 	*x = GetTEDResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3152,7 +3392,7 @@ func (x *GetTEDResponse) String() string {
 func (*GetTEDResponse) ProtoMessage() {}
 
 func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[39]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3165,7 +3405,7 @@ func (x *GetTEDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTEDResponse.ProtoReflect.Descriptor instead.
 func (*GetTEDResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{39}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetTEDResponse) GetEnabled() bool {
@@ -3191,7 +3431,7 @@ type DeleteSessionRequest struct {
 
 func (x *DeleteSessionRequest) Reset() {
 	*x = DeleteSessionRequest{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3203,7 +3443,7 @@ func (x *DeleteSessionRequest) String() string {
 func (*DeleteSessionRequest) ProtoMessage() {}
 
 func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[40]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3216,7 +3456,7 @@ func (x *DeleteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{40}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *DeleteSessionRequest) GetPeerAddr() []byte {
@@ -3234,7 +3474,7 @@ type DeleteSessionResponse struct {
 
 func (x *DeleteSessionResponse) Reset() {
 	*x = DeleteSessionResponse{}
-	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3246,7 +3486,7 @@ func (x *DeleteSessionResponse) String() string {
 func (*DeleteSessionResponse) ProtoMessage() {}
 
 func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_pola_v1_pola_proto_msgTypes[41]
+	mi := &file_api_pola_v1_pola_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3259,14 +3499,14 @@ func (x *DeleteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSessionResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{41}
+	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{43}
 }
 
 var File_api_pola_v1_pola_proto protoreflect.FileDescriptor
 
 const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\n" +
-	"\x16api/pola/v1/pola.proto\x12\vapi.pola.v1\"\x9f\x01\n" +
+	"\x16api/pola/v1/pola.proto\x12\vapi.pola.v1\"\xba\x02\n" +
 	"\aSegment\x12\x10\n" +
 	"\x03sid\x18\x01 \x01(\tR\x03sid\x12#\n" +
 	"\rsid_structure\x18\x02 \x01(\tR\fsidStructure\x12\x1d\n" +
@@ -3275,10 +3515,15 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\vremote_addr\x18\x04 \x01(\tR\n" +
 	"remoteAddr\x12\x1d\n" +
 	"\n" +
-	"sid_absent\x18\x05 \x01(\bR\tsidAbsent\"9\n" +
+	"sid_absent\x18\x05 \x01(\bR\tsidAbsent\x12\x1a\n" +
+	"\bbehavior\x18\x06 \x01(\rR\bbehavior\x12)\n" +
+	"\x0elocal_iface_id\x18\a \x01(\rH\x00R\flocalIfaceId\x88\x01\x01\x12+\n" +
+	"\x0fremote_iface_id\x18\b \x01(\rH\x01R\rremoteIfaceId\x88\x01\x01B\x11\n" +
+	"\x0f_local_iface_idB\x12\n" +
+	"\x10_remote_iface_id\"9\n" +
 	"\bWaypoint\x12\x1b\n" +
 	"\trouter_id\x18\x01 \x01(\tR\brouterId\x12\x10\n" +
-	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xac\x04\n" +
+	"\x03sid\x18\x02 \x01(\tR\x03sid\"\xa8\x05\n" +
 	"\bSRPolicy\x12\x1b\n" +
 	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\x12\x19\n" +
 	"\bsrc_addr\x18\x02 \x01(\fR\asrcAddr\x12\x19\n" +
@@ -3298,7 +3543,10 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\twaypoints\x18\f \x03(\v2\x15.api.pola.v1.WaypointR\twaypoints\x12\x17\n" +
 	"\aplsp_id\x18\r \x01(\rR\x06plspId\x12\x15\n" +
 	"\x06lsp_id\x18\x0e \x01(\rR\x05lspId\x120\n" +
-	"\x05state\x18\x0f \x01(\x0e2\x1a.api.pola.v1.SRPolicyStateR\x05state\"\xcb\x01\n" +
+	"\x05state\x18\x0f \x01(\x0e2\x1a.api.pola.v1.SRPolicyStateR\x05state\x12C\n" +
+	"\x0funderlay_family\x18\x10 \x01(\x0e2\x1a.api.pola.v1.AddressFamilyR\x0eunderlayFamily\x125\n" +
+	"\n" +
+	"data_plane\x18\x11 \x01(\x0e2\x16.api.pola.v1.DataPlaneR\tdataPlane\"\xcb\x01\n" +
 	"\x15CreateSRPolicyRequest\x122\n" +
 	"\tsr_policy\x18\x01 \x01(\v2\x15.api.pola.v1.SRPolicyR\bsrPolicy\x12\x10\n" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\x120\n" +
@@ -3451,18 +3699,25 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\vSrv6EndXSID\x12+\n" +
 	"\x11endpoint_behavior\x18\x01 \x01(\rR\x10endpointBehavior\x12$\n" +
 	"\x04sids\x18\x02 \x03(\v2\x10.api.pola.v1.SIDR\x04sids\x12>\n" +
-	"\rsid_structure\x18\x03 \x01(\v2\x19.api.pola.v1.SidStructureR\fsidStructure\"\xd5\x02\n" +
-	"\x06LsLink\x12&\n" +
-	"\x0flocal_router_id\x18\x01 \x01(\tR\rlocalRouterId\x12\x1b\n" +
-	"\tlocal_asn\x18\x02 \x01(\rR\blocalAsn\x12\x19\n" +
-	"\blocal_ip\x18\x03 \x01(\tR\alocalIp\x12(\n" +
-	"\x10remote_router_id\x18\x04 \x01(\tR\x0eremoteRouterId\x12\x1d\n" +
-	"\n" +
-	"remote_asn\x18\x05 \x01(\rR\tremoteAsn\x12\x1b\n" +
-	"\tremote_ip\x18\x06 \x01(\tR\bremoteIp\x12-\n" +
-	"\ametrics\x18\a \x03(\v2\x13.api.pola.v1.MetricR\ametrics\x12\x17\n" +
-	"\aadj_sid\x18\b \x01(\rR\x06adjSid\x12=\n" +
-	"\x0esrv6_end_x_sid\x18\t \x01(\v2\x18.api.pola.v1.Srv6EndXSIDR\vsrv6EndXSid\"\xc2\x02\n" +
+	"\rsid_structure\x18\x03 \x01(\v2\x19.api.pola.v1.SidStructureR\fsidStructure\"\xa0\x01\n" +
+	"\x0eLsLinkEndpoint\x12\x1b\n" +
+	"\trouter_id\x18\x01 \x01(\tR\brouterId\x12\x10\n" +
+	"\x03asn\x18\x02 \x01(\rR\x03asn\x12&\n" +
+	"\finterface_id\x18\x03 \x01(\rH\x00R\vinterfaceId\x88\x01\x01\x12\x12\n" +
+	"\x04ipv4\x18\x04 \x01(\tR\x04ipv4\x12\x12\n" +
+	"\x04ipv6\x18\x05 \x01(\tR\x04ipv6B\x0f\n" +
+	"\r_interface_id\"N\n" +
+	"\x06AdjSid\x122\n" +
+	"\x06family\x18\x01 \x01(\x0e2\x1a.api.pola.v1.AddressFamilyR\x06family\x12\x10\n" +
+	"\x03sid\x18\x02 \x01(\rR\x03sid\"\xfe\x02\n" +
+	"\x06LsLink\x121\n" +
+	"\x05local\x18\x01 \x01(\v2\x1b.api.pola.v1.LsLinkEndpointR\x05local\x123\n" +
+	"\x06remote\x18\x02 \x01(\v2\x1b.api.pola.v1.LsLinkEndpointR\x06remote\x12-\n" +
+	"\ametrics\x18\x03 \x03(\v2\x13.api.pola.v1.MetricR\ametrics\x12.\n" +
+	"\badj_sids\x18\x04 \x03(\v2\x13.api.pola.v1.AdjSidR\aadjSids\x12?\n" +
+	"\x0fsrv6_end_x_sids\x18\x05 \x03(\v2\x18.api.pola.v1.Srv6EndXSIDR\fsrv6EndXSidsJ\x04\b\x06\x10\n" +
+	"R\x0flocal_router_idR\tlocal_asnR\blocal_ipR\x10remote_router_idR\n" +
+	"remote_asnR\tremote_ipR\aadj_sidR\x0esrv6_end_x_sid\"\xc2\x02\n" +
 	"\x06LsNode\x12\x10\n" +
 	"\x03asn\x18\x01 \x01(\rR\x03asn\x12\x1b\n" +
 	"\trouter_id\x18\x02 \x01(\tR\brouterId\x12 \n" +
@@ -3491,7 +3746,15 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"\x14DeleteSessionRequest\x12\x1b\n" +
 	"\tpeer_addr\x18\x01 \x01(\fR\bpeerAddr\")\n" +
 	"\x15DeleteSessionResponseJ\x04\b\x01\x10\x02R\n" +
-	"is_success*g\n" +
+	"is_success*a\n" +
+	"\rAddressFamily\x12\x1e\n" +
+	"\x1aADDRESS_FAMILY_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13ADDRESS_FAMILY_IPV4\x10\x01\x12\x17\n" +
+	"\x13ADDRESS_FAMILY_IPV6\x10\x02*T\n" +
+	"\tDataPlane\x12\x1a\n" +
+	"\x16DATA_PLANE_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12DATA_PLANE_SR_MPLS\x10\x01\x12\x13\n" +
+	"\x0fDATA_PLANE_SRV6\x10\x02*g\n" +
 	"\fSRPolicyType\x12\x1e\n" +
 	"\x1aSR_POLICY_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17SR_POLICY_TYPE_EXPLICIT\x10\x01\x12\x1a\n" +
@@ -3561,135 +3824,145 @@ func file_api_pola_v1_pola_proto_rawDescGZIP() []byte {
 	return file_api_pola_v1_pola_proto_rawDescData
 }
 
-var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_api_pola_v1_pola_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_api_pola_v1_pola_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
 var file_api_pola_v1_pola_proto_goTypes = []any{
-	(SRPolicyType)(0),                   // 0: api.pola.v1.SRPolicyType
-	(SRPolicyState)(0),                  // 1: api.pola.v1.SRPolicyState
-	(SessionState)(0),                   // 2: api.pola.v1.SessionState
-	(PccType)(0),                        // 3: api.pola.v1.PccType
-	(CapabilityType)(0),                 // 4: api.pola.v1.CapabilityType
-	(SessionInitiator)(0),               // 5: api.pola.v1.SessionInitiator
-	(LspDbSyncState)(0),                 // 6: api.pola.v1.LspDbSyncState
-	(MetricType)(0),                     // 7: api.pola.v1.MetricType
-	(*Segment)(nil),                     // 8: api.pola.v1.Segment
-	(*Waypoint)(nil),                    // 9: api.pola.v1.Waypoint
-	(*SRPolicy)(nil),                    // 10: api.pola.v1.SRPolicy
-	(*CreateSRPolicyRequest)(nil),       // 11: api.pola.v1.CreateSRPolicyRequest
-	(*CreateSRPolicyResponse)(nil),      // 12: api.pola.v1.CreateSRPolicyResponse
-	(*DeleteSRPolicyRequest)(nil),       // 13: api.pola.v1.DeleteSRPolicyRequest
-	(*DeleteSRPolicyResponse)(nil),      // 14: api.pola.v1.DeleteSRPolicyResponse
-	(*StatefulCapability)(nil),          // 15: api.pola.v1.StatefulCapability
-	(*SrCapability)(nil),                // 16: api.pola.v1.SrCapability
-	(*Msd)(nil),                         // 17: api.pola.v1.Msd
-	(*Srv6Capability)(nil),              // 18: api.pola.v1.Srv6Capability
-	(*PathSetupTypeCapability)(nil),     // 19: api.pola.v1.PathSetupTypeCapability
-	(*AssocTypeListCapability)(nil),     // 20: api.pola.v1.AssocTypeListCapability
-	(*LspDbVersionCapability)(nil),      // 21: api.pola.v1.LspDbVersionCapability
-	(*MultipathCapability)(nil),         // 22: api.pola.v1.MultipathCapability
-	(*VendorInformationCapability)(nil), // 23: api.pola.v1.VendorInformationCapability
-	(*UnknownCapability)(nil),           // 24: api.pola.v1.UnknownCapability
-	(*Capability)(nil),                  // 25: api.pola.v1.Capability
-	(*SessionTimers)(nil),               // 26: api.pola.v1.SessionTimers
-	(*EffectiveTimers)(nil),             // 27: api.pola.v1.EffectiveTimers
-	(*MessageCounter)(nil),              // 28: api.pola.v1.MessageCounter
-	(*SessionStats)(nil),                // 29: api.pola.v1.SessionStats
-	(*Session)(nil),                     // 30: api.pola.v1.Session
-	(*SRPolicySession)(nil),             // 31: api.pola.v1.SRPolicySession
-	(*EndpointBehavior)(nil),            // 32: api.pola.v1.EndpointBehavior
-	(*SidStructure)(nil),                // 33: api.pola.v1.SidStructure
-	(*SID)(nil),                         // 34: api.pola.v1.SID
-	(*MultiTopoID)(nil),                 // 35: api.pola.v1.MultiTopoID
-	(*LsSrv6SID)(nil),                   // 36: api.pola.v1.LsSrv6SID
-	(*LsPrefix)(nil),                    // 37: api.pola.v1.LsPrefix
-	(*Metric)(nil),                      // 38: api.pola.v1.Metric
-	(*Srv6EndXSID)(nil),                 // 39: api.pola.v1.Srv6EndXSID
-	(*LsLink)(nil),                      // 40: api.pola.v1.LsLink
-	(*LsNode)(nil),                      // 41: api.pola.v1.LsNode
-	(*GetSessionListRequest)(nil),       // 42: api.pola.v1.GetSessionListRequest
-	(*GetSessionListResponse)(nil),      // 43: api.pola.v1.GetSessionListResponse
-	(*GetSRPolicyListRequest)(nil),      // 44: api.pola.v1.GetSRPolicyListRequest
-	(*GetSRPolicyListResponse)(nil),     // 45: api.pola.v1.GetSRPolicyListResponse
-	(*GetTEDRequest)(nil),               // 46: api.pola.v1.GetTEDRequest
-	(*GetTEDResponse)(nil),              // 47: api.pola.v1.GetTEDResponse
-	(*DeleteSessionRequest)(nil),        // 48: api.pola.v1.DeleteSessionRequest
-	(*DeleteSessionResponse)(nil),       // 49: api.pola.v1.DeleteSessionResponse
+	(AddressFamily)(0),                  // 0: api.pola.v1.AddressFamily
+	(DataPlane)(0),                      // 1: api.pola.v1.DataPlane
+	(SRPolicyType)(0),                   // 2: api.pola.v1.SRPolicyType
+	(SRPolicyState)(0),                  // 3: api.pola.v1.SRPolicyState
+	(SessionState)(0),                   // 4: api.pola.v1.SessionState
+	(PccType)(0),                        // 5: api.pola.v1.PccType
+	(CapabilityType)(0),                 // 6: api.pola.v1.CapabilityType
+	(SessionInitiator)(0),               // 7: api.pola.v1.SessionInitiator
+	(LspDbSyncState)(0),                 // 8: api.pola.v1.LspDbSyncState
+	(MetricType)(0),                     // 9: api.pola.v1.MetricType
+	(*Segment)(nil),                     // 10: api.pola.v1.Segment
+	(*Waypoint)(nil),                    // 11: api.pola.v1.Waypoint
+	(*SRPolicy)(nil),                    // 12: api.pola.v1.SRPolicy
+	(*CreateSRPolicyRequest)(nil),       // 13: api.pola.v1.CreateSRPolicyRequest
+	(*CreateSRPolicyResponse)(nil),      // 14: api.pola.v1.CreateSRPolicyResponse
+	(*DeleteSRPolicyRequest)(nil),       // 15: api.pola.v1.DeleteSRPolicyRequest
+	(*DeleteSRPolicyResponse)(nil),      // 16: api.pola.v1.DeleteSRPolicyResponse
+	(*StatefulCapability)(nil),          // 17: api.pola.v1.StatefulCapability
+	(*SrCapability)(nil),                // 18: api.pola.v1.SrCapability
+	(*Msd)(nil),                         // 19: api.pola.v1.Msd
+	(*Srv6Capability)(nil),              // 20: api.pola.v1.Srv6Capability
+	(*PathSetupTypeCapability)(nil),     // 21: api.pola.v1.PathSetupTypeCapability
+	(*AssocTypeListCapability)(nil),     // 22: api.pola.v1.AssocTypeListCapability
+	(*LspDbVersionCapability)(nil),      // 23: api.pola.v1.LspDbVersionCapability
+	(*MultipathCapability)(nil),         // 24: api.pola.v1.MultipathCapability
+	(*VendorInformationCapability)(nil), // 25: api.pola.v1.VendorInformationCapability
+	(*UnknownCapability)(nil),           // 26: api.pola.v1.UnknownCapability
+	(*Capability)(nil),                  // 27: api.pola.v1.Capability
+	(*SessionTimers)(nil),               // 28: api.pola.v1.SessionTimers
+	(*EffectiveTimers)(nil),             // 29: api.pola.v1.EffectiveTimers
+	(*MessageCounter)(nil),              // 30: api.pola.v1.MessageCounter
+	(*SessionStats)(nil),                // 31: api.pola.v1.SessionStats
+	(*Session)(nil),                     // 32: api.pola.v1.Session
+	(*SRPolicySession)(nil),             // 33: api.pola.v1.SRPolicySession
+	(*EndpointBehavior)(nil),            // 34: api.pola.v1.EndpointBehavior
+	(*SidStructure)(nil),                // 35: api.pola.v1.SidStructure
+	(*SID)(nil),                         // 36: api.pola.v1.SID
+	(*MultiTopoID)(nil),                 // 37: api.pola.v1.MultiTopoID
+	(*LsSrv6SID)(nil),                   // 38: api.pola.v1.LsSrv6SID
+	(*LsPrefix)(nil),                    // 39: api.pola.v1.LsPrefix
+	(*Metric)(nil),                      // 40: api.pola.v1.Metric
+	(*Srv6EndXSID)(nil),                 // 41: api.pola.v1.Srv6EndXSID
+	(*LsLinkEndpoint)(nil),              // 42: api.pola.v1.LsLinkEndpoint
+	(*AdjSid)(nil),                      // 43: api.pola.v1.AdjSid
+	(*LsLink)(nil),                      // 44: api.pola.v1.LsLink
+	(*LsNode)(nil),                      // 45: api.pola.v1.LsNode
+	(*GetSessionListRequest)(nil),       // 46: api.pola.v1.GetSessionListRequest
+	(*GetSessionListResponse)(nil),      // 47: api.pola.v1.GetSessionListResponse
+	(*GetSRPolicyListRequest)(nil),      // 48: api.pola.v1.GetSRPolicyListRequest
+	(*GetSRPolicyListResponse)(nil),     // 49: api.pola.v1.GetSRPolicyListResponse
+	(*GetTEDRequest)(nil),               // 50: api.pola.v1.GetTEDRequest
+	(*GetTEDResponse)(nil),              // 51: api.pola.v1.GetTEDResponse
+	(*DeleteSessionRequest)(nil),        // 52: api.pola.v1.DeleteSessionRequest
+	(*DeleteSessionResponse)(nil),       // 53: api.pola.v1.DeleteSessionResponse
 }
 var file_api_pola_v1_pola_proto_depIdxs = []int32{
-	0,  // 0: api.pola.v1.SRPolicy.type:type_name -> api.pola.v1.SRPolicyType
-	8,  // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
-	7,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
-	9,  // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
-	1,  // 4: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
-	10, // 5: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	10, // 6: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
-	17, // 7: api.pola.v1.Srv6Capability.msds:type_name -> api.pola.v1.Msd
-	25, // 8: api.pola.v1.PathSetupTypeCapability.sub_capabilities:type_name -> api.pola.v1.Capability
-	4,  // 9: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
-	15, // 10: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
-	16, // 11: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
-	18, // 12: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
-	19, // 13: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
-	20, // 14: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
-	21, // 15: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
-	22, // 16: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
-	23, // 17: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
-	24, // 18: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
-	28, // 19: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
-	28, // 20: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
-	28, // 21: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
-	28, // 22: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
-	28, // 23: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
-	28, // 24: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
-	28, // 25: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
-	28, // 26: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
-	28, // 27: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
-	28, // 28: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
-	2,  // 29: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
-	25, // 30: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
-	3,  // 31: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
-	25, // 32: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
-	26, // 33: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
-	26, // 34: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
-	27, // 35: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
-	5,  // 36: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
-	6,  // 37: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	29, // 38: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
-	2,  // 39: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
-	6,  // 40: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
-	10, // 41: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
-	34, // 42: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
-	32, // 43: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
-	33, // 44: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
-	35, // 45: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
-	7,  // 46: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
-	34, // 47: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
-	33, // 48: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	38, // 49: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	39, // 50: api.pola.v1.LsLink.srv6_end_x_sid:type_name -> api.pola.v1.Srv6EndXSID
-	40, // 51: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
-	37, // 52: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
-	36, // 53: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	30, // 54: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	31, // 55: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
-	41, // 56: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
-	11, // 57: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	13, // 58: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	42, // 59: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	44, // 60: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	46, // 61: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	48, // 62: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	12, // 63: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	14, // 64: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	43, // 65: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	45, // 66: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	47, // 67: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	49, // 68: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	63, // [63:69] is the sub-list for method output_type
-	57, // [57:63] is the sub-list for method input_type
-	57, // [57:57] is the sub-list for extension type_name
-	57, // [57:57] is the sub-list for extension extendee
-	0,  // [0:57] is the sub-list for field type_name
+	2,  // 0: api.pola.v1.SRPolicy.type:type_name -> api.pola.v1.SRPolicyType
+	10, // 1: api.pola.v1.SRPolicy.segment_list:type_name -> api.pola.v1.Segment
+	9,  // 2: api.pola.v1.SRPolicy.metric:type_name -> api.pola.v1.MetricType
+	11, // 3: api.pola.v1.SRPolicy.waypoints:type_name -> api.pola.v1.Waypoint
+	3,  // 4: api.pola.v1.SRPolicy.state:type_name -> api.pola.v1.SRPolicyState
+	0,  // 5: api.pola.v1.SRPolicy.underlay_family:type_name -> api.pola.v1.AddressFamily
+	1,  // 6: api.pola.v1.SRPolicy.data_plane:type_name -> api.pola.v1.DataPlane
+	12, // 7: api.pola.v1.CreateSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	12, // 8: api.pola.v1.DeleteSRPolicyRequest.sr_policy:type_name -> api.pola.v1.SRPolicy
+	19, // 9: api.pola.v1.Srv6Capability.msds:type_name -> api.pola.v1.Msd
+	27, // 10: api.pola.v1.PathSetupTypeCapability.sub_capabilities:type_name -> api.pola.v1.Capability
+	6,  // 11: api.pola.v1.Capability.type:type_name -> api.pola.v1.CapabilityType
+	17, // 12: api.pola.v1.Capability.stateful:type_name -> api.pola.v1.StatefulCapability
+	18, // 13: api.pola.v1.Capability.sr:type_name -> api.pola.v1.SrCapability
+	20, // 14: api.pola.v1.Capability.srv6:type_name -> api.pola.v1.Srv6Capability
+	21, // 15: api.pola.v1.Capability.path_setup_type:type_name -> api.pola.v1.PathSetupTypeCapability
+	22, // 16: api.pola.v1.Capability.assoc_type_list:type_name -> api.pola.v1.AssocTypeListCapability
+	23, // 17: api.pola.v1.Capability.lsp_db_version:type_name -> api.pola.v1.LspDbVersionCapability
+	24, // 18: api.pola.v1.Capability.multipath:type_name -> api.pola.v1.MultipathCapability
+	25, // 19: api.pola.v1.Capability.vendor_information:type_name -> api.pola.v1.VendorInformationCapability
+	26, // 20: api.pola.v1.Capability.unknown:type_name -> api.pola.v1.UnknownCapability
+	30, // 21: api.pola.v1.SessionStats.keepalive:type_name -> api.pola.v1.MessageCounter
+	30, // 22: api.pola.v1.SessionStats.pcerr:type_name -> api.pola.v1.MessageCounter
+	30, // 23: api.pola.v1.SessionStats.pcntf:type_name -> api.pola.v1.MessageCounter
+	30, // 24: api.pola.v1.SessionStats.report:type_name -> api.pola.v1.MessageCounter
+	30, // 25: api.pola.v1.SessionStats.update:type_name -> api.pola.v1.MessageCounter
+	30, // 26: api.pola.v1.SessionStats.initiate:type_name -> api.pola.v1.MessageCounter
+	30, // 27: api.pola.v1.SessionStats.open:type_name -> api.pola.v1.MessageCounter
+	30, // 28: api.pola.v1.SessionStats.close:type_name -> api.pola.v1.MessageCounter
+	30, // 29: api.pola.v1.SessionStats.pcreq:type_name -> api.pola.v1.MessageCounter
+	30, // 30: api.pola.v1.SessionStats.pcrep:type_name -> api.pola.v1.MessageCounter
+	4,  // 31: api.pola.v1.Session.state:type_name -> api.pola.v1.SessionState
+	27, // 32: api.pola.v1.Session.local_capabilities:type_name -> api.pola.v1.Capability
+	5,  // 33: api.pola.v1.Session.pcc_type:type_name -> api.pola.v1.PccType
+	27, // 34: api.pola.v1.Session.peer_capabilities:type_name -> api.pola.v1.Capability
+	28, // 35: api.pola.v1.Session.local_timers:type_name -> api.pola.v1.SessionTimers
+	28, // 36: api.pola.v1.Session.peer_timers:type_name -> api.pola.v1.SessionTimers
+	29, // 37: api.pola.v1.Session.effective_timers:type_name -> api.pola.v1.EffectiveTimers
+	7,  // 38: api.pola.v1.Session.initiator:type_name -> api.pola.v1.SessionInitiator
+	8,  // 39: api.pola.v1.Session.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	31, // 40: api.pola.v1.Session.stats:type_name -> api.pola.v1.SessionStats
+	4,  // 41: api.pola.v1.SRPolicySession.state:type_name -> api.pola.v1.SessionState
+	8,  // 42: api.pola.v1.SRPolicySession.sync_state:type_name -> api.pola.v1.LspDbSyncState
+	12, // 43: api.pola.v1.SRPolicySession.sr_policies:type_name -> api.pola.v1.SRPolicy
+	36, // 44: api.pola.v1.LsSrv6SID.sids:type_name -> api.pola.v1.SID
+	34, // 45: api.pola.v1.LsSrv6SID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	35, // 46: api.pola.v1.LsSrv6SID.sid_structure:type_name -> api.pola.v1.SidStructure
+	37, // 47: api.pola.v1.LsSrv6SID.multi_topo_ids:type_name -> api.pola.v1.MultiTopoID
+	9,  // 48: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
+	36, // 49: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
+	35, // 50: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
+	0,  // 51: api.pola.v1.AdjSid.family:type_name -> api.pola.v1.AddressFamily
+	42, // 52: api.pola.v1.LsLink.local:type_name -> api.pola.v1.LsLinkEndpoint
+	42, // 53: api.pola.v1.LsLink.remote:type_name -> api.pola.v1.LsLinkEndpoint
+	40, // 54: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	43, // 55: api.pola.v1.LsLink.adj_sids:type_name -> api.pola.v1.AdjSid
+	41, // 56: api.pola.v1.LsLink.srv6_end_x_sids:type_name -> api.pola.v1.Srv6EndXSID
+	44, // 57: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
+	39, // 58: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
+	38, // 59: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	32, // 60: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	33, // 61: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
+	45, // 62: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
+	13, // 63: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	15, // 64: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	46, // 65: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	48, // 66: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	50, // 67: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	52, // 68: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	14, // 69: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	16, // 70: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	47, // 71: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	49, // 72: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	51, // 73: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	53, // 74: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	69, // [69:75] is the sub-list for method output_type
+	63, // [63:69] is the sub-list for method input_type
+	63, // [63:63] is the sub-list for extension type_name
+	63, // [63:63] is the sub-list for extension extendee
+	0,  // [0:63] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }
@@ -3697,6 +3970,7 @@ func file_api_pola_v1_pola_proto_init() {
 	if File_api_pola_v1_pola_proto != nil {
 		return
 	}
+	file_api_pola_v1_pola_proto_msgTypes[0].OneofWrappers = []any{}
 	file_api_pola_v1_pola_proto_msgTypes[8].OneofWrappers = []any{}
 	file_api_pola_v1_pola_proto_msgTypes[17].OneofWrappers = []any{
 		(*Capability_Stateful)(nil),
@@ -3711,13 +3985,14 @@ func file_api_pola_v1_pola_proto_init() {
 	}
 	file_api_pola_v1_pola_proto_msgTypes[22].OneofWrappers = []any{}
 	file_api_pola_v1_pola_proto_msgTypes[29].OneofWrappers = []any{}
+	file_api_pola_v1_pola_proto_msgTypes[32].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_pola_v1_pola_proto_rawDesc), len(file_api_pola_v1_pola_proto_rawDesc)),
-			NumEnums:      8,
-			NumMessages:   42,
+			NumEnums:      10,
+			NumMessages:   44,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/pola/v1/pola.pb.go
+++ b/api/pola/v1/pola.pb.go
@@ -2898,9 +2898,10 @@ func (x *Metric) GetValue() uint32 {
 
 type Srv6EndXSID struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
-	EndpointBehavior uint32                 `protobuf:"varint,1,opt,name=endpoint_behavior,json=endpointBehavior,proto3" json:"endpoint_behavior,omitempty"`
 	Sids             []*SID                 `protobuf:"bytes,2,rep,name=sids,proto3" json:"sids,omitempty"`
 	SidStructure     *SidStructure          `protobuf:"bytes,3,opt,name=sid_structure,json=sidStructure,proto3" json:"sid_structure,omitempty"`
+	Weight           uint32                 `protobuf:"varint,4,opt,name=weight,proto3" json:"weight,omitempty"`
+	EndpointBehavior *EndpointBehavior      `protobuf:"bytes,5,opt,name=endpoint_behavior,json=endpointBehavior,proto3" json:"endpoint_behavior,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -2935,13 +2936,6 @@ func (*Srv6EndXSID) Descriptor() ([]byte, []int) {
 	return file_api_pola_v1_pola_proto_rawDescGZIP(), []int{34}
 }
 
-func (x *Srv6EndXSID) GetEndpointBehavior() uint32 {
-	if x != nil {
-		return x.EndpointBehavior
-	}
-	return 0
-}
-
 func (x *Srv6EndXSID) GetSids() []*SID {
 	if x != nil {
 		return x.Sids
@@ -2952,6 +2946,20 @@ func (x *Srv6EndXSID) GetSids() []*SID {
 func (x *Srv6EndXSID) GetSidStructure() *SidStructure {
 	if x != nil {
 		return x.SidStructure
+	}
+	return nil
+}
+
+func (x *Srv6EndXSID) GetWeight() uint32 {
+	if x != nil {
+		return x.Weight
+	}
+	return 0
+}
+
+func (x *Srv6EndXSID) GetEndpointBehavior() *EndpointBehavior {
+	if x != nil {
+		return x.EndpointBehavior
 	}
 	return nil
 }
@@ -3825,11 +3833,12 @@ const file_api_pola_v1_pola_proto_rawDesc = "" +
 	"_sid_index\"K\n" +
 	"\x06Metric\x12+\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x17.api.pola.v1.MetricTypeR\x04type\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\rR\x05value\"\xa0\x01\n" +
-	"\vSrv6EndXSID\x12+\n" +
-	"\x11endpoint_behavior\x18\x01 \x01(\rR\x10endpointBehavior\x12$\n" +
+	"\x05value\x18\x02 \x01(\rR\x05value\"\xdd\x01\n" +
+	"\vSrv6EndXSID\x12$\n" +
 	"\x04sids\x18\x02 \x03(\v2\x10.api.pola.v1.SIDR\x04sids\x12>\n" +
-	"\rsid_structure\x18\x03 \x01(\v2\x19.api.pola.v1.SidStructureR\fsidStructure\"\xa0\x01\n" +
+	"\rsid_structure\x18\x03 \x01(\v2\x19.api.pola.v1.SidStructureR\fsidStructure\x12\x16\n" +
+	"\x06weight\x18\x04 \x01(\rR\x06weight\x12J\n" +
+	"\x11endpoint_behavior\x18\x05 \x01(\v2\x1d.api.pola.v1.EndpointBehaviorR\x10endpointBehaviorJ\x04\b\x01\x10\x02\"\xa0\x01\n" +
 	"\x0eLsLinkEndpoint\x12\x1b\n" +
 	"\trouter_id\x18\x01 \x01(\tR\brouterId\x12\x10\n" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\x12&\n" +
@@ -4066,35 +4075,36 @@ var file_api_pola_v1_pola_proto_depIdxs = []int32{
 	8,  // 52: api.pola.v1.Metric.type:type_name -> api.pola.v1.MetricType
 	38, // 53: api.pola.v1.Srv6EndXSID.sids:type_name -> api.pola.v1.SID
 	37, // 54: api.pola.v1.Srv6EndXSID.sid_structure:type_name -> api.pola.v1.SidStructure
-	0,  // 55: api.pola.v1.AdjSid.family:type_name -> api.pola.v1.AddressFamily
-	44, // 56: api.pola.v1.LsLink.local:type_name -> api.pola.v1.LsLinkEndpoint
-	44, // 57: api.pola.v1.LsLink.remote:type_name -> api.pola.v1.LsLinkEndpoint
-	42, // 58: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
-	45, // 59: api.pola.v1.LsLink.adj_sids:type_name -> api.pola.v1.AdjSid
-	43, // 60: api.pola.v1.LsLink.srv6_end_x_sids:type_name -> api.pola.v1.Srv6EndXSID
-	46, // 61: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
-	41, // 62: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
-	40, // 63: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
-	34, // 64: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
-	35, // 65: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
-	47, // 66: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
-	15, // 67: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
-	17, // 68: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
-	48, // 69: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
-	50, // 70: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
-	52, // 71: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
-	54, // 72: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
-	16, // 73: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
-	18, // 74: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
-	49, // 75: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
-	51, // 76: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
-	53, // 77: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
-	55, // 78: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
-	73, // [73:79] is the sub-list for method output_type
-	67, // [67:73] is the sub-list for method input_type
-	67, // [67:67] is the sub-list for extension type_name
-	67, // [67:67] is the sub-list for extension extendee
-	0,  // [0:67] is the sub-list for field type_name
+	36, // 55: api.pola.v1.Srv6EndXSID.endpoint_behavior:type_name -> api.pola.v1.EndpointBehavior
+	0,  // 56: api.pola.v1.AdjSid.family:type_name -> api.pola.v1.AddressFamily
+	44, // 57: api.pola.v1.LsLink.local:type_name -> api.pola.v1.LsLinkEndpoint
+	44, // 58: api.pola.v1.LsLink.remote:type_name -> api.pola.v1.LsLinkEndpoint
+	42, // 59: api.pola.v1.LsLink.metrics:type_name -> api.pola.v1.Metric
+	45, // 60: api.pola.v1.LsLink.adj_sids:type_name -> api.pola.v1.AdjSid
+	43, // 61: api.pola.v1.LsLink.srv6_end_x_sids:type_name -> api.pola.v1.Srv6EndXSID
+	46, // 62: api.pola.v1.LsNode.links:type_name -> api.pola.v1.LsLink
+	41, // 63: api.pola.v1.LsNode.prefixes:type_name -> api.pola.v1.LsPrefix
+	40, // 64: api.pola.v1.LsNode.srv6_sids:type_name -> api.pola.v1.LsSrv6SID
+	34, // 65: api.pola.v1.GetSessionListResponse.sessions:type_name -> api.pola.v1.Session
+	35, // 66: api.pola.v1.GetSRPolicyListResponse.sessions:type_name -> api.pola.v1.SRPolicySession
+	47, // 67: api.pola.v1.GetTEDResponse.nodes:type_name -> api.pola.v1.LsNode
+	15, // 68: api.pola.v1.PCEService.CreateSRPolicy:input_type -> api.pola.v1.CreateSRPolicyRequest
+	17, // 69: api.pola.v1.PCEService.DeleteSRPolicy:input_type -> api.pola.v1.DeleteSRPolicyRequest
+	48, // 70: api.pola.v1.PCEService.GetSessionList:input_type -> api.pola.v1.GetSessionListRequest
+	50, // 71: api.pola.v1.PCEService.GetSRPolicyList:input_type -> api.pola.v1.GetSRPolicyListRequest
+	52, // 72: api.pola.v1.PCEService.GetTED:input_type -> api.pola.v1.GetTEDRequest
+	54, // 73: api.pola.v1.PCEService.DeleteSession:input_type -> api.pola.v1.DeleteSessionRequest
+	16, // 74: api.pola.v1.PCEService.CreateSRPolicy:output_type -> api.pola.v1.CreateSRPolicyResponse
+	18, // 75: api.pola.v1.PCEService.DeleteSRPolicy:output_type -> api.pola.v1.DeleteSRPolicyResponse
+	49, // 76: api.pola.v1.PCEService.GetSessionList:output_type -> api.pola.v1.GetSessionListResponse
+	51, // 77: api.pola.v1.PCEService.GetSRPolicyList:output_type -> api.pola.v1.GetSRPolicyListResponse
+	53, // 78: api.pola.v1.PCEService.GetTED:output_type -> api.pola.v1.GetTEDResponse
+	55, // 79: api.pola.v1.PCEService.DeleteSession:output_type -> api.pola.v1.DeleteSessionResponse
+	74, // [74:80] is the sub-list for method output_type
+	68, // [68:74] is the sub-list for method input_type
+	68, // [68:68] is the sub-list for extension type_name
+	68, // [68:68] is the sub-list for extension extendee
+	0,  // [0:68] is the sub-list for field type_name
 }
 
 func init() { file_api_pola_v1_pola_proto_init() }

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -43,15 +43,9 @@ enum DataPlane {
   DATA_PLANE_SRV6 = 2;
 }
 
-enum SRPolicyType {
-  SR_POLICY_TYPE_UNSPECIFIED = 0;
-  SR_POLICY_TYPE_EXPLICIT = 1;
-  SR_POLICY_TYPE_DYNAMIC = 2;
-}
-
 message Waypoint {
   string router_id = 1;
-  string sid = 2; // Optional: explicit SID override
+  string sid = 2; // Optional explicit SID override.
 }
 
 enum SRPolicyState {
@@ -62,35 +56,67 @@ enum SRPolicyState {
   SR_POLICY_STATE_UNKNOWN = 4;
 }
 
+message DynamicPath {
+  MetricType metric = 1;
+  // Unspecified uses the unique viable data plane; rejected if ambiguous.
+  DataPlane data_plane = 2;
+  // Unspecified uses the unique viable family; rejected if ambiguous.
+  // Pola extension; no IETF counterpart.
+  AddressFamily underlay_family = 3;
+  repeated Waypoint waypoints = 4;
+}
+
+message ExplicitPath {
+  repeated Segment segment_list = 1;
+}
+
+message CandidatePath {
+  // Zero means "not set" in proto3 and is normalized server-side to
+  // table.DefaultPreference (100) (RFC 9256 §2.7).
+  uint32 preference = 1;
+
+  oneof path {
+    DynamicPath dynamic = 2;
+    ExplicitPath explicit = 3;
+  }
+}
+
 message SRPolicy {
   bytes peer_addr = 1;
-  bytes src_addr = 2;
-  bytes dst_addr = 3;
-  string src_router_id = 4;
-  string dst_router_id = 5;
+
+  // Policy identity addresses (RFC 9256 §2.1). Mutually exclusive with
+  // headend_router_id / endpoint_router_id.
+  bytes headend = 2;
+  bytes endpoint = 3;
+
+  // Router ID form for TED resolution. Mutually exclusive with headend / endpoint.
+  string headend_router_id = 4;
+  string endpoint_router_id = 5;
+  // Address family used to resolve endpoints from router IDs.
+  // Unspecified follows the underlay family; valid only with the router ID form.
+  AddressFamily endpoint_family = 18;
+
   uint32 color = 6;
-  uint32 preference = 7;
   string policy_name = 8;
-  SRPolicyType type = 9;
-  repeated Segment segment_list = 10;
-  MetricType metric = 11;
-  repeated Waypoint waypoints = 12;
+
+  CandidatePath candidate_path = 19;
+
   uint32 plsp_id = 13;
   uint32 lsp_id = 14;
   SRPolicyState state = 15;
-  // Underlay plane for dynamic path computation.
-  // Unspecified uses the TED node's unique viable plane and is rejected if ambiguous.
-  AddressFamily underlay_family = 16;
-  DataPlane data_plane = 17;
+  // Currently signaled segment list reported by the PCE, not request input.
+  repeated Segment segment_list = 20;
+
+  reserved 7, 9, 10, 11, 12, 16, 17;
+  reserved "preference", "type", "metric", "waypoints", "underlay_family", "data_plane";
 }
 
 message CreateSRPolicyRequest {
   SRPolicy sr_policy = 1;
   uint32 asn = 2;
-  reserved 3;
-  bool disable_path_compute = 4;
   bool no_sid_validate = 5;
-  reserved "sid_validate";
+  reserved 3, 4;
+  reserved "sid_validate", "disable_path_compute";
 }
 
 message CreateSRPolicyResponse {
@@ -242,8 +268,6 @@ message MessageCounter {
   uint64 rcvd = 2;
 }
 
-// SessionStats contains per-session PCEP message counters.
-// Open and close are Pola-specific additions.
 message SessionStats {
   MessageCounter keepalive = 1; // keepalive-sent / keepalive-rcvd (RFC 9826)
   MessageCounter pcerr = 2; // pcerr-sent / pcerr-rcvd (RFC 9826)

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -24,6 +24,23 @@ message Segment {
   string local_addr = 3;
   string remote_addr = 4;
   bool sid_absent = 5;
+  // SRv6 endpoint behavior advertised by the TED (RFC 9603 §4.3.1).
+  uint32 behavior = 6;
+  // Interface ID for link-local NAI scoping (RFC 8664/9603 §4.3.1).
+  optional uint32 local_iface_id = 7;
+  optional uint32 remote_iface_id = 8;
+}
+
+enum AddressFamily {
+  ADDRESS_FAMILY_UNSPECIFIED = 0;
+  ADDRESS_FAMILY_IPV4 = 1;
+  ADDRESS_FAMILY_IPV6 = 2;
+}
+
+enum DataPlane {
+  DATA_PLANE_UNSPECIFIED = 0;
+  DATA_PLANE_SR_MPLS = 1;
+  DATA_PLANE_SRV6 = 2;
 }
 
 enum SRPolicyType {
@@ -61,6 +78,10 @@ message SRPolicy {
   uint32 plsp_id = 13;
   uint32 lsp_id = 14;
   SRPolicyState state = 15;
+  // Underlay plane for dynamic path computation.
+  // Unspecified uses the TED node's unique viable plane and is rejected if ambiguous.
+  AddressFamily underlay_family = 16;
+  DataPlane data_plane = 17;
 }
 
 message CreateSRPolicyRequest {
@@ -324,16 +345,30 @@ message Srv6EndXSID {
   SidStructure sid_structure = 3;
 }
 
+message LsLinkEndpoint {
+  string router_id = 1;
+  uint32 asn = 2;
+  // Interface ID (BGP-LS TLV 258/259) for link-local IPv6 address scoping.
+  optional uint32 interface_id = 3;
+  string ipv4 = 4;
+  string ipv6 = 5;
+}
+
+message AdjSid {
+  // Unspecified when GoBGP cannot distinguish IPv4 and IPv6 Adjacency-SIDs.
+  AddressFamily family = 1;
+  uint32 sid = 2;
+}
+
 message LsLink {
-  string local_router_id = 1;
-  uint32 local_asn = 2;
-  string local_ip = 3;
-  string remote_router_id = 4;
-  uint32 remote_asn = 5;
-  string remote_ip = 6;
-  repeated Metric metrics = 7;
-  uint32 adj_sid = 8;
-  Srv6EndXSID srv6_end_x_sid = 9;
+  LsLinkEndpoint local = 1;
+  LsLinkEndpoint remote = 2;
+  repeated Metric metrics = 3;
+  repeated AdjSid adj_sids = 4;
+  repeated Srv6EndXSID srv6_end_x_sids = 5;
+  // Replaced by local, remote, adj_sids, and srv6_end_x_sids.
+  reserved 6 to 9;
+  reserved "local_router_id", "local_asn", "local_ip", "remote_router_id", "remote_asn", "remote_ip", "adj_sid", "srv6_end_x_sid";
 }
 
 message LsNode {

--- a/api/pola/v1/pola.proto
+++ b/api/pola/v1/pola.proto
@@ -364,9 +364,11 @@ message Metric {
 }
 
 message Srv6EndXSID {
-  uint32 endpoint_behavior = 1;
   repeated SID sids = 2;
   SidStructure sid_structure = 3;
+  uint32 weight = 4;
+  EndpointBehavior endpoint_behavior = 5;
+  reserved 1;
 }
 
 message LsLinkEndpoint {

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -237,15 +237,14 @@ JSON output
 ]
 ```
 
-Notes:
-
-- `state` and `lspDbSync` use the same vocabulary as `pola session`.
-- Policies appear after the first PCRpt is received.
-- `lspId` is omitted when zero.
-- `headendRouterId`/`endpointRouterId` are resolved from TED.
-- `candidatePath.dynamic.metric` is included for policies with a dynamic candidate path.
-- Top-level `segmentList` is the currently signaled segment list; for an
-  explicit candidate path, `candidatePath.explicit.segmentList` mirrors it.
+> [!NOTE]
+> - `state` and `lspDbSync` use the same vocabulary as `pola session`.
+> - Policies appear after the first PCRpt is received.
+> - `lspId` is omitted when zero.
+> - `headendRouterId`/`endpointRouterId` are resolved from TED.
+> - `candidatePath.dynamic.metric` is included for policies with a dynamic candidate path.
+> - Top-level `segmentList` is the currently signaled segment list; for an
+>   explicit candidate path, `candidatePath.explicit.segmentList` mirrors it.
 
 ### pola sr-policy add -f `filepath`
 
@@ -268,12 +267,16 @@ srPolicy:
       metric: igp
 ```
 
-`metric` can be `igp`, `te`, or `delay`.
+`metric` can be `igp`, `te`, `delay`, or `hopcount`.
 
 `candidatePath.dynamic.underlayFamily` selects the underlay address family.
 When unspecified, it follows `endpointFamily` or the endpoint's address
-family. Cross-AF configurations are supported by Pola but are not an IETF
-interoperability guarantee.
+family. Cross-address-family configurations are supported by Pola, but are not
+guaranteed for IETF interoperability.
+
+`candidatePath.dynamic.dataPlane` selects the data plane (`sr-mpls` or
+`srv6`). When unspecified, Pola uses the unique viable data plane; if multiple
+are available, the request is rejected.
 
 JSON output
 
@@ -313,16 +316,20 @@ JSON output
 
 #### Explicit path with endpoint addresses
 
-Instead of `headendRouterID`/`endpointRouterID`, endpoints can be given
-directly as `headend`/`endpoint` addresses (RFC 9256 §2.1), for either a
-dynamic or an explicit candidate path. For dynamic paths, router IDs needed
-for CSPF are resolved from the TED; `endpointFamily` selects the resolution
-family when necessary and is valid only with the router-ID form.
+Endpoints can be specified as `headend`/`endpoint` addresses instead of
+`headendRouterID`/`endpointRouterID` (RFC 9256 §2.1), for both dynamic and
+explicit candidate paths. For dynamic paths, router IDs required for CSPF are
+resolved from the TED; `endpointFamily` selects the resolution family and is
+only valid with the router-ID form.
 
-Each SID is still validated against the TED, so with `ted.enable: false` this
-form additionally requires `--no-sid-validate`.
+Each SID is validated against the TED. When `ted.enable: false`,
+`--no-sid-validate` is also required.
 
 `localAddr` is required for SRv6 SIDs and optional for SR-MPLS labels.
+
+`localInterfaceId` and `remoteInterfaceId` identify the interface for a
+link-local IPv6 adjacency segment (RFC 8664/9603 §4.3.1, NAI type 6).
+They are only meaningful for link-local IPv6 addresses.
 
 See [JSON schema](../../docs/schemas/cli/policy.json) for input details.
 
@@ -377,13 +384,14 @@ Node #0: 0000.0aff.0001
     10.255.0.1/32
       index: 1
   Links:
-    Local: 10.0.0.1 Remote: 10.0.0.2
+    Local: 10.0.0.1, 2001:db8::1 (interface 5) Remote: 10.0.0.2, 2001:db8::2
       RemoteRouterID: 0000.0aff.0002
       Metrics:
         igp: 10
-      Adj-SID: 17
+      Adj-SIDs:
+        unspecified: 17
       SRv6 End.X SID:
-        EndpointBehavior: ENDX
+        EndpointBehavior: ENDX, Flags: 0, Algorithm: 0, Weight: 0
         SIDs: [2001:db8:1::1]
         SID Structure: Block: 32, Node: 16, Func: 16, Arg: 0
   SRv6 SIDs:
@@ -404,9 +412,11 @@ Node #1: 0000.0aff.0002
   SRv6 SIDs:
 ```
 
-JSON output. The top level is an array of nodes; there is no wrapping
-`ted` object. `localIp`/`remoteIp` are omitted when no interface address
-is present in the BGP-LS descriptor.
+### JSON output
+
+- The top level is an array of nodes; there is no wrapping `ted` object.
+- `links[].local` and `links[].remote` always contain `routerId`; `ipv4`, `ipv6`, and `interfaceId` are included when present.
+- `adjSids` contains `{ "family", "sid" }` objects. `family` is always `"unspecified"` because the available Adjacency-SID information does not include its address family.
 
 ```json
 [
@@ -422,16 +432,18 @@ is present in the BGP-LS descriptor.
     ],
     "links": [
       {
-        "localIp": "10.0.0.1",
-        "remoteIp": "10.0.0.2",
-        "remoteRouterId": "0000.0aff.0002",
+        "local": { "routerId": "0000.0aff.0001", "ipv4": "10.0.0.1", "ipv6": "2001:db8::1", "interfaceId": 5 },
+        "remote": { "routerId": "0000.0aff.0002", "ipv4": "10.0.0.2", "ipv6": "2001:db8::2" },
         "metrics": [{ "type": "igp", "value": 10 }],
-        "adjSid": 17,
-        "srv6EndXSid": {
-          "endpointBehavior": { "behavior": 5, "name": "ENDX" },
-          "sids": ["2001:db8:1::1"],
-          "sidStructure": { "localBlock": 32, "localNode": 16, "localFunc": 16, "localArg": 0 }
-        }
+        "adjSids": [{ "family": "unspecified", "sid": 17 }],
+        "srv6EndXSids": [
+          {
+            "endpointBehavior": { "behavior": 5, "name": "ENDX", "flags": 0, "algorithm": 0 },
+            "weight": 0,
+            "sids": ["2001:db8:1::1"],
+            "sidStructure": { "localBlock": 32, "localNode": 16, "localFunc": 16, "localArg": 0 }
+          }
+        ]
       }
     ],
     "srv6Sids": [
@@ -459,13 +471,13 @@ is present in the BGP-LS descriptor.
 ]
 ```
 
-Notes:
-
-- `metrics[].type` is a lowercase token (`igp`, `te`, `delay`, `hopcount`),
-  matching the metric vocabulary used elsewhere.
-- `endpointBehavior.flags`/`.algorithm` are present for node SRv6 SIDs
-  (`srv6Sids`) but omitted for adjacency SIDs (`links[].srv6EndXSid`), which
-  carry only the behavior.
+> [!NOTE]
+> - `endpointBehavior` contains `behavior`, `flags`, and `algorithm` for node
+>   SRv6 SIDs (`srv6Sids`) and adjacency SIDs (`links[].srv6EndXSids`).
+> - `flags` is the raw octet; its interpretation depends on the advertising
+>   protocol and TLV.
+> - `weight` is the End.X SID load-balancing weight and appears only under
+>   `links[].srv6EndXSids`.
 
 ## Completion
 

--- a/cmd/pola/README.md
+++ b/cmd/pola/README.md
@@ -183,8 +183,8 @@ Session: 192.0.2.2 (State: up, LSP-DB Sync: finished)
     LSPID: 1
     State: up
     Type: explicit
-    SrcAddr: 192.0.2.2 (0000.0aff.0002)
-    DstAddr: 192.0.2.1 (0000.0aff.0001)
+    Headend: 192.0.2.2 (0000.0aff.0002)
+    Endpoint: 192.0.2.1 (0000.0aff.0001)
     Color: 999
     Preference: 100
     SegmentList: 16003 -> 16001
@@ -209,15 +209,22 @@ JSON output
           { "sid": 16003 },
           { "sid": 16001 }
         ],
-        "srcAddr": "192.0.2.2",
-        "dstAddr": "192.0.2.1",
-        "srcRouterId": "0000.0aff.0002",
-        "dstRouterId": "0000.0aff.0001",
+        "headend": "192.0.2.2",
+        "endpoint": "192.0.2.1",
+        "headendRouterId": "0000.0aff.0002",
+        "endpointRouterId": "0000.0aff.0001",
         "color": 999,
-        "preference": 100,
+        "candidatePath": {
+          "preference": 100,
+          "explicit": {
+            "segmentList": [
+              { "sid": 16003 },
+              { "sid": 16001 }
+            ]
+          }
+        },
         "lspId": 1,
-        "state": "up",
-        "type": "explicit"
+        "state": "up"
       }
     ]
   },
@@ -235,8 +242,10 @@ Notes:
 - `state` and `lspDbSync` use the same vocabulary as `pola session`.
 - Policies appear after the first PCRpt is received.
 - `lspId` is omitted when zero.
-- `srcRouterId`/`dstRouterId` are resolved from TED.
-- `metric` is included for policies created with `type: dynamic`.
+- `headendRouterId`/`endpointRouterId` are resolved from TED.
+- `candidatePath.dynamic.metric` is included for policies with a dynamic candidate path.
+- Top-level `segmentList` is the currently signaled segment list; for an
+  explicit candidate path, `candidatePath.explicit.segmentList` mirrors it.
 
 ### pola sr-policy add -f `filepath`
 
@@ -251,14 +260,20 @@ asn: 65000
 srPolicy:
   pcepSessionAddr: 192.0.2.1
   name: policy-name
-  srcRouterID: 0000.0aff.0001
-  dstRouterID: 0000.0aff.0004
+  headendRouterID: 0000.0aff.0001
+  endpointRouterID: 0000.0aff.0004
   color: 100
-  type: dynamic
-  metric: igp
+  candidatePath:
+    dynamic:
+      metric: igp
 ```
 
 `metric` can be `igp`, `te`, or `delay`.
+
+`candidatePath.dynamic.underlayFamily` selects the underlay address family.
+When unspecified, it follows `endpointFamily` or the endpoint's address
+family. Cross-AF configurations are supported by Pola but are not an IETF
+interoperability guarantee.
 
 JSON output
 
@@ -277,14 +292,15 @@ asn: 65000
 srPolicy:
   pcepSessionAddr: 192.0.2.1
   name: policy-name
-  srcRouterID: 0000.0aff.0001
-  dstRouterID: 0000.0aff.0004
+  headendRouterID: 0000.0aff.0001
+  endpointRouterID: 0000.0aff.0004
   color: 100
-  type: explicit
-  segmentList:
-    - sid: 16003
-    - sid: 16002
-    - sid: 16004
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: 16003
+        - sid: 16002
+        - sid: 16004
 ```
 
 JSON output
@@ -297,10 +313,11 @@ JSON output
 
 #### Explicit path with endpoint addresses
 
-Instead of `srcRouterID`/`dstRouterID`, endpoints can be given directly as
-`srcAddr`/`dstAddr`. This form bypasses path computation: no CSPF or router-ID
-resolution is performed, so it accepts only `type: explicit` and takes the
-segment list verbatim.
+Instead of `headendRouterID`/`endpointRouterID`, endpoints can be given
+directly as `headend`/`endpoint` addresses (RFC 9256 §2.1), for either a
+dynamic or an explicit candidate path. For dynamic paths, router IDs needed
+for CSPF are resolved from the TED; `endpointFamily` selects the resolution
+family when necessary and is valid only with the router-ID form.
 
 Each SID is still validated against the TED, so with `ted.enable: false` this
 form additionally requires `--no-sid-validate`.
@@ -315,17 +332,19 @@ YAML input format
 asn: 65000
 srPolicy:
   pcepSessionAddr: "2001:0db8::1"
-  srcAddr: "2001:0db8::1"
-  dstAddr: "2001:0db8::2"
+  headend: "2001:0db8::1"
+  endpoint: "2001:0db8::2"
   name: "policy-name"
   color: 100
-  segmentList:
-    - sid: "2001:0db8:1005::"
-      localAddr: "2001:0db8::5"
-      sidStructure: "32,16,0,80"
-    - sid: "2001:0db8:1006::"
-      localAddr: "2001:0db8::6"
-      sidStructure: "32,16,0,80"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "2001:0db8:1005::"
+          localAddr: "2001:0db8::5"
+          sidStructure: "32,16,0,80"
+        - sid: "2001:0db8:1006::"
+          localAddr: "2001:0db8::6"
+          sidStructure: "32,16,0,80"
 ```
 
 JSON output

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -611,14 +611,14 @@ func GetSRPolicyList(client pb.PCEServiceClient, peerAddr netip.Addr) ([]SRPolic
 }
 
 func convertSRPolicy(p *pb.SRPolicy) (table.SRPolicy, error) {
-	srcAddr, ok := netip.AddrFromSlice(p.GetSrcAddr())
+	headend, ok := netip.AddrFromSlice(p.GetHeadend())
 	if !ok {
-		return table.SRPolicy{}, fmt.Errorf("invalid SR policy source address: %v", p.GetSrcAddr())
+		return table.SRPolicy{}, fmt.Errorf("invalid SR policy headend address: %v", p.GetHeadend())
 	}
 
-	dstAddr, ok := netip.AddrFromSlice(p.GetDstAddr())
+	endpoint, ok := netip.AddrFromSlice(p.GetEndpoint())
 	if !ok {
-		return table.SRPolicy{}, fmt.Errorf("invalid SR policy destination address: %v", p.GetDstAddr())
+		return table.SRPolicy{}, fmt.Errorf("invalid SR policy endpoint address: %v", p.GetEndpoint())
 	}
 
 	segmentList := make([]table.Segment, 0, len(p.GetSegmentList()))
@@ -637,24 +637,44 @@ func convertSRPolicy(p *pb.SRPolicy) (table.SRPolicy, error) {
 	}
 
 	return table.SRPolicy{
-		PlspID:      p.GetPlspId(),
-		Name:        p.GetPolicyName(),
-		SegmentList: segmentList,
-		SrcAddr:     srcAddr,
-		DstAddr:     dstAddr,
-		SrcRouterID: p.GetSrcRouterId(),
-		DstRouterID: p.GetDstRouterId(),
-		Color:       p.GetColor(),
-		Preference:  p.GetPreference(),
-		LSPID:       lspID,
-		State:       policyStateFromPB(p.GetState()),
-		Type:        policyTypeFromPB(p.GetType()),
-		Metric:      metricTypeFromPB(p.GetMetric()),
-		Plane: table.Plane{
-			Family:    fromPBAddressFamily(p.GetUnderlayFamily()),
-			DataPlane: fromPBDataPlane(p.GetDataPlane()),
-		},
+		PlspID:           p.GetPlspId(),
+		Name:             p.GetPolicyName(),
+		SegmentList:      segmentList,
+		Headend:          headend,
+		Endpoint:         endpoint,
+		HeadendRouterID:  p.GetHeadendRouterId(),
+		EndpointRouterID: p.GetEndpointRouterId(),
+		Color:            p.GetColor(),
+		CandidatePath:    candidatePathFromPB(p.GetCandidatePath()),
+		LSPID:            lspID,
+		State:            policyStateFromPB(p.GetState()),
 	}, nil
+}
+
+func candidatePathFromPB(cp *pb.CandidatePath) table.CandidatePath {
+	tableCP := table.CandidatePath{Preference: cp.GetPreference()}
+
+	switch v := cp.GetPath().(type) {
+	case *pb.CandidatePath_Dynamic:
+		tableCP.Dynamic = &table.DynamicPath{
+			Metric: metricTypeFromPB(v.Dynamic.GetMetric()),
+			Plane: table.Plane{
+				Family:    fromPBAddressFamily(v.Dynamic.GetUnderlayFamily()),
+				DataPlane: fromPBDataPlane(v.Dynamic.GetDataPlane()),
+			},
+		}
+	case *pb.CandidatePath_Explicit:
+		segmentList := make([]table.Segment, 0, len(v.Explicit.GetSegmentList()))
+		for _, s := range v.Explicit.GetSegmentList() {
+			if seg, err := segmentFromPB(s); err == nil {
+				segmentList = append(segmentList, seg)
+			}
+		}
+
+		tableCP.Explicit = &table.ExplicitPath{SegmentList: segmentList}
+	}
+
+	return tableCP
 }
 
 func fromPBDataPlane(dp pb.DataPlane) table.DataPlane {
@@ -711,17 +731,6 @@ func policyStateFromPB(state pb.SRPolicyState) table.PolicyState {
 		return table.PolicyActive
 	case pb.SRPolicyState_SR_POLICY_STATE_UNKNOWN:
 		return table.PolicyUnknown
-	default:
-		return ""
-	}
-}
-
-func policyTypeFromPB(polType pb.SRPolicyType) table.PolicyType {
-	switch polType {
-	case pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT:
-		return table.PolicyTypeExplicit
-	case pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC:
-		return table.PolicyTypeDynamic
 	default:
 		return ""
 	}

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -1027,8 +1027,32 @@ func createMetric(metricInfo *pb.Metric) (*table.Metric, error) {
 	}
 }
 
+func endpointBehaviorFromPB(name string, eb *pb.EndpointBehavior) (table.EndpointBehavior, error) {
+	behavior, err := safecast.Uint16(eb.GetBehavior(), name+" endpoint behavior")
+	if err != nil {
+		return table.EndpointBehavior{}, err
+	}
+
+	flags, err := safecast.Uint8(eb.GetFlags(), name+" endpoint behavior flags")
+	if err != nil {
+		return table.EndpointBehavior{}, err
+	}
+
+	algorithm, err := safecast.Uint8(eb.GetAlgorithm(), name+" endpoint behavior algorithm")
+	if err != nil {
+		return table.EndpointBehavior{}, err
+	}
+
+	return table.EndpointBehavior{Behavior: behavior, Flags: flags, Algorithm: algorithm}, nil
+}
+
 func createSrv6EndXSID(srv6EndXSID *pb.Srv6EndXSID) (*table.Srv6EndXSID, error) {
-	endpointBehavior, err := safecast.Uint16(srv6EndXSID.GetEndpointBehavior(), "SRv6 End.X SID endpoint behavior")
+	endpointBehavior, err := endpointBehaviorFromPB("SRv6 End.X SID", srv6EndXSID.GetEndpointBehavior())
+	if err != nil {
+		return nil, err
+	}
+
+	weight, err := safecast.Uint8(srv6EndXSID.GetWeight(), "SRv6 End.X SID weight")
 	if err != nil {
 		return nil, err
 	}
@@ -1040,6 +1064,7 @@ func createSrv6EndXSID(srv6EndXSID *pb.Srv6EndXSID) (*table.Srv6EndXSID, error) 
 
 	lsSrv6EndXSID := &table.Srv6EndXSID{
 		EndpointBehavior: endpointBehavior,
+		Weight:           weight,
 		Sids:             []string{},
 		Srv6SIDStructure: structure,
 	}
@@ -1062,24 +1087,12 @@ func createSrv6SID(lsNode *table.LsNode, srv6SID *pb.LsSrv6SID) (*table.LsSrv6SI
 		lsSrv6SID.MultiTopoIDs = append(lsSrv6SID.MultiTopoIDs, topoID.GetMultiTopoId())
 	}
 
-	behavior, err := safecast.Uint16(srv6SID.GetEndpointBehavior().GetBehavior(), "SRv6 SID endpoint behavior")
+	endpointBehavior, err := endpointBehaviorFromPB("SRv6 SID", srv6SID.GetEndpointBehavior())
 	if err != nil {
 		return nil, err
 	}
 
-	flags, err := safecast.Uint8(srv6SID.GetEndpointBehavior().GetFlags(), "SRv6 SID endpoint behavior flags")
-	if err != nil {
-		return nil, err
-	}
-
-	algorithm, err := safecast.Uint8(srv6SID.GetEndpointBehavior().GetAlgorithm(), "SRv6 SID endpoint behavior algorithm")
-	if err != nil {
-		return nil, err
-	}
-
-	lsSrv6SID.EndpointBehavior.Behavior = behavior
-	lsSrv6SID.EndpointBehavior.Flags = flags
-	lsSrv6SID.EndpointBehavior.Algorithm = algorithm
+	lsSrv6SID.EndpointBehavior = endpointBehavior
 
 	structure, err := sidStructureFromPB(srv6SID.GetSidStructure())
 	if err != nil {

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -650,7 +650,22 @@ func convertSRPolicy(p *pb.SRPolicy) (table.SRPolicy, error) {
 		State:       policyStateFromPB(p.GetState()),
 		Type:        policyTypeFromPB(p.GetType()),
 		Metric:      metricTypeFromPB(p.GetMetric()),
+		Plane: table.Plane{
+			Family:    fromPBAddressFamily(p.GetUnderlayFamily()),
+			DataPlane: fromPBDataPlane(p.GetDataPlane()),
+		},
 	}, nil
+}
+
+func fromPBDataPlane(dp pb.DataPlane) table.DataPlane {
+	switch dp {
+	case pb.DataPlane_DATA_PLANE_SR_MPLS:
+		return table.DPSRMPLS
+	case pb.DataPlane_DATA_PLANE_SRV6:
+		return table.DPSRv6
+	default:
+		return table.DPUnspecified
+	}
 }
 
 func sidStructureFromPB(s *pb.SidStructure) (*table.SIDStructure, error) {
@@ -752,6 +767,14 @@ func segmentFromPB(s *pb.Segment) (table.Segment, error) {
 
 		v.Structure = structure
 
+		behavior, err := safecast.Uint16(s.GetBehavior(), "segment behavior")
+		if err != nil {
+			return nil, err
+		}
+
+		v.Behavior = behavior
+		v.LocalIfaceID, v.RemoteIfaceID = s.LocalIfaceId, s.RemoteIfaceId
+
 		return v, nil
 	case table.SegmentSRMPLS:
 		v.LocalAddr, err = parseOptionalAddr("SR-MPLS local address", s.GetLocalAddr())
@@ -765,6 +788,7 @@ func segmentFromPB(s *pb.Segment) (table.Segment, error) {
 		}
 
 		v.SidAbsent = s.GetSidAbsent()
+		v.LocalIfaceID, v.RemoteIfaceID = s.LocalIfaceId, s.RemoteIfaceId
 
 		return v, nil
 	default:

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -901,23 +901,25 @@ func createLsPrefix(lsNode *table.LsNode, prefix *pb.LsPrefix) (*table.LsPrefix,
 }
 
 func createLsLink(localNode, remoteNode *table.LsNode, link *pb.LsLink) (*table.LsLink, error) {
-	lsLink := &table.LsLink{
-		LocalNode:  localNode,
-		RemoteNode: remoteNode,
-		AdjSid:     link.GetAdjSid(),
+	lsLink := table.NewLsLink(localNode, remoteNode)
+
+	if adjSid := link.GetAdjSid(); adjSid != 0 {
+		lsLink.AdjSids = append(lsLink.AdjSids, table.AdjSID{Family: table.AFUnspecified, Sid: adjSid})
 	}
 
-	var err error
+	var localAddr, remoteAddr netip.Addr
 
-	err = lsLink.LocalIP.UnmarshalText([]byte(link.GetLocalIp()))
-	if err != nil {
+	if err := localAddr.UnmarshalText([]byte(link.GetLocalIp())); err != nil {
 		return nil, fmt.Errorf("invalid link local IP %q: %w", link.GetLocalIp(), err)
 	}
 
-	err = lsLink.RemoteIP.UnmarshalText([]byte(link.GetRemoteIp()))
-	if err != nil {
+	setLinkEndpointAddr(&lsLink.Local, localAddr)
+
+	if err := remoteAddr.UnmarshalText([]byte(link.GetRemoteIp())); err != nil {
 		return nil, fmt.Errorf("invalid link remote IP %q: %w", link.GetRemoteIp(), err)
 	}
+
+	setLinkEndpointAddr(&lsLink.Remote, remoteAddr)
 
 	for _, metricInfo := range link.GetMetrics() {
 		metric, err := createMetric(metricInfo)
@@ -934,10 +936,19 @@ func createLsLink(localNode, remoteNode *table.LsNode, link *pb.LsLink) (*table.
 			return nil, err
 		}
 
-		lsLink.Srv6EndXSID = srv6EndXSID
+		lsLink.Srv6EndXSIDs = append(lsLink.Srv6EndXSIDs, srv6EndXSID)
 	}
 
 	return lsLink, nil
+}
+
+// setLinkEndpointAddr stores addr in the IPv4 or IPv6 field matching its family.
+func setLinkEndpointAddr(e *table.LinkEndpoint, addr netip.Addr) {
+	if addr.Is4() {
+		e.IPv4 = addr
+	} else {
+		e.IPv6 = addr
+	}
 }
 
 func createMetric(metricInfo *pb.Metric) (*table.Metric, error) {

--- a/cmd/pola/grpc/grpc_client.go
+++ b/cmd/pola/grpc/grpc_client.go
@@ -850,8 +850,8 @@ func initializeLsNodes(ted *table.LsTED, nodes []*pb.LsNode) {
 
 func addLsNode(ted *table.LsTED, node *pb.LsNode) error {
 	for _, link := range node.GetLinks() {
-		localNode := ted.Nodes[link.GetLocalRouterId()]
-		remoteNode := ted.Nodes[link.GetRemoteRouterId()]
+		localNode := ted.Nodes[link.GetLocal().GetRouterId()]
+		remoteNode := ted.Nodes[link.GetRemote().GetRouterId()]
 
 		lsLink, err := createLsLink(localNode, remoteNode, link)
 		if err != nil {
@@ -903,23 +903,26 @@ func createLsPrefix(lsNode *table.LsNode, prefix *pb.LsPrefix) (*table.LsPrefix,
 func createLsLink(localNode, remoteNode *table.LsNode, link *pb.LsLink) (*table.LsLink, error) {
 	lsLink := table.NewLsLink(localNode, remoteNode)
 
-	if adjSid := link.GetAdjSid(); adjSid != 0 {
-		lsLink.AdjSids = append(lsLink.AdjSids, table.AdjSID{Family: table.AFUnspecified, Sid: adjSid})
+	local, err := createLinkEndpoint(localNode, link.GetLocal())
+	if err != nil {
+		return nil, fmt.Errorf("invalid local link endpoint: %w", err)
 	}
 
-	var localAddr, remoteAddr netip.Addr
+	lsLink.Local = local
 
-	if err := localAddr.UnmarshalText([]byte(link.GetLocalIp())); err != nil {
-		return nil, fmt.Errorf("invalid link local IP %q: %w", link.GetLocalIp(), err)
+	remote, err := createLinkEndpoint(remoteNode, link.GetRemote())
+	if err != nil {
+		return nil, fmt.Errorf("invalid remote link endpoint: %w", err)
 	}
 
-	setLinkEndpointAddr(&lsLink.Local, localAddr)
+	lsLink.Remote = remote
 
-	if err := remoteAddr.UnmarshalText([]byte(link.GetRemoteIp())); err != nil {
-		return nil, fmt.Errorf("invalid link remote IP %q: %w", link.GetRemoteIp(), err)
+	for _, adjSid := range link.GetAdjSids() {
+		lsLink.AdjSids = append(lsLink.AdjSids, table.AdjSID{
+			Family: fromPBAddressFamily(adjSid.GetFamily()),
+			Sid:    adjSid.GetSid(),
+		})
 	}
-
-	setLinkEndpointAddr(&lsLink.Remote, remoteAddr)
 
 	for _, metricInfo := range link.GetMetrics() {
 		metric, err := createMetric(metricInfo)
@@ -930,8 +933,8 @@ func createLsLink(localNode, remoteNode *table.LsNode, link *pb.LsLink) (*table.
 		lsLink.Metrics = append(lsLink.Metrics, metric)
 	}
 
-	if link.GetSrv6EndXSid() != nil {
-		srv6EndXSID, err := createSrv6EndXSID(link.GetSrv6EndXSid())
+	for _, pbEndXSID := range link.GetSrv6EndXSids() {
+		srv6EndXSID, err := createSrv6EndXSID(pbEndXSID)
 		if err != nil {
 			return nil, err
 		}
@@ -942,12 +945,37 @@ func createLsLink(localNode, remoteNode *table.LsNode, link *pb.LsLink) (*table.
 	return lsLink, nil
 }
 
-// setLinkEndpointAddr stores addr in the IPv4 or IPv6 field matching its family.
-func setLinkEndpointAddr(e *table.LinkEndpoint, addr netip.Addr) {
-	if addr.Is4() {
-		e.IPv4 = addr
-	} else {
-		e.IPv6 = addr
+func createLinkEndpoint(node *table.LsNode, pbEndpoint *pb.LsLinkEndpoint) (table.LinkEndpoint, error) {
+	e := table.LinkEndpoint{Node: node}
+
+	if s := pbEndpoint.GetIpv4(); s != "" {
+		if err := e.IPv4.UnmarshalText([]byte(s)); err != nil {
+			return table.LinkEndpoint{}, fmt.Errorf("invalid IPv4 address %q: %w", s, err)
+		}
+	}
+
+	if s := pbEndpoint.GetIpv6(); s != "" {
+		if err := e.IPv6.UnmarshalText([]byte(s)); err != nil {
+			return table.LinkEndpoint{}, fmt.Errorf("invalid IPv6 address %q: %w", s, err)
+		}
+	}
+
+	if pbEndpoint != nil && pbEndpoint.InterfaceId != nil {
+		ifaceID := pbEndpoint.GetInterfaceId()
+		e.InterfaceID = &ifaceID
+	}
+
+	return e, nil
+}
+
+func fromPBAddressFamily(af pb.AddressFamily) table.AddressFamily {
+	switch af {
+	case pb.AddressFamily_ADDRESS_FAMILY_IPV4:
+		return table.AFIPv4
+	case pb.AddressFamily_ADDRESS_FAMILY_IPV6:
+		return table.AFIPv6
+	default:
+		return table.AFUnspecified
 	}
 }
 

--- a/cmd/pola/grpc/grpc_client_internal_test.go
+++ b/cmd/pola/grpc/grpc_client_internal_test.go
@@ -179,6 +179,26 @@ func TestSegmentFromPB_SRMPLS(t *testing.T) {
 	}
 }
 
+func TestSegmentFromPB_SRMPLS_IfaceIDs(t *testing.T) {
+	t.Parallel()
+
+	localIfaceID, remoteIfaceID := uint32(5), uint32(6)
+
+	seg, err := segmentFromPB(&pb.Segment{
+		Sid:           "16003",
+		LocalIfaceId:  &localIfaceID,
+		RemoteIfaceId: &remoteIfaceID,
+	})
+	require.NoError(t, err)
+
+	mplsSeg, ok := seg.(table.SegmentSRMPLS)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", seg)
+	require.NotNil(t, mplsSeg.LocalIfaceID)
+	assert.Equal(t, localIfaceID, *mplsSeg.LocalIfaceID)
+	require.NotNil(t, mplsSeg.RemoteIfaceID)
+	assert.Equal(t, remoteIfaceID, *mplsSeg.RemoteIfaceID)
+}
+
 func TestSegmentFromPB_SRMPLS_SidAbsent(t *testing.T) {
 	t.Parallel()
 
@@ -198,11 +218,16 @@ func TestSegmentFromPB_SRMPLS_SidAbsent(t *testing.T) {
 func TestSegmentFromPB_SRv6(t *testing.T) {
 	t.Parallel()
 
+	localIfaceID, remoteIfaceID := uint32(5), uint32(6)
+
 	seg, err := segmentFromPB(&pb.Segment{
-		Sid:          "2001:db8:1005::",
-		LocalAddr:    "2001:db8::5",
-		RemoteAddr:   "2001:db8::6",
-		SidStructure: "32,16,0,80",
+		Sid:           "2001:db8:1005::",
+		LocalAddr:     "2001:db8::5",
+		RemoteAddr:    "2001:db8::6",
+		SidStructure:  "32,16,0,80",
+		Behavior:      uint32(table.BehaviorEND),
+		LocalIfaceId:  &localIfaceID,
+		RemoteIfaceId: &remoteIfaceID,
 	})
 	require.NoError(t, err)
 
@@ -212,6 +237,18 @@ func TestSegmentFromPB_SRv6(t *testing.T) {
 	assert.Equal(t, "2001:db8::5", srv6Seg.LocalAddr.String())
 	assert.Equal(t, "2001:db8::6", srv6Seg.RemoteAddr.String())
 	assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}, srv6Seg.Structure)
+	assert.Equal(t, table.BehaviorEND, srv6Seg.Behavior)
+	require.NotNil(t, srv6Seg.LocalIfaceID)
+	assert.Equal(t, localIfaceID, *srv6Seg.LocalIfaceID)
+	require.NotNil(t, srv6Seg.RemoteIfaceID)
+	assert.Equal(t, remoteIfaceID, *srv6Seg.RemoteIfaceID)
+}
+
+func TestSegmentFromPB_SRv6_BehaviorOverflow(t *testing.T) {
+	t.Parallel()
+
+	_, err := segmentFromPB(&pb.Segment{Sid: "2001:db8:1005::", Behavior: math.MaxUint16 + 1})
+	require.Error(t, err)
 }
 
 func TestSegmentFromPB_InvalidSID(t *testing.T) {
@@ -873,6 +910,20 @@ func TestConvertSRPolicy(t *testing.T) {
 			Metric:      table.UnspecifiedMetric,
 		}
 		assert.Equal(t, want, got)
+	})
+
+	t.Run("underlay plane", func(t *testing.T) {
+		t.Parallel()
+
+		p := &pb.SRPolicy{
+			SrcAddr:        netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+			DstAddr:        netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+			UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
+			DataPlane:      pb.DataPlane_DATA_PLANE_SRV6,
+		}
+		got, err := convertSRPolicy(p)
+		require.NoError(t, err)
+		assert.Equal(t, table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRv6}, got.Plane)
 	})
 
 	t.Run("invalid source address", func(t *testing.T) {

--- a/cmd/pola/grpc/grpc_client_internal_test.go
+++ b/cmd/pola/grpc/grpc_client_internal_test.go
@@ -1060,26 +1060,28 @@ func TestGetTED_Success(t *testing.T) {
 		SrgbEnd:    23999,
 		Links: []*pb.LsLink{
 			{
-				LocalRouterId:  testRouterID1,
-				RemoteRouterId: testRouterID2,
-				LocalIp:        testIPv4Addr1,
-				RemoteIp:       testIPv4Addr2,
-				AdjSid:         24001,
+				Local:  &pb.LsLinkEndpoint{RouterId: testRouterID1, Ipv4: testIPv4Addr1},
+				Remote: &pb.LsLinkEndpoint{RouterId: testRouterID2, Ipv4: testIPv4Addr2},
+				AdjSids: []*pb.AdjSid{
+					{Family: pb.AddressFamily_ADDRESS_FAMILY_IPV4, Sid: 24001},
+				},
 				Metrics: []*pb.Metric{
 					{Type: pb.MetricType_METRIC_TYPE_IGP, Value: 10},
 					{Type: pb.MetricType_METRIC_TYPE_TE, Value: 20},
 					{Type: pb.MetricType_METRIC_TYPE_DELAY, Value: 30},
 					{Type: pb.MetricType_METRIC_TYPE_HOPCOUNT, Value: 1},
 				},
-				Srv6EndXSid: &pb.Srv6EndXSID{
-					EndpointBehavior: uint32(table.BehaviorENDX),
-					Sids:             []*pb.SID{{Sid: "2001:db8:1::"}},
-					SidStructure:     &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80},
+				Srv6EndXSids: []*pb.Srv6EndXSID{
+					{
+						EndpointBehavior: uint32(table.BehaviorENDX),
+						Sids:             []*pb.SID{{Sid: "2001:db8:1::"}},
+						SidStructure:     &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80},
+					},
 				},
 			},
 			{
-				LocalRouterId:  testRouterID1,
-				RemoteRouterId: testRouterID2,
+				Local:  &pb.LsLinkEndpoint{RouterId: testRouterID1},
+				Remote: &pb.LsLinkEndpoint{RouterId: testRouterID2},
 			},
 		},
 		Prefixes: []*pb.LsPrefix{
@@ -1153,7 +1155,10 @@ func TestGetTED_PropagatesConversionErrors(t *testing.T) {
 		t.Parallel()
 
 		node := &pb.LsNode{RouterId: testRouterID1, Links: []*pb.LsLink{
-			{LocalRouterId: testRouterID1, RemoteRouterId: testRouterID1, LocalIp: "not-an-ip"},
+			{
+				Local:  &pb.LsLinkEndpoint{RouterId: testRouterID1, Ipv4: "not-an-ip"},
+				Remote: &pb.LsLinkEndpoint{RouterId: testRouterID1},
+			},
 		}}
 		_, err := GetTED(&fakeClient{tedResp: &pb.GetTEDResponse{Enabled: true, Nodes: []*pb.LsNode{node}}})
 		require.Error(t, err)
@@ -1185,17 +1190,17 @@ func TestCreateLsLink(t *testing.T) {
 		assert.False(t, link.Remote.IPv6.IsValid())
 	})
 
-	t.Run("invalid localIp", func(t *testing.T) {
+	t.Run("invalid local IPv4", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := createLsLink(localNode, remoteNode, &pb.LsLink{LocalIp: "not-an-ip"})
+		_, err := createLsLink(localNode, remoteNode, &pb.LsLink{Local: &pb.LsLinkEndpoint{Ipv4: "not-an-ip"}})
 		require.Error(t, err)
 	})
 
-	t.Run("invalid remoteIp", func(t *testing.T) {
+	t.Run("invalid remote IPv4", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := createLsLink(localNode, remoteNode, &pb.LsLink{RemoteIp: "not-an-ip"})
+		_, err := createLsLink(localNode, remoteNode, &pb.LsLink{Remote: &pb.LsLinkEndpoint{Ipv4: "not-an-ip"}})
 		require.Error(t, err)
 	})
 
@@ -1212,9 +1217,55 @@ func TestCreateLsLink(t *testing.T) {
 		t.Parallel()
 
 		_, err := createLsLink(localNode, remoteNode, &pb.LsLink{
-			Srv6EndXSid: &pb.Srv6EndXSID{EndpointBehavior: math.MaxUint16 + 1},
+			Srv6EndXSids: []*pb.Srv6EndXSID{{EndpointBehavior: math.MaxUint16 + 1}},
 		})
 		require.Error(t, err)
+	})
+
+	t.Run("valid local and remote IPv6", func(t *testing.T) {
+		t.Parallel()
+
+		link, err := createLsLink(localNode, remoteNode, &pb.LsLink{
+			Local:  &pb.LsLinkEndpoint{Ipv6: "2001:db8::1"},
+			Remote: &pb.LsLinkEndpoint{Ipv6: "2001:db8::2"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "2001:db8::1", link.Local.IPv6.String())
+		assert.Equal(t, "2001:db8::2", link.Remote.IPv6.String())
+	})
+
+	t.Run("invalid local IPv6", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := createLsLink(localNode, remoteNode, &pb.LsLink{Local: &pb.LsLinkEndpoint{Ipv6: "not-an-ip"}})
+		require.Error(t, err)
+	})
+
+	t.Run("interface ID is carried through", func(t *testing.T) {
+		t.Parallel()
+
+		ifaceID := uint32(7)
+		link, err := createLsLink(localNode, remoteNode, &pb.LsLink{
+			Local: &pb.LsLinkEndpoint{InterfaceId: &ifaceID},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, link.Local.InterfaceID)
+		assert.Equal(t, ifaceID, *link.Local.InterfaceID)
+	})
+
+	t.Run("AdjSid address family is converted", func(t *testing.T) {
+		t.Parallel()
+
+		link, err := createLsLink(localNode, remoteNode, &pb.LsLink{
+			AdjSids: []*pb.AdjSid{
+				{Family: pb.AddressFamily_ADDRESS_FAMILY_IPV6, Sid: 100},
+				{Family: pb.AddressFamily_ADDRESS_FAMILY_UNSPECIFIED, Sid: 200},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, link.AdjSids, 2)
+		assert.Equal(t, table.AFIPv6, link.AdjSids[0].Family)
+		assert.Equal(t, table.AFUnspecified, link.AdjSids[1].Family)
 	})
 }
 

--- a/cmd/pola/grpc/grpc_client_internal_test.go
+++ b/cmd/pola/grpc/grpc_client_internal_test.go
@@ -1160,9 +1160,12 @@ func TestGetTED_Success(t *testing.T) {
 				},
 				Srv6EndXSids: []*pb.Srv6EndXSID{
 					{
-						EndpointBehavior: uint32(table.BehaviorENDX),
-						Sids:             []*pb.SID{{Sid: "2001:db8:1::"}},
-						SidStructure:     &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80},
+						EndpointBehavior: &pb.EndpointBehavior{
+							Behavior: uint32(table.BehaviorENDX), Flags: 0xC0, Algorithm: 128,
+						},
+						Weight:       7,
+						Sids:         []*pb.SID{{Sid: "2001:db8:1::"}},
+						SidStructure: &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80},
 					},
 				},
 			},
@@ -1212,7 +1215,10 @@ func TestGetTED_Success(t *testing.T) {
 		table.NewMetric(table.HopcountMetric, 1),
 	}, link0.Metrics)
 	require.Len(t, link0.Srv6EndXSIDs, 1)
-	assert.Equal(t, table.BehaviorENDX, link0.Srv6EndXSIDs[0].EndpointBehavior)
+	assert.Equal(t, table.EndpointBehavior{
+		Behavior: table.BehaviorENDX, Flags: 0xC0, Algorithm: 128,
+	}, link0.Srv6EndXSIDs[0].EndpointBehavior)
+	assert.Equal(t, uint8(7), link0.Srv6EndXSIDs[0].Weight)
 	assert.Equal(t, []string{"2001:db8:1::"}, link0.Srv6EndXSIDs[0].Sids)
 	assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80}, link0.Srv6EndXSIDs[0].Srv6SIDStructure)
 
@@ -1304,7 +1310,9 @@ func TestCreateLsLink(t *testing.T) {
 		t.Parallel()
 
 		_, err := createLsLink(localNode, remoteNode, &pb.LsLink{
-			Srv6EndXSids: []*pb.Srv6EndXSID{{EndpointBehavior: math.MaxUint16 + 1}},
+			Srv6EndXSids: []*pb.Srv6EndXSID{{
+				EndpointBehavior: &pb.EndpointBehavior{Behavior: math.MaxUint16 + 1},
+			}},
 		})
 		require.Error(t, err)
 	})
@@ -1410,23 +1418,51 @@ func TestCreateSrv6EndXSID(t *testing.T) {
 		t.Parallel()
 
 		got, err := createSrv6EndXSID(&pb.Srv6EndXSID{
-			EndpointBehavior: uint32(table.BehaviorENDX),
-			Sids:             []*pb.SID{{Sid: "2001:db8::1:0"}},
-			SidStructure:     &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+			EndpointBehavior: &pb.EndpointBehavior{
+				Behavior: uint32(table.BehaviorENDX), Flags: 0xC0, Algorithm: 128,
+			},
+			Weight:       7,
+			Sids:         []*pb.SID{{Sid: "2001:db8::1:0"}},
+			SidStructure: &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, &table.Srv6EndXSID{
-			EndpointBehavior: table.BehaviorENDX,
+			EndpointBehavior: table.EndpointBehavior{
+				Behavior: table.BehaviorENDX, Flags: 0xC0, Algorithm: 128,
+			},
+			Weight:           7,
 			Sids:             []string{"2001:db8::1:0"},
 			Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 		}, got)
 	})
 
-	t.Run("endpoint behavior overflow", func(t *testing.T) {
+	t.Run("out-of-range fields are rejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := createSrv6EndXSID(&pb.Srv6EndXSID{EndpointBehavior: math.MaxUint16 + 1})
-		require.Error(t, err)
+		tests := []struct {
+			name string
+			sid  *pb.Srv6EndXSID
+		}{
+			{"endpoint behavior", &pb.Srv6EndXSID{
+				EndpointBehavior: &pb.EndpointBehavior{Behavior: math.MaxUint16 + 1},
+			}},
+			{"flags", &pb.Srv6EndXSID{
+				EndpointBehavior: &pb.EndpointBehavior{Flags: math.MaxUint8 + 1},
+			}},
+			{"algorithm", &pb.Srv6EndXSID{
+				EndpointBehavior: &pb.EndpointBehavior{Algorithm: math.MaxUint8 + 1},
+			}},
+			{"weight", &pb.Srv6EndXSID{Weight: math.MaxUint8 + 1}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				_, err := createSrv6EndXSID(tt.sid)
+				require.Error(t, err)
+			})
+		}
 	})
 
 	t.Run("SID structure overflow propagates", func(t *testing.T) {

--- a/cmd/pola/grpc/grpc_client_internal_test.go
+++ b/cmd/pola/grpc/grpc_client_internal_test.go
@@ -828,26 +828,6 @@ func TestPolicyStateFromPB(t *testing.T) {
 	}
 }
 
-func TestPolicyTypeFromPB(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		in   pb.SRPolicyType
-		want table.PolicyType
-	}{
-		{"explicit", pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, table.PolicyTypeExplicit},
-		{"dynamic", pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, table.PolicyTypeDynamic},
-		{"unspecified maps to the unknown type", pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED, table.PolicyType("")},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, policyTypeFromPB(tt.in))
-		})
-	}
-}
-
 func TestMetricTypeFromPB(t *testing.T) {
 	t.Parallel()
 
@@ -877,37 +857,33 @@ func TestConvertSRPolicy(t *testing.T) {
 		t.Parallel()
 
 		p := &pb.SRPolicy{
-			PlspId:      7,
-			PolicyName:  testPolicyName,
-			SrcAddr:     netip.MustParseAddr(testIPv4Addr1).AsSlice(),
-			DstAddr:     netip.MustParseAddr(testIPv4Addr2).AsSlice(),
-			SrcRouterId: testRouterID1,
-			DstRouterId: testRouterID2,
-			Color:       100,
-			Preference:  200,
-			LspId:       3,
-			State:       pb.SRPolicyState_SR_POLICY_STATE_UP,
-			Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-			Metric:      pb.MetricType_METRIC_TYPE_UNSPECIFIED,
-			SegmentList: []*pb.Segment{{Sid: "16003"}},
+			PlspId:           7,
+			PolicyName:       testPolicyName,
+			Headend:          netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+			Endpoint:         netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+			HeadendRouterId:  testRouterID1,
+			EndpointRouterId: testRouterID2,
+			Color:            100,
+			CandidatePath:    &pb.CandidatePath{Preference: 200},
+			LspId:            3,
+			State:            pb.SRPolicyState_SR_POLICY_STATE_UP,
+			SegmentList:      []*pb.Segment{{Sid: "16003"}},
 		}
 		got, err := convertSRPolicy(p)
 		require.NoError(t, err)
 
 		want := table.SRPolicy{
-			PlspID:      7,
-			Name:        testPolicyName,
-			SegmentList: []table.Segment{table.SegmentSRMPLS{Sid: 16003}},
-			SrcAddr:     netip.MustParseAddr(testIPv4Addr1),
-			DstAddr:     netip.MustParseAddr(testIPv4Addr2),
-			SrcRouterID: testRouterID1,
-			DstRouterID: testRouterID2,
-			Color:       100,
-			Preference:  200,
-			LSPID:       3,
-			State:       table.PolicyUp,
-			Type:        table.PolicyTypeExplicit,
-			Metric:      table.UnspecifiedMetric,
+			PlspID:           7,
+			Name:             testPolicyName,
+			SegmentList:      []table.Segment{table.SegmentSRMPLS{Sid: 16003}},
+			Headend:          netip.MustParseAddr(testIPv4Addr1),
+			Endpoint:         netip.MustParseAddr(testIPv4Addr2),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath:    table.CandidatePath{Preference: 200},
+			LSPID:            3,
+			State:            table.PolicyUp,
 		}
 		assert.Equal(t, want, got)
 	})
@@ -916,27 +892,87 @@ func TestConvertSRPolicy(t *testing.T) {
 		t.Parallel()
 
 		p := &pb.SRPolicy{
-			SrcAddr:        netip.MustParseAddr(testIPv4Addr1).AsSlice(),
-			DstAddr:        netip.MustParseAddr(testIPv4Addr2).AsSlice(),
-			UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
-			DataPlane:      pb.DataPlane_DATA_PLANE_SRV6,
+			Headend:  netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+			Endpoint: netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+					UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
+					DataPlane:      pb.DataPlane_DATA_PLANE_SRV6,
+				}},
+			},
 		}
 		got, err := convertSRPolicy(p)
 		require.NoError(t, err)
-		assert.Equal(t, table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRv6}, got.Plane)
+		require.NotNil(t, got.CandidatePath.Dynamic)
+		assert.Equal(t, table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRv6}, got.CandidatePath.Dynamic.Plane)
+	})
+
+	t.Run("SR-MPLS underlay plane", func(t *testing.T) {
+		t.Parallel()
+
+		p := &pb.SRPolicy{
+			Headend:  netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+			Endpoint: netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+					UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV4,
+					DataPlane:      pb.DataPlane_DATA_PLANE_SR_MPLS,
+				}},
+			},
+		}
+		got, err := convertSRPolicy(p)
+		require.NoError(t, err)
+		require.NotNil(t, got.CandidatePath.Dynamic)
+		assert.Equal(t, table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS}, got.CandidatePath.Dynamic.Plane)
+	})
+
+	t.Run("unspecified data plane", func(t *testing.T) {
+		t.Parallel()
+
+		p := &pb.SRPolicy{
+			Headend:  netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+			Endpoint: netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+					DataPlane: pb.DataPlane_DATA_PLANE_UNSPECIFIED,
+				}},
+			},
+		}
+		got, err := convertSRPolicy(p)
+		require.NoError(t, err)
+		require.NotNil(t, got.CandidatePath.Dynamic)
+		assert.Equal(t, table.DPUnspecified, got.CandidatePath.Dynamic.Plane.DataPlane)
+	})
+
+	t.Run("explicit path", func(t *testing.T) {
+		t.Parallel()
+
+		p := &pb.SRPolicy{
+			Headend:  netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+			Endpoint: netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{
+					SegmentList: []*pb.Segment{{Sid: "16003"}},
+				}},
+			},
+		}
+		got, err := convertSRPolicy(p)
+		require.NoError(t, err)
+		require.NotNil(t, got.CandidatePath.Explicit)
+		assert.Equal(t, []table.Segment{table.SegmentSRMPLS{Sid: 16003}}, got.CandidatePath.Explicit.SegmentList)
 	})
 
 	t.Run("invalid source address", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := convertSRPolicy(&pb.SRPolicy{SrcAddr: []byte{1, 2, 3}, DstAddr: netip.MustParseAddr(testIPv4Addr2).AsSlice()})
+		_, err := convertSRPolicy(&pb.SRPolicy{Headend: []byte{1, 2, 3}, Endpoint: netip.MustParseAddr(testIPv4Addr2).AsSlice()})
 		require.Error(t, err)
 	})
 
 	t.Run("invalid destination address", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := convertSRPolicy(&pb.SRPolicy{SrcAddr: netip.MustParseAddr(testIPv4Addr1).AsSlice(), DstAddr: []byte{1, 2, 3}})
+		_, err := convertSRPolicy(&pb.SRPolicy{Headend: netip.MustParseAddr(testIPv4Addr1).AsSlice(), Endpoint: []byte{1, 2, 3}})
 		require.Error(t, err)
 	})
 
@@ -944,8 +980,8 @@ func TestConvertSRPolicy(t *testing.T) {
 		t.Parallel()
 
 		_, err := convertSRPolicy(&pb.SRPolicy{
-			SrcAddr:     netip.MustParseAddr(testIPv4Addr1).AsSlice(),
-			DstAddr:     netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+			Headend:     netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+			Endpoint:    netip.MustParseAddr(testIPv4Addr2).AsSlice(),
 			SegmentList: []*pb.Segment{{Sid: "not-a-sid"}},
 		})
 		require.Error(t, err)
@@ -955,9 +991,9 @@ func TestConvertSRPolicy(t *testing.T) {
 		t.Parallel()
 
 		_, err := convertSRPolicy(&pb.SRPolicy{
-			SrcAddr: netip.MustParseAddr(testIPv4Addr1).AsSlice(),
-			DstAddr: netip.MustParseAddr(testIPv4Addr2).AsSlice(),
-			LspId:   math.MaxUint16 + 1,
+			Headend:  netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+			Endpoint: netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+			LspId:    math.MaxUint16 + 1,
 		})
 		require.Error(t, err)
 	})
@@ -1006,8 +1042,8 @@ func TestGetSRPolicyList(t *testing.T) {
 				State:    pb.SessionState_SESSION_STATE_UP,
 				SrPolicies: []*pb.SRPolicy{{
 					PolicyName: testPolicyName,
-					SrcAddr:    netip.MustParseAddr(testIPv4Addr1).AsSlice(),
-					DstAddr:    netip.MustParseAddr(testIPv4Addr2).AsSlice(),
+					Headend:    netip.MustParseAddr(testIPv4Addr1).AsSlice(),
+					Endpoint:   netip.MustParseAddr(testIPv4Addr2).AsSlice(),
 				}},
 			}},
 		}}
@@ -1044,7 +1080,7 @@ func TestGetSRPolicyList(t *testing.T) {
 		client := &fakeClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
 			Sessions: []*pb.SRPolicySession{{
 				PeerAddr:   netip.MustParseAddr(testIPv4Addr1).AsSlice(),
-				SrPolicies: []*pb.SRPolicy{{SrcAddr: []byte{1, 2, 3}}},
+				SrPolicies: []*pb.SRPolicy{{Headend: []byte{1, 2, 3}}},
 			}},
 		}}
 		_, err := GetSRPolicyList(client, netip.Addr{})

--- a/cmd/pola/grpc/grpc_client_internal_test.go
+++ b/cmd/pola/grpc/grpc_client_internal_test.go
@@ -1111,24 +1111,27 @@ func TestGetTED_Success(t *testing.T) {
 	require.Len(t, a.Links, 2)
 
 	link0 := a.Links[0]
-	assert.Equal(t, testIPv4Addr1, link0.LocalIP.String())
-	assert.Equal(t, testIPv4Addr2, link0.RemoteIP.String())
-	assert.Same(t, ted.Nodes[testRouterID2], link0.RemoteNode)
-	assert.Equal(t, uint32(24001), link0.AdjSid)
+	assert.Equal(t, testIPv4Addr1, link0.Local.IPv4.String())
+	assert.Equal(t, testIPv4Addr2, link0.Remote.IPv4.String())
+	assert.Same(t, ted.Nodes[testRouterID2], link0.Remote.Node)
+	require.Len(t, link0.AdjSids, 1)
+	assert.Equal(t, uint32(24001), link0.AdjSids[0].Sid)
 	assert.Equal(t, []*table.Metric{
 		table.NewMetric(table.IGPMetric, 10),
 		table.NewMetric(table.TEMetric, 20),
 		table.NewMetric(table.DelayMetric, 30),
 		table.NewMetric(table.HopcountMetric, 1),
 	}, link0.Metrics)
-	require.NotNil(t, link0.Srv6EndXSID)
-	assert.Equal(t, table.BehaviorENDX, link0.Srv6EndXSID.EndpointBehavior)
-	assert.Equal(t, []string{"2001:db8:1::"}, link0.Srv6EndXSID.Sids)
-	assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80}, link0.Srv6EndXSID.Srv6SIDStructure)
+	require.Len(t, link0.Srv6EndXSIDs, 1)
+	assert.Equal(t, table.BehaviorENDX, link0.Srv6EndXSIDs[0].EndpointBehavior)
+	assert.Equal(t, []string{"2001:db8:1::"}, link0.Srv6EndXSIDs[0].Sids)
+	assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 80}, link0.Srv6EndXSIDs[0].Srv6SIDStructure)
 
 	link1 := a.Links[1]
-	assert.False(t, link1.LocalIP.IsValid())
-	assert.False(t, link1.RemoteIP.IsValid())
+	assert.False(t, link1.Local.IPv4.IsValid())
+	assert.False(t, link1.Local.IPv6.IsValid())
+	assert.False(t, link1.Remote.IPv4.IsValid())
+	assert.False(t, link1.Remote.IPv6.IsValid())
 
 	require.Len(t, a.Prefixes, 2)
 	assert.True(t, a.Prefixes[0].HasPrefixSID())
@@ -1176,8 +1179,10 @@ func TestCreateLsLink(t *testing.T) {
 
 		link, err := createLsLink(localNode, remoteNode, &pb.LsLink{})
 		require.NoError(t, err)
-		assert.False(t, link.LocalIP.IsValid())
-		assert.False(t, link.RemoteIP.IsValid())
+		assert.False(t, link.Local.IPv4.IsValid())
+		assert.False(t, link.Local.IPv6.IsValid())
+		assert.False(t, link.Remote.IPv4.IsValid())
+		assert.False(t, link.Remote.IPv6.IsValid())
 	})
 
 	t.Run("invalid localIp", func(t *testing.T) {

--- a/cmd/pola/sr_policy_add.go
+++ b/cmd/pola/sr_policy_add.go
@@ -71,10 +71,23 @@ func newSRPolicyAddCmd(c *cli) *cobra.Command {
 }
 
 type segment struct {
-	SID          string `yaml:"sid"`
-	LocalAddr    string `yaml:"localAddr"`
-	RemoteAddr   string `yaml:"remoteAddr"`
-	SIDStructure string `yaml:"sidStructure"`
+	SID               string  `yaml:"sid"`
+	LocalAddr         string  `yaml:"localAddr"`
+	RemoteAddr        string  `yaml:"remoteAddr"`
+	SIDStructure      string  `yaml:"sidStructure"`
+	LocalInterfaceID  *uint32 `yaml:"localInterfaceId"`
+	RemoteInterfaceID *uint32 `yaml:"remoteInterfaceId"`
+}
+
+func toPBSegment(s segment) *pb.Segment {
+	return &pb.Segment{
+		Sid:           s.SID,
+		LocalAddr:     s.LocalAddr,
+		RemoteAddr:    s.RemoteAddr,
+		SidStructure:  s.SIDStructure,
+		LocalIfaceId:  s.LocalInterfaceID,
+		RemoteIfaceId: s.RemoteInterfaceID,
+	}
 }
 
 type waypoint struct {
@@ -94,6 +107,8 @@ type srPolicy struct {
 	Type            string     `yaml:"type"`
 	Metric          string     `yaml:"metric"`
 	Waypoints       []waypoint `yaml:"waypoints"`
+	UnderlayFamily  string     `yaml:"underlayFamily"`
+	DataPlane       string     `yaml:"dataPlane"`
 }
 
 type inputFormat struct {
@@ -112,6 +127,44 @@ const (
 	metricTypeTE       = "te"
 	metricTypeHopcount = "hopcount"
 )
+
+const (
+	underlayFamilyIPv4 = "ipv4"
+	underlayFamilyIPv6 = "ipv6"
+)
+
+const (
+	dataPlaneSRMPLS = "sr-mpls"
+	dataPlaneSRv6   = "srv6"
+)
+
+// Empty input leaves the choice to the server's resolvePlane default.
+func parseUnderlayFamily(s string) (pb.AddressFamily, error) {
+	switch s {
+	case "":
+		return pb.AddressFamily_ADDRESS_FAMILY_UNSPECIFIED, nil
+	case underlayFamilyIPv4:
+		return pb.AddressFamily_ADDRESS_FAMILY_IPV4, nil
+	case underlayFamilyIPv6:
+		return pb.AddressFamily_ADDRESS_FAMILY_IPV6, nil
+	default:
+		return 0, fmt.Errorf("invalid input `underlayFamily`: %q", s)
+	}
+}
+
+// Empty input leaves the choice to the server's resolvePlane default.
+func parseDataPlane(s string) (pb.DataPlane, error) {
+	switch s {
+	case "":
+		return pb.DataPlane_DATA_PLANE_UNSPECIFIED, nil
+	case dataPlaneSRMPLS:
+		return pb.DataPlane_DATA_PLANE_SR_MPLS, nil
+	case dataPlaneSRv6:
+		return pb.DataPlane_DATA_PLANE_SRV6, nil
+	default:
+		return 0, fmt.Errorf("invalid input `dataPlane`: %q", s)
+	}
+}
 
 func addSRPolicy(out, errOut io.Writer, input inputFormat, jsonFlag, noSIDValidate bool, client pb.PCEServiceClient) error {
 	if noSIDValidate {
@@ -190,6 +243,10 @@ func addSRPolicyWithEndpointAddr(input inputFormat, noSIDValidate bool, client p
 		return errors.New("`metric` and `waypoints` require a dynamic path, which the srcAddr / dstAddr form does not support")
 	}
 
+	if input.SRPolicy.UnderlayFamily != "" || input.SRPolicy.DataPlane != "" {
+		return errors.New("`underlayFamily` and `dataPlane` scope TED-based path computation, which the srcAddr / dstAddr form does not support")
+	}
+
 	if !input.SRPolicy.PCEPSessionAddr.IsValid() || input.SRPolicy.Color == 0 || !input.SRPolicy.SrcAddr.IsValid() || !input.SRPolicy.DstAddr.IsValid() || len(input.SRPolicy.SegmentList) == 0 {
 		sampleInput := "srPolicy:\n" +
 			"  pcepSessionAddr: 192.0.2.1\n" +
@@ -212,14 +269,8 @@ func addSRPolicyWithEndpointAddr(input inputFormat, noSIDValidate bool, client p
 
 	segmentList := []*pb.Segment{}
 
-	for _, segment := range input.SRPolicy.SegmentList {
-		pbSeg := &pb.Segment{
-			Sid:          segment.SID,
-			LocalAddr:    segment.LocalAddr,
-			RemoteAddr:   segment.RemoteAddr,
-			SidStructure: segment.SIDStructure,
-		}
-		segmentList = append(segmentList, pbSeg)
+	for _, seg := range input.SRPolicy.SegmentList {
+		segmentList = append(segmentList, toPBSegment(seg))
 	}
 
 	srPolicy := &pb.SRPolicy{
@@ -258,16 +309,28 @@ func addSRPolicyWithRouterID(input inputFormat, noSIDValidate bool, client pb.PC
 		return err
 	}
 
+	underlayFamily, err := parseUnderlayFamily(input.SRPolicy.UnderlayFamily)
+	if err != nil {
+		return err
+	}
+
+	dataPlane, err := parseDataPlane(input.SRPolicy.DataPlane)
+	if err != nil {
+		return err
+	}
+
 	srPolicy := &pb.SRPolicy{
-		PeerAddr:    input.SRPolicy.PCEPSessionAddr.AsSlice(),
-		SrcRouterId: input.SRPolicy.SrcRouterID,
-		DstRouterId: input.SRPolicy.DstRouterID,
-		Color:       input.SRPolicy.Color,
-		PolicyName:  input.SRPolicy.Name,
-		Type:        spec.Type,
-		SegmentList: spec.Segments,
-		Metric:      spec.Metric,
-		Waypoints:   spec.Waypoints,
+		PeerAddr:       input.SRPolicy.PCEPSessionAddr.AsSlice(),
+		SrcRouterId:    input.SRPolicy.SrcRouterID,
+		DstRouterId:    input.SRPolicy.DstRouterID,
+		Color:          input.SRPolicy.Color,
+		PolicyName:     input.SRPolicy.Name,
+		Type:           spec.Type,
+		SegmentList:    spec.Segments,
+		Metric:         spec.Metric,
+		Waypoints:      spec.Waypoints,
+		UnderlayFamily: underlayFamily,
+		DataPlane:      dataPlane,
 	}
 
 	req := &pb.CreateSRPolicyRequest{
@@ -361,12 +424,7 @@ func buildExplicitPolicy(input inputFormat, sampleExplicit string) (policySpec, 
 
 	var segments []*pb.Segment
 	for _, s := range input.SRPolicy.SegmentList {
-		segments = append(segments, &pb.Segment{
-			Sid:          s.SID,
-			LocalAddr:    s.LocalAddr,
-			RemoteAddr:   s.RemoteAddr,
-			SidStructure: s.SIDStructure,
-		})
+		segments = append(segments, toPBSegment(s))
 	}
 
 	return policySpec{Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, Segments: segments}, nil

--- a/cmd/pola/sr_policy_add.go
+++ b/cmd/pola/sr_policy_add.go
@@ -95,31 +95,43 @@ type waypoint struct {
 	SID      string `yaml:"sid"` // optional: fixed SID override
 }
 
+type dynamicPath struct {
+	Metric         string     `yaml:"metric"`
+	DataPlane      string     `yaml:"dataPlane"`
+	UnderlayFamily string     `yaml:"underlayFamily"`
+	Waypoints      []waypoint `yaml:"waypoints"`
+}
+
+type explicitPath struct {
+	SegmentList []segment `yaml:"segmentList"`
+}
+
+type candidatePath struct {
+	Preference uint32        `yaml:"preference"`
+	Dynamic    *dynamicPath  `yaml:"dynamic"`
+	Explicit   *explicitPath `yaml:"explicit"`
+}
+
+// Endpoints use either address or router-ID form, mutually exclusively (RFC 9256 §2.1).
 type srPolicy struct {
 	PCEPSessionAddr netip.Addr `yaml:"pcepSessionAddr"`
-	SrcAddr         netip.Addr `yaml:"srcAddr"`
-	DstAddr         netip.Addr `yaml:"dstAddr"`
-	SrcRouterID     string     `yaml:"srcRouterID"`
-	DstRouterID     string     `yaml:"dstRouterID"`
-	Name            string     `yaml:"name"`
-	SegmentList     []segment  `yaml:"segmentList"`
-	Color           uint32     `yaml:"color"`
-	Type            string     `yaml:"type"`
-	Metric          string     `yaml:"metric"`
-	Waypoints       []waypoint `yaml:"waypoints"`
-	UnderlayFamily  string     `yaml:"underlayFamily"`
-	DataPlane       string     `yaml:"dataPlane"`
+
+	Headend  netip.Addr `yaml:"headend"`
+	Endpoint netip.Addr `yaml:"endpoint"`
+
+	HeadendRouterID  string `yaml:"headendRouterID"`
+	EndpointRouterID string `yaml:"endpointRouterID"`
+	EndpointFamily   string `yaml:"endpointFamily"`
+
+	Name          string        `yaml:"name"`
+	Color         uint32        `yaml:"color"`
+	CandidatePath candidatePath `yaml:"candidatePath"`
 }
 
 type inputFormat struct {
 	SRPolicy srPolicy `yaml:"srPolicy"`
 	ASN      uint32   `yaml:"asn"`
 }
-
-const (
-	srPolicyTypeExplicit = "explicit"
-	srPolicyTypeDynamic  = "dynamic"
-)
 
 const (
 	metricTypeIGP      = "igp"
@@ -138,8 +150,8 @@ const (
 	dataPlaneSRv6   = "srv6"
 )
 
-// Empty input leaves the choice to the server's resolvePlane default.
-func parseUnderlayFamily(s string) (pb.AddressFamily, error) {
+// Empty input leaves the choice to the server's default.
+func parseAddressFamily(s string) (pb.AddressFamily, error) {
 	switch s {
 	case "":
 		return pb.AddressFamily_ADDRESS_FAMILY_UNSPECIFIED, nil
@@ -148,11 +160,11 @@ func parseUnderlayFamily(s string) (pb.AddressFamily, error) {
 	case underlayFamilyIPv6:
 		return pb.AddressFamily_ADDRESS_FAMILY_IPV6, nil
 	default:
-		return 0, fmt.Errorf("invalid input `underlayFamily`: %q", s)
+		return 0, fmt.Errorf("invalid address family %q", s)
 	}
 }
 
-// Empty input leaves the choice to the server's resolvePlane default.
+// Empty input leaves the choice to the server's default.
 func parseDataPlane(s string) (pb.DataPlane, error) {
 	switch s {
 	case "":
@@ -173,33 +185,24 @@ func addSRPolicy(out, errOut io.Writer, input inputFormat, jsonFlag, noSIDValida
 		}
 	}
 
-	usesRouterID := input.SRPolicy.SrcRouterID != "" || input.SRPolicy.DstRouterID != ""
-
-	usesEndpointAddr := input.SRPolicy.SrcAddr.IsValid() || input.SRPolicy.DstAddr.IsValid()
-	if usesRouterID && usesEndpointAddr {
-		return errors.New("srcRouterID / dstRouterID and srcAddr / dstAddr are mutually exclusive, use one form only")
+	req, err := buildCreateSRPolicyRequest(input, noSIDValidate)
+	if err != nil {
+		return err
 	}
 
-	if usesRouterID {
-		if err := addSRPolicyWithRouterID(input, noSIDValidate, client); err != nil {
-			return translateCreateSRPolicyError(err)
-		}
-	} else {
-		if err := addSRPolicyWithEndpointAddr(input, noSIDValidate, client); err != nil {
-			return translateCreateSRPolicyError(err)
-		}
+	if err := grpc.CreateSRPolicy(client, req); err != nil {
+		return translateCreateSRPolicyError(err)
 	}
 
 	if jsonFlag {
 		return writeJSON(out, statusResult{Status: statusSuccess})
 	}
 
-	_, err := fmt.Fprintln(out, "success!")
+	_, err = fmt.Fprintln(out, "success!")
 
 	return err
 }
 
-// translateCreateSRPolicyError converts gRPC errors into CLI-friendly messages.
 func translateCreateSRPolicyError(err error) error {
 	st, ok := status.FromError(err)
 	if !ok {
@@ -234,225 +237,172 @@ func translateCreateSRPolicyError(err error) error {
 	return errors.New(msg)
 }
 
-func addSRPolicyWithEndpointAddr(input inputFormat, noSIDValidate bool, client pb.PCEServiceClient) error {
-	if input.SRPolicy.Type != "" && input.SRPolicy.Type != srPolicyTypeExplicit {
-		return fmt.Errorf("the srcAddr / dstAddr form supports `type: explicit` only, got %q", input.SRPolicy.Type)
-	}
+const sampleInput = "asn: 65000\n" +
+	"srPolicy:\n" +
+	"  pcepSessionAddr: 192.0.2.1\n" +
+	"  headend: 192.0.2.1\n" +
+	"  endpoint: 192.0.2.2\n" +
+	"  name: name\n" +
+	"  color: 100\n" +
+	"  candidatePath:\n" +
+	"    explicit:\n" +
+	"      segmentList:\n" +
+	"        - sid: 16003\n" +
+	"        - sid: 16002\n\n" +
+	"or, to resolve endpoints from the TED by router ID and compute a dynamic path,\n" +
+	"use headendRouterID / endpointRouterID and candidatePath.dynamic:\n\n" +
+	"asn: 65000\n" +
+	"srPolicy:\n" +
+	"  pcepSessionAddr: 192.0.2.1\n" +
+	"  headendRouterID: 0000.0aff.0001\n" +
+	"  endpointRouterID: 0000.0aff.0004\n" +
+	"  name: name\n" +
+	"  color: 100\n" +
+	"  candidatePath:\n" +
+	"    dynamic:\n" +
+	"      metric: igp\n"
 
-	if input.SRPolicy.Metric != "" || len(input.SRPolicy.Waypoints) > 0 {
-		return errors.New("`metric` and `waypoints` require a dynamic path, which the srcAddr / dstAddr form does not support")
-	}
-
-	if input.SRPolicy.UnderlayFamily != "" || input.SRPolicy.DataPlane != "" {
-		return errors.New("`underlayFamily` and `dataPlane` scope TED-based path computation, which the srcAddr / dstAddr form does not support")
-	}
-
-	if !input.SRPolicy.PCEPSessionAddr.IsValid() || input.SRPolicy.Color == 0 || !input.SRPolicy.SrcAddr.IsValid() || !input.SRPolicy.DstAddr.IsValid() || len(input.SRPolicy.SegmentList) == 0 {
-		sampleInput := "srPolicy:\n" +
-			"  pcepSessionAddr: 192.0.2.1\n" +
-			"  srcAddr: 192.0.2.1\n" +
-			"  dstAddr: 192.0.2.2\n" +
-			"  name: name\n" +
-			"  color: 100\n" +
-			"  segmentList:\n" +
-			"    - sid: 16003\n" +
-			"    - sid: 16002\n\n"
-
-		errMsg := "invalid input\n" +
-			"input example is below\n\n" +
-			sampleInput +
-			"or, to resolve endpoints from the TED by router ID instead,\n" +
-			"use the srcRouterID / dstRouterID form\n"
-
-		return errors.New(errMsg)
-	}
-
-	segmentList := []*pb.Segment{}
-
-	for _, seg := range input.SRPolicy.SegmentList {
-		segmentList = append(segmentList, toPBSegment(seg))
-	}
-
-	srPolicy := &pb.SRPolicy{
-		PeerAddr:    input.SRPolicy.PCEPSessionAddr.AsSlice(),
-		SrcAddr:     input.SRPolicy.SrcAddr.AsSlice(),
-		DstAddr:     input.SRPolicy.DstAddr.AsSlice(),
-		SegmentList: segmentList,
-		Color:       input.SRPolicy.Color,
-		PolicyName:  input.SRPolicy.Name,
-		Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-	}
-
-	request := &pb.CreateSRPolicyRequest{
-		SrPolicy:           srPolicy,
-		Asn:                input.ASN,
-		DisablePathCompute: true,
-		NoSidValidate:      noSIDValidate,
-	}
-
-	if err := grpc.CreateSRPolicy(client, request); err != nil {
-		return fmt.Errorf("failed to create SR policy: %w", err)
-	}
-
-	return nil
+func invalidInputError() error {
+	return fmt.Errorf("invalid input, example below:\n\n%s", sampleInput)
 }
 
-func addSRPolicyWithRouterID(input inputFormat, noSIDValidate bool, client pb.PCEServiceClient) error {
-	sampleInputDynamic, sampleInputExplicit := sampleInputs()
-
-	if err := validateCommonInput(input, sampleInputDynamic, sampleInputExplicit); err != nil {
-		return err
+func buildCreateSRPolicyRequest(input inputFormat, noSIDValidate bool) (*pb.CreateSRPolicyRequest, error) {
+	if !input.SRPolicy.PCEPSessionAddr.IsValid() || input.SRPolicy.Color == 0 {
+		return nil, invalidInputError()
 	}
 
-	spec, err := buildPolicyByType(input, sampleInputDynamic, sampleInputExplicit)
+	endpointFields, err := buildEndpointFields(input.SRPolicy)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	underlayFamily, err := parseUnderlayFamily(input.SRPolicy.UnderlayFamily)
+	candidatePath, err := buildPBCandidatePath(input.SRPolicy.CandidatePath)
 	if err != nil {
-		return err
-	}
-
-	dataPlane, err := parseDataPlane(input.SRPolicy.DataPlane)
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	srPolicy := &pb.SRPolicy{
-		PeerAddr:       input.SRPolicy.PCEPSessionAddr.AsSlice(),
-		SrcRouterId:    input.SRPolicy.SrcRouterID,
-		DstRouterId:    input.SRPolicy.DstRouterID,
-		Color:          input.SRPolicy.Color,
-		PolicyName:     input.SRPolicy.Name,
-		Type:           spec.Type,
-		SegmentList:    spec.Segments,
-		Metric:         spec.Metric,
-		Waypoints:      spec.Waypoints,
-		UnderlayFamily: underlayFamily,
-		DataPlane:      dataPlane,
+		PeerAddr:      input.SRPolicy.PCEPSessionAddr.AsSlice(),
+		Color:         input.SRPolicy.Color,
+		PolicyName:    input.SRPolicy.Name,
+		CandidatePath: candidatePath,
 	}
+	endpointFields(srPolicy)
 
-	req := &pb.CreateSRPolicyRequest{
+	return &pb.CreateSRPolicyRequest{
 		SrPolicy:      srPolicy,
 		Asn:           input.ASN,
 		NoSidValidate: noSIDValidate,
-	}
-
-	if err := grpc.CreateSRPolicy(client, req); err != nil {
-		return fmt.Errorf("failed to create SR policy: %w", err)
-	}
-
-	return nil
+	}, nil
 }
 
-func sampleInputs() (dynamic, explicit string) {
-	dynamic = "#case: dynamic path\n" +
-		"asn: 65000\n" +
-		"srPolicy:\n" +
-		"  pcepSessionAddr: 192.0.2.1\n" +
-		"  srcRouterID: 0000.0aff.0001\n" +
-		"  dstRouterID: 0000.0aff.0004\n" +
-		"  name: name\n" +
-		"  color: 100\n" +
-		"  type: dynamic\n" +
-		"  metric: igp / te / delay\n"
+func buildEndpointFields(policy srPolicy) (func(*pb.SRPolicy), error) {
+	usesAddr := policy.Headend.IsValid() || policy.Endpoint.IsValid()
+	usesRouterID := policy.HeadendRouterID != "" || policy.EndpointRouterID != ""
 
-	explicit = "#case: explicit path\n" +
-		"asn: 65000\n" +
-		"srPolicy:\n" +
-		"  pcepSessionAddr: 192.0.2.1\n" +
-		"  srcRouterID: 0000.0aff.0001\n" +
-		"  dstRouterID: 0000.0aff.0002\n" +
-		"  name: name\n" +
-		"  color: 100\n" +
-		"  type: explicit\n" +
-		"  segmentList:\n" +
-		"    - sid: 16003\n" +
-		"    - sid: 16002\n"
+	switch {
+	case usesAddr && usesRouterID:
+		return nil, errors.New("headend/endpoint and headendRouterID/endpointRouterID are mutually exclusive, use one form only")
+	case usesAddr:
+		if policy.EndpointFamily != "" {
+			return nil, errors.New("endpointFamily is valid only with the headendRouterID/endpointRouterID form")
+		}
 
-	return dynamic, explicit
-}
+		if !policy.Headend.IsValid() || !policy.Endpoint.IsValid() {
+			return nil, invalidInputError()
+		}
 
-func validateCommonInput(input inputFormat, sampleDynamic, sampleExplicit string) error {
-	if input.ASN == 0 ||
-		!input.SRPolicy.PCEPSessionAddr.IsValid() ||
-		input.SRPolicy.Color == 0 ||
-		input.SRPolicy.SrcRouterID == "" ||
-		input.SRPolicy.DstRouterID == "" {
-		return errors.New(
-			"invalid input\n" +
-				"input example is below\n\n" +
-				sampleDynamic +
-				sampleExplicit +
-				"or, to specify endpoints directly instead of resolving router IDs from the TED,\n" +
-				"use the srcAddr / dstAddr form\n",
-		)
-	}
+		return func(p *pb.SRPolicy) {
+			p.Headend = policy.Headend.AsSlice()
+			p.Endpoint = policy.Endpoint.AsSlice()
+		}, nil
+	case usesRouterID:
+		if policy.HeadendRouterID == "" || policy.EndpointRouterID == "" {
+			return nil, invalidInputError()
+		}
 
-	return nil
-}
+		endpointFamily, err := parseAddressFamily(policy.EndpointFamily)
+		if err != nil {
+			return nil, err
+		}
 
-// policySpec is the outcome of translating YAML input into the fields of a
-// pb.SRPolicy that depend on the policy's type (explicit vs. dynamic).
-type policySpec struct {
-	Type      pb.SRPolicyType
-	Metric    pb.MetricType
-	Segments  []*pb.Segment
-	Waypoints []*pb.Waypoint
-}
-
-func buildPolicyByType(input inputFormat, sampleDynamic, sampleExplicit string) (policySpec, error) {
-	switch input.SRPolicy.Type {
-	case srPolicyTypeExplicit:
-		return buildExplicitPolicy(input, sampleExplicit)
-	case srPolicyTypeDynamic:
-		return buildDynamicPolicy(input, sampleDynamic)
+		return func(p *pb.SRPolicy) {
+			p.HeadendRouterId = policy.HeadendRouterID
+			p.EndpointRouterId = policy.EndpointRouterID
+			p.EndpointFamily = endpointFamily
+		}, nil
 	default:
-		return policySpec{}, errors.New("invalid input `type`")
+		return nil, invalidInputError()
 	}
 }
 
-func buildExplicitPolicy(input inputFormat, sampleExplicit string) (policySpec, error) {
-	if len(input.SRPolicy.SegmentList) == 0 {
-		return policySpec{}, errors.New(
-			"invalid input\n" +
-				"input example is below\n\n" +
-				sampleExplicit,
-		)
-	}
+func buildPBCandidatePath(cp candidatePath) (*pb.CandidatePath, error) {
+	switch {
+	case cp.Dynamic != nil && cp.Explicit != nil:
+		return nil, errors.New("candidatePath.dynamic and candidatePath.explicit are mutually exclusive")
+	case cp.Dynamic != nil:
+		dynamic, err := buildPBDynamicPath(*cp.Dynamic)
+		if err != nil {
+			return nil, err
+		}
 
-	var segments []*pb.Segment
-	for _, s := range input.SRPolicy.SegmentList {
-		segments = append(segments, toPBSegment(s))
-	}
+		return &pb.CandidatePath{
+			Preference: cp.Preference,
+			Path:       &pb.CandidatePath_Dynamic{Dynamic: dynamic},
+		}, nil
+	case cp.Explicit != nil:
+		if len(cp.Explicit.SegmentList) == 0 {
+			return nil, invalidInputError()
+		}
 
-	return policySpec{Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, Segments: segments}, nil
+		segmentList := make([]*pb.Segment, 0, len(cp.Explicit.SegmentList))
+		for _, s := range cp.Explicit.SegmentList {
+			segmentList = append(segmentList, toPBSegment(s))
+		}
+
+		return &pb.CandidatePath{
+			Preference: cp.Preference,
+			Path:       &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{SegmentList: segmentList}},
+		}, nil
+	default:
+		return nil, errors.New("candidatePath must specify either dynamic or explicit")
+	}
 }
 
-func buildDynamicPolicy(input inputFormat, sampleDynamic string) (policySpec, error) {
-	if input.SRPolicy.Metric == "" {
-		return policySpec{}, errors.New(
-			"invalid input\n" +
-				"input example is below\n\n" +
-				sampleDynamic,
-		)
+func buildPBDynamicPath(d dynamicPath) (*pb.DynamicPath, error) {
+	if d.Metric == "" {
+		return nil, invalidInputError()
 	}
 
-	metric, err := parseMetric(input.SRPolicy.Metric)
+	metric, err := parseMetric(d.Metric)
 	if err != nil {
-		return policySpec{}, err
+		return nil, err
+	}
+
+	dataPlane, err := parseDataPlane(d.DataPlane)
+	if err != nil {
+		return nil, err
+	}
+
+	underlayFamily, err := parseAddressFamily(d.UnderlayFamily)
+	if err != nil {
+		return nil, err
 	}
 
 	var waypoints []*pb.Waypoint
-	for _, wp := range input.SRPolicy.Waypoints {
+	for _, wp := range d.Waypoints {
 		waypoints = append(waypoints, &pb.Waypoint{
 			RouterId: wp.RouterID,
 			Sid:      wp.SID,
 		})
 	}
 
-	return policySpec{Type: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, Metric: metric, Waypoints: waypoints}, nil
+	return &pb.DynamicPath{
+		Metric:         metric,
+		DataPlane:      dataPlane,
+		UnderlayFamily: underlayFamily,
+		Waypoints:      waypoints,
+	}, nil
 }
 
 func parseMetric(metric string) (pb.MetricType, error) {

--- a/cmd/pola/sr_policy_add_test.go
+++ b/cmd/pola/sr_policy_add_test.go
@@ -328,6 +328,16 @@ func TestAddSRPolicyWithEndpointAddr(t *testing.T) {
 		assert.Contains(t, err.Error(), "dynamic path")
 	})
 
+	t.Run("underlayFamily and dataPlane require TED-based computation", func(t *testing.T) {
+		t.Parallel()
+
+		p := base()
+		p.UnderlayFamily = underlayFamilyIPv6
+		err := addSRPolicyWithEndpointAddr(inputFormat{SRPolicy: p}, false, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "underlayFamily")
+	})
+
 	t.Run("missing mandatory fields", func(t *testing.T) {
 		t.Parallel()
 
@@ -414,6 +424,61 @@ func TestAddSRPolicyWithRouterID(t *testing.T) {
 		assert.Equal(t, uint32(65000), fake.createSRPolicyReq.GetAsn())
 		assert.True(t, fake.createSRPolicyReq.GetNoSidValidate())
 		assert.False(t, fake.createSRPolicyReq.GetDisablePathCompute())
+	})
+
+	t.Run("dynamic path with underlayFamily=ipv6 and dataPlane=srv6", func(t *testing.T) {
+		t.Parallel()
+
+		fake := &fakePCEServiceClient{}
+		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
+			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
+			SrcRouterID:     testRouterID1,
+			DstRouterID:     testRouterID2,
+			Color:           100,
+			Type:            srPolicyTypeDynamic,
+			Metric:          metricTypeIGP,
+			UnderlayFamily:  underlayFamilyIPv6,
+			DataPlane:       dataPlaneSRv6,
+		}}
+		require.NoError(t, addSRPolicyWithRouterID(input, false, fake))
+
+		require.NotNil(t, fake.createSRPolicyReq)
+		assert.Equal(t, pb.AddressFamily_ADDRESS_FAMILY_IPV6, fake.createSRPolicyReq.GetSrPolicy().GetUnderlayFamily())
+		assert.Equal(t, pb.DataPlane_DATA_PLANE_SRV6, fake.createSRPolicyReq.GetSrPolicy().GetDataPlane())
+	})
+
+	t.Run("invalid underlayFamily is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
+			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
+			SrcRouterID:     testRouterID1,
+			DstRouterID:     testRouterID2,
+			Color:           100,
+			Type:            srPolicyTypeDynamic,
+			Metric:          metricTypeIGP,
+			UnderlayFamily:  "ipv5",
+		}}
+		err := addSRPolicyWithRouterID(input, false, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "underlayFamily")
+	})
+
+	t.Run("invalid dataPlane is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
+			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
+			SrcRouterID:     testRouterID1,
+			DstRouterID:     testRouterID2,
+			Color:           100,
+			Type:            srPolicyTypeDynamic,
+			Metric:          metricTypeIGP,
+			DataPlane:       "srv7",
+		}}
+		err := addSRPolicyWithRouterID(input, false, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dataPlane")
 	})
 
 	t.Run("explicit path builds the request", func(t *testing.T) {
@@ -565,6 +630,90 @@ func TestBuildPolicyByType(t *testing.T) {
 		t.Parallel()
 
 		_, err := buildPolicyByType(inputFormat{SRPolicy: srPolicy{Type: srPolicyTypeDynamic, Metric: "bandwidth"}}, "d", "e")
+		require.Error(t, err)
+	})
+}
+
+func TestToPBSegment(t *testing.T) {
+	t.Parallel()
+
+	localIfaceID, remoteIfaceID := uint32(5), uint32(6)
+	got := toPBSegment(segment{
+		SID:               "16003",
+		LocalAddr:         testPeerAddr1,
+		RemoteAddr:        testPeerAddr2,
+		SIDStructure:      "32,16,0,80",
+		LocalInterfaceID:  &localIfaceID,
+		RemoteInterfaceID: &remoteIfaceID,
+	})
+
+	want := &pb.Segment{
+		Sid:           "16003",
+		LocalAddr:     testPeerAddr1,
+		RemoteAddr:    testPeerAddr2,
+		SidStructure:  "32,16,0,80",
+		LocalIfaceId:  &localIfaceID,
+		RemoteIfaceId: &remoteIfaceID,
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestParseUnderlayFamily(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want pb.AddressFamily
+	}{
+		{"unset", "", pb.AddressFamily_ADDRESS_FAMILY_UNSPECIFIED},
+		{underlayFamilyIPv4, underlayFamilyIPv4, pb.AddressFamily_ADDRESS_FAMILY_IPV4},
+		{underlayFamilyIPv6, underlayFamilyIPv6, pb.AddressFamily_ADDRESS_FAMILY_IPV6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseUnderlayFamily(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("unrecognized value is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parseUnderlayFamily("ipv5")
+		require.Error(t, err)
+	})
+}
+
+func TestParseDataPlane(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want pb.DataPlane
+	}{
+		{"unset", "", pb.DataPlane_DATA_PLANE_UNSPECIFIED},
+		{dataPlaneSRMPLS, dataPlaneSRMPLS, pb.DataPlane_DATA_PLANE_SR_MPLS},
+		{dataPlaneSRv6, dataPlaneSRv6, pb.DataPlane_DATA_PLANE_SRV6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseDataPlane(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("unrecognized value is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parseDataPlane("srv7")
 		require.Error(t, err)
 	})
 }

--- a/cmd/pola/sr_policy_add_test.go
+++ b/cmd/pola/sr_policy_add_test.go
@@ -104,10 +104,12 @@ func validEndpointInput() inputFormat {
 		ASN: 65000,
 		SRPolicy: srPolicy{
 			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcAddr:         netip.MustParseAddr(testPeerAddr1),
-			DstAddr:         netip.MustParseAddr(testPeerAddr2),
+			Headend:         netip.MustParseAddr(testPeerAddr1),
+			Endpoint:        netip.MustParseAddr(testPeerAddr2),
 			Color:           100,
-			SegmentList:     []segment{{SID: "16003"}},
+			CandidatePath: candidatePath{
+				Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}},
+			},
 		},
 	}
 }
@@ -169,14 +171,17 @@ func TestNewSRPolicyAddCmd_RunE(t *testing.T) {
 	t.Run("success delegates to addSRPolicy", func(t *testing.T) {
 		t.Parallel()
 		path := filepath.Join(t.TempDir(), "policy.yaml")
-		yamlContent := "srPolicy:\n" +
+		yamlContent := "asn: 65000\n" +
+			"srPolicy:\n" +
 			"  pcepSessionAddr: 192.0.2.1\n" +
-			"  srcAddr: 192.0.2.1\n" +
-			"  dstAddr: 192.0.2.2\n" +
+			"  headend: 192.0.2.1\n" +
+			"  endpoint: 192.0.2.2\n" +
 			"  name: pol1\n" +
 			"  color: 100\n" +
-			"  segmentList:\n" +
-			"    - sid: \"16003\"\n"
+			"  candidatePath:\n" +
+			"    explicit:\n" +
+			"      segmentList:\n" +
+			"        - sid: \"16003\"\n"
 		require.NoError(t, os.WriteFile(path, []byte(yamlContent), 0o600))
 
 		cmd := newTestSRPolicyAddCmd(&fakePCEServiceClient{})
@@ -201,12 +206,17 @@ func TestNewSRPolicyAddCmd_RunE(t *testing.T) {
 func TestAddSRPolicy(t *testing.T) {
 	t.Parallel()
 
-	t.Run("srcRouterID/dstRouterID and srcAddr/dstAddr are mutually exclusive", func(t *testing.T) {
+	t.Run("headendRouterID/endpointRouterID and headend/endpoint are mutually exclusive", func(t *testing.T) {
 		t.Parallel()
 
 		input := inputFormat{SRPolicy: srPolicy{
-			SrcRouterID: testRouterID1,
-			SrcAddr:     netip.MustParseAddr(testPeerAddr1),
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			Color:            100,
+			HeadendRouterID:  testRouterID1,
+			Headend:          netip.MustParseAddr(testPeerAddr1),
+			EndpointRouterID: testRouterID2,
+			Endpoint:         netip.MustParseAddr(testPeerAddr2),
+			CandidatePath:    candidatePath{Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}}},
 		}}
 		err := addSRPolicy(&bytes.Buffer{}, &bytes.Buffer{}, input, false, false, nil)
 		require.Error(t, err)
@@ -252,16 +262,15 @@ func TestAddSRPolicy(t *testing.T) {
 
 		fake := &fakePCEServiceClient{}
 		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
-			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
-			Color:           100,
-			Type:            srPolicyTypeExplicit,
-			SegmentList:     []segment{{SID: "16003"}},
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath:    candidatePath{Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}}},
 		}}
 		require.NoError(t, addSRPolicy(&bytes.Buffer{}, &bytes.Buffer{}, input, false, false, fake))
 		require.NotNil(t, fake.createSRPolicyReq)
-		assert.Equal(t, testRouterID1, fake.createSRPolicyReq.GetSrPolicy().GetSrcRouterId())
+		assert.Equal(t, testRouterID1, fake.createSRPolicyReq.GetSrPolicy().GetHeadendRouterId())
 	})
 
 	t.Run("router ID form grpc error is translated too", func(t *testing.T) {
@@ -269,12 +278,11 @@ func TestAddSRPolicy(t *testing.T) {
 
 		fake := &fakePCEServiceClient{createSRPolicyErr: assert.AnError}
 		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
-			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
-			Color:           100,
-			Type:            srPolicyTypeExplicit,
-			SegmentList:     []segment{{SID: "16003"}},
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath:    candidatePath{Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}}},
 		}}
 		err := addSRPolicy(&bytes.Buffer{}, &bytes.Buffer{}, input, false, false, fake)
 		require.ErrorIs(t, err, assert.AnError)
@@ -295,341 +303,294 @@ func TestAddSRPolicy(t *testing.T) {
 	})
 }
 
-func TestAddSRPolicyWithEndpointAddr(t *testing.T) {
+func TestBuildCreateSRPolicyRequest(t *testing.T) {
 	t.Parallel()
-
-	base := func() srPolicy {
-		return srPolicy{
-			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcAddr:         netip.MustParseAddr(testPeerAddr1),
-			DstAddr:         netip.MustParseAddr(testPeerAddr2),
-			Color:           100,
-			SegmentList:     []segment{{SID: "16003"}},
-		}
-	}
-
-	t.Run("type must be explicit (or empty)", func(t *testing.T) {
-		t.Parallel()
-
-		p := base()
-		p.Type = srPolicyTypeDynamic
-		err := addSRPolicyWithEndpointAddr(inputFormat{SRPolicy: p}, false, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), srPolicyTypeExplicit)
-	})
-
-	t.Run("metric and waypoints require a dynamic path", func(t *testing.T) {
-		t.Parallel()
-
-		p := base()
-		p.Metric = metricTypeIGP
-		err := addSRPolicyWithEndpointAddr(inputFormat{SRPolicy: p}, false, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "dynamic path")
-	})
-
-	t.Run("underlayFamily and dataPlane require TED-based computation", func(t *testing.T) {
-		t.Parallel()
-
-		p := base()
-		p.UnderlayFamily = underlayFamilyIPv6
-		err := addSRPolicyWithEndpointAddr(inputFormat{SRPolicy: p}, false, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "underlayFamily")
-	})
 
 	t.Run("missing mandatory fields", func(t *testing.T) {
 		t.Parallel()
 
-		err := addSRPolicyWithEndpointAddr(inputFormat{}, false, nil)
+		_, err := buildCreateSRPolicyRequest(inputFormat{}, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid input")
-	})
-
-	t.Run("success builds the explicit request", func(t *testing.T) {
-		t.Parallel()
-
-		fake := &fakePCEServiceClient{}
-		p := base()
-		p.Name = testPolicyName
-		p.SegmentList = []segment{{SID: "16003", LocalAddr: testPeerAddr1, RemoteAddr: testPeerAddr2, SIDStructure: "32,16,0,80"}}
-
-		require.NoError(t, addSRPolicyWithEndpointAddr(inputFormat{ASN: 65000, SRPolicy: p}, true, fake))
-
-		require.NotNil(t, fake.createSRPolicyReq)
-
-		want := &pb.SRPolicy{
-			PeerAddr:    netip.MustParseAddr(testPeerAddr1).AsSlice(),
-			SrcAddr:     netip.MustParseAddr(testPeerAddr1).AsSlice(),
-			DstAddr:     netip.MustParseAddr(testPeerAddr2).AsSlice(),
-			SegmentList: []*pb.Segment{{Sid: "16003", LocalAddr: testPeerAddr1, RemoteAddr: testPeerAddr2, SidStructure: "32,16,0,80"}},
-			Color:       100,
-			PolicyName:  testPolicyName,
-			Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-		}
-		assert.Equal(t, want, fake.createSRPolicyReq.GetSrPolicy())
-		assert.Equal(t, uint32(65000), fake.createSRPolicyReq.GetAsn())
-		assert.True(t, fake.createSRPolicyReq.GetDisablePathCompute())
-		assert.True(t, fake.createSRPolicyReq.GetNoSidValidate())
-	})
-
-	t.Run("grpc error propagates", func(t *testing.T) {
-		t.Parallel()
-
-		fake := &fakePCEServiceClient{createSRPolicyErr: assert.AnError}
-		err := addSRPolicyWithEndpointAddr(inputFormat{SRPolicy: base()}, false, fake)
-		require.ErrorIs(t, err, assert.AnError)
-	})
-}
-
-func TestAddSRPolicyWithRouterID(t *testing.T) {
-	t.Parallel()
-
-	t.Run("invalid common input", func(t *testing.T) {
-		t.Parallel()
-
-		err := addSRPolicyWithRouterID(inputFormat{}, false, nil)
-		require.Error(t, err)
-	})
-
-	t.Run("dynamic path builds the request", func(t *testing.T) {
-		t.Parallel()
-
-		fake := &fakePCEServiceClient{}
-		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
-			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
-			Name:            testPolicyName,
-			Color:           100,
-			Type:            srPolicyTypeDynamic,
-			Metric:          metricTypeDelay,
-			Waypoints:       []waypoint{{RouterID: "0000.0aff.0003"}},
-		}}
-		require.NoError(t, addSRPolicyWithRouterID(input, true, fake))
-
-		require.NotNil(t, fake.createSRPolicyReq)
-
-		want := &pb.SRPolicy{
-			PeerAddr:    netip.MustParseAddr(testPeerAddr1).AsSlice(),
-			SrcRouterId: testRouterID1,
-			DstRouterId: testRouterID2,
-			Color:       100,
-			PolicyName:  testPolicyName,
-			Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-			Metric:      pb.MetricType_METRIC_TYPE_DELAY,
-			Waypoints:   []*pb.Waypoint{{RouterId: "0000.0aff.0003"}},
-		}
-		assert.Equal(t, want, fake.createSRPolicyReq.GetSrPolicy())
-		assert.Equal(t, uint32(65000), fake.createSRPolicyReq.GetAsn())
-		assert.True(t, fake.createSRPolicyReq.GetNoSidValidate())
-		assert.False(t, fake.createSRPolicyReq.GetDisablePathCompute())
-	})
-
-	t.Run("dynamic path with underlayFamily=ipv6 and dataPlane=srv6", func(t *testing.T) {
-		t.Parallel()
-
-		fake := &fakePCEServiceClient{}
-		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
-			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
-			Color:           100,
-			Type:            srPolicyTypeDynamic,
-			Metric:          metricTypeIGP,
-			UnderlayFamily:  underlayFamilyIPv6,
-			DataPlane:       dataPlaneSRv6,
-		}}
-		require.NoError(t, addSRPolicyWithRouterID(input, false, fake))
-
-		require.NotNil(t, fake.createSRPolicyReq)
-		assert.Equal(t, pb.AddressFamily_ADDRESS_FAMILY_IPV6, fake.createSRPolicyReq.GetSrPolicy().GetUnderlayFamily())
-		assert.Equal(t, pb.DataPlane_DATA_PLANE_SRV6, fake.createSRPolicyReq.GetSrPolicy().GetDataPlane())
-	})
-
-	t.Run("invalid underlayFamily is rejected", func(t *testing.T) {
-		t.Parallel()
-
-		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
-			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
-			Color:           100,
-			Type:            srPolicyTypeDynamic,
-			Metric:          metricTypeIGP,
-			UnderlayFamily:  "ipv5",
-		}}
-		err := addSRPolicyWithRouterID(input, false, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "underlayFamily")
-	})
-
-	t.Run("invalid dataPlane is rejected", func(t *testing.T) {
-		t.Parallel()
-
-		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
-			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
-			Color:           100,
-			Type:            srPolicyTypeDynamic,
-			Metric:          metricTypeIGP,
-			DataPlane:       "srv7",
-		}}
-		err := addSRPolicyWithRouterID(input, false, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "dataPlane")
 	})
 
 	t.Run("explicit path builds the request", func(t *testing.T) {
 		t.Parallel()
 
-		fake := &fakePCEServiceClient{}
-		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
+		p := srPolicy{
 			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
+			Headend:         netip.MustParseAddr(testPeerAddr1),
+			Endpoint:        netip.MustParseAddr(testPeerAddr2),
 			Color:           100,
-			Type:            srPolicyTypeExplicit,
-			SegmentList:     []segment{{SID: "16003"}},
-		}}
-		require.NoError(t, addSRPolicyWithRouterID(input, false, fake))
+			Name:            testPolicyName,
+			CandidatePath: candidatePath{
+				Preference: 200,
+				Explicit: &explicitPath{SegmentList: []segment{
+					{SID: "16003", LocalAddr: testPeerAddr1, RemoteAddr: testPeerAddr2, SIDStructure: "32,16,0,80"},
+				}},
+			},
+		}
 
-		require.NotNil(t, fake.createSRPolicyReq)
-		assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, fake.createSRPolicyReq.GetSrPolicy().GetType())
-		assert.Equal(t, []*pb.Segment{{Sid: "16003"}}, fake.createSRPolicyReq.GetSrPolicy().GetSegmentList())
+		req, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, true)
+		require.NoError(t, err)
+
+		want := &pb.SRPolicy{
+			PeerAddr:   netip.MustParseAddr(testPeerAddr1).AsSlice(),
+			Headend:    netip.MustParseAddr(testPeerAddr1).AsSlice(),
+			Endpoint:   netip.MustParseAddr(testPeerAddr2).AsSlice(),
+			Color:      100,
+			PolicyName: testPolicyName,
+			CandidatePath: &pb.CandidatePath{
+				Preference: 200,
+				Path: &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{
+					SegmentList: []*pb.Segment{{Sid: "16003", LocalAddr: testPeerAddr1, RemoteAddr: testPeerAddr2, SidStructure: "32,16,0,80"}},
+				}},
+			},
+		}
+		assert.Equal(t, want, req.GetSrPolicy())
+		assert.Equal(t, uint32(65000), req.GetAsn())
+		assert.True(t, req.GetNoSidValidate())
 	})
 
-	t.Run("invalid type is rejected", func(t *testing.T) {
+	t.Run("dynamic path builds the request", func(t *testing.T) {
 		t.Parallel()
 
-		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Name:             testPolicyName,
+			Color:            100,
+			CandidatePath: candidatePath{
+				Dynamic: &dynamicPath{
+					Metric:    metricTypeDelay,
+					Waypoints: []waypoint{{RouterID: "0000.0aff.0003"}},
+				},
+			},
+		}
+
+		req, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.NoError(t, err)
+
+		want := &pb.SRPolicy{
+			PeerAddr:         netip.MustParseAddr(testPeerAddr1).AsSlice(),
+			HeadendRouterId:  testRouterID1,
+			EndpointRouterId: testRouterID2,
+			Color:            100,
+			PolicyName:       testPolicyName,
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+					Metric:    pb.MetricType_METRIC_TYPE_DELAY,
+					Waypoints: []*pb.Waypoint{{RouterId: "0000.0aff.0003"}},
+				}},
+			},
+		}
+		assert.Equal(t, want, req.GetSrPolicy())
+	})
+
+	t.Run("dynamic path with underlayFamily=ipv6 and dataPlane=srv6", func(t *testing.T) {
+		t.Parallel()
+
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath: candidatePath{
+				Dynamic: &dynamicPath{Metric: metricTypeIGP, UnderlayFamily: underlayFamilyIPv6, DataPlane: dataPlaneSRv6},
+			},
+		}
+
+		req, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.NoError(t, err)
+
+		dyn := req.GetSrPolicy().GetCandidatePath().GetDynamic()
+		require.NotNil(t, dyn)
+		assert.Equal(t, pb.AddressFamily_ADDRESS_FAMILY_IPV6, dyn.GetUnderlayFamily())
+		assert.Equal(t, pb.DataPlane_DATA_PLANE_SRV6, dyn.GetDataPlane())
+	})
+
+	t.Run("endpointFamily is valid only with the router ID form", func(t *testing.T) {
+		t.Parallel()
+
+		p := srPolicy{
 			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
+			Headend:         netip.MustParseAddr(testPeerAddr1),
+			Endpoint:        netip.MustParseAddr(testPeerAddr2),
+			EndpointFamily:  underlayFamilyIPv4,
 			Color:           100,
-			Type:            "unknown",
-		}}
-		err := addSRPolicyWithRouterID(input, false, nil)
+			CandidatePath:   candidatePath{Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "endpointFamily")
+	})
+
+	t.Run("invalid endpointFamily is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			EndpointFamily:   "ipv5",
+			Color:            100,
+			CandidatePath:    candidatePath{Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
 		require.Error(t, err)
 	})
 
-	t.Run("grpc error propagates", func(t *testing.T) {
+	t.Run("invalid underlayFamily is rejected", func(t *testing.T) {
 		t.Parallel()
 
-		fake := &fakePCEServiceClient{createSRPolicyErr: assert.AnError}
-		input := inputFormat{ASN: 65000, SRPolicy: srPolicy{
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath:    candidatePath{Dynamic: &dynamicPath{Metric: metricTypeIGP, UnderlayFamily: "ipv5"}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid dataPlane is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath:    candidatePath{Dynamic: &dynamicPath{Metric: metricTypeIGP, DataPlane: "srv7"}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.Error(t, err)
+	})
+
+	t.Run("only headend set without endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		p := srPolicy{
 			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			SrcRouterID:     testRouterID1,
-			DstRouterID:     testRouterID2,
+			Headend:         netip.MustParseAddr(testPeerAddr1),
 			Color:           100,
-			Type:            srPolicyTypeExplicit,
-			SegmentList:     []segment{{SID: "16003"}},
-		}}
-		err := addSRPolicyWithRouterID(input, false, fake)
-		require.ErrorIs(t, err, assert.AnError)
-	})
-}
+			CandidatePath:   candidatePath{Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}}},
+		}
 
-func TestSampleInputs(t *testing.T) {
-	t.Parallel()
-
-	dynamic, explicit := sampleInputs()
-	assert.Contains(t, dynamic, "type: dynamic")
-	assert.Contains(t, explicit, "type: explicit")
-}
-
-func TestValidateCommonInput(t *testing.T) {
-	t.Parallel()
-
-	valid := srPolicy{
-		PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-		Color:           100,
-		SrcRouterID:     testRouterID1,
-		DstRouterID:     testRouterID2,
-	}
-
-	t.Run("all mandatory fields present", func(t *testing.T) {
-		t.Parallel()
-		require.NoError(t, validateCommonInput(inputFormat{ASN: 65000, SRPolicy: valid}, "dynamic-sample", "explicit-sample"))
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid input")
 	})
 
-	tests := []struct {
-		name  string
-		input inputFormat
-	}{
-		{"missing ASN", inputFormat{SRPolicy: valid}},
-		{"missing pcepSessionAddr", inputFormat{ASN: 65000, SRPolicy: srPolicy{Color: 100, SrcRouterID: "a", DstRouterID: "b"}}},
-		{"missing color", inputFormat{ASN: 65000, SRPolicy: srPolicy{PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1), SrcRouterID: "a", DstRouterID: "b"}}},
-		{"missing srcRouterID", inputFormat{ASN: 65000, SRPolicy: srPolicy{PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1), Color: 100, DstRouterID: "b"}}},
-		{"missing dstRouterID", inputFormat{ASN: 65000, SRPolicy: srPolicy{PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1), Color: 100, SrcRouterID: "a"}}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := validateCommonInput(tt.input, "dynamic-sample", "explicit-sample")
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "dynamic-sample")
-			assert.Contains(t, err.Error(), "explicit-sample")
-		})
-	}
-}
-
-func TestBuildPolicyByType(t *testing.T) {
-	t.Parallel()
-
-	t.Run(srPolicyTypeExplicit, func(t *testing.T) {
+	t.Run("only headendRouterID set without endpointRouterID", func(t *testing.T) {
 		t.Parallel()
 
-		input := inputFormat{SRPolicy: srPolicy{Type: srPolicyTypeExplicit, SegmentList: []segment{{SID: "16003"}}}}
-		spec, err := buildPolicyByType(input, "d", "e")
-		require.NoError(t, err)
-		assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, spec.Type)
-		assert.Equal(t, pb.MetricType_METRIC_TYPE_UNSPECIFIED, spec.Metric)
-		assert.Equal(t, []*pb.Segment{{Sid: "16003"}}, spec.Segments)
-		assert.Nil(t, spec.Waypoints)
+		p := srPolicy{
+			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID: testRouterID1,
+			Color:           100,
+			CandidatePath:   candidatePath{Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid input")
 	})
 
-	t.Run(srPolicyTypeDynamic, func(t *testing.T) {
+	t.Run("neither address nor router ID form is specified", func(t *testing.T) {
 		t.Parallel()
 
-		input := inputFormat{SRPolicy: srPolicy{Type: srPolicyTypeDynamic, Metric: metricTypeIGP, Waypoints: []waypoint{{RouterID: "r1"}}}}
-		spec, err := buildPolicyByType(input, "d", "e")
-		require.NoError(t, err)
-		assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, spec.Type)
-		assert.Equal(t, pb.MetricType_METRIC_TYPE_IGP, spec.Metric)
-		assert.Nil(t, spec.Segments)
-		assert.Equal(t, []*pb.Waypoint{{RouterId: "r1"}}, spec.Waypoints)
+		p := srPolicy{
+			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
+			Color:           100,
+			CandidatePath:   candidatePath{Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid input")
 	})
 
-	t.Run("unrecognized type is rejected", func(t *testing.T) {
+	t.Run("dynamic and explicit are mutually exclusive", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := buildPolicyByType(inputFormat{SRPolicy: srPolicy{Type: "unknown"}}, "d", "e")
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath: candidatePath{
+				Dynamic:  &dynamicPath{Metric: metricTypeIGP},
+				Explicit: &explicitPath{SegmentList: []segment{{SID: "16003"}}},
+			},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
+		require.Error(t, err)
+	})
+
+	t.Run("candidatePath must specify either dynamic or explicit", func(t *testing.T) {
+		t.Parallel()
+
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
 		require.Error(t, err)
 	})
 
 	t.Run("explicit with no segments", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := buildPolicyByType(inputFormat{SRPolicy: srPolicy{Type: srPolicyTypeExplicit}}, "d", "sample-explicit")
+		p := srPolicy{
+			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
+			Headend:         netip.MustParseAddr(testPeerAddr1),
+			Endpoint:        netip.MustParseAddr(testPeerAddr2),
+			Color:           100,
+			CandidatePath:   candidatePath{Explicit: &explicitPath{}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "sample-explicit")
 	})
 
 	t.Run("dynamic with no metric", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := buildPolicyByType(inputFormat{SRPolicy: srPolicy{Type: srPolicyTypeDynamic}}, "sample-dynamic", "e")
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath:    candidatePath{Dynamic: &dynamicPath{}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "sample-dynamic")
 	})
 
 	t.Run("dynamic with invalid metric", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := buildPolicyByType(inputFormat{SRPolicy: srPolicy{Type: srPolicyTypeDynamic, Metric: "bandwidth"}}, "d", "e")
+		p := srPolicy{
+			PCEPSessionAddr:  netip.MustParseAddr(testPeerAddr1),
+			HeadendRouterID:  testRouterID1,
+			EndpointRouterID: testRouterID2,
+			Color:            100,
+			CandidatePath:    candidatePath{Dynamic: &dynamicPath{Metric: "bandwidth"}},
+		}
+
+		_, err := buildCreateSRPolicyRequest(inputFormat{ASN: 65000, SRPolicy: p}, false)
 		require.Error(t, err)
 	})
 }
@@ -658,7 +619,7 @@ func TestToPBSegment(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-func TestParseUnderlayFamily(t *testing.T) {
+func TestParseAddressFamily(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -674,7 +635,7 @@ func TestParseUnderlayFamily(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := parseUnderlayFamily(tt.in)
+			got, err := parseAddressFamily(tt.in)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -683,7 +644,7 @@ func TestParseUnderlayFamily(t *testing.T) {
 	t.Run("unrecognized value is rejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := parseUnderlayFamily("ipv5")
+		_, err := parseAddressFamily("ipv5")
 		require.Error(t, err)
 	})
 }

--- a/cmd/pola/sr_policy_delete.go
+++ b/cmd/pola/sr_policy_delete.go
@@ -63,10 +63,10 @@ func newSRPolicyDeleteCmd(c *cli) *cobra.Command {
 }
 
 func deleteSRPolicy(out io.Writer, input inputFormat, jsonFlag bool, client pb.PCEServiceClient) error {
-	if !input.SRPolicy.PCEPSessionAddr.IsValid() || input.SRPolicy.Color == 0 || !input.SRPolicy.DstAddr.IsValid() || input.SRPolicy.Name == "" {
+	if !input.SRPolicy.PCEPSessionAddr.IsValid() || input.SRPolicy.Color == 0 || !input.SRPolicy.Endpoint.IsValid() || input.SRPolicy.Name == "" {
 		sampleInput := "srPolicy:\n" +
 			"  pcepSessionAddr: 192.0.2.1\n" +
-			"  dstAddr: 192.0.2.2\n" +
+			"  endpoint: 192.0.2.2\n" +
 			"  color: 100\n" +
 			"  name: name\n"
 		errMsg := "invalid input\n" +
@@ -78,7 +78,7 @@ func deleteSRPolicy(out io.Writer, input inputFormat, jsonFlag bool, client pb.P
 
 	srPolicy := &pb.SRPolicy{
 		PeerAddr:   input.SRPolicy.PCEPSessionAddr.AsSlice(),
-		DstAddr:    input.SRPolicy.DstAddr.AsSlice(),
+		Endpoint:   input.SRPolicy.Endpoint.AsSlice(),
 		Color:      input.SRPolicy.Color,
 		PolicyName: input.SRPolicy.Name,
 	}

--- a/cmd/pola/sr_policy_delete_test.go
+++ b/cmd/pola/sr_policy_delete_test.go
@@ -73,7 +73,7 @@ func TestNewSRPolicyDeleteCmd_RunE(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "policy.yaml")
 		yamlContent := "srPolicy:\n" +
 			"  pcepSessionAddr: 192.0.2.1\n" +
-			"  dstAddr: 192.0.2.2\n" +
+			"  endpoint: 192.0.2.2\n" +
 			"  color: 100\n" +
 			"  name: pol1\n"
 		require.NoError(t, os.WriteFile(path, []byte(yamlContent), 0o600))
@@ -103,7 +103,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 	validPolicy := func() srPolicy {
 		return srPolicy{
 			PCEPSessionAddr: netip.MustParseAddr(testPeerAddr1),
-			DstAddr:         netip.MustParseAddr(testPeerAddr2),
+			Endpoint:        netip.MustParseAddr(testPeerAddr2),
 			Color:           100,
 			Name:            testPolicyName,
 		}
@@ -128,7 +128,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 
 		require.NotNil(t, fake.deleteSRPolicyReq)
 		assert.Equal(t, netip.MustParseAddr(testPeerAddr1).AsSlice(), fake.deleteSRPolicyReq.GetSrPolicy().GetPeerAddr())
-		assert.Equal(t, netip.MustParseAddr(testPeerAddr2).AsSlice(), fake.deleteSRPolicyReq.GetSrPolicy().GetDstAddr())
+		assert.Equal(t, netip.MustParseAddr(testPeerAddr2).AsSlice(), fake.deleteSRPolicyReq.GetSrPolicy().GetEndpoint())
 		assert.Equal(t, uint32(100), fake.deleteSRPolicyReq.GetSrPolicy().GetColor())
 		assert.Equal(t, testPolicyName, fake.deleteSRPolicyReq.GetSrPolicy().GetPolicyName())
 		assert.Equal(t, uint32(65000), fake.deleteSRPolicyReq.GetAsn())

--- a/cmd/pola/sr_policy_list_test.go
+++ b/cmd/pola/sr_policy_list_test.go
@@ -209,24 +209,25 @@ func TestShowSRPolicyList(t *testing.T) {
 				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 				SrPolicies: []*pb.SRPolicy{
 					{
-						PolicyName:  testPolicyName,
-						PlspId:      1,
-						LspId:       2,
-						State:       pb.SRPolicyState_SR_POLICY_STATE_UP,
-						Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-						Metric:      pb.MetricType_METRIC_TYPE_TE,
-						SrcAddr:     netip.MustParseAddr(testPeerAddr1).AsSlice(),
-						SrcRouterId: testRouterID1,
-						DstAddr:     netip.MustParseAddr(testPeerAddr2).AsSlice(),
-						DstRouterId: testRouterID2,
-						Color:       100,
-						Preference:  200,
+						PolicyName:       testPolicyName,
+						PlspId:           1,
+						LspId:            2,
+						State:            pb.SRPolicyState_SR_POLICY_STATE_UP,
+						Headend:          netip.MustParseAddr(testPeerAddr1).AsSlice(),
+						HeadendRouterId:  testRouterID1,
+						Endpoint:         netip.MustParseAddr(testPeerAddr2).AsSlice(),
+						EndpointRouterId: testRouterID2,
+						Color:            100,
+						CandidatePath: &pb.CandidatePath{
+							Preference: 200,
+							Path:       &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{Metric: pb.MetricType_METRIC_TYPE_TE}},
+						},
 						SegmentList: []*pb.Segment{{Sid: "16003"}, {Sid: "16002"}},
 					},
 					{
 						PolicyName: "pol2",
-						SrcAddr:    netip.MustParseAddr("192.0.2.3").AsSlice(),
-						DstAddr:    netip.MustParseAddr("192.0.2.4").AsSlice(),
+						Headend:    netip.MustParseAddr("192.0.2.3").AsSlice(),
+						Endpoint:   netip.MustParseAddr("192.0.2.4").AsSlice(),
 					},
 				},
 			}},
@@ -245,8 +246,8 @@ func TestShowSRPolicyList(t *testing.T) {
 			"    State: up\n" +
 			"    Type: dynamic\n" +
 			"    Metric: te\n" +
-			"    SrcAddr: 192.0.2.1 (0000.0aff.0001)\n" +
-			"    DstAddr: 192.0.2.2 (0000.0aff.0002)\n" +
+			"    Headend: 192.0.2.1 (0000.0aff.0001)\n" +
+			"    Endpoint: 192.0.2.2 (0000.0aff.0002)\n" +
 			"    Color: 100\n" +
 			"    Preference: 200\n" +
 			"    SegmentList: 16003 -> 16002\n" +
@@ -254,8 +255,8 @@ func TestShowSRPolicyList(t *testing.T) {
 			"    PlspID: 0\n" +
 			"    LSPID: 0\n" +
 			"    State: \n" +
-			"    SrcAddr: 192.0.2.3\n" +
-			"    DstAddr: 192.0.2.4\n" +
+			"    Headend: 192.0.2.3\n" +
+			"    Endpoint: 192.0.2.4\n" +
 			"    Color: 0\n" +
 			"    Preference: 0\n" +
 			"    SegmentList: None\n"
@@ -271,12 +272,15 @@ func TestShowSRPolicyList(t *testing.T) {
 				State:     pb.SessionState_SESSION_STATE_UP,
 				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 				SrPolicies: []*pb.SRPolicy{{
-					PolicyName:     testPolicyName,
-					Type:           pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-					UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
-					DataPlane:      pb.DataPlane_DATA_PLANE_SRV6,
-					SrcAddr:        netip.MustParseAddr("2001:db8::1").AsSlice(),
-					DstAddr:        netip.MustParseAddr("2001:db8::2").AsSlice(),
+					PolicyName: testPolicyName,
+					CandidatePath: &pb.CandidatePath{
+						Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+							UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
+							DataPlane:      pb.DataPlane_DATA_PLANE_SRV6,
+						}},
+					},
+					Headend:  netip.MustParseAddr("2001:db8::1").AsSlice(),
+					Endpoint: netip.MustParseAddr("2001:db8::2").AsSlice(),
 				}},
 			}},
 		}}
@@ -344,8 +348,8 @@ func TestShowSRPolicyList(t *testing.T) {
 				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
 				SrPolicies: []*pb.SRPolicy{{
 					PolicyName: testPolicyName,
-					SrcAddr:    netip.MustParseAddr(testPeerAddr1).AsSlice(),
-					DstAddr:    netip.MustParseAddr(testPeerAddr2).AsSlice(),
+					Headend:    netip.MustParseAddr(testPeerAddr1).AsSlice(),
+					Endpoint:   netip.MustParseAddr(testPeerAddr2).AsSlice(),
 				}},
 			}},
 		}}
@@ -363,10 +367,10 @@ func TestShowSRPolicyList(t *testing.T) {
 			"srPolicies": [{
 				"policyName": "pol1",
 				"segmentList": [],
-				"srcAddr": "192.0.2.1",
-				"dstAddr": "192.0.2.2",
+				"headend": "192.0.2.1",
+				"endpoint": "192.0.2.2",
 				"color": 0,
-				"preference": 0
+				"candidatePath": {"preference": 0}
 			}]
 		}]`
 		assert.JSONEq(t, want, out.String())

--- a/cmd/pola/sr_policy_list_test.go
+++ b/cmd/pola/sr_policy_list_test.go
@@ -111,7 +111,7 @@ func TestSegmentDisplayString(t *testing.T) {
 func TestSegmentDisplayString_SRv6(t *testing.T) {
 	t.Parallel()
 
-	sid := netip.MustParseAddr("2001:db8:1005::")
+	sid := table.SRv6SID(netip.MustParseAddr("2001:db8:1005::"))
 	local := netip.MustParseAddr("2001:db8::5")
 	remote := netip.MustParseAddr("2001:db8::6")
 

--- a/cmd/pola/sr_policy_list_test.go
+++ b/cmd/pola/sr_policy_list_test.go
@@ -150,6 +150,21 @@ func TestSegmentDisplayString_SRv6(t *testing.T) {
 	}
 }
 
+func TestSegmentDisplayString_BehaviorAndIfaceIDs(t *testing.T) {
+	t.Parallel()
+
+	localIfaceID, remoteIfaceID := uint32(5), uint32(6)
+	sid := table.SRv6SID(netip.MustParseAddr("2001:db8:1005::"))
+
+	got := segmentDisplayString(table.SegmentSRv6{
+		Sid:           sid,
+		Behavior:      table.BehaviorEND,
+		LocalIfaceID:  &localIfaceID,
+		RemoteIfaceID: &remoteIfaceID,
+	})
+	assert.Equal(t, "2001:db8:1005:: (localIface=5, remoteIface=6, behavior="+table.BehaviorToString(table.BehaviorEND)+")", got)
+}
+
 func TestSrcDstDisplay(t *testing.T) {
 	t.Parallel()
 
@@ -245,6 +260,34 @@ func TestShowSRPolicyList(t *testing.T) {
 			"    Preference: 0\n" +
 			"    SegmentList: None\n"
 		assert.Equal(t, want, out.String())
+	})
+
+	t.Run("plain text output shows the underlay plane", func(t *testing.T) {
+		t.Parallel()
+
+		client := &fakePCEServiceClient{srPolicyListResp: &pb.GetSRPolicyListResponse{
+			Sessions: []*pb.SRPolicySession{{
+				PeerAddr:  netip.MustParseAddr(testPeerAddr1).AsSlice(),
+				State:     pb.SessionState_SESSION_STATE_UP,
+				SyncState: pb.LspDbSyncState_LSP_DB_SYNC_STATE_FINISHED,
+				SrPolicies: []*pb.SRPolicy{{
+					PolicyName:     testPolicyName,
+					Type:           pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
+					UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
+					DataPlane:      pb.DataPlane_DATA_PLANE_SRV6,
+					SrcAddr:        netip.MustParseAddr("2001:db8::1").AsSlice(),
+					DstAddr:        netip.MustParseAddr("2001:db8::2").AsSlice(),
+				}},
+			}},
+		}}
+
+		cmd := newTestSRPolicyListCmd(client, false)
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, showSRPolicyList(cmd, []string{}, client, false))
+		assert.Contains(t, out.String(), "UnderlayFamily: ipv6")
+		assert.Contains(t, out.String(), "DataPlane: srv6")
 	})
 
 	t.Run("synced session with no policies", func(t *testing.T) {

--- a/cmd/pola/sr_policy_text.go
+++ b/cmd/pola/sr_policy_text.go
@@ -60,6 +60,11 @@ func writeSRPolicyItemText(ew *errWriter, policy table.SRPolicy) {
 		ew.printf("    Metric: %s\n", policy.Metric.DisplayString())
 	}
 
+	if policy.Plane != (table.Plane{}) {
+		ew.printf("    UnderlayFamily: %s\n", policy.Plane.Family)
+		ew.printf("    DataPlane: %s\n", policy.Plane.DataPlane)
+	}
+
 	ew.printf("    SrcAddr: %s\n", srcDstDisplay(policy.SrcAddr.String(), policy.SrcRouterID))
 	ew.printf("    DstAddr: %s\n", srcDstDisplay(policy.DstAddr.String(), policy.DstRouterID))
 	ew.printf("    Color: %d\n", policy.Color)
@@ -91,7 +96,7 @@ func (ew *errWriter) println(a ...any) {
 
 func segmentListDisplayString(segmentList []table.Segment) string {
 	if len(segmentList) == 0 {
-		return "None"
+		return displayNone
 	}
 
 	tokens := make([]string, len(segmentList))
@@ -113,6 +118,10 @@ func srcDstDisplay(addr, routerID string) string {
 func segmentDisplayString(seg table.Segment) string {
 	var localAddr, remoteAddr string
 
+	var localIfaceID, remoteIfaceID *uint32
+
+	var behavior uint16
+
 	switch v := seg.(type) {
 	case table.SegmentSRv6:
 		if v.LocalAddr.IsValid() {
@@ -122,6 +131,9 @@ func segmentDisplayString(seg table.Segment) string {
 		if v.RemoteAddr.IsValid() {
 			remoteAddr = v.RemoteAddr.String()
 		}
+
+		localIfaceID, remoteIfaceID = v.LocalIfaceID, v.RemoteIfaceID
+		behavior = v.Behavior
 	case table.SegmentSRMPLS:
 		if v.LocalAddr.IsValid() {
 			localAddr = v.LocalAddr.String()
@@ -130,16 +142,35 @@ func segmentDisplayString(seg table.Segment) string {
 		if v.RemoteAddr.IsValid() {
 			remoteAddr = v.RemoteAddr.String()
 		}
+
+		localIfaceID, remoteIfaceID = v.LocalIfaceID, v.RemoteIfaceID
 	}
 
-	switch {
-	case localAddr == "" && remoteAddr == "":
-		return seg.SidString()
-	case remoteAddr == "":
-		return fmt.Sprintf("%s (local=%s)", seg.SidString(), localAddr)
-	case localAddr == "":
-		return fmt.Sprintf("%s (remote=%s)", seg.SidString(), remoteAddr)
-	default:
-		return fmt.Sprintf("%s (local=%s, remote=%s)", seg.SidString(), localAddr, remoteAddr)
+	var details []string
+
+	if localAddr != "" {
+		details = append(details, "local="+localAddr)
 	}
+
+	if remoteAddr != "" {
+		details = append(details, "remote="+remoteAddr)
+	}
+
+	if localIfaceID != nil {
+		details = append(details, fmt.Sprintf("localIface=%d", *localIfaceID))
+	}
+
+	if remoteIfaceID != nil {
+		details = append(details, fmt.Sprintf("remoteIface=%d", *remoteIfaceID))
+	}
+
+	if behavior != 0 {
+		details = append(details, "behavior="+table.BehaviorToString(behavior))
+	}
+
+	if len(details) == 0 {
+		return seg.SidString()
+	}
+
+	return fmt.Sprintf("%s (%s)", seg.SidString(), strings.Join(details, ", "))
 }

--- a/cmd/pola/sr_policy_text.go
+++ b/cmd/pola/sr_policy_text.go
@@ -52,23 +52,23 @@ func writeSRPolicyItemText(ew *errWriter, policy table.SRPolicy) {
 	ew.printf("    LSPID: %d\n", policy.LSPID)
 	ew.printf("    State: %s\n", policy.State)
 
-	if policy.Type != "" {
-		ew.printf("    Type: %s\n", policy.Type)
+	switch {
+	case policy.CandidatePath.Dynamic != nil:
+		ew.printf("    Type: dynamic\n")
+		ew.printf("    Metric: %s\n", policy.CandidatePath.Dynamic.Metric.DisplayString())
+
+		if plane := policy.CandidatePath.Dynamic.Plane; plane != (table.Plane{}) {
+			ew.printf("    UnderlayFamily: %s\n", plane.Family)
+			ew.printf("    DataPlane: %s\n", plane.DataPlane)
+		}
+	case policy.CandidatePath.Explicit != nil:
+		ew.printf("    Type: explicit\n")
 	}
 
-	if policy.Metric != table.UnspecifiedMetric {
-		ew.printf("    Metric: %s\n", policy.Metric.DisplayString())
-	}
-
-	if policy.Plane != (table.Plane{}) {
-		ew.printf("    UnderlayFamily: %s\n", policy.Plane.Family)
-		ew.printf("    DataPlane: %s\n", policy.Plane.DataPlane)
-	}
-
-	ew.printf("    SrcAddr: %s\n", srcDstDisplay(policy.SrcAddr.String(), policy.SrcRouterID))
-	ew.printf("    DstAddr: %s\n", srcDstDisplay(policy.DstAddr.String(), policy.DstRouterID))
+	ew.printf("    Headend: %s\n", srcDstDisplay(policy.Headend.String(), policy.HeadendRouterID))
+	ew.printf("    Endpoint: %s\n", srcDstDisplay(policy.Endpoint.String(), policy.EndpointRouterID))
 	ew.printf("    Color: %d\n", policy.Color)
-	ew.printf("    Preference: %d\n", policy.Preference)
+	ew.printf("    Preference: %d\n", policy.CandidatePath.Preference)
 	ew.printf("    SegmentList: %s\n", segmentListDisplayString(policy.SegmentList))
 }
 

--- a/cmd/pola/sr_policy_text_test.go
+++ b/cmd/pola/sr_policy_text_test.go
@@ -94,6 +94,28 @@ func TestWriteSRPolicyText_PropagatesSeparatorWriteError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestWriteSRPolicyItemText_ExplicitPath(t *testing.T) {
+	t.Parallel()
+
+	views := []srPolicySessionView{
+		{
+			PeerAddress: testPeerAddr1,
+			State:       "up",
+			LSPDBSync:   "finished",
+			SRPolicies: []table.SRPolicy{
+				{
+					Name:          "policy1",
+					CandidatePath: table.CandidatePath{Explicit: &table.ExplicitPath{}},
+				},
+			},
+		},
+	}
+
+	w := &condFailWriter{}
+	require.NoError(t, writeSRPolicyText(w, views))
+	require.Contains(t, w.buf.String(), "    Type: explicit\n")
+}
+
 func TestWriteSRPolicyText_SeparatesMultipleSessionsWithBlankLine(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/pola/ted_test.go
+++ b/cmd/pola/ted_test.go
@@ -94,17 +94,15 @@ func TestShowTED(t *testing.T) {
 			Hostname: "routerA",
 			Links: []*pb.LsLink{
 				{
-					LocalRouterId:  testRouterID1,
-					RemoteRouterId: testRouterID1,
-					LocalIp:        testPeerAddr1,
-					Metrics:        []*pb.Metric{{Type: pb.MetricType_METRIC_TYPE_IGP, Value: 10}},
-					AdjSid:         24001,
+					Local:   &pb.LsLinkEndpoint{RouterId: testRouterID1, Ipv4: testPeerAddr1},
+					Remote:  &pb.LsLinkEndpoint{RouterId: testRouterID1},
+					Metrics: []*pb.Metric{{Type: pb.MetricType_METRIC_TYPE_IGP, Value: 10}},
+					AdjSids: []*pb.AdjSid{{Family: pb.AddressFamily_ADDRESS_FAMILY_IPV4, Sid: 24001}},
 				},
 				{
-					LocalRouterId:  testRouterID1,
-					RemoteRouterId: testRouterID1,
-					RemoteIp:       testPeerAddr2,
-					AdjSid:         24002,
+					Local:   &pb.LsLinkEndpoint{RouterId: testRouterID1},
+					Remote:  &pb.LsLinkEndpoint{RouterId: testRouterID1, Ipv4: testPeerAddr2},
+					AdjSids: []*pb.AdjSid{{Family: pb.AddressFamily_ADDRESS_FAMILY_IPV4, Sid: 24002}},
 				},
 			},
 			Prefixes: []*pb.LsPrefix{

--- a/cmd/pola/ted_test.go
+++ b/cmd/pola/ted_test.go
@@ -133,16 +133,29 @@ func TestShowTED(t *testing.T) {
 		require.Len(t, links, 2)
 		linkMap, ok := links[0].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, testPeerAddr1, linkMap["localIp"])
-		_, hasRemoteIP := linkMap["remoteIp"]
-		assert.False(t, hasRemoteIP, "unset remoteIp must be omitted, not a \"None\" sentinel")
+
+		localMap, ok := linkMap["local"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, testPeerAddr1, localMap["ipv4"])
+
+		remoteMap, ok := linkMap["remote"].(map[string]any)
+		require.True(t, ok)
+
+		_, hasRemoteIPv4 := remoteMap["ipv4"]
+		assert.False(t, hasRemoteIPv4, "unset remote ipv4 must be omitted, not a \"None\" sentinel")
 
 		linkMap2, ok := links[1].(map[string]any)
 		require.True(t, ok)
 
-		_, hasLocalIP := linkMap2["localIp"]
-		assert.False(t, hasLocalIP)
-		assert.Equal(t, testPeerAddr2, linkMap2["remoteIp"])
+		localMap2, ok := linkMap2["local"].(map[string]any)
+		require.True(t, ok)
+
+		_, hasLocalIPv4 := localMap2["ipv4"]
+		assert.False(t, hasLocalIPv4)
+
+		remoteMap2, ok := linkMap2["remote"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, testPeerAddr2, remoteMap2["ipv4"])
 
 		prefixes, ok := nodeMap["prefixes"].([]any)
 		require.True(t, ok)
@@ -158,5 +171,86 @@ func TestShowTED(t *testing.T) {
 		srv6SIDs, ok := nodeMap["srv6Sids"].([]any)
 		require.True(t, ok)
 		assert.Len(t, srv6SIDs, 1)
+	})
+
+	t.Run("dual-stack link shows both IPv4 and IPv6 addresses", func(t *testing.T) {
+		t.Parallel()
+
+		ifaceID := uint32(9)
+		node := &pb.LsNode{
+			Asn:      65000,
+			RouterId: testRouterID1,
+			Links: []*pb.LsLink{
+				{
+					Local: &pb.LsLinkEndpoint{
+						RouterId:    testRouterID1,
+						Ipv4:        testPeerAddr1,
+						Ipv6:        "2001:db8::1",
+						InterfaceId: new(ifaceID),
+					},
+					Remote: &pb.LsLinkEndpoint{
+						RouterId: testRouterID2,
+						Ipv4:     testPeerAddr2,
+						Ipv6:     "2001:db8::2",
+					},
+				},
+			},
+		}
+		client := &fakePCEServiceClient{tedResp: &pb.GetTEDResponse{
+			Enabled: true,
+			Nodes:   []*pb.LsNode{node, {RouterId: testRouterID2}},
+		}}
+
+		t.Run("json", func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			require.NoError(t, showTED(&buf, outputJSON, client))
+
+			var nodes []map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &nodes))
+
+			var link map[string]any
+
+			for _, n := range nodes {
+				if n["routerId"] != testRouterID1 {
+					continue
+				}
+
+				links, ok := n["links"].([]any)
+				require.True(t, ok)
+				require.Len(t, links, 1)
+				link, ok = links[0].(map[string]any)
+				require.True(t, ok)
+			}
+
+			require.NotNil(t, link)
+
+			local, ok := link["local"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, testPeerAddr1, local["ipv4"])
+			assert.Equal(t, "2001:db8::1", local["ipv6"])
+			//nolint:testifylint // exact integer value after JSON float64 decoding.
+			assert.Equal(t, float64(ifaceID), local["interfaceId"])
+
+			remote, ok := link["remote"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, testPeerAddr2, remote["ipv4"])
+			assert.Equal(t, "2001:db8::2", remote["ipv6"])
+		})
+
+		t.Run("text", func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			require.NoError(t, showTED(&buf, outputText, client))
+
+			out := buf.String()
+			assert.Contains(t, out, testPeerAddr1)
+			assert.Contains(t, out, "2001:db8::1")
+			assert.Contains(t, out, testPeerAddr2)
+			assert.Contains(t, out, "2001:db8::2")
+			assert.Contains(t, out, "interface 9")
+		})
 	})
 }

--- a/cmd/pola/ted_text.go
+++ b/cmd/pola/ted_text.go
@@ -116,7 +116,8 @@ func linkEndpointDisplay(e tedLinkEndpointView) string {
 
 func writeTEDSrv6EndXSIDText(ew *errWriter, sid tedSrv6EndXSIDView) {
 	ew.println("      SRv6 End.X SID:")
-	ew.printf("        EndpointBehavior: %s\n", sid.EndpointBehavior.Name)
+	ew.printf("        EndpointBehavior: %s, Flags: %d, Algorithm: %d, Weight: %d\n",
+		sid.EndpointBehavior.Name, sid.EndpointBehavior.Flags, sid.EndpointBehavior.Algorithm, sid.Weight)
 	ew.printf("        SIDs: %v\n", sid.Sids)
 
 	if sid.SidStructure == nil {
@@ -146,16 +147,7 @@ func writeTEDSrv6SIDText(ew *errWriter, sid tedSrv6SIDView) {
 			sid.SidStructure.LocalBlock, sid.SidStructure.LocalNode, sid.SidStructure.LocalFunc, sid.SidStructure.LocalArg)
 	}
 
-	var flags, algorithm uint8
-	if sid.EndpointBehavior.Flags != nil {
-		flags = *sid.EndpointBehavior.Flags
-	}
-
-	if sid.EndpointBehavior.Algorithm != nil {
-		algorithm = *sid.EndpointBehavior.Algorithm
-	}
-
 	ew.printf("    EndpointBehavior: %s, Flags: %d, Algorithm: %d\n",
-		sid.EndpointBehavior.Name, flags, algorithm)
+		sid.EndpointBehavior.Name, sid.EndpointBehavior.Flags, sid.EndpointBehavior.Algorithm)
 	ew.printf("    MultiTopoIDs: %v\n", sid.MultiTopoIDs)
 }

--- a/cmd/pola/ted_text.go
+++ b/cmd/pola/ted_text.go
@@ -6,7 +6,9 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"strings"
 )
 
 // writeTEDText expects nodes to be sorted by router ID for deterministic output.
@@ -58,17 +60,19 @@ func writeTEDNodeLinksText(ew *errWriter, node tedNodeView) {
 	}
 }
 
+const displayNone = "None"
+
 func orNone(s string) string {
 	if s == "" {
-		return "None"
+		return displayNone
 	}
 
 	return s
 }
 
 func writeTEDLinkText(ew *errWriter, link tedLinkView) {
-	ew.printf("    Local: %s Remote: %s\n", orNone(link.LocalIP), orNone(link.RemoteIP))
-	ew.printf("      RemoteRouterID: %s\n", orNone(link.RemoteRouterID))
+	ew.printf("    Local: %s Remote: %s\n", linkEndpointDisplay(link.Local), linkEndpointDisplay(link.Remote))
+	ew.printf("      RemoteRouterID: %s\n", orNone(link.Remote.RouterID))
 
 	ew.println("      Metrics:")
 
@@ -76,11 +80,38 @@ func writeTEDLinkText(ew *errWriter, link tedLinkView) {
 		ew.printf("        %s: %d\n", m.Type, m.Value)
 	}
 
-	ew.printf("      Adj-SID: %d\n", link.AdjSid)
+	ew.println("      Adj-SIDs:")
 
-	if link.Srv6EndXSID != nil {
-		writeTEDSrv6EndXSIDText(ew, *link.Srv6EndXSID)
+	for _, a := range link.AdjSids {
+		ew.printf("        %s: %d\n", a.Family, a.Sid)
 	}
+
+	for _, sid := range link.Srv6EndXSIDs {
+		writeTEDSrv6EndXSIDText(ew, sid)
+	}
+}
+
+func linkEndpointDisplay(e tedLinkEndpointView) string {
+	var addrs []string
+
+	if e.IPv4 != "" {
+		addrs = append(addrs, e.IPv4)
+	}
+
+	if e.IPv6 != "" {
+		addrs = append(addrs, e.IPv6)
+	}
+
+	if len(addrs) == 0 {
+		return displayNone
+	}
+
+	s := strings.Join(addrs, ", ")
+	if e.InterfaceID != nil {
+		s += fmt.Sprintf(" (interface %d)", *e.InterfaceID)
+	}
+
+	return s
 }
 
 func writeTEDSrv6EndXSIDText(ew *errWriter, sid tedSrv6EndXSIDView) {

--- a/cmd/pola/ted_text_test.go
+++ b/cmd/pola/ted_text_test.go
@@ -17,7 +17,6 @@ import (
 // fullTEDNodeViewFixture exercises the rendering branches in ted_text.go.
 func fullTEDNodeViewFixture() tedNodeView {
 	sidIdx := uint32(7)
-	flags, algorithm := uint8(1), uint8(2)
 	ifaceID := uint32(5)
 
 	return tedNodeView{
@@ -40,7 +39,8 @@ func fullTEDNodeViewFixture() tedNodeView {
 				AdjSids: []tedAdjSidView{{Family: "ipv6", Sid: 200}},
 				Srv6EndXSIDs: []tedSrv6EndXSIDView{
 					{
-						EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
+						EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR", Flags: 0xC0, Algorithm: 128},
+						Weight:           7,
 						Sids:             []string{testSrv6EndXSID},
 						SidStructure:     &table.SIDStructure{LocalBlock: 21, LocalNode: 22, LocalFunc: 23, LocalArg: 24},
 					},
@@ -56,7 +56,7 @@ func fullTEDNodeViewFixture() tedNodeView {
 			},
 			{
 				Sids:             []string{"fc00:0:2:node2::"},
-				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-2", Flags: &flags, Algorithm: &algorithm},
+				EndpointBehavior: endpointBehaviorView{Name: "NODE-SID-BEHAVIOR-2", Flags: 1, Algorithm: 2},
 				SidStructure:     &table.SIDStructure{LocalBlock: 41, LocalNode: 42, LocalFunc: 43, LocalArg: 44},
 				MultiTopoIDs:     []uint32{2, 3},
 			},

--- a/cmd/pola/ted_text_test.go
+++ b/cmd/pola/ted_text_test.go
@@ -18,6 +18,7 @@ import (
 func fullTEDNodeViewFixture() tedNodeView {
 	sidIdx := uint32(7)
 	flags, algorithm := uint8(1), uint8(2)
+	ifaceID := uint32(5)
 
 	return tedNodeView{
 		RouterID:   testRouterID1,
@@ -30,19 +31,19 @@ func fullTEDNodeViewFixture() tedNodeView {
 		},
 		Links: []tedLinkView{
 			{
-				RemoteRouterID: "",
-				AdjSid:         100,
+				AdjSids: []tedAdjSidView{{Family: "ipv4", Sid: 100}},
 			},
 			{
-				LocalIP:        testPeerAddr2,
-				RemoteIP:       "192.0.2.3",
-				RemoteRouterID: testRouterID2,
-				Metrics:        []tedMetricView{{Type: metricTypeIGP, Value: 10}},
-				AdjSid:         200,
-				Srv6EndXSID: &tedSrv6EndXSIDView{
-					EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
-					Sids:             []string{testSrv6EndXSID},
-					SidStructure:     &table.SIDStructure{LocalBlock: 21, LocalNode: 22, LocalFunc: 23, LocalArg: 24},
+				Local:   tedLinkEndpointView{IPv4: testPeerAddr2, IPv6: "2001:db8::2", InterfaceID: &ifaceID},
+				Remote:  tedLinkEndpointView{IPv4: "192.0.2.3", IPv6: "2001:db8::3", RouterID: testRouterID2},
+				Metrics: []tedMetricView{{Type: metricTypeIGP, Value: 10}},
+				AdjSids: []tedAdjSidView{{Family: "ipv6", Sid: 200}},
+				Srv6EndXSIDs: []tedSrv6EndXSIDView{
+					{
+						EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
+						Sids:             []string{testSrv6EndXSID},
+						SidStructure:     &table.SIDStructure{LocalBlock: 21, LocalNode: 22, LocalFunc: 23, LocalArg: 24},
+					},
 				},
 			},
 		},
@@ -85,10 +86,12 @@ func TestWriteTEDText_SidStructureNotAdvertised(t *testing.T) {
 		RouterID: testRouterID1,
 		Links: []tedLinkView{
 			{
-				RemoteRouterID: testRouterID2,
-				Srv6EndXSID: &tedSrv6EndXSIDView{
-					EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
-					Sids:             []string{testSrv6EndXSID},
+				Remote: tedLinkEndpointView{RouterID: testRouterID2},
+				Srv6EndXSIDs: []tedSrv6EndXSIDView{
+					{
+						EndpointBehavior: endpointBehaviorView{Name: "END-X-BEHAVIOR"},
+						Sids:             []string{testSrv6EndXSID},
+					},
 				},
 			},
 		},
@@ -123,7 +126,9 @@ func TestWriteTEDText_PropagatesWriteErrors(t *testing.T) {
 		{"link remote router id", containsFail("RemoteRouterID: None")},
 		{"link metrics header", containsFail("      Metrics:")},
 		{"link metric line", containsFail("igp: 10")},
-		{"link adj-sid", containsFail("Adj-SID: 100")},
+		{"link adj-sids header", containsFail("Adj-SIDs:")},
+		{"link adj-sid line", containsFail("ipv4: 100")},
+		{"link interface id", containsFail("interface 5")},
 		{"srv6 end.x sid header", containsFail("SRv6 End.X SID:")},
 		{"srv6 end.x endpoint behavior", containsFail("EndpointBehavior: END-X-BEHAVIOR")},
 		{"srv6 end.x sids", containsFail(testSrv6EndXSID)},

--- a/cmd/pola/ted_view.go
+++ b/cmd/pola/ted_view.go
@@ -33,12 +33,23 @@ type tedPrefixView struct {
 }
 
 type tedLinkView struct {
-	LocalIP        string              `json:"localIp,omitempty"`
-	RemoteIP       string              `json:"remoteIp,omitempty"`
-	RemoteRouterID string              `json:"remoteRouterId"`
-	Metrics        []tedMetricView     `json:"metrics"`
-	AdjSid         uint32              `json:"adjSid"`
-	Srv6EndXSID    *tedSrv6EndXSIDView `json:"srv6EndXSid,omitempty"`
+	Local        tedLinkEndpointView  `json:"local"`
+	Remote       tedLinkEndpointView  `json:"remote"`
+	Metrics      []tedMetricView      `json:"metrics"`
+	AdjSids      []tedAdjSidView      `json:"adjSids"`
+	Srv6EndXSIDs []tedSrv6EndXSIDView `json:"srv6EndXSids,omitempty"`
+}
+
+type tedLinkEndpointView struct {
+	RouterID    string  `json:"routerId,omitempty"`
+	IPv4        string  `json:"ipv4,omitempty"`
+	IPv6        string  `json:"ipv6,omitempty"`
+	InterfaceID *uint32 `json:"interfaceId,omitempty"`
+}
+
+type tedAdjSidView struct {
+	Family string `json:"family"` // ipv4 | ipv6 | unspecified
+	Sid    uint32 `json:"sid"`
 }
 
 type tedMetricView struct {
@@ -133,35 +144,53 @@ func newTEDLinkViews(links []*table.LsLink) []tedLinkView {
 
 func newTEDLinkView(l *table.LsLink) tedLinkView {
 	v := tedLinkView{
+		Local:   newTEDLinkEndpointView(l.Local),
+		Remote:  newTEDLinkEndpointView(l.Remote),
 		Metrics: newTEDMetricViews(l.Metrics),
+		AdjSids: newTEDAdjSidViews(l.AdjSids),
 	}
 
-	if len(l.AdjSids) > 0 {
-		v.AdjSid = l.AdjSids[0].Sid
-	}
+	for _, sid := range l.Srv6EndXSIDs {
+		if sid == nil {
+			continue
+		}
 
-	if l.Local.IPv4.IsValid() {
-		v.LocalIP = l.Local.IPv4.String()
-	} else if l.Local.IPv6.IsValid() {
-		v.LocalIP = l.Local.IPv6.String()
-	}
-
-	if l.Remote.IPv4.IsValid() {
-		v.RemoteIP = l.Remote.IPv4.String()
-	} else if l.Remote.IPv6.IsValid() {
-		v.RemoteIP = l.Remote.IPv6.String()
-	}
-
-	if l.Remote.Node != nil {
-		v.RemoteRouterID = l.Remote.Node.RouterID
-	}
-
-	if len(l.Srv6EndXSIDs) > 0 && l.Srv6EndXSIDs[0] != nil {
-		sid := newTEDSrv6EndXSIDView(l.Srv6EndXSIDs[0])
-		v.Srv6EndXSID = &sid
+		v.Srv6EndXSIDs = append(v.Srv6EndXSIDs, newTEDSrv6EndXSIDView(sid))
 	}
 
 	return v
+}
+
+func newTEDLinkEndpointView(e table.LinkEndpoint) tedLinkEndpointView {
+	v := tedLinkEndpointView{}
+
+	if e.Node != nil {
+		v.RouterID = e.Node.RouterID
+	}
+
+	if e.IPv4.IsValid() {
+		v.IPv4 = e.IPv4.String()
+	}
+
+	if e.IPv6.IsValid() {
+		v.IPv6 = e.IPv6.String()
+	}
+
+	if e.InterfaceID != nil {
+		ifaceID := *e.InterfaceID
+		v.InterfaceID = &ifaceID
+	}
+
+	return v
+}
+
+func newTEDAdjSidViews(adjSids []table.AdjSID) []tedAdjSidView {
+	views := make([]tedAdjSidView, 0, len(adjSids))
+	for _, a := range adjSids {
+		views = append(views, tedAdjSidView{Family: a.Family.String(), Sid: a.Sid})
+	}
+
+	return views
 }
 
 func newTEDMetricViews(metrics []*table.Metric) []tedMetricView {

--- a/cmd/pola/ted_view.go
+++ b/cmd/pola/ted_view.go
@@ -66,16 +66,16 @@ type tedSrv6SIDView struct {
 
 type tedSrv6EndXSIDView struct {
 	EndpointBehavior endpointBehaviorView `json:"endpointBehavior"`
+	Weight           uint8                `json:"weight"`
 	Sids             []string             `json:"sids"`
 	SidStructure     *table.SIDStructure  `json:"sidStructure,omitempty"`
 }
 
-// endpointBehaviorView omits Flags and Algorithm for End.X SIDs, which carry only the behavior.
 type endpointBehaviorView struct {
 	Behavior  uint16 `json:"behavior"`
 	Name      string `json:"name"` // table.BehaviorToString
-	Flags     *uint8 `json:"flags,omitempty"`
-	Algorithm *uint8 `json:"algorithm,omitempty"`
+	Flags     uint8  `json:"flags"`
+	Algorithm uint8  `json:"algorithm"`
 }
 
 // newTEDNodeViews returns views in router ID order for deterministic output.
@@ -226,27 +226,18 @@ func newTEDSrv6SIDViews(sids []*table.LsSrv6SID) []tedSrv6SIDView {
 
 func newTEDSrv6EndXSIDView(s *table.Srv6EndXSID) tedSrv6EndXSIDView {
 	return tedSrv6EndXSIDView{
-		EndpointBehavior: endpointBehaviorViewFromBehavior(s.EndpointBehavior),
+		EndpointBehavior: endpointBehaviorViewFrom(s.EndpointBehavior),
+		Weight:           s.Weight,
 		Sids:             s.Sids,
 		SidStructure:     s.Srv6SIDStructure,
 	}
 }
 
 func endpointBehaviorViewFrom(eb table.EndpointBehavior) endpointBehaviorView {
-	flags := eb.Flags
-	algorithm := eb.Algorithm
-
 	return endpointBehaviorView{
 		Behavior:  eb.Behavior,
 		Name:      table.BehaviorToString(eb.Behavior),
-		Flags:     &flags,
-		Algorithm: &algorithm,
-	}
-}
-
-func endpointBehaviorViewFromBehavior(behavior uint16) endpointBehaviorView {
-	return endpointBehaviorView{
-		Behavior: behavior,
-		Name:     table.BehaviorToString(behavior),
+		Flags:     eb.Flags,
+		Algorithm: eb.Algorithm,
 	}
 }

--- a/cmd/pola/ted_view.go
+++ b/cmd/pola/ted_view.go
@@ -134,22 +134,30 @@ func newTEDLinkViews(links []*table.LsLink) []tedLinkView {
 func newTEDLinkView(l *table.LsLink) tedLinkView {
 	v := tedLinkView{
 		Metrics: newTEDMetricViews(l.Metrics),
-		AdjSid:  l.AdjSid,
-	}
-	if l.LocalIP.IsValid() {
-		v.LocalIP = l.LocalIP.String()
 	}
 
-	if l.RemoteIP.IsValid() {
-		v.RemoteIP = l.RemoteIP.String()
+	if len(l.AdjSids) > 0 {
+		v.AdjSid = l.AdjSids[0].Sid
 	}
 
-	if l.RemoteNode != nil {
-		v.RemoteRouterID = l.RemoteNode.RouterID
+	if l.Local.IPv4.IsValid() {
+		v.LocalIP = l.Local.IPv4.String()
+	} else if l.Local.IPv6.IsValid() {
+		v.LocalIP = l.Local.IPv6.String()
 	}
 
-	if l.Srv6EndXSID != nil {
-		sid := newTEDSrv6EndXSIDView(l.Srv6EndXSID)
+	if l.Remote.IPv4.IsValid() {
+		v.RemoteIP = l.Remote.IPv4.String()
+	} else if l.Remote.IPv6.IsValid() {
+		v.RemoteIP = l.Remote.IPv6.String()
+	}
+
+	if l.Remote.Node != nil {
+		v.RemoteRouterID = l.Remote.Node.RouterID
+	}
+
+	if len(l.Srv6EndXSIDs) > 0 && l.Srv6EndXSIDs[0] != nil {
+		sid := newTEDSrv6EndXSIDView(l.Srv6EndXSIDs[0])
 		v.Srv6EndXSID = &sid
 	}
 

--- a/cmd/pola/ted_view_test.go
+++ b/cmd/pola/ted_view_test.go
@@ -35,12 +35,14 @@ func TestNewTEDLinkView_OmitsUnsetIPs(t *testing.T) {
 
 	link := &table.LsLink{Remote: table.LinkEndpoint{Node: &table.LsNode{RouterID: testRouterID2}}}
 	v := newTEDLinkView(link)
-	assert.Empty(t, v.LocalIP)
-	assert.Empty(t, v.RemoteIP)
-	assert.Equal(t, testRouterID2, v.RemoteRouterID)
+	assert.Empty(t, v.Local.IPv4)
+	assert.Empty(t, v.Local.IPv6)
+	assert.Empty(t, v.Remote.IPv4)
+	assert.Empty(t, v.Remote.IPv6)
+	assert.Equal(t, testRouterID2, v.Remote.RouterID)
 }
 
-func TestNewTEDLinkView_FallsBackToIPv6(t *testing.T) {
+func TestNewTEDLinkView_IPv6Only(t *testing.T) {
 	t.Parallel()
 
 	link := &table.LsLink{
@@ -48,8 +50,48 @@ func TestNewTEDLinkView_FallsBackToIPv6(t *testing.T) {
 		Remote: table.LinkEndpoint{IPv6: netip.MustParseAddr("2001:db8::2")},
 	}
 	v := newTEDLinkView(link)
-	assert.Equal(t, "2001:db8::1", v.LocalIP)
-	assert.Equal(t, "2001:db8::2", v.RemoteIP)
+	assert.Empty(t, v.Local.IPv4)
+	assert.Equal(t, "2001:db8::1", v.Local.IPv6)
+	assert.Empty(t, v.Remote.IPv4)
+	assert.Equal(t, "2001:db8::2", v.Remote.IPv6)
+}
+
+func TestNewTEDLinkView_DualStack(t *testing.T) {
+	t.Parallel()
+
+	ifaceID := uint32(7)
+	link := &table.LsLink{
+		Local: table.LinkEndpoint{
+			IPv4:        netip.MustParseAddr(testPeerAddr1),
+			IPv6:        netip.MustParseAddr("2001:db8::1"),
+			InterfaceID: &ifaceID,
+		},
+		Remote: table.LinkEndpoint{
+			IPv4: netip.MustParseAddr(testPeerAddr2),
+			IPv6: netip.MustParseAddr("2001:db8::2"),
+		},
+	}
+	v := newTEDLinkView(link)
+	assert.Equal(t, testPeerAddr1, v.Local.IPv4)
+	assert.Equal(t, "2001:db8::1", v.Local.IPv6)
+	require.NotNil(t, v.Local.InterfaceID)
+	assert.Equal(t, ifaceID, *v.Local.InterfaceID)
+	assert.Equal(t, testPeerAddr2, v.Remote.IPv4)
+	assert.Equal(t, "2001:db8::2", v.Remote.IPv6)
+}
+
+func TestNewTEDAdjSidViews(t *testing.T) {
+	t.Parallel()
+
+	views := newTEDAdjSidViews([]table.AdjSID{
+		{Family: table.AFIPv4, Sid: 100},
+		{Family: table.AFIPv6, Sid: 200},
+		{Sid: 300},
+	})
+	require.Len(t, views, 3)
+	assert.Equal(t, tedAdjSidView{Family: "ipv4", Sid: 100}, views[0])
+	assert.Equal(t, tedAdjSidView{Family: "ipv6", Sid: 200}, views[1])
+	assert.Equal(t, tedAdjSidView{Family: "unspecified", Sid: 300}, views[2])
 }
 
 func TestEndpointBehaviorViewFrom_IncludesFlagsAndAlgorithm(t *testing.T) {
@@ -87,7 +129,7 @@ func TestNewTEDLinkViews_SkipsNilEntries(t *testing.T) {
 	l := &table.LsLink{Remote: table.LinkEndpoint{Node: &table.LsNode{RouterID: testRouterID2}}}
 	views := newTEDLinkViews([]*table.LsLink{nil, l})
 	require.Len(t, views, 1)
-	assert.Equal(t, testRouterID2, views[0].RemoteRouterID)
+	assert.Equal(t, testRouterID2, views[0].Remote.RouterID)
 }
 
 func TestNewTEDLinkView_IncludesSrv6EndXSID(t *testing.T) {
@@ -102,10 +144,27 @@ func TestNewTEDLinkView_IncludesSrv6EndXSID(t *testing.T) {
 	}
 
 	v := newTEDLinkView(link)
-	require.NotNil(t, v.Srv6EndXSID)
-	assert.Equal(t, []string{testSrv6EndXSID}, v.Srv6EndXSID.Sids)
-	assert.Equal(t, table.BehaviorENDX, v.Srv6EndXSID.EndpointBehavior.Behavior)
-	assert.Equal(t, uint8(1), v.Srv6EndXSID.SidStructure.LocalBlock)
+	require.Len(t, v.Srv6EndXSIDs, 1)
+	assert.Equal(t, []string{testSrv6EndXSID}, v.Srv6EndXSIDs[0].Sids)
+	assert.Equal(t, table.BehaviorENDX, v.Srv6EndXSIDs[0].EndpointBehavior.Behavior)
+	assert.Equal(t, uint8(1), v.Srv6EndXSIDs[0].SidStructure.LocalBlock)
+}
+
+func TestNewTEDLinkView_MultipleSrv6EndXSIDs(t *testing.T) {
+	t.Parallel()
+
+	link := &table.LsLink{
+		Srv6EndXSIDs: []*table.Srv6EndXSID{
+			{EndpointBehavior: table.BehaviorENDX, Sids: []string{"fc00:0:1:1::"}},
+			{EndpointBehavior: table.BehaviorENDX, Sids: []string{"fc00:0:1:2::"}},
+			nil,
+		},
+	}
+
+	v := newTEDLinkView(link)
+	require.Len(t, v.Srv6EndXSIDs, 2)
+	assert.Equal(t, []string{"fc00:0:1:1::"}, v.Srv6EndXSIDs[0].Sids)
+	assert.Equal(t, []string{"fc00:0:1:2::"}, v.Srv6EndXSIDs[1].Sids)
 }
 
 func TestNewTEDMetricViews_SkipsNilEntries(t *testing.T) {

--- a/cmd/pola/ted_view_test.go
+++ b/cmd/pola/ted_view_test.go
@@ -33,11 +33,23 @@ func TestNewTEDNodeViews_SortedByRouterID(t *testing.T) {
 func TestNewTEDLinkView_OmitsUnsetIPs(t *testing.T) {
 	t.Parallel()
 
-	link := &table.LsLink{RemoteNode: &table.LsNode{RouterID: testRouterID2}}
+	link := &table.LsLink{Remote: table.LinkEndpoint{Node: &table.LsNode{RouterID: testRouterID2}}}
 	v := newTEDLinkView(link)
 	assert.Empty(t, v.LocalIP)
 	assert.Empty(t, v.RemoteIP)
 	assert.Equal(t, testRouterID2, v.RemoteRouterID)
+}
+
+func TestNewTEDLinkView_FallsBackToIPv6(t *testing.T) {
+	t.Parallel()
+
+	link := &table.LsLink{
+		Local:  table.LinkEndpoint{IPv6: netip.MustParseAddr("2001:db8::1")},
+		Remote: table.LinkEndpoint{IPv6: netip.MustParseAddr("2001:db8::2")},
+	}
+	v := newTEDLinkView(link)
+	assert.Equal(t, "2001:db8::1", v.LocalIP)
+	assert.Equal(t, "2001:db8::2", v.RemoteIP)
 }
 
 func TestEndpointBehaviorViewFrom_IncludesFlagsAndAlgorithm(t *testing.T) {
@@ -72,7 +84,7 @@ func TestNewTEDPrefixViews_SkipsNilEntries(t *testing.T) {
 func TestNewTEDLinkViews_SkipsNilEntries(t *testing.T) {
 	t.Parallel()
 
-	l := &table.LsLink{RemoteNode: &table.LsNode{RouterID: testRouterID2}}
+	l := &table.LsLink{Remote: table.LinkEndpoint{Node: &table.LsNode{RouterID: testRouterID2}}}
 	views := newTEDLinkViews([]*table.LsLink{nil, l})
 	require.Len(t, views, 1)
 	assert.Equal(t, testRouterID2, views[0].RemoteRouterID)
@@ -82,11 +94,11 @@ func TestNewTEDLinkView_IncludesSrv6EndXSID(t *testing.T) {
 	t.Parallel()
 
 	link := &table.LsLink{
-		Srv6EndXSID: &table.Srv6EndXSID{
+		Srv6EndXSIDs: []*table.Srv6EndXSID{{
 			EndpointBehavior: table.BehaviorENDX,
 			Sids:             []string{testSrv6EndXSID},
 			Srv6SIDStructure: &table.SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
-		},
+		}},
 	}
 
 	v := newTEDLinkView(link)

--- a/cmd/pola/ted_view_test.go
+++ b/cmd/pola/ted_view_test.go
@@ -99,19 +99,23 @@ func TestEndpointBehaviorViewFrom_IncludesFlagsAndAlgorithm(t *testing.T) {
 
 	v := endpointBehaviorViewFrom(table.EndpointBehavior{Behavior: table.BehaviorEND, Flags: 1, Algorithm: 2})
 	assert.Equal(t, table.BehaviorEND, v.Behavior)
-	require.NotNil(t, v.Flags)
-	assert.Equal(t, uint8(1), *v.Flags)
-	require.NotNil(t, v.Algorithm)
-	assert.Equal(t, uint8(2), *v.Algorithm)
+	assert.Equal(t, uint8(1), v.Flags)
+	assert.Equal(t, uint8(2), v.Algorithm)
 }
 
-func TestEndpointBehaviorViewFromBehavior_OmitsFlagsAndAlgorithm(t *testing.T) {
+func TestNewTEDSrv6EndXSIDView_IncludesFlagsAlgorithmAndWeight(t *testing.T) {
 	t.Parallel()
 
-	v := endpointBehaviorViewFromBehavior(table.BehaviorENDX)
-	assert.Equal(t, table.BehaviorENDX, v.Behavior)
-	assert.Nil(t, v.Flags)
-	assert.Nil(t, v.Algorithm)
+	v := newTEDSrv6EndXSIDView(&table.Srv6EndXSID{
+		EndpointBehavior: table.EndpointBehavior{
+			Behavior: table.BehaviorENDX, Flags: 0xC0, Algorithm: 128,
+		},
+		Weight: 7,
+	})
+	assert.Equal(t, table.BehaviorENDX, v.EndpointBehavior.Behavior)
+	assert.Equal(t, uint8(0xC0), v.EndpointBehavior.Flags)
+	assert.Equal(t, uint8(128), v.EndpointBehavior.Algorithm)
+	assert.Equal(t, uint8(7), v.Weight)
 }
 
 func TestNewTEDPrefixViews_SkipsNilEntries(t *testing.T) {
@@ -137,7 +141,7 @@ func TestNewTEDLinkView_IncludesSrv6EndXSID(t *testing.T) {
 
 	link := &table.LsLink{
 		Srv6EndXSIDs: []*table.Srv6EndXSID{{
-			EndpointBehavior: table.BehaviorENDX,
+			EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorENDX},
 			Sids:             []string{testSrv6EndXSID},
 			Srv6SIDStructure: &table.SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
 		}},
@@ -155,8 +159,8 @@ func TestNewTEDLinkView_MultipleSrv6EndXSIDs(t *testing.T) {
 
 	link := &table.LsLink{
 		Srv6EndXSIDs: []*table.Srv6EndXSID{
-			{EndpointBehavior: table.BehaviorENDX, Sids: []string{"fc00:0:1:1::"}},
-			{EndpointBehavior: table.BehaviorENDX, Sids: []string{"fc00:0:1:2::"}},
+			{EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorENDX}, Sids: []string{"fc00:0:1:1::"}},
+			{EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorENDX}, Sids: []string{"fc00:0:1:2::"}},
 			nil,
 		},
 	}

--- a/docs/schemas/cli/policy.json
+++ b/docs/schemas/cli/policy.json
@@ -37,7 +37,15 @@
                 },
                 "metric": {
                     "type": "string",
-                    "enum": ["igp", "te", "delay"]
+                    "enum": ["igp", "te", "delay", "hopcount"]
+                },
+                "underlayFamily": {
+                    "type": "string",
+                    "enum": ["ipv4", "ipv6"]
+                },
+                "dataPlane": {
+                    "type": "string",
+                    "enum": ["sr-mpls", "srv6"]
                 },
                 "segmentList": {
                     "type": "array",
@@ -103,7 +111,9 @@
                             { "required": ["srcRouterID"] },
                             { "required": ["dstRouterID"] },
                             { "required": ["metric"] },
-                            { "required": ["waypoints"] }
+                            { "required": ["waypoints"] },
+                            { "required": ["underlayFamily"] },
+                            { "required": ["dataPlane"] }
                         ]
                     }
                 }

--- a/docs/schemas/cli/policy.json
+++ b/docs/schemas/cli/policy.json
@@ -12,17 +12,21 @@
                 "pcepSessionAddr": {
                     "$ref": "#/$defs/ipAddr"
                 },
-                "srcAddr": {
+                "headend": {
                     "$ref": "#/$defs/ipAddr"
                 },
-                "dstAddr": {
+                "endpoint": {
                     "$ref": "#/$defs/ipAddr"
                 },
-                "srcRouterID": {
+                "headendRouterID": {
                     "type": "string"
                 },
-                "dstRouterID": {
+                "endpointRouterID": {
                     "type": "string"
+                },
+                "endpointFamily": {
+                    "type": "string",
+                    "enum": ["ipv4", "ipv6"]
                 },
                 "name": {
                     "type": "string"
@@ -31,89 +35,91 @@
                     "type": "integer",
                     "minimum": 1
                 },
-                "type": {
-                    "type": "string",
-                    "enum": ["explicit", "dynamic"]
-                },
-                "metric": {
-                    "type": "string",
-                    "enum": ["igp", "te", "delay", "hopcount"]
-                },
-                "underlayFamily": {
-                    "type": "string",
-                    "enum": ["ipv4", "ipv6"]
-                },
-                "dataPlane": {
-                    "type": "string",
-                    "enum": ["sr-mpls", "srv6"]
-                },
-                "segmentList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "segment.json"
-                    }
-                },
-                "waypoints": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "routerID": {
-                                "type": "string"
-                            },
-                            "sid": {
-                                "type": "string"
-                            }
+                "candidatePath": {
+                    "type": "object",
+                    "properties": {
+                        "preference": {
+                            "type": "integer",
+                            "minimum": 1
                         },
-                        "required": ["routerID"],
-                        "additionalProperties": false
-                    }
+                        "dynamic": {
+                            "type": "object",
+                            "properties": {
+                                "metric": {
+                                    "type": "string",
+                                    "enum": ["igp", "te", "delay", "hopcount"]
+                                },
+                                "dataPlane": {
+                                    "type": "string",
+                                    "enum": ["sr-mpls", "srv6"]
+                                },
+                                "underlayFamily": {
+                                    "type": "string",
+                                    "enum": ["ipv4", "ipv6"]
+                                },
+                                "waypoints": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "routerID": {
+                                                "type": "string"
+                                            },
+                                            "sid": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": ["routerID"],
+                                        "additionalProperties": false
+                                    }
+                                }
+                            },
+                            "required": ["metric"],
+                            "additionalProperties": false
+                        },
+                        "explicit": {
+                            "type": "object",
+                            "properties": {
+                                "segmentList": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "segment.json"
+                                    },
+                                    "minItems": 1
+                                }
+                            },
+                            "required": ["segmentList"],
+                            "additionalProperties": false
+                        }
+                    },
+                    "oneOf": [
+                        { "required": ["dynamic"], "not": { "required": ["explicit"] } },
+                        { "required": ["explicit"], "not": { "required": ["dynamic"] } }
+                    ],
+                    "additionalProperties": false
                 }
             },
+            "required": ["pcepSessionAddr", "name", "color", "candidatePath"],
             "additionalProperties": false,
             "oneOf": [
                 {
                     "title": "Endpoints resolved from the TED by router ID",
-                    "required": ["pcepSessionAddr", "srcRouterID", "dstRouterID", "name", "color", "type"],
+                    "required": ["headendRouterID", "endpointRouterID"],
                     "not": {
                         "anyOf": [
-                            { "required": ["srcAddr"] },
-                            { "required": ["dstAddr"] }
+                            { "required": ["headend"] },
+                            { "required": ["endpoint"] }
                         ]
-                    },
-                    "allOf": [
-                        {
-                            "if": {
-                                "properties": { "type": { "const": "explicit" } }
-                            },
-                            "then": {
-                                "required": ["segmentList"]
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": { "type": { "const": "dynamic" } }
-                            },
-                            "then": {
-                                "required": ["metric"]
-                            }
-                        }
-                    ]
+                    }
                 },
                 {
-                    "title": "Endpoints given directly; no path computation, so explicit only",
-                    "required": ["pcepSessionAddr", "srcAddr", "dstAddr", "name", "color", "segmentList"],
-                    "properties": {
-                        "type": { "const": "explicit" }
-                    },
+                    "title": "Endpoints given directly as addresses",
+                    "required": ["headend", "endpoint"],
                     "not": {
                         "anyOf": [
-                            { "required": ["srcRouterID"] },
-                            { "required": ["dstRouterID"] },
-                            { "required": ["metric"] },
-                            { "required": ["waypoints"] },
-                            { "required": ["underlayFamily"] },
-                            { "required": ["dataPlane"] }
+                            { "required": ["headendRouterID"] },
+                            { "required": ["endpointRouterID"] },
+                            { "required": ["endpointFamily"] }
                         ]
                     }
                 }
@@ -131,9 +137,28 @@
                 "properties": {
                     "srPolicy": {
                         "anyOf": [
-                            { "required": ["srcRouterID"] },
-                            { "required": ["dstRouterID"] }
+                            { "required": ["headendRouterID"] },
+                            { "required": ["endpointRouterID"] }
                         ]
+                    }
+                }
+            },
+            "then": {
+                "required": ["asn"]
+            }
+        },
+        {
+            "$comment": "A dynamic candidate path is TED-computed, which is keyed by ASN",
+            "if": {
+                "required": ["srPolicy"],
+                "properties": {
+                    "srPolicy": {
+                        "required": ["candidatePath"],
+                        "properties": {
+                            "candidatePath": {
+                                "required": ["dynamic"]
+                            }
+                        }
                     }
                 }
             },

--- a/docs/schemas/cli/segment.json
+++ b/docs/schemas/cli/segment.json
@@ -17,6 +17,7 @@
                 },
                 {
                     "title": "SRv6 SID, IPv6 only",
+                    "description": "IPv4-mapped IPv6 addresses (e.g. ::ffff:192.0.2.1) are not allowed.",
                     "type": "string",
                     "format": "ipv6"
                 }
@@ -32,6 +33,18 @@
             "type": "string",
             "pattern": "^[0-9]+,[0-9]+,[0-9]+,[0-9]+$",
             "description": "<locator-block>,<locator-node>,<function>,<argument>"
+        },
+        "localInterfaceId": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "Local interface ID for link-local IPv6 NAI scoping (RFC 8664/9603 §4.3.1)."
+        },
+        "remoteInterfaceId": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "Remote interface ID for link-local IPv6 NAI scoping (RFC 8664/9603 §4.3.1)."
         }
     },
     "required": [

--- a/docs/sources/getting-started.md
+++ b/docs/sources/getting-started.md
@@ -31,7 +31,7 @@ Configure the IP address and port for PCEP and gRPC.
 `address` must be a literal IPv4 or IPv6 address; hostnames are not resolved.
 See [JSON schema](../schemas/server/polad_config.json) for config details.
 
-### TED disable
+### Disabling TED
 
 To manage SR Policy without using TED, disable TED as follows.
 
@@ -91,7 +91,7 @@ global:
     maxKeepalive: 60
 ```
 
-### TED enable
+### Enabling TED
 
 To manage SR Policy using TED, enable TED as follows.
 This also enables dynamic path calculation.
@@ -99,7 +99,26 @@ This also enables dynamic path calculation.
 TED updates require a supported BGP-LS source.
 Currently, only GoBGP is supported.
 
-**Not currently available for IPv6 underlay (IPv6 SR-MPLS / SRv6).**
+#### Underlay address family
+
+Path computation runs on an **underlay plane**, a combination of address
+family and data plane.
+
+Supported combinations:
+
+| underlayFamily | dataPlane | Status         |
+| -------------- | --------- | -------------- |
+| ipv4           | sr-mpls   | Supported      |
+| ipv6           | sr-mpls   | Supported      |
+| ipv6           | srv6      | Supported      |
+| ipv4           | srv6      | Not applicable |
+
+A dynamic candidate path selects the plane with `underlayFamily` and
+`dataPlane`. If both are unspecified, Pola uses the headend's unique viable
+plane and rejects the request when multiple planes are available.
+
+The endpoint and underlay address families are independent, so cross-AF
+policies are supported.
 
 ```yaml
 global:
@@ -141,9 +160,21 @@ neighbors:
       afi-safi-name: ls
 ```
 
+#### Known limitations
+
+* **BGP-LS Multi-Topology ID (TLV 263)** is not exposed through GoBGP's
+  Node/Link/Prefix NLRI API. Pola infers MT-0/MT-2 adjacency usability from the
+  advertised interface address family.
+* **SR Adjacency-SID**: At most one SR Adjacency-SID is available per link, so
+  IPv4- and IPv6-specific SIDs cannot be distinguished on the same dual-stack link.
+* **IOS-XR interoperability**: IPv6-endpoint PCE-initiated SR-MPLS policies were
+  observed to be rejected locally by IOS-XR 24.4.1 (`pcinitiate: bad sock info`),
+  even though the PCEP message is valid on the wire. Cross-AF behavior may vary
+  by PCC implementation and version.
+
 ## Run Polad
 
-Start polad. Specify the created configuration file with the -f option.
+Start polad. Specify the created configuration file with the `-f` option.
 
 ```bash
 $ sudo polad -f polad.yaml

--- a/docs/sources/getting-started.md
+++ b/docs/sources/getting-started.md
@@ -162,15 +162,12 @@ neighbors:
 
 #### Known limitations
 
-* **BGP-LS Multi-Topology ID (TLV 263)** is not exposed through GoBGP's
-  Node/Link/Prefix NLRI API. Pola infers MT-0/MT-2 adjacency usability from the
-  advertised interface address family.
-* **SR Adjacency-SID**: At most one SR Adjacency-SID is available per link, so
+* **SR Adjacency-SID**: Only one SR Adjacency-SID is available per link, so
   IPv4- and IPv6-specific SIDs cannot be distinguished on the same dual-stack link.
-* **IOS-XR interoperability**: IPv6-endpoint PCE-initiated SR-MPLS policies were
-  observed to be rejected locally by IOS-XR 24.4.1 (`pcinitiate: bad sock info`),
-  even though the PCEP message is valid on the wire. Cross-AF behavior may vary
-  by PCC implementation and version.
+* **IOS-XR interoperability**: IOS-XR 24.4.1 rejected IPv6-endpoint
+  PCE-initiated SR-MPLS policies (`pcinitiate: bad sock info`).
+* **Junos interoperability**: Junos 25.2R1.9 rejected IPv6-endpoint
+  PCE-initiated SR-MPLS policies (`IPv6 SRPAG received for non SRv6 LSP`).
 
 ## Run Polad
 

--- a/docs/sources/technical-specifications.md
+++ b/docs/sources/technical-specifications.md
@@ -1,0 +1,53 @@
+# Technical Specifications
+
+This document provides technical details on data models, SRv6/SR-MPLS concepts, and protocol specifications used in Pola PCE.
+
+## SRv6 Endpoint Behavior
+
+### Overview
+
+SRv6 Endpoint Behavior defines how a network node processes SRv6 SIDs. It is carried in the TED as part of the Endpoint Behavior TLV (RFC 9603 §4.3.1).
+
+### EndpointBehavior Message Structure
+
+The `EndpointBehavior` message in the gRPC API contains three fields:
+
+- **behavior** (uint32): Endpoint behavior code as advertised via BGP-LS.
+  - Defines how the node processes this SID: End, End.X, End.DT4, End.DT6, End.AD, etc. (see RFC 8986)
+  - Used during segment list computation to understand node capabilities
+
+- **flags** (uint32): 8-bit flags octet.
+  - For End.X SID TLVs: B (Backup), S (Set), P (Persistent) flags are defined in RFC 9352, RFC 9513, and RFC 9514 §7.2
+  - For Endpoint Behavior TLV: flags are currently undefined by IETF
+  - Pola preserves and transports this field during TED ingestion and segment generation, but does not currently interpret or utilize the flag values
+
+- **algorithm** (uint32): SRv6 Prefix-SID algorithm number.
+  - Controls how a Prefix-SID label is derived from the SID value
+  - RFC 8986 Fig. 8 defines:
+    - 0 = Shortest Path First (SPF)
+    - 1 = Strict Shortest Path First
+  - Used by nodes implementing Prefix-SID construction from the locator
+
+## TED Data Model
+
+### Topology Encoding Database (TED)
+
+The TED aggregates topology information from BGP-LS (RFC 7752) and makes it available for path computation via CSPF.
+
+### Key Concepts
+
+- **Node Identity**: Identified by IGP Router-ID (a string), not IP address. Dual-stack nodes are represented as a single node.
+- **Link Identity**: Uniquely identified by (local router ID, remote router ID, local interface identifier, remote interface identifier, address family)
+- **Address Family**: Link endpoints carry both IPv4 and IPv6 addresses independently; CSPF filters edges by the target address family
+- **Underlay Plane**: A combination of address family (IPv4/IPv6) and data plane (SR-MPLS/SRv6) that constrains path computation
+
+### Supported Underlay Planes
+
+| Address Family | Data Plane | Status      |
+| -------------- | ---------- | ----------- |
+| IPv4           | SR-MPLS    | Supported   |
+| IPv6           | SR-MPLS    | Supported   |
+| IPv6           | SRv6       | Supported   |
+| IPv4           | SRv6       | Not allowed |
+
+(IPv4 + SRv6 is not supported because SRv6 SIDs are IPv6 addresses.)

--- a/examples/containerlab/sr-mpls-explicit-path-l3vpn/sr-policies/pe01-policy1.yaml
+++ b/examples/containerlab/sr-mpls-explicit-path-l3vpn/sr-policies/pe01-policy1.yaml
@@ -1,14 +1,16 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "10.0.255.1"
-  srcAddr: "10.255.0.1"
-  dstAddr: "10.255.0.3"
+  headend: "10.255.0.1"
+  endpoint: "10.255.0.3"
   name: pe01-policy1
   color: 1
-  segmentList:
-    - sid: "16002"
-      localAddr: "10.255.0.2"
-    - sid: "16004"
-      localAddr: "10.255.0.4"
-    - sid: "16003"
-      localAddr: "10.255.0.3"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "16002"
+          localAddr: "10.255.0.2"
+        - sid: "16004"
+          localAddr: "10.255.0.4"
+        - sid: "16003"
+          localAddr: "10.255.0.3"

--- a/examples/containerlab/sr-mpls-explicit-path/sr-policies/pe01-policy1.yaml
+++ b/examples/containerlab/sr-mpls-explicit-path/sr-policies/pe01-policy1.yaml
@@ -1,12 +1,14 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "10.0.255.1"
-  srcAddr: "10.255.0.1"
-  dstAddr: "10.255.0.2"
+  headend: "10.255.0.1"
+  endpoint: "10.255.0.2"
   name: pe01-policy1
   color: 1
-  segmentList:
-    - sid: "16002"
-      localAddr: "10.255.0.2"
-    - sid: "16003"
-      localAddr: "10.255.0.3"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "16002"
+          localAddr: "10.255.0.2"
+        - sid: "16003"
+          localAddr: "10.255.0.3"

--- a/examples/containerlab/sr-mpls-explicit-path/sr-policies/pe02-policy1.yaml
+++ b/examples/containerlab/sr-mpls-explicit-path/sr-policies/pe02-policy1.yaml
@@ -1,12 +1,14 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "10.0.255.2"
-  srcAddr: "10.255.0.2"
-  dstAddr: "10.255.0.1"
+  headend: "10.255.0.2"
+  endpoint: "10.255.0.1"
   name: pe02-policy1
   color: 1
-  segmentList:
-    - sid: "16001"
-      localAddr: "10.255.0.1"
-    - sid: "16003"
-      localAddr: "10.255.0.3"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "16001"
+          localAddr: "10.255.0.1"
+        - sid: "16003"
+          localAddr: "10.255.0.3"

--- a/examples/containerlab/sr-mpls-explicit-path/sr-policies/pe03-policy1.yaml
+++ b/examples/containerlab/sr-mpls-explicit-path/sr-policies/pe03-policy1.yaml
@@ -1,12 +1,14 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "10.0.255.3"
-  srcAddr: "10.255.0.3"
-  dstAddr: "10.255.0.1"
+  headend: "10.255.0.3"
+  endpoint: "10.255.0.1"
   name: pe03-policy1
   color: 1
-  segmentList:
-    - sid: "16001"
-      localAddr: "10.255.0.1"
-    - sid: "16002"
-      localAddr: "10.255.0.2"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "16001"
+          localAddr: "10.255.0.1"
+        - sid: "16002"
+          localAddr: "10.255.0.2"

--- a/examples/containerlab/srv6-explicit-path-l3vpn/sr-policies/pe01-policy1.yaml
+++ b/examples/containerlab/srv6-explicit-path-l3vpn/sr-policies/pe01-policy1.yaml
@@ -1,14 +1,16 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "fd00::1"
-  srcAddr: "fd00:ffff::1"
-  dstAddr: "fd00:ffff:2:0:1::"
+  headend: "fd00:ffff::1"
+  endpoint: "fd00:ffff:2:0:1::"
   name: pe01-policy1
   color: 1
-  segmentList:
-    - sid: "fd00:ffff:3:0:1::"
-      localAddr: "fd00:ffff::3"
-    - sid: "fd00:ffff:4:0:1::"
-      localAddr: "fd00:ffff::4"
-    - sid: "fd00:ffff:2:0:1::"
-      localAddr: "fd00:ffff::2"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "fd00:ffff:3:0:1::"
+          localAddr: "fd00:ffff::3"
+        - sid: "fd00:ffff:4:0:1::"
+          localAddr: "fd00:ffff::4"
+        - sid: "fd00:ffff:2:0:1::"
+          localAddr: "fd00:ffff::2"

--- a/examples/containerlab/srv6-explicit-path-l3vpn/sr-policies/pe02-policy1.yaml
+++ b/examples/containerlab/srv6-explicit-path-l3vpn/sr-policies/pe02-policy1.yaml
@@ -1,14 +1,16 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "fd00::2"
-  srcAddr: "fd00:ffff::2"
-  dstAddr: "fd00:ffff:1:0:1::"
+  headend: "fd00:ffff::2"
+  endpoint: "fd00:ffff:1:0:1::"
   name: pe02-policy1
   color: 1
-  segmentList:
-    - sid: "fd00:ffff:4:0:1::"
-      localAddr: "fd00:ffff::4"
-    - sid: "fd00:ffff:3:0:1::"
-      localAddr: "fd00:ffff::3"
-    - sid: "fd00:ffff:1:0:1::"
-      localAddr: "fd00:ffff::1"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "fd00:ffff:4:0:1::"
+          localAddr: "fd00:ffff::4"
+        - sid: "fd00:ffff:3:0:1::"
+          localAddr: "fd00:ffff::3"
+        - sid: "fd00:ffff:1:0:1::"
+          localAddr: "fd00:ffff::1"

--- a/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/README.md
@@ -66,7 +66,7 @@ Node #0: 0000.0001.0001
         igp: 1
       Adj-SID: 0
       SRv6 End.X SID:
-        EndpointBehavior: UA
+        EndpointBehavior: UA, Flags: 0, Algorithm: 0, Weight: 0
         SIDs: [fcbb:bb00:1001:e000::]
         SID Structure: Block: 32, Node: 16, Func: 16, Arg: 64
     Local: None Remote: None
@@ -75,7 +75,7 @@ Node #0: 0000.0001.0001
         igp: 1
       Adj-SID: 0
       SRv6 End.X SID:
-        EndpointBehavior: UA
+        EndpointBehavior: UA, Flags: 0, Algorithm: 0, Weight: 0
         SIDs: [fcbb:bb00:1001:e001::]
         SID Structure: Block: 32, Node: 16, Func: 16, Arg: 64
   SRv6 SIDs:

--- a/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/sr-policies/pe02-policy1.yaml
+++ b/examples/containerlab/srv6-usid-dynamic-path-loose-source-routing-sfc/sr-policies/pe02-policy1.yaml
@@ -1,14 +1,15 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "fd00::2"
-  srcRouterID: "0000.0001.0002"
-  dstRouterID: "0000.0001.0001"
+  headendRouterID: "0000.0001.0002"
+  endpointRouterID: "0000.0001.0001"
   name: "DYNAMIC-POLICY"
   color: 100
-  type: dynamic
-  metric: igp
-  waypoints:
-    - routerID: "0000.0001.0003"
-    - routerID: "0000.0001.0004"
-    - routerID: "0000.0001.0003"
-      sid: "fcbb:bb00:1003::"
+  candidatePath:
+    dynamic:
+      metric: igp
+      waypoints:
+        - routerID: "0000.0001.0003"
+        - routerID: "0000.0001.0004"
+        - routerID: "0000.0001.0003"
+          sid: "fcbb:bb00:1003::"

--- a/examples/containerlab/srv6-usid-dynamic-path/README.md
+++ b/examples/containerlab/srv6-usid-dynamic-path/README.md
@@ -66,7 +66,7 @@ Node #0: 0000.0001.0001
         igp: 100
       Adj-SID: 0
       SRv6 End.X SID:
-        EndpointBehavior: UA
+        EndpointBehavior: UA, Flags: 0, Algorithm: 0, Weight: 0
         SIDs: [fcbb:bb00:1001:e001::]
         SID Structure: Block: 32, Node: 16, Func: 16, Arg: 64
     Local: None Remote: None
@@ -75,7 +75,7 @@ Node #0: 0000.0001.0001
         igp: 10
       Adj-SID: 0
       SRv6 End.X SID:
-        EndpointBehavior: UA
+        EndpointBehavior: UA, Flags: 0, Algorithm: 0, Weight: 0
         SIDs: [fcbb:bb00:1001:e000::]
         SID Structure: Block: 32, Node: 16, Func: 16, Arg: 64
   SRv6 SIDs:

--- a/examples/containerlab/srv6-usid-dynamic-path/sr-policies/pe02-policy1.yaml
+++ b/examples/containerlab/srv6-usid-dynamic-path/sr-policies/pe02-policy1.yaml
@@ -1,9 +1,10 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "fd00::2"
-  srcRouterID: "0000.0001.0002"
-  dstRouterID: "0000.0001.0001"
+  headendRouterID: "0000.0001.0002"
+  endpointRouterID: "0000.0001.0001"
   name: "DYNAMIC-POLICY"
   color: 100
-  type: dynamic
-  metric: igp
+  candidatePath:
+    dynamic:
+      metric: igp

--- a/examples/grpc/go/README.md
+++ b/examples/grpc/go/README.md
@@ -7,12 +7,12 @@ Use them as a starting point for building your own controller.
 
 | Directory | RPC | Description |
 | --- | --- | --- |
-| [`sr-policy-create-dynamic/`](sr-policy-create-dynamic/) | `CreateSRPolicy` | Dynamic SR Policy with the path computed from the TED (`Type: DYNAMIC`, `DisablePathCompute: false`). Also shows optional waypoints. |
-| [`sr-policy-create-explicit/`](sr-policy-create-explicit/) | `CreateSRPolicy` | Explicit SR Policy with endpoints resolved through the TED (`Type: EXPLICIT`, `DisablePathCompute: false`). |
-| [`sr-policy-create-no-sid-validate/`](sr-policy-create-no-sid-validate/) | `CreateSRPolicy` | Explicit SR Policy with the supplied segment list installed as-is; no TED required (`DisablePathCompute: true`, `NoSidValidate: true`). |
-| [`sr-policy-create-srv6/`](sr-policy-create-srv6/) | `CreateSRPolicy` | Explicit SRv6 SR Policy with `LocalAddr` and `SidStructure` (`DisablePathCompute: true`, `NoSidValidate: true`). |
+| [`sr-policy-create-dynamic/`](sr-policy-create-dynamic/) | `CreateSRPolicy` | Create a dynamic SR Policy with optional waypoints. |
+| [`sr-policy-create-explicit/`](sr-policy-create-explicit/) | `CreateSRPolicy` | Create an explicit SR Policy. |
+| [`sr-policy-create-no-sid-validate/`](sr-policy-create-no-sid-validate/) | `CreateSRPolicy` | Create an explicit SR Policy without TED or SID validation. |
+| [`sr-policy-create-srv6/`](sr-policy-create-srv6/) | `CreateSRPolicy` | Create an explicit SRv6 SR Policy with `LocalAddr` and `SidStructure`. |
 | [`sr-policy-delete/`](sr-policy-delete/) | `DeleteSRPolicy` | Delete an SR Policy. |
-| [`sr-policy-list/`](sr-policy-list/) | `GetSRPolicyList` | List the SR Policies known to polad. |
+| [`sr-policy-list/`](sr-policy-list/) | `GetSRPolicyList` | List SR Policies known to polad. |
 | [`session-list/`](session-list/) | `GetSessionList` | List PCEP sessions with state, capabilities and sync status. |
 | [`session-delete/`](session-delete/) | `DeleteSession` | Delete a PCEP session. |
 | [`ted-get/`](ted-get/) | `GetTED` | Dump the traffic engineering database. |

--- a/examples/grpc/go/examples_test.go
+++ b/examples/grpc/go/examples_test.go
@@ -332,13 +332,12 @@ func TestSRPolicyCreateDynamic(t *testing.T) {
 
 		req := f.createReq
 		require.NotNil(t, req, "server received no request")
-		// Dynamic policies require TED-based path computation.
-		assert.False(t, req.GetDisablePathCompute())
-		assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, req.GetSrPolicy().GetType())
+		dynamic := req.GetSrPolicy().GetCandidatePath().GetDynamic()
+		require.NotNil(t, dynamic, "want a dynamic candidate path")
 		assert.NotZero(t, req.GetAsn(), "want the TED ASN")
-		assert.NotEmpty(t, req.GetSrPolicy().GetSrcRouterId())
-		assert.Len(t, req.GetSrPolicy().GetWaypoints(), 1)
-		assert.Equal(t, pb.MetricType_METRIC_TYPE_TE, req.GetSrPolicy().GetMetric())
+		assert.NotEmpty(t, req.GetSrPolicy().GetHeadendRouterId())
+		assert.Len(t, dynamic.GetWaypoints(), 1)
+		assert.Equal(t, pb.MetricType_METRIC_TYPE_TE, dynamic.GetMetric())
 		assert.False(t, req.GetNoSidValidate())
 	})
 
@@ -362,9 +361,9 @@ func TestSRPolicyCreateExplicit(t *testing.T) {
 
 		req := f.createReq
 		require.NotNil(t, req, "server received no request")
-		assert.False(t, req.GetDisablePathCompute())
-		assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, req.GetSrPolicy().GetType())
-		assert.NotEmpty(t, req.GetSrPolicy().GetSegmentList())
+		explicit := req.GetSrPolicy().GetCandidatePath().GetExplicit()
+		require.NotNil(t, explicit, "want an explicit candidate path")
+		assert.NotEmpty(t, explicit.GetSegmentList())
 		assert.False(t, req.GetNoSidValidate())
 	})
 
@@ -388,11 +387,11 @@ func TestSRPolicyCreateNoSIDValidate(t *testing.T) {
 
 		req := f.createReq
 		require.NotNil(t, req, "server received no request")
-		assert.True(t, req.GetDisablePathCompute())
-		assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, req.GetSrPolicy().GetType())
-		assert.NotEmpty(t, req.GetSrPolicy().GetSrcAddr())
-		assert.NotEmpty(t, req.GetSrPolicy().GetDstAddr())
-		assert.NotEmpty(t, req.GetSrPolicy().GetSegmentList())
+		explicit := req.GetSrPolicy().GetCandidatePath().GetExplicit()
+		require.NotNil(t, explicit, "want an explicit candidate path")
+		assert.NotEmpty(t, req.GetSrPolicy().GetHeadend())
+		assert.NotEmpty(t, req.GetSrPolicy().GetEndpoint())
+		assert.NotEmpty(t, explicit.GetSegmentList())
 		assert.True(t, req.GetNoSidValidate())
 	})
 
@@ -417,7 +416,7 @@ func TestSRPolicyCreateSRv6(t *testing.T) {
 		req := f.createReq
 		require.NotNil(t, req, "server received no request")
 		// SRv6 segments require LocalAddr and SidStructure.
-		for _, seg := range req.GetSrPolicy().GetSegmentList() {
+		for _, seg := range req.GetSrPolicy().GetCandidatePath().GetExplicit().GetSegmentList() {
 			assert.NotEmpty(t, seg.GetLocalAddr(), "segment %s", seg.GetSid())
 			assert.NotEmpty(t, seg.GetSidStructure(), "segment %s", seg.GetSid())
 		}
@@ -447,7 +446,7 @@ func TestSRPolicyDelete(t *testing.T) {
 		require.NotNil(t, req, "server received no request")
 		// polad identifies the policy by these four fields, so all must be set.
 		assert.NotEmpty(t, req.GetSrPolicy().GetPeerAddr())
-		assert.NotEmpty(t, req.GetSrPolicy().GetDstAddr())
+		assert.NotEmpty(t, req.GetSrPolicy().GetEndpoint())
 		assert.NotZero(t, req.GetSrPolicy().GetColor())
 		assert.NotEmpty(t, req.GetSrPolicy().GetPolicyName())
 	})
@@ -530,12 +529,12 @@ func TestSRPolicyList(t *testing.T) {
 			{
 				PeerAddr: addrBytes(t, "192.0.2.1"),
 				SrPolicies: []*pb.SRPolicy{{
-					SrcAddr:     addrBytes(t, "192.0.2.1"),
-					DstAddr:     addrBytes(t, "192.0.2.2"),
-					PolicyName:  "with-segments",
-					Color:       100,
-					Preference:  200,
-					SegmentList: []*pb.Segment{{Sid: "16002"}, {Sid: "16003"}},
+					Headend:       addrBytes(t, "192.0.2.1"),
+					Endpoint:      addrBytes(t, "192.0.2.2"),
+					PolicyName:    "with-segments",
+					Color:         100,
+					CandidatePath: &pb.CandidatePath{Preference: 200},
+					SegmentList:   []*pb.Segment{{Sid: "16002"}, {Sid: "16003"}},
 				}},
 			},
 			{
@@ -549,8 +548,8 @@ func TestSRPolicyList(t *testing.T) {
 		wantOutput(t, out, code,
 			"srPolicy(0):",
 			"policyName: with-segments",
-			"srcAddr: 192.0.2.1",
-			"dstAddr: 192.0.2.2",
+			"headend: 192.0.2.1",
+			"endpoint: 192.0.2.2",
 			"color: 100",
 			"preference: 200",
 			"path: 16002 -> 16003",
@@ -581,7 +580,7 @@ func TestTEDGet(t *testing.T) {
 				RouterId: "0000.0aff.0001",
 				Hostname: "node1",
 				Prefixes: []*pb.LsPrefix{{Prefix: "10.0.0.1/32"}},
-				Links:    []*pb.LsLink{{LocalRouterId: "0000.0aff.0001"}},
+				Links:    []*pb.LsLink{{Local: &pb.LsLinkEndpoint{RouterId: "0000.0aff.0001"}}},
 			}},
 		}}
 		out, code := run(t, "ted-get", serve(t, f))

--- a/examples/grpc/go/sr-policy-create-dynamic/main.go
+++ b/examples/grpc/go/sr-policy-create-dynamic/main.go
@@ -46,19 +46,23 @@ func main() {
 	_, err = c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
 		Asn: 65000,
 		SrPolicy: &pb.SRPolicy{
-			PeerAddr:    ssAddr.AsSlice(),
-			SrcRouterId: "0000.0aff.0001",
-			DstRouterId: "0000.0aff.0004",
-			Color:       100,
-			PolicyName:  "sample-name",
-			Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-			Metric:      pb.MetricType_METRIC_TYPE_TE,
-			// Optional: constrain the computed path through these routers.
-			Waypoints: []*pb.Waypoint{
-				{RouterId: "0000.0aff.0002"},
+			PeerAddr:         ssAddr.AsSlice(),
+			HeadendRouterId:  "0000.0aff.0001",
+			EndpointRouterId: "0000.0aff.0004",
+			Color:            100,
+			PolicyName:       "sample-name",
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Dynamic{
+					Dynamic: &pb.DynamicPath{
+						Metric: pb.MetricType_METRIC_TYPE_TE,
+						// Optional: constrain the computed path through these routers.
+						Waypoints: []*pb.Waypoint{
+							{RouterId: "0000.0aff.0002"},
+						},
+					},
+				},
 			},
 		},
-		DisablePathCompute: false,
 	})
 	if err != nil {
 		log.Fatalf("c.CreateSRPolicy error: %v", err) //nolint:gocritic // main exits immediately.

--- a/examples/grpc/go/sr-policy-create-explicit/main.go
+++ b/examples/grpc/go/sr-policy-create-explicit/main.go
@@ -45,19 +45,23 @@ func main() {
 	_, err = c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
 		Asn: 65000,
 		SrPolicy: &pb.SRPolicy{
-			PeerAddr:    ssAddr.AsSlice(),
-			SrcRouterId: "0000.0aff.0001",
-			DstRouterId: "0000.0aff.0004",
-			Color:       100,
-			PolicyName:  "sample-name",
-			Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-			SegmentList: []*pb.Segment{
-				{Sid: "16002"},
-				{Sid: "16003"},
-				{Sid: "16004"},
+			PeerAddr:         ssAddr.AsSlice(),
+			HeadendRouterId:  "0000.0aff.0001",
+			EndpointRouterId: "0000.0aff.0004",
+			Color:            100,
+			PolicyName:       "sample-name",
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Explicit{
+					Explicit: &pb.ExplicitPath{
+						SegmentList: []*pb.Segment{
+							{Sid: "16002"},
+							{Sid: "16003"},
+							{Sid: "16004"},
+						},
+					},
+				},
 			},
 		},
-		DisablePathCompute: false,
 	})
 	if err != nil {
 		log.Fatalf("c.CreateSRPolicy error: %v", err) //nolint:gocritic // main exits immediately.

--- a/examples/grpc/go/sr-policy-create-no-sid-validate/main.go
+++ b/examples/grpc/go/sr-policy-create-no-sid-validate/main.go
@@ -4,7 +4,7 @@
 // see https://github.com/nttcom/pola/blob/main/LICENSE
 
 // Command sr-policy-create-no-sid-validate creates an explicit SR Policy
-// without TED-based path computation or SID validation.
+// with directly specified endpoints and without SID validation.
 package main
 
 import (
@@ -42,25 +42,29 @@ func main() {
 	defer cancel()
 
 	ssAddr := netip.MustParseAddr("192.0.2.1")
-	srcAddr := netip.MustParseAddr("192.0.2.1")
-	dstAddr := netip.MustParseAddr("192.0.2.2")
+	headend := netip.MustParseAddr("192.0.2.1")
+	endpoint := netip.MustParseAddr("192.0.2.2")
 
 	_, err = c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
 			PeerAddr:   ssAddr.AsSlice(),
-			SrcAddr:    srcAddr.AsSlice(),
-			DstAddr:    dstAddr.AsSlice(),
+			Headend:    headend.AsSlice(),
+			Endpoint:   endpoint.AsSlice(),
 			Color:      100,
 			PolicyName: "sample-name",
-			Type:       pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-			SegmentList: []*pb.Segment{
-				{Sid: "16002"},
-				{Sid: "16003"},
-				{Sid: "16004"},
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Explicit{
+					Explicit: &pb.ExplicitPath{
+						SegmentList: []*pb.Segment{
+							{Sid: "16002"},
+							{Sid: "16003"},
+							{Sid: "16004"},
+						},
+					},
+				},
 			},
 		},
-		DisablePathCompute: true,
-		NoSidValidate:      true,
+		NoSidValidate: true,
 	})
 	if err != nil {
 		log.Fatalf("c.CreateSRPolicy error: %v", err) //nolint:gocritic // main exits immediately.

--- a/examples/grpc/go/sr-policy-create-srv6/main.go
+++ b/examples/grpc/go/sr-policy-create-srv6/main.go
@@ -42,32 +42,36 @@ func main() {
 	defer cancel()
 
 	ssAddr := netip.MustParseAddr("2001:db8::1")
-	srcAddr := netip.MustParseAddr("2001:db8::1")
-	dstAddr := netip.MustParseAddr("2001:db8::2")
+	headend := netip.MustParseAddr("2001:db8::1")
+	endpoint := netip.MustParseAddr("2001:db8::2")
 
 	_, err = c.CreateSRPolicy(ctx, &pb.CreateSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
 			PeerAddr:   ssAddr.AsSlice(),
-			SrcAddr:    srcAddr.AsSlice(),
-			DstAddr:    dstAddr.AsSlice(),
+			Headend:    headend.AsSlice(),
+			Endpoint:   endpoint.AsSlice(),
 			Color:      100,
 			PolicyName: "sample-srv6",
-			Type:       pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-			SegmentList: []*pb.Segment{
-				{
-					Sid:          "2001:db8:1005::",
-					LocalAddr:    "2001:db8::5",
-					SidStructure: "32,16,0,80",
-				},
-				{
-					Sid:          "2001:db8:1006::",
-					LocalAddr:    "2001:db8::6",
-					SidStructure: "32,16,0,80",
+			CandidatePath: &pb.CandidatePath{
+				Path: &pb.CandidatePath_Explicit{
+					Explicit: &pb.ExplicitPath{
+						SegmentList: []*pb.Segment{
+							{
+								Sid:          "2001:db8:1005::",
+								LocalAddr:    "2001:db8::5",
+								SidStructure: "32,16,0,80",
+							},
+							{
+								Sid:          "2001:db8:1006::",
+								LocalAddr:    "2001:db8::6",
+								SidStructure: "32,16,0,80",
+							},
+						},
+					},
 				},
 			},
 		},
-		DisablePathCompute: true,
-		NoSidValidate:      true,
+		NoSidValidate: true,
 	})
 	if err != nil {
 		log.Fatalf("c.CreateSRPolicy error: %v", err) //nolint:gocritic // main exits immediately.

--- a/examples/grpc/go/sr-policy-delete/main.go
+++ b/examples/grpc/go/sr-policy-delete/main.go
@@ -4,7 +4,7 @@
 // see https://github.com/nttcom/pola/blob/main/LICENSE
 
 // Command sr-policy-delete deletes an SR Policy.
-// The policy is identified by PeerAddr, Color, DstAddr and PolicyName.
+// The policy is identified by PeerAddr, Color, Endpoint and PolicyName.
 package main
 
 import (
@@ -42,12 +42,12 @@ func main() {
 	defer cancel()
 
 	ssAddr := netip.MustParseAddr("192.0.2.1")
-	dstAddr := netip.MustParseAddr("192.0.2.2")
+	endpoint := netip.MustParseAddr("192.0.2.2")
 
 	_, err = c.DeleteSRPolicy(ctx, &pb.DeleteSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
 			PeerAddr:   ssAddr.AsSlice(),
-			DstAddr:    dstAddr.AsSlice(),
+			Endpoint:   endpoint.AsSlice(),
 			Color:      100,
 			PolicyName: "sample-name",
 		},

--- a/examples/grpc/go/sr-policy-list/main.go
+++ b/examples/grpc/go/sr-policy-list/main.go
@@ -59,10 +59,10 @@ func main() {
 
 			fmt.Printf("  peerAddr: %s\n", peerAddr)
 			fmt.Printf("  policyName: %s\n", srPolicy.GetPolicyName())
-			fmt.Printf("  srcAddr: %s\n", formatAddr(srPolicy.GetSrcAddr()))
-			fmt.Printf("  dstAddr: %s\n", formatAddr(srPolicy.GetDstAddr()))
+			fmt.Printf("  headend: %s\n", formatAddr(srPolicy.GetHeadend()))
+			fmt.Printf("  endpoint: %s\n", formatAddr(srPolicy.GetEndpoint()))
 			fmt.Printf("  color: %d\n", srPolicy.GetColor())
-			fmt.Printf("  preference: %d\n", srPolicy.GetPreference())
+			fmt.Printf("  preference: %d\n", srPolicy.GetCandidatePath().GetPreference())
 			fmt.Printf("  path: %s\n", formatSegmentList(srPolicy.GetSegmentList()))
 		}
 	}

--- a/internal/gobgp/interface.go
+++ b/internal/gobgp/interface.go
@@ -632,8 +632,37 @@ func parseOptionalAddr(s string) (netip.Addr, error) {
 	return addr, nil
 }
 
+func endpointBehaviorFromAPI(name string, behavior, flags, algorithm uint32) (table.EndpointBehavior, error) {
+	b, err := safecast.Uint16(behavior, name+" endpoint behavior")
+	if err != nil {
+		return table.EndpointBehavior{}, err
+	}
+
+	f, err := safecast.Uint8(flags, name+" endpoint behavior flags")
+	if err != nil {
+		return table.EndpointBehavior{}, err
+	}
+
+	a, err := safecast.Uint8(algorithm, name+" endpoint behavior algorithm")
+	if err != nil {
+		return table.EndpointBehavior{}, err
+	}
+
+	return table.EndpointBehavior{Behavior: b, Flags: f, Algorithm: a}, nil
+}
+
 func srv6EndXSIDFromAPI(srv6EndXSID *api.LsSrv6EndXSID) (*table.Srv6EndXSID, error) {
-	endpointBehavior, err := safecast.Uint16(srv6EndXSID.GetEndpointBehavior(), "SRv6 End.X SID endpoint behavior")
+	endpointBehavior, err := endpointBehaviorFromAPI(
+		"SRv6 End.X SID",
+		srv6EndXSID.GetEndpointBehavior(),
+		srv6EndXSID.GetFlags(),
+		srv6EndXSID.GetAlgorithm(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	weight, err := safecast.Uint8(srv6EndXSID.GetWeight(), "SRv6 End.X SID weight")
 	if err != nil {
 		return nil, err
 	}
@@ -645,6 +674,7 @@ func srv6EndXSIDFromAPI(srv6EndXSID *api.LsSrv6EndXSID) (*table.Srv6EndXSID, err
 
 	return &table.Srv6EndXSID{
 		EndpointBehavior: endpointBehavior,
+		Weight:           weight,
 		Sids:             srv6EndXSID.GetSids(),
 		Srv6SIDStructure: structure,
 	}, nil
@@ -805,17 +835,12 @@ func getLsSrv6SID(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrSrv6SID *api.LsAtt
 		return nil, err
 	}
 
-	behavior, err := safecast.Uint16(endpointBehavior.GetEndpointBehavior(), "SRv6 SID endpoint behavior")
-	if err != nil {
-		return nil, err
-	}
-
-	flags, err := safecast.Uint8(endpointBehavior.GetFlags(), "SRv6 SID endpoint behavior flags")
-	if err != nil {
-		return nil, err
-	}
-
-	algorithm, err := safecast.Uint8(endpointBehavior.GetAlgorithm(), "SRv6 SID endpoint behavior algorithm")
+	behavior, err := endpointBehaviorFromAPI(
+		"SRv6 SID",
+		endpointBehavior.GetEndpointBehavior(),
+		endpointBehavior.GetFlags(),
+		endpointBehavior.GetAlgorithm(),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -823,9 +848,7 @@ func getLsSrv6SID(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrSrv6SID *api.LsAtt
 	localNode := table.NewLsNode(localNodeASN, localNodeID)
 	lsSrv6SID := table.NewLsSrv6SID(localNode)
 	lsSrv6SID.SIDStructure = structure
-	lsSrv6SID.EndpointBehavior.Behavior = behavior
-	lsSrv6SID.EndpointBehavior.Flags = flags
-	lsSrv6SID.EndpointBehavior.Algorithm = algorithm
+	lsSrv6SID.EndpointBehavior = behavior
 	lsSrv6SID.Sids = srv6SIDs
 	lsSrv6SID.MultiTopoIDs = multiTopoIDs
 

--- a/internal/gobgp/interface.go
+++ b/internal/gobgp/interface.go
@@ -587,6 +587,13 @@ func getLsLink(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrLink *api.LsAttribute
 	lsLink.Local.InterfaceID = linkDescriptor.LinkLocalId
 	lsLink.Remote.InterfaceID = linkDescriptor.LinkRemoteId
 
+	if multiTopoIDs := linkDescriptor.GetMultiTopoId().GetMultiTopoIds(); len(multiTopoIDs) != 0 {
+		lsLink.MultiTopoIDs = make(map[uint16]struct{}, len(multiTopoIDs))
+		for _, id := range multiTopoIDs {
+			lsLink.MultiTopoIDs[uint16(id)] = struct{}{}
+		}
+	}
+
 	lsLink.Metrics = append(lsLink.Metrics, table.NewMetric(table.IGPMetric, lsAttrLink.GetIgpMetric()))
 
 	teMetric := lsAttrLink.GetDefaultTeMetric()

--- a/internal/gobgp/interface.go
+++ b/internal/gobgp/interface.go
@@ -559,46 +559,33 @@ func getLsLink(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrLink *api.LsAttribute
 	localNode := table.NewLsNode(lsLinkNLRI.GetLocalNode().GetAsn(), lsLinkNLRI.GetLocalNode().GetIgpRouterId())
 	remoteNode := table.NewLsNode(lsLinkNLRI.GetRemoteNode().GetAsn(), lsLinkNLRI.GetRemoteNode().GetIgpRouterId())
 
-	var (
-		err     error
-		localIP netip.Addr
-	)
+	linkDescriptor := lsLinkNLRI.GetLinkDescriptor()
 
-	switch {
-	case lsLinkNLRI.GetLinkDescriptor().GetInterfaceAddrIpv4() != "":
-		localIP, err = netip.ParseAddr(lsLinkNLRI.GetLinkDescriptor().GetInterfaceAddrIpv4())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse local IPv4 address: %w", err)
-		}
-	case lsLinkNLRI.GetLinkDescriptor().GetInterfaceAddrIpv6() != "":
-		localIP, err = netip.ParseAddr(lsLinkNLRI.GetLinkDescriptor().GetInterfaceAddrIpv6())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse local IPv6 address: %w", err)
-		}
-	default:
-		localIP = netip.Addr{}
+	localIPv4, err := parseOptionalAddr(linkDescriptor.GetInterfaceAddrIpv4())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse local IPv4 address: %w", err)
 	}
 
-	var remoteIP netip.Addr
+	localIPv6, err := parseOptionalAddr(linkDescriptor.GetInterfaceAddrIpv6())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse local IPv6 address: %w", err)
+	}
 
-	switch {
-	case lsLinkNLRI.GetLinkDescriptor().GetNeighborAddrIpv4() != "":
-		remoteIP, err = netip.ParseAddr(lsLinkNLRI.GetLinkDescriptor().GetNeighborAddrIpv4())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse remote IPv4 address: %w", err)
-		}
-	case lsLinkNLRI.GetLinkDescriptor().GetNeighborAddrIpv6() != "":
-		remoteIP, err = netip.ParseAddr(lsLinkNLRI.GetLinkDescriptor().GetNeighborAddrIpv6())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse remote IPv6 address: %w", err)
-		}
-	default:
-		remoteIP = netip.Addr{}
+	remoteIPv4, err := parseOptionalAddr(linkDescriptor.GetNeighborAddrIpv4())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse remote IPv4 address: %w", err)
+	}
+
+	remoteIPv6, err := parseOptionalAddr(linkDescriptor.GetNeighborAddrIpv6())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse remote IPv6 address: %w", err)
 	}
 
 	lsLink := table.NewLsLink(localNode, remoteNode)
-	lsLink.LocalIP = localIP
-	lsLink.RemoteIP = remoteIP
+	lsLink.Local.IPv4, lsLink.Local.IPv6 = localIPv4, localIPv6
+	lsLink.Remote.IPv4, lsLink.Remote.IPv6 = remoteIPv4, remoteIPv6
+	lsLink.Local.InterfaceID = linkDescriptor.LinkLocalId
+	lsLink.Remote.InterfaceID = linkDescriptor.LinkRemoteId
 
 	lsLink.Metrics = append(lsLink.Metrics, table.NewMetric(table.IGPMetric, lsAttrLink.GetIgpMetric()))
 
@@ -614,7 +601,10 @@ func getLsLink(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrLink *api.LsAttribute
 		)
 	}
 
-	lsLink.AdjSid = lsAttrLink.GetSrAdjacencySid()
+	// GoBGP does not distinguish IPv4 and IPv6 Adj-SIDs, so leave the family unspecified.
+	if adjSid := lsAttrLink.GetSrAdjacencySid(); adjSid != 0 {
+		lsLink.AdjSids = append(lsLink.AdjSids, table.AdjSID{Family: table.AFUnspecified, Sid: adjSid})
+	}
 
 	if srv6EndXSID := lsAttrLink.GetSrv6EndXSid(); srv6EndXSID != nil {
 		converted, err := srv6EndXSIDFromAPI(srv6EndXSID)
@@ -622,10 +612,24 @@ func getLsLink(typedLinkStateNLRI *api.LsAddrPrefix, lsAttrLink *api.LsAttribute
 			return nil, err
 		}
 
-		lsLink.Srv6EndXSID = converted
+		lsLink.Srv6EndXSIDs = append(lsLink.Srv6EndXSIDs, converted)
 	}
 
 	return lsLink, nil
+}
+
+// parseOptionalAddr returns the zero address for an empty string.
+func parseOptionalAddr(s string) (netip.Addr, error) {
+	if s == "" {
+		return netip.Addr{}, nil
+	}
+
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("parse address %q: %w", s, err)
+	}
+
+	return addr, nil
 }
 
 func srv6EndXSIDFromAPI(srv6EndXSID *api.LsSrv6EndXSID) (*table.Srv6EndXSID, error) {

--- a/internal/gobgp/interface_internal_test.go
+++ b/internal/gobgp/interface_internal_test.go
@@ -486,6 +486,22 @@ func TestGetLsLink(t *testing.T) {
 					}},
 				},
 			},
+			{
+				// IS-IS Multi-Topology uses a Multi-Topology ID to distinguish Link NLRIs
+				// for different topologies (RFC 7752, Section 3.2.1.5).
+				name: "Multi-Topology ID is preserved",
+				desc: &api.LsLinkDescriptor{
+					InterfaceAddrIpv4: "10.0.0.1", NeighborAddrIpv4: "10.0.0.2",
+					MultiTopoId: &api.LsMultiTopologyIdentifier{MultiTopoIds: []uint32{2}},
+				},
+				attr: &api.LsAttributeLink{IgpMetric: 10},
+				want: &table.LsLink{
+					Local:        table.LinkEndpoint{Node: expectedLocal, IPv4: netip.MustParseAddr("10.0.0.1")},
+					Remote:       table.LinkEndpoint{Node: expectedRemote, IPv4: netip.MustParseAddr("10.0.0.2")},
+					Metrics:      []*table.Metric{table.NewMetric(table.IGPMetric, 10)},
+					MultiTopoIDs: map[uint16]struct{}{2: {}},
+				},
+			},
 		}
 
 		for _, tt := range tests {

--- a/internal/gobgp/interface_internal_test.go
+++ b/internal/gobgp/interface_internal_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -396,11 +397,9 @@ func TestGetLsLink(t *testing.T) {
 				desc: &api.LsLinkDescriptor{InterfaceAddrIpv4: "10.0.0.1", NeighborAddrIpv4: "10.0.0.2"},
 				attr: &api.LsAttributeLink{IgpMetric: 10},
 				want: &table.LsLink{
-					LocalNode:  expectedLocal,
-					RemoteNode: expectedRemote,
-					LocalIP:    netip.MustParseAddr("10.0.0.1"),
-					RemoteIP:   netip.MustParseAddr("10.0.0.2"),
-					Metrics:    []*table.Metric{table.NewMetric(table.IGPMetric, 10)},
+					Local:   table.LinkEndpoint{Node: expectedLocal, IPv4: netip.MustParseAddr("10.0.0.1")},
+					Remote:  table.LinkEndpoint{Node: expectedRemote, IPv4: netip.MustParseAddr("10.0.0.2")},
+					Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, 10)},
 				},
 			},
 			{
@@ -413,16 +412,50 @@ func TestGetLsLink(t *testing.T) {
 					SrAdjacencySid:          12345,
 				},
 				want: &table.LsLink{
-					LocalNode:  expectedLocal,
-					RemoteNode: expectedRemote,
-					LocalIP:    netip.MustParseAddr("2001:db8::1"),
-					RemoteIP:   netip.MustParseAddr("2001:db8::2"),
+					Local:  table.LinkEndpoint{Node: expectedLocal, IPv6: netip.MustParseAddr("2001:db8::1")},
+					Remote: table.LinkEndpoint{Node: expectedRemote, IPv6: netip.MustParseAddr("2001:db8::2")},
 					Metrics: []*table.Metric{
 						table.NewMetric(table.IGPMetric, 10),
 						table.NewMetric(table.TEMetric, 20),
 						table.NewMetric(table.DelayMetric, 30),
 					},
-					AdjSid: 12345,
+					AdjSids: []table.AdjSID{{Family: table.AFUnspecified, Sid: 12345}},
+				},
+			},
+			{
+				name: "dual-stack link keeps both IPv4 and IPv6 addresses",
+				desc: &api.LsLinkDescriptor{
+					InterfaceAddrIpv4: "10.0.0.1", NeighborAddrIpv4: "10.0.0.2",
+					InterfaceAddrIpv6: "2001:db8::1", NeighborAddrIpv6: "2001:db8::2",
+				},
+				attr: &api.LsAttributeLink{IgpMetric: 10},
+				want: &table.LsLink{
+					Local: table.LinkEndpoint{
+						Node: expectedLocal,
+						IPv4: netip.MustParseAddr("10.0.0.1"), IPv6: netip.MustParseAddr("2001:db8::1"),
+					},
+					Remote: table.LinkEndpoint{
+						Node: expectedRemote,
+						IPv4: netip.MustParseAddr("10.0.0.2"), IPv6: netip.MustParseAddr("2001:db8::2"),
+					},
+					Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, 10)},
+				},
+			},
+			{
+				name: "link-local IDs are preserved",
+				desc: &api.LsLinkDescriptor{
+					InterfaceAddrIpv6: "fe80::1", NeighborAddrIpv6: "fe80::2",
+					LinkLocalId: proto.Uint32(7), LinkRemoteId: proto.Uint32(8),
+				},
+				attr: &api.LsAttributeLink{IgpMetric: 10},
+				want: &table.LsLink{
+					Local: table.LinkEndpoint{
+						Node: expectedLocal, IPv6: netip.MustParseAddr("fe80::1"), InterfaceID: proto.Uint32(7),
+					},
+					Remote: table.LinkEndpoint{
+						Node: expectedRemote, IPv6: netip.MustParseAddr("fe80::2"), InterfaceID: proto.Uint32(8),
+					},
+					Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, 10)},
 				},
 			},
 			{
@@ -437,16 +470,14 @@ func TestGetLsLink(t *testing.T) {
 					},
 				},
 				want: &table.LsLink{
-					LocalNode:  expectedLocal,
-					RemoteNode: expectedRemote,
-					LocalIP:    netip.Addr{},
-					RemoteIP:   netip.Addr{},
-					Metrics:    []*table.Metric{table.NewMetric(table.IGPMetric, 5)},
-					Srv6EndXSID: &table.Srv6EndXSID{
+					Local:   table.LinkEndpoint{Node: expectedLocal},
+					Remote:  table.LinkEndpoint{Node: expectedRemote},
+					Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, 5)},
+					Srv6EndXSIDs: []*table.Srv6EndXSID{{
 						EndpointBehavior: table.BehaviorENDX,
 						Sids:             []string{testSrv6EndXSID},
 						Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
-					},
+					}},
 				},
 			},
 		}
@@ -802,7 +833,7 @@ func TestGetLsSrv6SID_LocatorRegistrationEndToEnd(t *testing.T) {
 
 	idx := table.NewSIDIndex(ted)
 
-	container := table.NewSegmentSRv6(netip.MustParseAddr("fc00:1::99"))
+	container := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00:1::99")))
 	container.USid = true
 	assert.True(t, idx.Has(container), "expected the /32 locator to be registered despite LocalNode being 0")
 }

--- a/internal/gobgp/interface_internal_test.go
+++ b/internal/gobgp/interface_internal_test.go
@@ -465,6 +465,9 @@ func TestGetLsLink(t *testing.T) {
 					IgpMetric: 5,
 					Srv6EndXSid: &api.LsSrv6EndXSID{
 						EndpointBehavior: uint32(table.BehaviorENDX),
+						Flags:            0xC0,
+						Algorithm:        128,
+						Weight:           7,
 						Sids:             []string{testSrv6EndXSID},
 						Srv6SidStructure: &api.LsSrv6SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 					},
@@ -474,7 +477,10 @@ func TestGetLsLink(t *testing.T) {
 					Remote:  table.LinkEndpoint{Node: expectedRemote},
 					Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, 5)},
 					Srv6EndXSIDs: []*table.Srv6EndXSID{{
-						EndpointBehavior: table.BehaviorENDX,
+						EndpointBehavior: table.EndpointBehavior{
+							Behavior: table.BehaviorENDX, Flags: 0xC0, Algorithm: 128,
+						},
+						Weight:           7,
 						Sids:             []string{testSrv6EndXSID},
 						Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 					}},
@@ -567,25 +573,46 @@ func TestSrv6EndXSIDFromAPI(t *testing.T) {
 
 		got, err := srv6EndXSIDFromAPI(&api.LsSrv6EndXSID{
 			EndpointBehavior: uint32(table.BehaviorENDX),
+			Flags:            0xC0,
+			Algorithm:        128,
+			Weight:           7,
 			Sids:             []string{testSrv6EndXSID},
 			Srv6SidStructure: validStructure,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, &table.Srv6EndXSID{
-			EndpointBehavior: table.BehaviorENDX,
+			EndpointBehavior: table.EndpointBehavior{
+				Behavior: table.BehaviorENDX, Flags: 0xC0, Algorithm: 128,
+			},
+			Weight:           7,
 			Sids:             []string{testSrv6EndXSID},
 			Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 		}, got)
 	})
 
-	t.Run("endpoint behavior overflow", func(t *testing.T) {
+	t.Run("out-of-range fields are rejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := srv6EndXSIDFromAPI(&api.LsSrv6EndXSID{
-			EndpointBehavior: math.MaxUint16 + 1,
-			Srv6SidStructure: validStructure,
-		})
-		require.Error(t, err)
+		tests := []struct {
+			name string
+			sid  *api.LsSrv6EndXSID
+		}{
+			{"endpoint behavior", &api.LsSrv6EndXSID{EndpointBehavior: math.MaxUint16 + 1}},
+			{"flags", &api.LsSrv6EndXSID{Flags: math.MaxUint8 + 1}},
+			{"algorithm", &api.LsSrv6EndXSID{Algorithm: math.MaxUint8 + 1}},
+			{"weight", &api.LsSrv6EndXSID{Weight: math.MaxUint8 + 1}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				tt.sid.Srv6SidStructure = validStructure
+
+				_, err := srv6EndXSIDFromAPI(tt.sid)
+				require.Error(t, err)
+			})
+		}
 	})
 
 	t.Run("SID structure overflow propagates", func(t *testing.T) {
@@ -607,7 +634,7 @@ func TestSrv6EndXSIDFromAPI(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, &table.Srv6EndXSID{
-			EndpointBehavior: table.BehaviorENDX,
+			EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorENDX},
 			Sids:             []string{testSrv6EndXSID},
 		}, got)
 	})

--- a/pkg/cspf/cspf.go
+++ b/pkg/cspf/cspf.go
@@ -169,13 +169,13 @@ func buildWaypointSegment(node *table.LsNode, explicitSID string) (table.Segment
 		if err != nil {
 			return nil, invalidInputf("invalid explicit SID %q: %w", explicitSID, err)
 		}
-		// Explicit SID must be an IPv6 address.
-		addr = addr.Unmap()
-		if !addr.Is6() {
+		// Explicit SID must be an IPv6 SRv6 SID.
+		sid, err := table.ParseSRv6SID(addr.Unmap().String())
+		if err != nil {
 			return nil, invalidInputf("explicit SID %q must be an IPv6 SRv6 SID", explicitSID)
 		}
 
-		seg, err := table.NewSegmentSRv6WithNodeInfo(addr, node)
+		seg, err := table.NewSegmentSRv6WithNodeInfo(sid, node)
 		if err != nil {
 			return nil, topologyLimitationf(reasonTEDDataIncomplete, "%w", err)
 		}
@@ -183,9 +183,25 @@ func buildWaypointSegment(node *table.LsNode, explicitSID string) (table.Segment
 		return seg, nil
 	}
 
-	seg, err := node.NodeSegment()
+	seg, err := nodeSegment(node)
 	if err != nil {
 		return nil, topologyLimitationf(reasonTEDDataIncomplete, "%w", err)
+	}
+
+	return seg, nil
+}
+
+// nodeSegment builds a Segment using the node's unambiguous default plane.
+// CSPF does not yet accept an explicit plane from its caller.
+func nodeSegment(node *table.LsNode) (table.Segment, error) {
+	plane, err := node.DefaultPlane()
+	if err != nil {
+		return nil, fmt.Errorf("get default plane: %w", err)
+	}
+
+	seg, err := node.NodeSegment(plane)
+	if err != nil {
+		return nil, fmt.Errorf("build node segment: %w", err)
 	}
 
 	return seg, nil
@@ -257,7 +273,7 @@ func initNodeMap(srcRouterID string, network map[string]*table.LsNode) (map[stri
 		return nil, invalidInputf("source router %s not found in TED", srcRouterID)
 	}
 
-	startNodeSeg, err := srcNode.NodeSegment()
+	startNodeSeg, err := nodeSegment(srcNode)
 	if err != nil {
 		return nil, topologyLimitationf(reasonTEDDataIncomplete, "%w", err)
 	}
@@ -276,11 +292,13 @@ func updateNeighborCosts(calcNodeID string, calculatingNodes map[string]*node, n
 	}
 
 	for _, link := range calcNode.Links {
-		if link == nil || link.RemoteNode == nil {
+		if link == nil || link.Remote.Node == nil {
 			continue
 		}
 
-		if _, ok := nodeInTED(network, link.RemoteNode.RouterID); !ok {
+		remoteRouterID := link.Remote.Node.RouterID
+
+		if _, ok := nodeInTED(network, remoteRouterID); !ok {
 			continue
 		}
 
@@ -289,20 +307,20 @@ func updateNeighborCosts(calcNodeID string, calculatingNodes map[string]*node, n
 			return topologyLimitationf(reasonMetricNotCarried, "%w", err)
 		}
 
-		if remoteNode, exists := calculatingNodes[link.RemoteNode.RouterID]; exists {
+		if remoteNode, exists := calculatingNodes[remoteRouterID]; exists {
 			if calculatingNodes[calcNodeID].cost+metric < remoteNode.cost {
 				remoteNode.cost = calculatingNodes[calcNodeID].cost + metric
 				remoteNode.prevNode = calcNodeID
 			}
 		} else {
-			remoteNodeSeg, err := link.RemoteNode.NodeSegment()
+			remoteNodeSeg, err := nodeSegment(link.Remote.Node)
 			if err != nil {
 				return topologyLimitationf(reasonTEDDataIncomplete, "%w", err)
 			}
 
-			remoteNode := newNode(link.RemoteNode.RouterID, calculatingNodes[calcNodeID].cost+metric, remoteNodeSeg)
+			remoteNode := newNode(remoteRouterID, calculatingNodes[calcNodeID].cost+metric, remoteNodeSeg)
 			remoteNode.prevNode = calcNodeID
-			calculatingNodes[link.RemoteNode.RouterID] = remoteNode
+			calculatingNodes[remoteRouterID] = remoteNode
 		}
 	}
 

--- a/pkg/cspf/cspf.go
+++ b/pkg/cspf/cspf.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"strconv"
 
 	"github.com/nttcom/pola/pkg/table"
 )
@@ -47,6 +48,12 @@ const (
 
 const errNextNodeNotFound = "next node not found"
 
+// PathScope constrains path computation to a single underlay plane.
+// The plane must be fully specified; no implicit default is used.
+type PathScope struct {
+	Plane table.Plane
+}
+
 type node struct {
 	id          string
 	calculated  bool
@@ -63,7 +70,6 @@ func newNode(id string, cost uint32, nodeSeg table.Segment) *node {
 	}
 }
 
-// validateMetricType rejects metric types that cannot be used for path computation.
 func validateMetricType(metric table.MetricType) error {
 	if !metric.IsValid() {
 		return invalidInputf("unsupported metric type %d", int(metric))
@@ -76,8 +82,8 @@ func validateMetricType(metric table.MetricType) error {
 	return nil
 }
 
-// CSPF computes the shortest path from srcRouterID to dstRouterID using the given metric.
-func CSPF(srcRouterID, dstRouterID string, metric table.MetricType, ted *table.LsTED) ([]table.Segment, error) {
+// CSPF computes the shortest path from srcRouterID to dstRouterID using the given metric and scope.
+func CSPF(srcRouterID, dstRouterID string, metric table.MetricType, scope PathScope, ted *table.LsTED) ([]table.Segment, error) {
 	if ted == nil {
 		return nil, errors.New("ted is nil")
 	}
@@ -86,7 +92,11 @@ func CSPF(srcRouterID, dstRouterID string, metric table.MetricType, ted *table.L
 		return nil, err
 	}
 
-	segmentList, err := spf(srcRouterID, dstRouterID, metric, ted.Nodes)
+	if err := scope.Plane.Validate(); err != nil {
+		return nil, invalidInputf("invalid scope: %w", err)
+	}
+
+	segmentList, err := spf(srcRouterID, dstRouterID, metric, scope, ted.Nodes)
 	if err != nil {
 		return nil, err
 	}
@@ -99,6 +109,7 @@ func WithLooseSourceRouting(
 	src, dst string,
 	waypoints []table.Waypoint,
 	metric table.MetricType,
+	scope PathScope,
 	ted *table.LsTED,
 ) ([]table.Segment, error) {
 	if ted == nil {
@@ -107,6 +118,10 @@ func WithLooseSourceRouting(
 
 	if err := validateMetricType(metric); err != nil {
 		return nil, err
+	}
+
+	if err := scope.Plane.Validate(); err != nil {
+		return nil, invalidInputf("invalid scope: %w", err)
 	}
 
 	// Validate waypoints before computing any section.
@@ -123,7 +138,7 @@ func WithLooseSourceRouting(
 	allWaypoints := append(append([]table.Waypoint{}, waypoints...), table.Waypoint{RouterID: dst})
 
 	for _, wp := range allWaypoints {
-		sectionSegs, seg, err := buildSectionSegments(prev, wp, metric, ted, fullList)
+		sectionSegs, seg, err := buildSectionSegments(prev, wp, metric, scope, ted, fullList)
 		if err != nil {
 			return nil, err
 		}
@@ -136,15 +151,15 @@ func WithLooseSourceRouting(
 	return fullList, nil
 }
 
-// buildSectionSegments calculates CSPF to waypoint and builds the waypoint segment.
 func buildSectionSegments(
 	prev string,
 	wp table.Waypoint,
 	metric table.MetricType,
+	scope PathScope,
 	ted *table.LsTED,
 	fullList []table.Segment,
 ) (sectionSegs []table.Segment, waypointSeg table.Segment, err error) {
-	sectionSegs, err = CSPF(prev, wp.RouterID, metric, ted)
+	sectionSegs, err = CSPF(prev, wp.RouterID, metric, scope, ted)
 	if err != nil {
 		return nil, nil, fmt.Errorf("CSPF failed between %s and %s: %w", prev, wp.RouterID, err)
 	}
@@ -154,7 +169,7 @@ func buildSectionSegments(
 	// Existence is guaranteed by the CSPF call above.
 	node, _ := nodeInTED(ted.Nodes, wp.RouterID)
 
-	waypointSeg, err = buildWaypointSegment(node, wp.SID)
+	waypointSeg, err = buildWaypointSegment(node, wp.SID, scope)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build segment for waypoint %s: %w", wp.RouterID, err)
 	}
@@ -162,17 +177,32 @@ func buildSectionSegments(
 	return sectionSegs, waypointSeg, nil
 }
 
-// buildWaypointSegment builds a Segment for a waypoint using the node and optional explicit SID.
-func buildWaypointSegment(node *table.LsNode, explicitSID string) (table.Segment, error) {
+func buildWaypointSegment(node *table.LsNode, explicitSID string, scope PathScope) (table.Segment, error) {
 	if explicitSID != "" {
+		return buildExplicitWaypointSegment(node, explicitSID, scope)
+	}
+
+	seg, err := node.NodeSegment(scope.Plane)
+	if err != nil {
+		return nil, topologyLimitationf(reasonTEDDataIncomplete, "%w", err)
+	}
+
+	return seg, nil
+}
+
+// buildExplicitWaypointSegment parses and validates an explicit waypoint SID
+// according to the scope's data plane.
+func buildExplicitWaypointSegment(node *table.LsNode, explicitSID string, scope PathScope) (table.Segment, error) {
+	switch scope.Plane.DataPlane {
+	case table.DPSRv6:
 		addr, err := netip.ParseAddr(explicitSID)
 		if err != nil {
 			return nil, invalidInputf("invalid explicit SID %q: %w", explicitSID, err)
 		}
-		// Explicit SID must be an IPv6 SRv6 SID.
+
 		sid, err := table.ParseSRv6SID(addr.Unmap().String())
 		if err != nil {
-			return nil, invalidInputf("explicit SID %q must be an IPv6 SRv6 SID", explicitSID)
+			return nil, invalidInputf("explicit SID %q must be an IPv6 SRv6 SID: %w", explicitSID, err)
 		}
 
 		seg, err := table.NewSegmentSRv6WithNodeInfo(sid, node)
@@ -181,33 +211,22 @@ func buildWaypointSegment(node *table.LsNode, explicitSID string) (table.Segment
 		}
 
 		return seg, nil
-	}
+	case table.DPSRMPLS:
+		label, err := strconv.ParseUint(explicitSID, 10, 32)
+		if err != nil {
+			return nil, invalidInputf("invalid explicit SID %q: %w", explicitSID, err)
+		}
 
-	seg, err := nodeSegment(node)
-	if err != nil {
-		return nil, topologyLimitationf(reasonTEDDataIncomplete, "%w", err)
-	}
+		if label > uint64(table.MPLSLabelMax) {
+			return nil, invalidInputf("explicit SID %q exceeds the maximum SR-MPLS label %d", explicitSID, table.MPLSLabelMax)
+		}
 
-	return seg, nil
+		return table.NewSegmentSRMPLS(uint32(label)), nil
+	default:
+		return nil, invalidInputf("data plane must be specified to build a waypoint segment")
+	}
 }
 
-// nodeSegment builds a Segment using the node's unambiguous default plane.
-// CSPF does not yet accept an explicit plane from its caller.
-func nodeSegment(node *table.LsNode) (table.Segment, error) {
-	plane, err := node.DefaultPlane()
-	if err != nil {
-		return nil, fmt.Errorf("get default plane: %w", err)
-	}
-
-	seg, err := node.NodeSegment(plane)
-	if err != nil {
-		return nil, fmt.Errorf("build node segment: %w", err)
-	}
-
-	return seg, nil
-}
-
-// removeDuplicateFirst removes the first segment of section if it equals the last of fullList.
 func removeDuplicateFirst(fullList, section []table.Segment) []table.Segment {
 	if len(fullList) > 0 && len(section) > 0 && table.SegmentsEqual(fullList[len(fullList)-1], section[0]) {
 		return section[1:]
@@ -216,7 +235,6 @@ func removeDuplicateFirst(fullList, section []table.Segment) []table.Segment {
 	return section
 }
 
-// appendIfNotDuplicate appends a segment to the list if it is not equal to the last segment.
 func appendIfNotDuplicate(list []table.Segment, seg table.Segment) []table.Segment {
 	if len(list) == 0 || !table.SegmentsEqual(list[len(list)-1], seg) {
 		list = append(list, seg)
@@ -225,8 +243,8 @@ func appendIfNotDuplicate(list []table.Segment, seg table.Segment) []table.Segme
 	return list
 }
 
-func spf(srcRouterID, dstRouterID string, metricType table.MetricType, network map[string]*table.LsNode) ([]table.Segment, error) {
-	calculatingNodes, err := initNodeMap(srcRouterID, network)
+func spf(srcRouterID, dstRouterID string, metricType table.MetricType, scope PathScope, network map[string]*table.LsNode) ([]table.Segment, error) {
+	calculatingNodes, err := initNodeMap(srcRouterID, scope, network)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +253,6 @@ func spf(srcRouterID, dstRouterID string, metricType table.MetricType, network m
 		return nil, invalidInputf("destination router %s not found in TED", dstRouterID)
 	}
 
-	// Keep calculating the shortest path until the destination node is reached.
 	for {
 		calcNodeID, err := nextNode(calculatingNodes)
 		if err != nil {
@@ -246,7 +263,7 @@ func spf(srcRouterID, dstRouterID string, metricType table.MetricType, network m
 			break
 		}
 
-		if err := updateNeighborCosts(calcNodeID, calculatingNodes, network, metricType); err != nil {
+		if err := updateNeighborCosts(calcNodeID, calculatingNodes, network, metricType, scope); err != nil {
 			return nil, err
 		}
 
@@ -256,7 +273,6 @@ func spf(srcRouterID, dstRouterID string, metricType table.MetricType, network m
 	return buildSegmentListFromPath(srcRouterID, dstRouterID, calculatingNodes), nil
 }
 
-// nodeInTED returns the node for routerID if it exists and is non-nil.
 func nodeInTED(network map[string]*table.LsNode, routerID string) (*table.LsNode, bool) {
 	node, ok := network[routerID]
 	if !ok || node == nil {
@@ -266,14 +282,13 @@ func nodeInTED(network map[string]*table.LsNode, routerID string) (*table.LsNode
 	return node, true
 }
 
-// initNodeMap initializes the map of nodes used for SPF calculation.
-func initNodeMap(srcRouterID string, network map[string]*table.LsNode) (map[string]*node, error) {
+func initNodeMap(srcRouterID string, scope PathScope, network map[string]*table.LsNode) (map[string]*node, error) {
 	srcNode, ok := nodeInTED(network, srcRouterID)
 	if !ok {
 		return nil, invalidInputf("source router %s not found in TED", srcRouterID)
 	}
 
-	startNodeSeg, err := nodeSegment(srcNode)
+	startNodeSeg, err := srcNode.NodeSegment(scope.Plane)
 	if err != nil {
 		return nil, topologyLimitationf(reasonTEDDataIncomplete, "%w", err)
 	}
@@ -284,8 +299,22 @@ func initNodeMap(srcRouterID string, network map[string]*table.LsNode) (map[stri
 	return map[string]*node{srcRouterID: startNode}, nil
 }
 
-// updateNeighborCosts updates costs for neighbors of the given node in SPF calculation.
-func updateNeighborCosts(calcNodeID string, calculatingNodes map[string]*node, network map[string]*table.LsNode, metricType table.MetricType) error {
+// linkUsable is the sole edge filter for path computation.
+// Unnumbered links remain usable; otherwise both endpoints must support the scope's family.
+func linkUsable(link *table.LsLink, scope PathScope) bool {
+	if link.Families().Has(scope.Plane.Family) {
+		return true
+	}
+
+	return linkUnnumbered(link)
+}
+
+func linkUnnumbered(link *table.LsLink) bool {
+	return !link.Local.IPv4.IsValid() && !link.Local.IPv6.IsValid() &&
+		!link.Remote.IPv4.IsValid() && !link.Remote.IPv6.IsValid()
+}
+
+func updateNeighborCosts(calcNodeID string, calculatingNodes map[string]*node, network map[string]*table.LsNode, metricType table.MetricType, scope PathScope) error {
 	calcNode, ok := nodeInTED(network, calcNodeID)
 	if !ok {
 		return topologyLimitationf(reasonTEDDataIncomplete, "router %s not found in TED", calcNodeID)
@@ -293,6 +322,10 @@ func updateNeighborCosts(calcNodeID string, calculatingNodes map[string]*node, n
 
 	for _, link := range calcNode.Links {
 		if link == nil || link.Remote.Node == nil {
+			continue
+		}
+
+		if !linkUsable(link, scope) {
 			continue
 		}
 
@@ -313,7 +346,7 @@ func updateNeighborCosts(calcNodeID string, calculatingNodes map[string]*node, n
 				remoteNode.prevNode = calcNodeID
 			}
 		} else {
-			remoteNodeSeg, err := nodeSegment(link.Remote.Node)
+			remoteNodeSeg, err := link.Remote.Node.NodeSegment(scope.Plane)
 			if err != nil {
 				return topologyLimitationf(reasonTEDDataIncomplete, "%w", err)
 			}
@@ -327,14 +360,12 @@ func updateNeighborCosts(calcNodeID string, calculatingNodes map[string]*node, n
 	return nil
 }
 
-// buildSegmentListFromPath builds the segment list from SPF results.
 func buildSegmentListFromPath(srcRouterID, dstRouterID string, calculatingNodes map[string]*node) []table.Segment {
 	segmentList := []table.Segment{}
 	for pathNode := calculatingNodes[dstRouterID]; pathNode.id != srcRouterID; pathNode = calculatingNodes[pathNode.prevNode] {
 		segmentList = append(segmentList, pathNode.nodeSegment)
 	}
 
-	// Reverse the segment list to get correct order from src → dst
 	for i, j := 0, len(segmentList)-1; i < j; i, j = i+1, j-1 {
 		segmentList[i], segmentList[j] = segmentList[j], segmentList[i]
 	}
@@ -342,7 +373,6 @@ func buildSegmentListFromPath(srcRouterID, dstRouterID string, calculatingNodes 
 	return segmentList
 }
 
-// nextNode returns the ID of the next node to calculate.
 func nextNode(calculatingNodes map[string]*node) (string, error) {
 	nextNodeID := ""
 

--- a/pkg/cspf/cspf.go
+++ b/pkg/cspf/cspf.go
@@ -300,9 +300,9 @@ func initNodeMap(srcRouterID string, scope PathScope, network map[string]*table.
 }
 
 // linkUsable is the sole edge filter for path computation.
-// Unnumbered links remain usable; otherwise both endpoints must support the scope's family.
+// Unnumbered links are considered usable.
 func linkUsable(link *table.LsLink, scope PathScope) bool {
-	if link.Families().Has(scope.Plane.Family) {
+	if link.UsableForFamily(scope.Plane.Family) {
 		return true
 	}
 

--- a/pkg/cspf/cspf_internal_test.go
+++ b/pkg/cspf/cspf_internal_test.go
@@ -291,8 +291,6 @@ func TestUpdateNeighborCosts_UnknownCalcNode(t *testing.T) {
 	assert.EqualError(t, err, "router Z not found in TED")
 }
 
-// TestLinkUsable covers U9: linkUsable is the sole edge filter, gating strictly
-// on whether the link carries the scope's address family on both endpoints.
 func TestLinkUsable(t *testing.T) {
 	t.Parallel()
 
@@ -342,6 +340,12 @@ func TestLinkUsable(t *testing.T) {
 			link:  &table.LsLink{Local: table.LinkEndpoint{Node: a, IPv4: cspfInternalTestLocalIPv4}, Remote: table.LinkEndpoint{Node: b}},
 			scope: cspfInternalTestScopeV4SRMPLS,
 			want:  false,
+		},
+		{
+			name:  "an unnumbered link with no address in either family is usable under any scope",
+			link:  &table.LsLink{Local: table.LinkEndpoint{Node: a}, Remote: table.LinkEndpoint{Node: b}},
+			scope: cspfInternalTestScopeV6SRv6,
+			want:  true,
 		},
 	}
 
@@ -463,6 +467,13 @@ func TestBuildWaypointSegment(t *testing.T) {
 			explicitSID: "::ffff:10.0.0.1",
 			scope:       cspfInternalTestScopeV6SRv6,
 			wantErr:     `explicit SID "::ffff:10.0.0.1" must be an IPv6 SRv6 SID`,
+		},
+		{
+			name:        "explicit SID with an unspecified data plane is rejected",
+			node:        cspfInternalTestSRv6Node(),
+			explicitSID: cspfInternalTestOverrideSID,
+			scope:       PathScope{Plane: table.Plane{Family: table.AFIPv6}},
+			wantErr:     "data plane must be specified to build a waypoint segment",
 		},
 	}
 

--- a/pkg/cspf/cspf_internal_test.go
+++ b/pkg/cspf/cspf_internal_test.go
@@ -26,7 +26,7 @@ func cspfInternalTestSRMPLSNode(routerID string, sidIndex uint32) *table.LsNode 
 		RouterID:  routerID,
 		SrgbBegin: 16000,
 		Prefixes: []*table.LsPrefix{
-			{SidIndex: sidIndex, HasSidIndex: true},
+			{Prefix: netip.MustParsePrefix("192.0.2.1/32"), SidIndex: sidIndex, HasSidIndex: true},
 		},
 	}
 }
@@ -52,8 +52,9 @@ func cspfInternalTestSRv6DefaultSeg(sid string) table.SegmentSRv6 {
 	addr := netip.MustParseAddr(sid)
 
 	return table.SegmentSRv6{
-		Sid:       addr,
+		Sid:       table.SRv6SID(addr),
 		LocalAddr: addr,
+		Behavior:  table.BehaviorEND,
 		Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 	}
 }
@@ -64,9 +65,9 @@ func cspfInternalTestNodeWithoutSID(routerID string) *table.LsNode {
 
 func cspfInternalTestConnect(local, remote *table.LsNode) {
 	local.Links = append(local.Links, &table.LsLink{
-		LocalNode:  local,
-		RemoteNode: remote,
-		Metrics:    []*table.Metric{table.NewMetric(table.IGPMetric, 1)},
+		Local:   table.LinkEndpoint{Node: local},
+		Remote:  table.LinkEndpoint{Node: remote},
+		Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, 1)},
 	})
 }
 
@@ -109,7 +110,7 @@ func TestCSPF_Errors(t *testing.T) {
 				return cspfInternalTestBuildTED(a, b)
 			},
 			src: "A", dst: "B", metric: table.IGPMetric,
-			wantErr: "node doesn't have a Node SID",
+			wantErr: "get default plane: node doesn't have a Node SID",
 		},
 		{
 			name: "a newly discovered neighbor has no Node SID",
@@ -120,7 +121,7 @@ func TestCSPF_Errors(t *testing.T) {
 				return cspfInternalTestBuildTED(a, b)
 			},
 			src: "A", dst: "B", metric: table.IGPMetric,
-			wantErr: "node doesn't have a Node SID",
+			wantErr: "get default plane: node doesn't have a Node SID",
 		},
 		{
 			name: "destination router is absent from the TED",
@@ -180,7 +181,7 @@ func TestCSPF_Errors(t *testing.T) {
 			name: "a link with a nil remote node is skipped instead of panicking",
 			buildTED: func() *table.LsTED {
 				a, d := cspfInternalTestSRMPLSNode("A", 0), cspfInternalTestSRMPLSNode("D", 3)
-				a.Links = append(a.Links, &table.LsLink{LocalNode: a, RemoteNode: nil})
+				a.Links = append(a.Links, &table.LsLink{Local: table.LinkEndpoint{Node: a}})
 
 				return cspfInternalTestBuildTED(a, d)
 			},
@@ -286,8 +287,9 @@ func TestBuildWaypointSegment(t *testing.T) {
 			node:        cspfInternalTestSRv6Node(),
 			explicitSID: cspfInternalTestOverrideSID,
 			want: table.SegmentSRv6{
-				Sid:       netip.MustParseAddr(cspfInternalTestOverrideSID),
+				Sid:       table.SRv6SID(netip.MustParseAddr(cspfInternalTestOverrideSID)),
 				LocalAddr: netip.MustParseAddr("2001:db8::a"),
+				Behavior:  table.BehaviorEND,
 				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 			},
 		},
@@ -306,8 +308,9 @@ func TestBuildWaypointSegment(t *testing.T) {
 			},
 			explicitSID: cspfInternalTestOverrideSID,
 			want: table.SegmentSRv6{
-				Sid:       netip.MustParseAddr(cspfInternalTestOverrideSID),
+				Sid:       table.SRv6SID(netip.MustParseAddr(cspfInternalTestOverrideSID)),
 				LocalAddr: netip.MustParseAddr("2001:db8::a"),
+				Behavior:  table.BehaviorUN,
 				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 				USid:      true,
 			},

--- a/pkg/cspf/cspf_internal_test.go
+++ b/pkg/cspf/cspf_internal_test.go
@@ -21,6 +21,19 @@ const (
 	cspfInternalTestOverrideSID   = "2001:db8::ffff"
 )
 
+var (
+	cspfInternalTestScopeV4SRMPLS = PathScope{Plane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS}}
+	cspfInternalTestScopeV6SRMPLS = PathScope{Plane: table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRMPLS}}
+	cspfInternalTestScopeV6SRv6   = PathScope{Plane: table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRv6}}
+)
+
+var (
+	cspfInternalTestLocalIPv4  = netip.MustParseAddr("192.0.2.101")
+	cspfInternalTestRemoteIPv4 = netip.MustParseAddr("192.0.2.102")
+	cspfInternalTestLocalIPv6  = netip.MustParseAddr("2001:db8:f::1")
+	cspfInternalTestRemoteIPv6 = netip.MustParseAddr("2001:db8:f::2")
+)
+
 func cspfInternalTestSRMPLSNode(routerID string, sidIndex uint32) *table.LsNode {
 	return &table.LsNode{
 		RouterID:  routerID,
@@ -59,14 +72,27 @@ func cspfInternalTestSRv6DefaultSeg(sid string) table.SegmentSRv6 {
 	}
 }
 
+// cspfInternalTestDualStackSRMPLSNode advertises independent IPv4 and IPv6
+// Prefix-SIDs so a test can tell which family's label was resolved.
+func cspfInternalTestDualStackSRMPLSNode(routerID string, v4SidIndex, v6SidIndex uint32) *table.LsNode {
+	return &table.LsNode{
+		RouterID:  routerID,
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("192.0.2.1/32"), SidIndex: v4SidIndex, HasSidIndex: true},
+			{Prefix: netip.MustParsePrefix("2001:db8::1/128"), SidIndex: v6SidIndex, HasSidIndex: true},
+		},
+	}
+}
+
 func cspfInternalTestNodeWithoutSID(routerID string) *table.LsNode {
 	return &table.LsNode{RouterID: routerID}
 }
 
 func cspfInternalTestConnect(local, remote *table.LsNode) {
 	local.Links = append(local.Links, &table.LsLink{
-		Local:   table.LinkEndpoint{Node: local},
-		Remote:  table.LinkEndpoint{Node: remote},
+		Local:   table.LinkEndpoint{Node: local, IPv4: cspfInternalTestLocalIPv4},
+		Remote:  table.LinkEndpoint{Node: remote, IPv4: cspfInternalTestRemoteIPv4},
 		Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, 1)},
 	})
 }
@@ -110,7 +136,7 @@ func TestCSPF_Errors(t *testing.T) {
 				return cspfInternalTestBuildTED(a, b)
 			},
 			src: "A", dst: "B", metric: table.IGPMetric,
-			wantErr: "get default plane: node doesn't have a Node SID",
+			wantErr: "node doesn't have a ipv4 Prefix-SID",
 		},
 		{
 			name: "a newly discovered neighbor has no Node SID",
@@ -121,7 +147,7 @@ func TestCSPF_Errors(t *testing.T) {
 				return cspfInternalTestBuildTED(a, b)
 			},
 			src: "A", dst: "B", metric: table.IGPMetric,
-			wantErr: "get default plane: node doesn't have a Node SID",
+			wantErr: "node doesn't have a ipv4 Prefix-SID",
 		},
 		{
 			name: "destination router is absent from the TED",
@@ -195,7 +221,7 @@ func TestCSPF_Errors(t *testing.T) {
 			t.Parallel()
 
 			ted := tt.buildTED()
-			got, err := CSPF(tt.src, tt.dst, tt.metric, ted)
+			got, err := CSPF(tt.src, tt.dst, tt.metric, cspfInternalTestScopeV4SRMPLS, ted)
 			assert.Nil(t, got)
 			assert.EqualError(t, err, tt.wantErr)
 		})
@@ -218,17 +244,30 @@ func TestCSPF_TopologyLimitationClassification(t *testing.T) {
 		wantReason string
 	}{
 		{"an unreachable destination", func() error {
-			_, err := CSPF("A", "B", table.IGPMetric, cspfInternalTestBuildTED(cspfInternalTestSRMPLSNode("A", 0), cspfInternalTestSRMPLSNode("B", 1)))
+			_, err := CSPF("A", "B", table.IGPMetric, cspfInternalTestScopeV4SRMPLS, cspfInternalTestBuildTED(cspfInternalTestSRMPLSNode("A", 0), cspfInternalTestSRMPLSNode("B", 1)))
 			return err
 		}, reasonDestinationUnreachable},
-		{"a metric absent from a traversed link", func() error { _, err := CSPF("A", "B", table.TEMetric, linear()); return err }, reasonMetricNotCarried},
+		{"a metric absent from a traversed link", func() error {
+			_, err := CSPF("A", "B", table.TEMetric, cspfInternalTestScopeV4SRMPLS, linear())
+			return err
+		}, reasonMetricNotCarried},
 		{"a node without a Node SID", func() error {
 			a, b := cspfInternalTestNodeWithoutSID("A"), cspfInternalTestSRMPLSNode("B", 0)
 			cspfInternalTestConnect(a, b)
-			_, err := CSPF("A", "B", table.IGPMetric, cspfInternalTestBuildTED(a, b))
+			_, err := CSPF("A", "B", table.IGPMetric, cspfInternalTestScopeV4SRMPLS, cspfInternalTestBuildTED(a, b))
 
 			return err
 		}, reasonTEDDataIncomplete},
+		{"a scope address family absent from every link", func() error {
+			// Both nodes have a viable IPv6 segment; only the link is IPv4-only,
+			// isolating the edge filter from node-segment resolution.
+			a := cspfInternalTestDualStackSRMPLSNode("A", 0, 10)
+			b := cspfInternalTestDualStackSRMPLSNode("B", 1, 11)
+			cspfInternalTestConnect(a, b)
+			_, err := CSPF("A", "B", table.IGPMetric, cspfInternalTestScopeV6SRMPLS, cspfInternalTestBuildTED(a, b))
+
+			return err
+		}, reasonDestinationUnreachable},
 	}
 
 	for _, tt := range tests {
@@ -248,8 +287,70 @@ func TestCSPF_TopologyLimitationClassification(t *testing.T) {
 func TestUpdateNeighborCosts_UnknownCalcNode(t *testing.T) {
 	t.Parallel()
 
-	err := updateNeighborCosts("Z", map[string]*node{}, map[string]*table.LsNode{}, table.IGPMetric)
+	err := updateNeighborCosts("Z", map[string]*node{}, map[string]*table.LsNode{}, table.IGPMetric, cspfInternalTestScopeV4SRMPLS)
 	assert.EqualError(t, err, "router Z not found in TED")
+}
+
+// TestLinkUsable covers U9: linkUsable is the sole edge filter, gating strictly
+// on whether the link carries the scope's address family on both endpoints.
+func TestLinkUsable(t *testing.T) {
+	t.Parallel()
+
+	a, b := cspfInternalTestSRMPLSNode("A", 0), cspfInternalTestSRMPLSNode("B", 1)
+
+	tests := []struct {
+		name  string
+		link  *table.LsLink
+		scope PathScope
+		want  bool
+	}{
+		{
+			name:  "IPv4-only link is usable under an IPv4 scope",
+			link:  &table.LsLink{Local: table.LinkEndpoint{Node: a, IPv4: cspfInternalTestLocalIPv4}, Remote: table.LinkEndpoint{Node: b, IPv4: cspfInternalTestRemoteIPv4}},
+			scope: cspfInternalTestScopeV4SRMPLS,
+			want:  true,
+		},
+		{
+			name:  "IPv4-only link is not usable under an IPv6 scope",
+			link:  &table.LsLink{Local: table.LinkEndpoint{Node: a, IPv4: cspfInternalTestLocalIPv4}, Remote: table.LinkEndpoint{Node: b, IPv4: cspfInternalTestRemoteIPv4}},
+			scope: cspfInternalTestScopeV6SRMPLS,
+			want:  false,
+		},
+		{
+			name:  "IPv6-only link is usable under an IPv6 scope",
+			link:  &table.LsLink{Local: table.LinkEndpoint{Node: a, IPv6: cspfInternalTestLocalIPv6}, Remote: table.LinkEndpoint{Node: b, IPv6: cspfInternalTestRemoteIPv6}},
+			scope: cspfInternalTestScopeV6SRv6,
+			want:  true,
+		},
+		{
+			name:  "IPv6-only link is not usable under an IPv4 scope",
+			link:  &table.LsLink{Local: table.LinkEndpoint{Node: a, IPv6: cspfInternalTestLocalIPv6}, Remote: table.LinkEndpoint{Node: b, IPv6: cspfInternalTestRemoteIPv6}},
+			scope: cspfInternalTestScopeV4SRMPLS,
+			want:  false,
+		},
+		{
+			name: "a dual-stack link is usable under either scope",
+			link: &table.LsLink{
+				Local:  table.LinkEndpoint{Node: a, IPv4: cspfInternalTestLocalIPv4, IPv6: cspfInternalTestLocalIPv6},
+				Remote: table.LinkEndpoint{Node: b, IPv4: cspfInternalTestRemoteIPv4, IPv6: cspfInternalTestRemoteIPv6},
+			},
+			scope: cspfInternalTestScopeV6SRMPLS,
+			want:  true,
+		},
+		{
+			name:  "an address advertised on only one side is not usable in that family",
+			link:  &table.LsLink{Local: table.LinkEndpoint{Node: a, IPv4: cspfInternalTestLocalIPv4}, Remote: table.LinkEndpoint{Node: b}},
+			scope: cspfInternalTestScopeV4SRMPLS,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, linkUsable(tt.link, tt.scope))
+		})
+	}
 }
 
 func TestBuildWaypointSegment(t *testing.T) {
@@ -259,6 +360,7 @@ func TestBuildWaypointSegment(t *testing.T) {
 		name           string
 		node           *table.LsNode
 		explicitSID    string
+		scope          PathScope
 		want           table.Segment
 		wantErr        string
 		wantTopoReason string
@@ -267,18 +369,21 @@ func TestBuildWaypointSegment(t *testing.T) {
 			name:        "empty SID falls back to the node's default SR-MPLS segment",
 			node:        cspfInternalTestSRMPLSNode("A", 0),
 			explicitSID: "",
+			scope:       cspfInternalTestScopeV4SRMPLS,
 			want:        cspfInternalTestMPLSSeg(0),
 		},
 		{
 			name:        "empty SID falls back to the node's default SRv6 segment",
 			node:        cspfInternalTestSRv6Node(),
 			explicitSID: "",
+			scope:       cspfInternalTestScopeV6SRv6,
 			want:        cspfInternalTestSRv6DefaultSeg("2001:db8::a"),
 		},
 		{
 			name:           "empty SID returns an error when the node has no Node SID",
 			node:           cspfInternalTestNodeWithoutSID("A"),
 			explicitSID:    "",
+			scope:          cspfInternalTestScopeV6SRv6,
 			wantErr:        "node doesn't have a Node SID",
 			wantTopoReason: reasonTEDDataIncomplete,
 		},
@@ -286,6 +391,7 @@ func TestBuildWaypointSegment(t *testing.T) {
 			name:        "explicit SID overrides the SID but keeps the node's SID structure",
 			node:        cspfInternalTestSRv6Node(),
 			explicitSID: cspfInternalTestOverrideSID,
+			scope:       cspfInternalTestScopeV6SRv6,
 			want: table.SegmentSRv6{
 				Sid:       table.SRv6SID(netip.MustParseAddr(cspfInternalTestOverrideSID)),
 				LocalAddr: netip.MustParseAddr("2001:db8::a"),
@@ -307,6 +413,7 @@ func TestBuildWaypointSegment(t *testing.T) {
 				},
 			},
 			explicitSID: cspfInternalTestOverrideSID,
+			scope:       cspfInternalTestScopeV6SRv6,
 			want: table.SegmentSRv6{
 				Sid:       table.SRv6SID(netip.MustParseAddr(cspfInternalTestOverrideSID)),
 				LocalAddr: netip.MustParseAddr("2001:db8::a"),
@@ -316,28 +423,45 @@ func TestBuildWaypointSegment(t *testing.T) {
 			},
 		},
 		{
-			name:        "invalid explicit SID returns a parse error",
-			node:        cspfInternalTestSRMPLSNode("A", 0),
+			name:        "invalid explicit SID returns a parse error under SRv6 scope",
+			node:        cspfInternalTestSRv6Node(),
 			explicitSID: cspfInternalTestInvalidSID,
+			scope:       cspfInternalTestScopeV6SRv6,
 			wantErr:     `invalid explicit SID "not-an-address": ParseAddr("not-an-address"): unable to parse IP`,
 		},
 		{
-			name:           "explicit SID on a node without any SRv6 SIDs returns an error",
-			node:           cspfInternalTestSRMPLSNode("A", 0),
-			explicitSID:    cspfInternalTestOverrideSID,
-			wantErr:        "no SRv6 SIDs available",
-			wantTopoReason: reasonTEDDataIncomplete,
+			name:        "explicit SID under SR-MPLS scope overrides the node's default label",
+			node:        cspfInternalTestSRMPLSNode("A", 0),
+			explicitSID: "20000",
+			scope:       cspfInternalTestScopeV4SRMPLS,
+			want:        table.NewSegmentSRMPLS(20000),
+		},
+		{
+			name:        "non-numeric explicit SID under SR-MPLS scope returns a parse error",
+			node:        cspfInternalTestSRMPLSNode("A", 0),
+			explicitSID: cspfInternalTestInvalidSID,
+			scope:       cspfInternalTestScopeV4SRMPLS,
+			wantErr:     `invalid explicit SID "not-an-address": strconv.ParseUint: parsing "not-an-address": invalid syntax`,
+		},
+		{
+			name:        "explicit SID exceeding the maximum SR-MPLS label is rejected",
+			node:        cspfInternalTestSRMPLSNode("A", 0),
+			explicitSID: "1048576",
+			scope:       cspfInternalTestScopeV4SRMPLS,
+			wantErr:     `explicit SID "1048576" exceeds the maximum SR-MPLS label 1048575`,
 		},
 		{
 			name:        "IPv4 explicit SID is rejected",
 			node:        cspfInternalTestSRv6Node(),
 			explicitSID: "10.0.0.1",
+			scope:       cspfInternalTestScopeV6SRv6,
 			wantErr:     `explicit SID "10.0.0.1" must be an IPv6 SRv6 SID`,
 		},
 		{
 			name:        "IPv4-mapped explicit SID is rejected",
 			node:        cspfInternalTestSRv6Node(),
 			explicitSID: "::ffff:10.0.0.1",
+			scope:       cspfInternalTestScopeV6SRv6,
 			wantErr:     `explicit SID "::ffff:10.0.0.1" must be an IPv6 SRv6 SID`,
 		},
 	}
@@ -346,7 +470,7 @@ func TestBuildWaypointSegment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := buildWaypointSegment(tt.node, tt.explicitSID)
+			got, err := buildWaypointSegment(tt.node, tt.explicitSID, tt.scope)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/pkg/cspf/cspf_test.go
+++ b/pkg/cspf/cspf_test.go
@@ -128,6 +128,16 @@ func connectV6(local, remote *table.LsNode, igpCost uint32) {
 	})
 }
 
+// connectMultiTopo creates an IPv4/IPv6 dual-stack LsLink for a single multi-topology ID.
+func connectMultiTopo(local, remote *table.LsNode, mtID uint16, igpCost uint32) {
+	local.Links = append(local.Links, &table.LsLink{
+		Local:        table.LinkEndpoint{Node: local, IPv4: testLinkLocalIPv4, IPv6: testLinkLocalIPv6},
+		Remote:       table.LinkEndpoint{Node: remote, IPv4: testLinkRemoteIPv4, IPv6: testLinkRemoteIPv6},
+		Metrics:      []*table.Metric{table.NewMetric(table.IGPMetric, igpCost)},
+		MultiTopoIDs: map[uint16]struct{}{mtID: {}},
+	})
+}
+
 func buildTED(nodes ...*table.LsNode) *table.LsTED {
 	m := make(map[string]*table.LsNode, len(nodes))
 	for _, n := range nodes {
@@ -300,6 +310,52 @@ func TestCSPF_PathSelection(t *testing.T) {
 			},
 			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV6SRMPLS,
 			want: []table.Segment{mplsSeg(11)},
+		},
+		{
+			name: "multi-topology per-family metrics are not conflated across parallel transit paths",
+			buildTED: func() *table.LsTED {
+				a := dualStackNode("A", 0, 10, "2001:db8::a")
+				b := dualStackNode("B", 1, 11, "2001:db8::b")
+				p1 := dualStackNode("P1", 2, 12, "2001:db8::c") // true IPv4 cost 10
+				p2 := dualStackNode("P2", 3, 13, "2001:db8::d") // true IPv4 cost 200, IPv6 cost 1
+
+				connectMultiTopo(a, p1, 0, 10)
+				connectMultiTopo(a, p1, 2, 500)
+				connectMultiTopo(p1, b, 0, 10)
+				connectMultiTopo(p1, b, 2, 500)
+
+				connectMultiTopo(a, p2, 0, 200)
+				connectMultiTopo(a, p2, 2, 1)
+				connectMultiTopo(p2, b, 0, 200)
+				connectMultiTopo(p2, b, 2, 1)
+
+				return buildTED(a, b, p1, p2)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV4SRMPLS,
+			want: []table.Segment{mplsSeg(2), mplsSeg(1)},
+		},
+		{
+			name: "multi-topology per-family metrics are not conflated across parallel transit paths (IPv6)",
+			buildTED: func() *table.LsTED {
+				a := dualStackNode("A", 0, 10, "2001:db8::a")
+				b := dualStackNode("B", 1, 11, "2001:db8::b")
+				p1 := dualStackNode("P1", 2, 12, "2001:db8::c") // true IPv4 cost 1, IPv6 cost 500
+				p2 := dualStackNode("P2", 3, 13, "2001:db8::d") // true IPv6 cost 10
+
+				connectMultiTopo(a, p1, 0, 1)
+				connectMultiTopo(a, p1, 2, 500)
+				connectMultiTopo(p1, b, 0, 1)
+				connectMultiTopo(p1, b, 2, 500)
+
+				connectMultiTopo(a, p2, 0, 500)
+				connectMultiTopo(a, p2, 2, 10)
+				connectMultiTopo(p2, b, 0, 500)
+				connectMultiTopo(p2, b, 2, 10)
+
+				return buildTED(a, b, p1, p2)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV6SRMPLS,
+			want: []table.Segment{mplsSeg(13), mplsSeg(11)},
 		},
 		{
 			name: "an IPv6 scope never selects a cheaper IPv4-only edge",

--- a/pkg/cspf/cspf_test.go
+++ b/pkg/cspf/cspf_test.go
@@ -29,7 +29,7 @@ func srMPLSNode(routerID string, sidIndex uint32) *table.LsNode {
 		RouterID:  routerID,
 		SrgbBegin: 16000,
 		Prefixes: []*table.LsPrefix{
-			{SidIndex: sidIndex, HasSidIndex: true},
+			{Prefix: netip.MustParsePrefix("192.0.2.1/32"), SidIndex: sidIndex, HasSidIndex: true},
 		},
 	}
 }
@@ -56,8 +56,9 @@ func srv6DefaultSeg(sid string) table.SegmentSRv6 {
 	addr := netip.MustParseAddr(sid)
 
 	return table.SegmentSRv6{
-		Sid:       addr,
+		Sid:       table.SRv6SID(addr),
 		LocalAddr: addr,
+		Behavior:  table.BehaviorEND,
 		Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 	}
 }
@@ -68,9 +69,9 @@ func nodeWithoutSID(routerID string) *table.LsNode {
 
 func connect(local, remote *table.LsNode, igpCost uint32) {
 	local.Links = append(local.Links, &table.LsLink{
-		LocalNode:  local,
-		RemoteNode: remote,
-		Metrics:    []*table.Metric{table.NewMetric(table.IGPMetric, igpCost)},
+		Local:   table.LinkEndpoint{Node: local},
+		Remote:  table.LinkEndpoint{Node: remote},
+		Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, igpCost)},
 	})
 }
 
@@ -385,8 +386,9 @@ func TestWithLooseSourceRouting(t *testing.T) {
 		want := []table.Segment{
 			srv6DefaultSeg("2001:db8::2"),
 			table.SegmentSRv6{
-				Sid:       netip.MustParseAddr("2001:db8::2ff"),
+				Sid:       table.SRv6SID(netip.MustParseAddr("2001:db8::2ff")),
 				LocalAddr: netip.MustParseAddr("2001:db8::2"),
+				Behavior:  table.BehaviorEND,
 				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 			},
 			srv6DefaultSeg("2001:db8::3"),

--- a/pkg/cspf/cspf_test.go
+++ b/pkg/cspf/cspf_test.go
@@ -23,7 +23,19 @@ const (
 	testOverrideSID   = "2001:db8::ffff"
 )
 
-// srMPLSNode uses an SRGB starting at 16000.
+var (
+	scopeV4SRMPLS = cspf.PathScope{Plane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS}}
+	scopeV6SRMPLS = cspf.PathScope{Plane: table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRMPLS}}
+	scopeV6SRv6   = cspf.PathScope{Plane: table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRv6}}
+)
+
+var (
+	testLinkLocalIPv4  = netip.MustParseAddr("192.0.2.101")
+	testLinkRemoteIPv4 = netip.MustParseAddr("192.0.2.102")
+	testLinkLocalIPv6  = netip.MustParseAddr("2001:db8:f::1")
+	testLinkRemoteIPv6 = netip.MustParseAddr("2001:db8:f::2")
+)
+
 func srMPLSNode(routerID string, sidIndex uint32) *table.LsNode {
 	return &table.LsNode{
 		RouterID:  routerID,
@@ -34,11 +46,38 @@ func srMPLSNode(routerID string, sidIndex uint32) *table.LsNode {
 	}
 }
 
+func srMPLSNodeV6(routerID string, sidIndex uint32) *table.LsNode {
+	return &table.LsNode{
+		RouterID:  routerID,
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("2001:db8::1/128"), SidIndex: sidIndex, HasSidIndex: true},
+		},
+	}
+}
+
+func dualStackNode(routerID string, v4SidIndex, v6SidIndex uint32, srv6Sid string) *table.LsNode {
+	return &table.LsNode{
+		RouterID:  routerID,
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("192.0.2.1/32"), SidIndex: v4SidIndex, HasSidIndex: true},
+			{Prefix: netip.MustParsePrefix("2001:db8::1/128"), SidIndex: v6SidIndex, HasSidIndex: true},
+		},
+		SRv6SIDs: []*table.LsSrv6SID{
+			{
+				Sids:             []string{srv6Sid},
+				EndpointBehavior: table.EndpointBehavior{Behavior: table.BehaviorEND},
+				SIDStructure:     &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+			},
+		},
+	}
+}
+
 func mplsSeg(sidIndex uint32) table.Segment {
 	return table.NewSegmentSRMPLS(16000 + sidIndex)
 }
 
-// srv6Node returns a node advertising an End SID with a 32/16/16/0 SID structure.
 func srv6Node(routerID, sid string) *table.LsNode {
 	return &table.LsNode{
 		RouterID: routerID,
@@ -67,10 +106,24 @@ func nodeWithoutSID(routerID string) *table.LsNode {
 	return &table.LsNode{RouterID: routerID}
 }
 
-func connect(local, remote *table.LsNode, igpCost uint32) {
+// connect is a single-cost alias for connectV4 where the address family
+// and cost are irrelevant to the test.
+func connect(local, remote *table.LsNode) {
+	connectV4(local, remote, 1)
+}
+
+func connectV4(local, remote *table.LsNode, igpCost uint32) {
 	local.Links = append(local.Links, &table.LsLink{
-		Local:   table.LinkEndpoint{Node: local},
-		Remote:  table.LinkEndpoint{Node: remote},
+		Local:   table.LinkEndpoint{Node: local, IPv4: testLinkLocalIPv4},
+		Remote:  table.LinkEndpoint{Node: remote, IPv4: testLinkRemoteIPv4},
+		Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, igpCost)},
+	})
+}
+
+func connectV6(local, remote *table.LsNode, igpCost uint32) {
+	local.Links = append(local.Links, &table.LsLink{
+		Local:   table.LinkEndpoint{Node: local, IPv6: testLinkLocalIPv6},
+		Remote:  table.LinkEndpoint{Node: remote, IPv6: testLinkRemoteIPv6},
 		Metrics: []*table.Metric{table.NewMetric(table.IGPMetric, igpCost)},
 	})
 }
@@ -92,6 +145,7 @@ func TestCSPF_PathSelection(t *testing.T) {
 		buildTED func() *table.LsTED
 		src, dst string
 		metric   table.MetricType
+		scope    cspf.PathScope
 		want     []table.Segment
 	}{
 		{
@@ -99,92 +153,185 @@ func TestCSPF_PathSelection(t *testing.T) {
 			buildTED: func() *table.LsTED {
 				return buildTED(srMPLSNode("A", 0))
 			},
-			src: "A", dst: "A", metric: table.IGPMetric,
+			src: "A", dst: "A", metric: table.IGPMetric, scope: scopeV4SRMPLS,
 			want: []table.Segment{},
 		},
 		{
 			name: "IGP metric selects the lowest cumulative cost path over a longer detour",
 			buildTED: func() *table.LsTED {
 				a, b, c, d := srMPLSNode("A", 0), srMPLSNode("B", 1), srMPLSNode("C", 2), srMPLSNode("D", 3)
-				connect(a, b, 1)
-				connect(b, d, 1)
-				connect(a, c, 3)
-				connect(c, d, 1)
+				connectV4(a, b, 1)
+				connectV4(b, d, 1)
+				connectV4(a, c, 3)
+				connectV4(c, d, 1)
 
 				return buildTED(a, b, c, d)
 			},
-			src: "A", dst: "D", metric: table.IGPMetric,
+			src: "A", dst: "D", metric: table.IGPMetric, scope: scopeV4SRMPLS,
 			want: []table.Segment{mplsSeg(1), mplsSeg(3)},
 		},
 		{
 			name: "IGP metric prefers the cheaper multi-hop path over a costly shortcut",
 			buildTED: func() *table.LsTED {
 				a, b, e, f, d := srMPLSNode("A", 0), srMPLSNode("B", 1), srMPLSNode("E", 4), srMPLSNode("F", 5), srMPLSNode("D", 3)
-				connect(a, b, 100)
-				connect(b, d, 100)
-				connect(a, e, 1)
-				connect(e, f, 1)
-				connect(f, d, 1)
+				connectV4(a, b, 100)
+				connectV4(b, d, 100)
+				connectV4(a, e, 1)
+				connectV4(e, f, 1)
+				connectV4(f, d, 1)
 
 				return buildTED(a, b, e, f, d)
 			},
-			src: "A", dst: "D", metric: table.IGPMetric,
+			src: "A", dst: "D", metric: table.IGPMetric, scope: scopeV4SRMPLS,
 			want: []table.Segment{mplsSeg(4), mplsSeg(5), mplsSeg(3)},
 		},
 		{
 			name: "hopcount metric ignores link weights and picks the fewest hops",
 			buildTED: func() *table.LsTED {
 				a, b, e, f, d := srMPLSNode("A", 0), srMPLSNode("B", 1), srMPLSNode("E", 4), srMPLSNode("F", 5), srMPLSNode("D", 3)
-				connect(a, b, 100)
-				connect(b, d, 100)
-				connect(a, e, 1)
-				connect(e, f, 1)
-				connect(f, d, 1)
+				connectV4(a, b, 100)
+				connectV4(b, d, 100)
+				connectV4(a, e, 1)
+				connectV4(e, f, 1)
+				connectV4(f, d, 1)
 
 				return buildTED(a, b, e, f, d)
 			},
-			src: "A", dst: "D", metric: table.HopcountMetric,
+			src: "A", dst: "D", metric: table.HopcountMetric, scope: scopeV4SRMPLS,
 			want: []table.Segment{mplsSeg(1), mplsSeg(3)},
 		},
 		{
 			name: "a cheaper path to an already-discovered node replaces the recorded cost",
 			buildTED: func() *table.LsTED {
 				a, b, c, d := srMPLSNode("A", 0), srMPLSNode("B", 1), srMPLSNode("C", 2), srMPLSNode("D", 3)
-				connect(a, b, 1)
-				connect(a, c, 2)
-				connect(b, d, 10)
-				connect(c, d, 1)
+				connectV4(a, b, 1)
+				connectV4(a, c, 2)
+				connectV4(b, d, 10)
+				connectV4(c, d, 1)
 
 				return buildTED(a, b, c, d)
 			},
-			src: "A", dst: "D", metric: table.IGPMetric,
+			src: "A", dst: "D", metric: table.IGPMetric, scope: scopeV4SRMPLS,
 			want: []table.Segment{mplsSeg(2), mplsSeg(3)},
 		},
 		{
 			name: "a costlier path to an already-discovered node keeps the recorded cost",
 			buildTED: func() *table.LsTED {
 				a, b, c, d, e := srMPLSNode("A", 0), srMPLSNode("B", 1), srMPLSNode("C", 2), srMPLSNode("D", 3), srMPLSNode("E", 4)
-				connect(a, b, 1)
-				connect(a, c, 3)
-				connect(b, d, 1)
-				connect(c, d, 1)
-				connect(d, e, 5)
+				connectV4(a, b, 1)
+				connectV4(a, c, 3)
+				connectV4(b, d, 1)
+				connectV4(c, d, 1)
+				connectV4(d, e, 5)
 
 				return buildTED(a, b, c, d, e)
 			},
-			src: "A", dst: "E", metric: table.IGPMetric,
+			src: "A", dst: "E", metric: table.IGPMetric, scope: scopeV4SRMPLS,
 			want: []table.Segment{mplsSeg(1), mplsSeg(3), mplsSeg(4)},
+		},
+		{
+			name: "IPv6 SR-MPLS node segments are used end-to-end",
+			buildTED: func() *table.LsTED {
+				a, b := srMPLSNodeV6("A", 0), srMPLSNodeV6("B", 1)
+				connectV6(a, b, 1)
+
+				return buildTED(a, b)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV6SRMPLS,
+			want: []table.Segment{mplsSeg(1)},
 		},
 		{
 			name: "SRv6 node segments are used end-to-end",
 			buildTED: func() *table.LsTED {
 				a, b := srv6Node("A", "2001:db8::a"), srv6Node("B", "2001:db8::b")
-				connect(a, b, 1)
+				connectV6(a, b, 1)
 
 				return buildTED(a, b)
 			},
-			src: "A", dst: "B", metric: table.IGPMetric,
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV6SRv6,
 			want: []table.Segment{srv6DefaultSeg("2001:db8::b")},
+		},
+		{
+			name: "mixed SR-MPLS/SRv6 TED resolves SR-MPLS labels under an SR-MPLS scope",
+			buildTED: func() *table.LsTED {
+				a := dualStackNode("A", 0, 10, "2001:db8::a")
+				b := dualStackNode("B", 1, 11, "2001:db8::b")
+				connectV6(a, b, 1)
+
+				return buildTED(a, b)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV6SRMPLS,
+			want: []table.Segment{mplsSeg(11)},
+		},
+		{
+			name: "mixed SR-MPLS/SRv6 TED resolves SRv6 SIDs under an SRv6 scope",
+			buildTED: func() *table.LsTED {
+				a := dualStackNode("A", 0, 10, "2001:db8::a")
+				b := dualStackNode("B", 1, 11, "2001:db8::b")
+				connectV6(a, b, 1)
+
+				return buildTED(a, b)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV6SRv6,
+			want: []table.Segment{srv6DefaultSeg("2001:db8::b")},
+		},
+		{
+			name: "dual-stack routers with per-family parallel links use the IPv4 label under an IPv4 scope",
+			buildTED: func() *table.LsTED {
+				a := dualStackNode("A", 0, 10, "2001:db8::a")
+				b := dualStackNode("B", 1, 11, "2001:db8::b")
+				connectV4(a, b, 10)
+				connectV6(a, b, 100)
+
+				return buildTED(a, b)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV4SRMPLS,
+			want: []table.Segment{mplsSeg(1)},
+		},
+		{
+			name: "dual-stack routers with per-family parallel links use the IPv6 label under an IPv6 scope",
+			buildTED: func() *table.LsTED {
+				a := dualStackNode("A", 0, 10, "2001:db8::a")
+				b := dualStackNode("B", 1, 11, "2001:db8::b")
+				connectV4(a, b, 10)
+				connectV6(a, b, 100)
+
+				return buildTED(a, b)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV6SRMPLS,
+			want: []table.Segment{mplsSeg(11)},
+		},
+		{
+			name: "an IPv6 scope never selects a cheaper IPv4-only edge",
+			buildTED: func() *table.LsTED {
+				a := dualStackNode("A", 0, 10, "2001:db8::a")
+				b := dualStackNode("B", 1, 11, "2001:db8::b")
+				c := srMPLSNodeV6("C", 12)
+
+				connectV4(a, b, 1)
+				connectV6(a, c, 5)
+				connectV6(c, b, 5)
+
+				return buildTED(a, b, c)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV6SRMPLS,
+			want: []table.Segment{mplsSeg(12), mplsSeg(11)},
+		},
+		{
+			name: "an IPv4 scope on the same mixed topology takes the direct IPv4 edge",
+			buildTED: func() *table.LsTED {
+				a := dualStackNode("A", 0, 10, "2001:db8::a")
+				b := dualStackNode("B", 1, 11, "2001:db8::b")
+				c := srMPLSNodeV6("C", 12)
+
+				connectV4(a, b, 1)
+				connectV6(a, c, 5)
+				connectV6(c, b, 5)
+
+				return buildTED(a, b, c)
+			},
+			src: "A", dst: "B", metric: table.IGPMetric, scope: scopeV4SRMPLS,
+			want: []table.Segment{mplsSeg(1)},
 		},
 	}
 
@@ -193,11 +340,63 @@ func TestCSPF_PathSelection(t *testing.T) {
 			t.Parallel()
 
 			ted := tt.buildTED()
-			got, err := cspf.CSPF(tt.src, tt.dst, tt.metric, ted)
+			got, err := cspf.CSPF(tt.src, tt.dst, tt.metric, tt.scope, ted)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestCSPF_PlaneScopingUnreachable(t *testing.T) {
+	t.Parallel()
+
+	a := dualStackNode("A", 0, 10, "2001:db8::a")
+	b := srMPLSNode("B", 1) // IPv4-only node
+	connectV4(a, b, 1)
+	ted := buildTED(a, b)
+
+	got, err := cspf.CSPF("A", "B", table.IGPMetric, scopeV6SRMPLS, ted)
+	assert.Nil(t, got)
+	require.Error(t, err)
+
+	var topoErr *cspf.TopologyLimitationError
+	require.ErrorAs(t, err, &topoErr)
+	assert.Equal(t, "DESTINATION_UNREACHABLE", topoErr.Reason)
+}
+
+func TestCSPF_EndpointFamilyIndependentOfUnderlay(t *testing.T) {
+	t.Parallel()
+
+	a := dualStackNode("A", 0, 10, "2001:db8::a")
+	b := dualStackNode("B", 1, 11, "2001:db8::b")
+	connectV6(a, b, 1)
+	ted := buildTED(a, b)
+
+	t.Run("I8: IPv4 endpoint over an IPv6 SR-MPLS underlay", func(t *testing.T) {
+		t.Parallel()
+
+		segs, err := cspf.CSPF("A", "B", table.IGPMetric, scopeV6SRMPLS, ted)
+		require.NoError(t, err)
+		assert.Equal(t, []table.Segment{mplsSeg(11)}, segs)
+
+		endpoint, err := b.LoopbackAddr(table.AFIPv4)
+		require.NoError(t, err)
+		assert.Equal(t, netip.MustParseAddr("192.0.2.1"), endpoint)
+	})
+
+	t.Run("I9: IPv6 endpoint over an IPv4 SR-MPLS underlay", func(t *testing.T) {
+		t.Parallel()
+
+		connectV4(a, b, 1)
+
+		segs, err := cspf.CSPF("A", "B", table.IGPMetric, scopeV4SRMPLS, ted)
+		require.NoError(t, err)
+		assert.Equal(t, []table.Segment{mplsSeg(1)}, segs)
+
+		endpoint, err := b.LoopbackAddr(table.AFIPv6)
+		require.NoError(t, err)
+		assert.Equal(t, netip.MustParseAddr("2001:db8::1"), endpoint)
+	})
 }
 
 func TestCSPF_MetricValidation(t *testing.T) {
@@ -205,7 +404,7 @@ func TestCSPF_MetricValidation(t *testing.T) {
 
 	linked := func() *table.LsTED {
 		a, b := srMPLSNode("A", 0), srMPLSNode("B", 1)
-		connect(a, b, 1)
+		connect(a, b)
 
 		return buildTED(a, b)
 	}
@@ -213,21 +412,21 @@ func TestCSPF_MetricValidation(t *testing.T) {
 	t.Run("an unrecognized metric type is rejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := cspf.CSPF("A", "B", table.MetricType(99), linked())
+		_, err := cspf.CSPF("A", "B", table.MetricType(99), scopeV4SRMPLS, linked())
 		assert.EqualError(t, err, "unsupported metric type 99")
 	})
 
 	t.Run("the unspecified metric is rejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := cspf.CSPF("A", "B", table.UnspecifiedMetric, linked())
+		_, err := cspf.CSPF("A", "B", table.UnspecifiedMetric, scopeV4SRMPLS, linked())
 		assert.EqualError(t, err, "metric type must be specified for path computation")
 	})
 
 	t.Run("an unrecognized metric is rejected even when source equals destination", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := cspf.CSPF("A", "A", table.MetricType(99), linked())
+		_, err := cspf.CSPF("A", "A", table.MetricType(99), scopeV4SRMPLS, linked())
 		assert.EqualError(t, err, "unsupported metric type 99")
 	})
 
@@ -235,15 +434,54 @@ func TestCSPF_MetricValidation(t *testing.T) {
 		t.Parallel()
 
 		waypoints := []table.Waypoint{{RouterID: testGhostRouterID}}
-		_, err := cspf.WithLooseSourceRouting("A", "B", waypoints, table.MetricType(99), linked())
+		_, err := cspf.WithLooseSourceRouting("A", "B", waypoints, table.MetricType(99), scopeV4SRMPLS, linked())
 		assert.EqualError(t, err, "unsupported metric type 99")
 	})
 
 	t.Run("a nil TED is reported before the metric", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := cspf.CSPF("A", "B", table.MetricType(99), nil)
+		_, err := cspf.CSPF("A", "B", table.MetricType(99), scopeV4SRMPLS, nil)
 		assert.EqualError(t, err, "ted is nil")
+	})
+}
+
+func TestCSPF_ScopeValidation(t *testing.T) {
+	t.Parallel()
+
+	linked := func() *table.LsTED {
+		a, b := srMPLSNode("A", 0), srMPLSNode("B", 1)
+		connect(a, b)
+
+		return buildTED(a, b)
+	}
+
+	t.Run("an unspecified plane is rejected by CSPF", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cspf.CSPF("A", "B", table.IGPMetric, cspf.PathScope{}, linked())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid scope")
+
+		var invalidInput *cspf.InvalidInputError
+		require.ErrorAs(t, err, &invalidInput)
+	})
+
+	t.Run("an unspecified plane is rejected by WithLooseSourceRouting", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cspf.WithLooseSourceRouting("A", "B", nil, table.IGPMetric, cspf.PathScope{}, linked())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid scope")
+	})
+
+	t.Run("SRv6 over IPv4 is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		invalidScope := cspf.PathScope{Plane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRv6}}
+		_, err := cspf.CSPF("A", "B", table.IGPMetric, invalidScope, linked())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid scope")
 	})
 }
 
@@ -252,7 +490,7 @@ func TestCSPF_InvalidInputClassification(t *testing.T) {
 
 	linear := func() *table.LsTED {
 		a, b := srMPLSNode("A", 0), srMPLSNode("B", 1)
-		connect(a, b, 1)
+		connect(a, b)
 
 		return buildTED(a, b)
 	}
@@ -262,30 +500,34 @@ func TestCSPF_InvalidInputClassification(t *testing.T) {
 		run         func() error
 		wantInvalid bool
 	}{
-		{"unknown source router is caller input", func() error { _, err := cspf.CSPF("Z", "B", table.IGPMetric, linear()); return err }, true},
-		{"unknown destination router is caller input", func() error { _, err := cspf.CSPF("A", "Z", table.IGPMetric, linear()); return err }, true},
+		{"unknown source router is caller input", func() error { _, err := cspf.CSPF("Z", "B", table.IGPMetric, scopeV4SRMPLS, linear()); return err }, true},
+		{"unknown destination router is caller input", func() error { _, err := cspf.CSPF("A", "Z", table.IGPMetric, scopeV4SRMPLS, linear()); return err }, true},
 		{"unknown waypoint is caller input", func() error {
-			_, err := cspf.WithLooseSourceRouting("A", "B", []table.Waypoint{{RouterID: "Z"}}, table.IGPMetric, linear())
+			_, err := cspf.WithLooseSourceRouting("A", "B", []table.Waypoint{{RouterID: "Z"}}, table.IGPMetric, scopeV4SRMPLS, linear())
 			return err
 		}, true},
 		{"malformed explicit waypoint SID is caller input", func() error {
-			_, err := cspf.WithLooseSourceRouting("A", "B", []table.Waypoint{{RouterID: "B", SID: testInvalidSID}}, table.IGPMetric, linear())
+			_, err := cspf.WithLooseSourceRouting("A", "B", []table.Waypoint{{RouterID: "B", SID: testInvalidSID}}, table.IGPMetric, scopeV4SRMPLS, linear())
 			return err
 		}, true},
-		{"unusable metric is caller input", func() error { _, err := cspf.CSPF("A", "B", table.UnspecifiedMetric, linear()); return err }, true},
+		{"unusable metric is caller input", func() error {
+			_, err := cspf.CSPF("A", "B", table.UnspecifiedMetric, scopeV4SRMPLS, linear())
+			return err
+		}, true},
+		{"an invalid scope is caller input", func() error { _, err := cspf.CSPF("A", "B", table.IGPMetric, cspf.PathScope{}, linear()); return err }, true},
 		{"an unreachable destination is not caller input", func() error {
-			_, err := cspf.CSPF("A", "B", table.IGPMetric, buildTED(srMPLSNode("A", 0), srMPLSNode("B", 1)))
+			_, err := cspf.CSPF("A", "B", table.IGPMetric, scopeV4SRMPLS, buildTED(srMPLSNode("A", 0), srMPLSNode("B", 1)))
 			return err
 		}, false},
-		{"a metric absent from a traversed link is not caller input", func() error { _, err := cspf.CSPF("A", "B", table.TEMetric, linear()); return err }, false},
+		{"a metric absent from a traversed link is not caller input", func() error { _, err := cspf.CSPF("A", "B", table.TEMetric, scopeV4SRMPLS, linear()); return err }, false},
 		{"a node without a Node SID is not caller input", func() error {
 			a, b := nodeWithoutSID("A"), srMPLSNode("B", 0)
-			connect(a, b, 1)
-			_, err := cspf.CSPF("A", "B", table.IGPMetric, buildTED(a, b))
+			connect(a, b)
+			_, err := cspf.CSPF("A", "B", table.IGPMetric, scopeV4SRMPLS, buildTED(a, b))
 
 			return err
 		}, false},
-		{"a nil TED is not classified as caller input", func() error { _, err := cspf.CSPF("A", "B", table.IGPMetric, nil); return err }, false},
+		{"a nil TED is not classified as caller input", func() error { _, err := cspf.CSPF("A", "B", table.IGPMetric, scopeV4SRMPLS, nil); return err }, false},
 	}
 
 	for _, tt := range tests {
@@ -304,10 +546,10 @@ func TestCSPF_InvalidInputClassification(t *testing.T) {
 func TestCSPF_NilTED(t *testing.T) {
 	t.Parallel()
 
-	_, err := cspf.CSPF("A", "B", table.IGPMetric, nil)
+	_, err := cspf.CSPF("A", "B", table.IGPMetric, scopeV4SRMPLS, nil)
 	require.EqualError(t, err, "ted is nil")
 
-	_, err = cspf.WithLooseSourceRouting("A", "B", nil, table.IGPMetric, nil)
+	_, err = cspf.WithLooseSourceRouting("A", "B", nil, table.IGPMetric, scopeV4SRMPLS, nil)
 	assert.EqualError(t, err, "ted is nil")
 }
 
@@ -336,10 +578,10 @@ func TestWithLooseSourceRouting(t *testing.T) {
 
 	linearChain := func() *table.LsTED {
 		s, w1, m, w2, d := srMPLSNode("S", 0), srMPLSNode("W1", 1), srMPLSNode("M", 2), srMPLSNode("W2", 3), srMPLSNode("D", 4)
-		connect(s, w1, 1)
-		connect(w1, m, 1)
-		connect(m, w2, 1)
-		connect(w2, d, 1)
+		connect(s, w1)
+		connect(w1, m)
+		connect(m, w2)
+		connect(w2, d)
 
 		return buildTED(s, w1, m, w2, d)
 	}
@@ -348,7 +590,7 @@ func TestWithLooseSourceRouting(t *testing.T) {
 	t.Run("no waypoints behaves like a direct CSPF call", func(t *testing.T) {
 		t.Parallel()
 
-		got, err := cspf.WithLooseSourceRouting("S", "D", nil, table.IGPMetric, linearChain())
+		got, err := cspf.WithLooseSourceRouting("S", "D", nil, table.IGPMetric, scopeV4SRMPLS, linearChain())
 		require.NoError(t, err)
 		assert.Equal(t, fullChainSegs, got)
 	})
@@ -357,7 +599,7 @@ func TestWithLooseSourceRouting(t *testing.T) {
 		t.Parallel()
 
 		waypoints := []table.Waypoint{{RouterID: "W1"}}
-		got, err := cspf.WithLooseSourceRouting("S", "D", waypoints, table.IGPMetric, linearChain())
+		got, err := cspf.WithLooseSourceRouting("S", "D", waypoints, table.IGPMetric, scopeV4SRMPLS, linearChain())
 		require.NoError(t, err)
 		assert.Equal(t, fullChainSegs, got)
 	})
@@ -366,7 +608,7 @@ func TestWithLooseSourceRouting(t *testing.T) {
 		t.Parallel()
 
 		waypoints := []table.Waypoint{{RouterID: "W1"}, {RouterID: "W2"}}
-		got, err := cspf.WithLooseSourceRouting("S", "D", waypoints, table.IGPMetric, linearChain())
+		got, err := cspf.WithLooseSourceRouting("S", "D", waypoints, table.IGPMetric, scopeV4SRMPLS, linearChain())
 		require.NoError(t, err)
 		assert.Equal(t, fullChainSegs, got)
 	})
@@ -375,12 +617,12 @@ func TestWithLooseSourceRouting(t *testing.T) {
 		t.Parallel()
 
 		s2, w, d2 := srv6Node("S2", "2001:db8::1"), srv6Node("W", "2001:db8::2"), srv6Node("D2", "2001:db8::3")
-		connect(s2, w, 1)
-		connect(w, d2, 1)
+		connectV6(s2, w, 1)
+		connectV6(w, d2, 1)
 		ted := buildTED(s2, w, d2)
 
 		waypoints := []table.Waypoint{{RouterID: "W", SID: "2001:db8::2ff"}}
-		got, err := cspf.WithLooseSourceRouting("S2", "D2", waypoints, table.IGPMetric, ted)
+		got, err := cspf.WithLooseSourceRouting("S2", "D2", waypoints, table.IGPMetric, scopeV6SRv6, ted)
 		require.NoError(t, err)
 
 		want := []table.Segment{
@@ -396,11 +638,31 @@ func TestWithLooseSourceRouting(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("an explicit SR-MPLS waypoint SID that differs from the node's default is kept as a separate segment", func(t *testing.T) {
+		t.Parallel()
+
+		s5, w5, d5 := srMPLSNode("S5", 0), srMPLSNode("W5", 1), srMPLSNode("D5", 2)
+		connect(s5, w5)
+		connect(w5, d5)
+		ted := buildTED(s5, w5, d5)
+
+		waypoints := []table.Waypoint{{RouterID: "W5", SID: "20000"}}
+		got, err := cspf.WithLooseSourceRouting("S5", "D5", waypoints, table.IGPMetric, scopeV4SRMPLS, ted)
+		require.NoError(t, err)
+
+		want := []table.Segment{
+			mplsSeg(1),
+			table.NewSegmentSRMPLS(20000),
+			mplsSeg(2),
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("a leg computation failure is wrapped with the router pair", func(t *testing.T) {
 		t.Parallel()
 
 		ted := buildTED(srMPLSNode("S3", 0))
-		got, err := cspf.WithLooseSourceRouting("S3", "D3", nil, table.IGPMetric, ted)
+		got, err := cspf.WithLooseSourceRouting("S3", "D3", nil, table.IGPMetric, scopeV4SRMPLS, ted)
 		assert.Nil(t, got)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "CSPF failed between S3 and D3")
@@ -411,11 +673,11 @@ func TestWithLooseSourceRouting(t *testing.T) {
 		// Intentionally leaves GHOST out of ted.Nodes while keeping it on the link.
 		s4 := srMPLSNode("S4", 0)
 		ghost := srMPLSNode(testGhostRouterID, 1)
-		connect(s4, ghost, 1)
+		connect(s4, ghost)
 		ted := buildTED(s4)
 
 		waypoints := []table.Waypoint{{RouterID: testGhostRouterID}}
-		got, err := cspf.WithLooseSourceRouting("S4", testGhostRouterID, waypoints, table.IGPMetric, ted)
+		got, err := cspf.WithLooseSourceRouting("S4", testGhostRouterID, waypoints, table.IGPMetric, scopeV4SRMPLS, ted)
 		assert.Nil(t, got)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "waypoint router GHOST not found in TED")
@@ -425,7 +687,7 @@ func TestWithLooseSourceRouting(t *testing.T) {
 		t.Parallel()
 
 		waypoints := []table.Waypoint{{RouterID: testGhostRouterID}}
-		got, err := cspf.WithLooseSourceRouting("S", "D", waypoints, table.IGPMetric, linearChain())
+		got, err := cspf.WithLooseSourceRouting("S", "D", waypoints, table.IGPMetric, scopeV4SRMPLS, linearChain())
 		assert.Nil(t, got)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "waypoint router GHOST not found in TED")
@@ -435,9 +697,32 @@ func TestWithLooseSourceRouting(t *testing.T) {
 		t.Parallel()
 
 		waypoints := []table.Waypoint{{RouterID: "W1", SID: testInvalidSID}}
-		got, err := cspf.WithLooseSourceRouting("S", "D", waypoints, table.IGPMetric, linearChain())
+		got, err := cspf.WithLooseSourceRouting("S", "D", waypoints, table.IGPMetric, scopeV4SRMPLS, linearChain())
 		assert.Nil(t, got)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to build segment for waypoint W1")
 	})
+}
+
+func TestWithLooseSourceRouting_PlaneScoping(t *testing.T) {
+	t.Parallel()
+
+	a := dualStackNode("A", 0, 10, "2001:db8::a")
+	b := dualStackNode("B", 1, 11, "2001:db8::b")
+	w := srv6Node("W", "2001:db8::9")
+
+	connectV4(a, b, 1)
+	connectV6(a, w, 5)
+	connectV6(w, b, 5)
+	ted := buildTED(a, b, w)
+
+	waypoints := []table.Waypoint{{RouterID: "W"}}
+	got, err := cspf.WithLooseSourceRouting("A", "B", waypoints, table.IGPMetric, scopeV6SRv6, ted)
+	require.NoError(t, err)
+
+	want := []table.Segment{
+		srv6DefaultSeg("2001:db8::9"),
+		srv6DefaultSeg("2001:db8::b"),
+	}
+	assert.Equal(t, want, got)
 }

--- a/pkg/packet/pcep/message.go
+++ b/pkg/packet/pcep/message.go
@@ -724,7 +724,7 @@ func NewPCInitiateMessage(srpID uint32, srPolicy table.SRPolicy, opt ...Opt) (*P
 
 	// PLSP-ID is 0 on instantiation; the PCC assigns it (RFC 8281 §5.3.1).
 	m.LSPObject = NewLSPObject(srPolicy.Name, &srPolicy.Color, 0)
-	if m.EndpointsObject, err = NewEndpointsObject(srPolicy.DstAddr, srPolicy.SrcAddr); err != nil {
+	if m.EndpointsObject, err = NewEndpointsObject(srPolicy.Endpoint, srPolicy.Headend); err != nil {
 		return nil, err
 	}
 
@@ -732,21 +732,23 @@ func NewPCInitiateMessage(srpID uint32, srPolicy table.SRPolicy, opt ...Opt) (*P
 		return nil, err
 	}
 
+	preference := srPolicy.CandidatePath.Preference
+
 	switch opts.pccType {
 	case JuniperLegacy:
-		if m.AssociationObject, err = NewAssociationObject(srPolicy.SrcAddr, srPolicy.DstAddr, srPolicy.Color, srPolicy.Preference, VendorSpecific(opts.pccType), OriginatorASN(opts.originatorASN)); err != nil {
+		if m.AssociationObject, err = NewAssociationObject(srPolicy.Headend, srPolicy.Endpoint, srPolicy.Color, preference, VendorSpecific(opts.pccType), OriginatorASN(opts.originatorASN)); err != nil {
 			return nil, err
 		}
 	case CiscoLegacy:
-		if m.VendorInformationObject, err = NewVendorInformationObject(CiscoLegacy, srPolicy.Color, srPolicy.Preference); err != nil {
+		if m.VendorInformationObject, err = NewVendorInformationObject(CiscoLegacy, srPolicy.Color, preference); err != nil {
 			return nil, err
 		}
 	case RFCCompliant:
-		if m.AssociationObject, err = NewAssociationObject(srPolicy.SrcAddr, srPolicy.DstAddr, srPolicy.Color, srPolicy.Preference, OriginatorASN(opts.originatorASN)); err != nil {
+		if m.AssociationObject, err = NewAssociationObject(srPolicy.Headend, srPolicy.Endpoint, srPolicy.Color, preference, OriginatorASN(opts.originatorASN)); err != nil {
 			return nil, err
 		}
 
-		if m.VendorInformationObject, err = NewVendorInformationObject(CiscoLegacy, srPolicy.Color, srPolicy.Preference); err != nil {
+		if m.VendorInformationObject, err = NewVendorInformationObject(CiscoLegacy, srPolicy.Color, preference); err != nil {
 			return nil, err
 		}
 	default:

--- a/pkg/packet/pcep/message_test.go
+++ b/pkg/packet/pcep/message_test.go
@@ -143,7 +143,7 @@ func TestNewPCInitiateMessage_OriginatorASNReachesWire(t *testing.T) {
 			t.Parallel()
 
 			m, err := pcep.NewPCInitiateMessage(1, table.SRPolicy{
-				Name: testPolicyName, SegmentList: segmentList, Color: 100, Preference: 200, SrcAddr: srcAddr, DstAddr: dstAddr,
+				Name: testPolicyName, SegmentList: segmentList, Color: 100, CandidatePath: table.CandidatePath{Preference: 200}, Headend: srcAddr, Endpoint: dstAddr,
 			}, tt.opts...)
 			require.NoError(t, err, "NewPCInitiateMessage failed")
 			require.NotNil(t, m.AssociationObject, "RFC compliant PCInitiate must carry an ASSOCIATION object")
@@ -167,7 +167,7 @@ func TestNewPCInitiateMessage_OriginatorASNReachesWire(t *testing.T) {
 				[]uint8{0x00, 0x39, 0x00, 0x1c}, // SRPOLICY-CPATH-ID TLV: type=0x0039, len=28
 				[]uint8{0x0a, 0x00, 0x00, 0x00}, // protocol origin + mbz
 				pcep.Uint32ToByteSlice(tt.expectedASN),
-				make([]uint8, 12), dstAddr.AsSlice(), // originator address (IPv4 in the 16 byte field)
+				make([]uint8, 12), srcAddr.AsSlice(), // originator address is the headend (IPv4 in the 16 byte field)
 				[]uint8{0x00, 0x00, 0x00, 0x01}, // discriminator
 			)
 			assert.True(t, bytes.Contains(raw, expectedTLV), "serialized message does not carry ASN %d in the SRPOLICY-CPATH-ID TLV", tt.expectedASN)
@@ -211,7 +211,7 @@ func TestNewPCInitiateMessage_VendorObjectSelection(t *testing.T) {
 			t.Parallel()
 
 			m, err := pcep.NewPCInitiateMessage(1, table.SRPolicy{
-				Name: testPolicyName, SegmentList: segmentList, Color: 100, Preference: 200, SrcAddr: srcAddr, DstAddr: dstAddr,
+				Name: testPolicyName, SegmentList: segmentList, Color: 100, CandidatePath: table.CandidatePath{Preference: 200}, Headend: srcAddr, Endpoint: dstAddr,
 			}, pcep.VendorSpecific(tt.pccType))
 			require.NoError(t, err, "NewPCInitiateMessage failed")
 
@@ -729,7 +729,7 @@ func TestNewPCInitiateDeleteMessage(t *testing.T) {
 
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16001)}
 	m, err := pcep.NewPCInitiateDeleteMessage(1, table.SRPolicy{
-		Name: testPolicyName, PlspID: 5, SegmentList: segmentList, Color: 100, Preference: 200,
+		Name: testPolicyName, PlspID: 5, SegmentList: segmentList, Color: 100, CandidatePath: table.CandidatePath{Preference: 200},
 	})
 	require.NoError(t, err)
 
@@ -754,7 +754,7 @@ func TestNewPCInitiateMessage_Errors(t *testing.T) {
 	t.Parallel()
 
 	v4a, v4b := netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr("192.0.2.2")
-	v6a, v6b := netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr("2001:db8::2")
+	v6b := netip.MustParseAddr("2001:db8::2")
 	validSeg := []table.Segment{table.NewSegmentSRMPLS(16001)}
 
 	cases := map[string]struct {
@@ -772,9 +772,6 @@ func TestNewPCInitiateMessage_Errors(t *testing.T) {
 		"InvalidSecondSegmentType": {
 			segmentList: []table.Segment{table.NewSegmentSRMPLS(16001), fakeSegment{}}, srcAddr: v4a, dstAddr: v4b,
 		},
-		"JuniperLegacyRejectsIPv6": {
-			segmentList: validSeg, srcAddr: v6a, dstAddr: v6b, opts: []pcep.Opt{pcep.VendorSpecific(pcep.JuniperLegacy)},
-		},
 		"UndefinedPccType": {
 			segmentList: validSeg, srcAddr: v4a, dstAddr: v4b, opts: []pcep.Opt{pcep.VendorSpecific(pcep.PccType(99))},
 		},
@@ -785,7 +782,7 @@ func TestNewPCInitiateMessage_Errors(t *testing.T) {
 			t.Parallel()
 
 			m, err := pcep.NewPCInitiateMessage(1, table.SRPolicy{
-				Name: testPolicyName, SegmentList: tt.segmentList, Color: 100, Preference: 200, SrcAddr: tt.srcAddr, DstAddr: tt.dstAddr,
+				Name: testPolicyName, SegmentList: tt.segmentList, Color: 100, CandidatePath: table.CandidatePath{Preference: 200}, Headend: tt.srcAddr, Endpoint: tt.dstAddr,
 			}, tt.opts...)
 			require.Error(t, err)
 			assert.Nil(t, m)

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1302,6 +1302,13 @@ func (o *SREroSubobject) decodeNAI(subobject []uint8, off int) (int, error) {
 		half := off + int(naiLength)/2
 		o.Segment.LocalAddr, _ = netip.AddrFromSlice(subobject[off:half])
 		o.Segment.RemoteAddr, _ = netip.AddrFromSlice(subobject[half : off+int(naiLength)])
+	case NAITypeSRIPv6AdjacencyLinkLocal:
+		o.Segment.LocalAddr, _ = netip.AddrFromSlice(subobject[off : off+16])
+		localIfaceID := binary.BigEndian.Uint32(subobject[off+16 : off+20])
+		o.Segment.LocalIfaceID = &localIfaceID
+		o.Segment.RemoteAddr, _ = netip.AddrFromSlice(subobject[off+20 : off+36])
+		remoteIfaceID := binary.BigEndian.Uint32(subobject[off+36 : off+40])
+		o.Segment.RemoteIfaceID = &remoteIfaceID
 	}
 
 	return off + int(naiLength), nil
@@ -1341,9 +1348,29 @@ func (o *SREroSubobject) serializeNAI() ([]uint8, error) {
 		}
 
 		return AppendByteSlices(local.AsSlice(), remote.AsSlice()), nil
+	case NAITypeSRIPv6AdjacencyLinkLocal:
+		return serializeIPv6LinkLocalNAI(local, remote, o.Segment.LocalIfaceID, o.Segment.RemoteIfaceID)
 	default:
 		return nil, errors.New("unsupported naitype")
 	}
+}
+
+func serializeIPv6LinkLocalNAI(local, remote netip.Addr, localIfaceID, remoteIfaceID *uint32) ([]uint8, error) {
+	if !local.Is6() || !remote.Is6() {
+		return nil, errors.New("IPv6 link-local adjacency NAI requires IPv6 LocalAddr and RemoteAddr")
+	}
+
+	if localIfaceID == nil || remoteIfaceID == nil {
+		return nil, errors.New("IPv6 link-local adjacency NAI requires LocalIfaceID and RemoteIfaceID")
+	}
+
+	localIfaceIDBytes := make([]uint8, 4)
+	binary.BigEndian.PutUint32(localIfaceIDBytes, *localIfaceID)
+
+	remoteIfaceIDBytes := make([]uint8, 4)
+	binary.BigEndian.PutUint32(remoteIfaceIDBytes, *remoteIfaceID)
+
+	return AppendByteSlices(local.AsSlice(), localIfaceIDBytes, remote.AsSlice(), remoteIfaceIDBytes), nil
 }
 
 // Serialize encodes the receiver into bytes.
@@ -1411,8 +1438,10 @@ func (nt NAITypeSR) naiLength() (uint16, error) {
 		return 8, nil
 	case NAITypeSRIPv6AdjacencyGlobal:
 		return 32, nil
+	case NAITypeSRIPv6AdjacencyLinkLocal:
+		return 40, nil
 	default:
-		// Unnumbered and link-local adjacency NAIs are not supported by the decoder.
+		// Unnumbered adjacency NAIs are not supported by the decoder.
 		return 0, errors.New("unsupported naitype")
 	}
 }
@@ -1465,7 +1494,11 @@ func naiTypeSRFor(seg table.SegmentSRMPLS) (NAITypeSR, error) {
 	}
 
 	if local.IsLinkLocalUnicast() || remote.IsLinkLocalUnicast() {
-		return NAITypeSRAbsent, errors.New("SegmentSRMPLS: link-local IPv6 adjacency NAI is unsupported")
+		if seg.LocalIfaceID == nil || seg.RemoteIfaceID == nil {
+			return NAITypeSRAbsent, errors.New("SegmentSRMPLS: link-local IPv6 adjacency NAI requires LocalIfaceID and RemoteIfaceID")
+		}
+
+		return NAITypeSRIPv6AdjacencyLinkLocal, nil
 	}
 
 	return NAITypeSRIPv6AdjacencyGlobal, nil
@@ -1684,9 +1717,12 @@ func (o *SRv6EroSubobject) decodeNAI(subobject []uint8, off int) (int, error) {
 		}
 
 		o.Segment.LocalAddr, _ = netip.AddrFromSlice(subobject[off : off+16])
-		// subobject[off+16 : off+20] — Local Interface ID (not parsed)
+		localIfaceID := binary.BigEndian.Uint32(subobject[off+16 : off+20])
+		o.Segment.LocalIfaceID = &localIfaceID
 		o.Segment.RemoteAddr, _ = netip.AddrFromSlice(subobject[off+20 : off+36])
-		// subobject[off+36 : off+40] — Remote Interface ID (not parsed)
+		remoteIfaceID := binary.BigEndian.Uint32(subobject[off+36 : off+40])
+		o.Segment.RemoteIfaceID = &remoteIfaceID
+
 		return off + 40, nil
 	default:
 		return off, nil
@@ -1727,9 +1763,22 @@ func (o *SRv6EroSubobject) Serialize() ([]uint8, error) {
 
 	byteSid := o.Segment.Sid.Addr().AsSlice()
 
-	byteNAI := o.Segment.LocalAddr.AsSlice()
-	if o.Segment.RemoteAddr.IsValid() {
-		byteNAI = append(byteNAI, o.Segment.RemoteAddr.AsSlice()...)
+	var byteNAI []uint8
+
+	if o.NAIType == NAITypeSRv6IPv6AdjacencyLinkLocal {
+		nai, err := serializeIPv6LinkLocalNAI(
+			o.Segment.LocalAddr, o.Segment.RemoteAddr, o.Segment.LocalIfaceID, o.Segment.RemoteIfaceID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("SRv6EroSubobject: %w", err)
+		}
+
+		byteNAI = nai
+	} else {
+		byteNAI = o.Segment.LocalAddr.AsSlice()
+		if o.Segment.RemoteAddr.IsValid() {
+			byteNAI = append(byteNAI, o.Segment.RemoteAddr.AsSlice()...)
+		}
 	}
 
 	byteSidStructure := []uint8{}
@@ -1777,6 +1826,35 @@ func (o *SRv6EroSubobject) Len() (uint16, error) {
 	return length, nil
 }
 
+// naiTypeSRv6For derives the NAI type and F flag from the segment addresses.
+func naiTypeSRv6For(seg table.SegmentSRv6) (NAITypeSRv6, bool, error) {
+	local, remote := seg.LocalAddr.Unmap(), seg.RemoteAddr.Unmap()
+
+	switch {
+	case !local.IsValid():
+		if remote.IsValid() {
+			return NAITypeSRv6Absent, false, errors.New("SegmentSRv6: RemoteAddr requires LocalAddr")
+		}
+
+		return NAITypeSRv6Absent, true, nil
+	case !local.Is6():
+		return NAITypeSRv6Absent, false, errors.New("SegmentSRv6: NAI LocalAddr must be IPv6")
+	case remote.IsValid() && !remote.Is6():
+		return NAITypeSRv6Absent, false, errors.New("SegmentSRv6: NAI RemoteAddr must be IPv6")
+	case local.IsLinkLocalUnicast() || remote.IsLinkLocalUnicast():
+		// Link-local adjacencies require interface IDs to scope the addresses (RFC 8664/9603 §4.3.1).
+		if seg.LocalIfaceID == nil || seg.RemoteIfaceID == nil {
+			return NAITypeSRv6Absent, false, errors.New("SegmentSRv6: link-local IPv6 adjacency NAI requires LocalIfaceID and RemoteIfaceID")
+		}
+
+		return NAITypeSRv6IPv6AdjacencyLinkLocal, false, nil
+	case remote.IsValid():
+		return NAITypeSRv6IPv6AdjacencyGlobal, false, nil
+	default:
+		return NAITypeSRv6IPv6Node, false, nil
+	}
+}
+
 // NewSRv6EroSubobject creates and returns a new SRv6EroSubobject.
 func NewSRv6EroSubobject(seg table.SegmentSRv6) (*SRv6EroSubobject, error) {
 	subo := &SRv6EroSubobject{
@@ -1790,30 +1868,17 @@ func NewSRv6EroSubobject(seg table.SegmentSRv6) (*SRv6EroSubobject, error) {
 
 	subo.TFlag = subo.Segment.Structure != nil
 
-	local, remote := seg.LocalAddr.Unmap(), seg.RemoteAddr.Unmap()
-	switch {
-	case !local.IsValid():
-		if remote.IsValid() {
-			return nil, errors.New("SegmentSRv6: RemoteAddr requires LocalAddr")
-		}
-
-		subo.FFlag = true
-		subo.NAIType = NAITypeSRv6Absent
-	case !local.Is6():
-		return nil, errors.New("SegmentSRv6: NAI LocalAddr must be IPv6")
-	case remote.IsValid() && !remote.Is6():
-		return nil, errors.New("SegmentSRv6: NAI RemoteAddr must be IPv6")
-	case local.IsLinkLocalUnicast() || remote.IsLinkLocalUnicast():
-		// Link-local adjacencies require NAITypeSRv6IPv6AdjacencyLinkLocal
-		// (RFC 9603 §4.3.1), which is not yet supported for encoding.
-		return nil, errors.New("SegmentSRv6: link-local IPv6 adjacency NAI is unsupported")
-	case remote.IsValid():
-		subo.FFlag = false
-		subo.NAIType = NAITypeSRv6IPv6AdjacencyGlobal
-	default:
-		subo.FFlag = false
-		subo.NAIType = NAITypeSRv6IPv6Node
+	sidAddr := seg.Sid.Addr()
+	if !sidAddr.IsValid() || !sidAddr.Is6() || sidAddr.Is4In6() {
+		return nil, errors.New("SegmentSRv6: Sid must be an IPv6 address")
 	}
+
+	naiType, fFlag, err := naiTypeSRv6For(seg)
+	if err != nil {
+		return nil, err
+	}
+
+	subo.NAIType, subo.FFlag = naiType, fFlag
 
 	length, err := subo.Len()
 	if err != nil {

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -2229,6 +2229,7 @@ func (o *AssociationObject) Len() (int, error) {
 }
 
 // NewAssociationObject creates and returns a new AssociationObject.
+// The Association Object-Type is determined by the source address (RFC 8697 §6.1, RFC 9862 §4.4).
 func NewAssociationObject(srcAddr, dstAddr netip.Addr, color, preference uint32, opt ...Opt) (*AssociationObject, error) {
 	opts := optParams{
 		pccType: RFCCompliant,
@@ -2241,12 +2242,12 @@ func NewAssociationObject(srcAddr, dstAddr netip.Addr, color, preference uint32,
 	var objectType ObjectType
 
 	switch {
-	case dstAddr.Is4() && srcAddr.Is4():
+	case srcAddr.Is4():
 		objectType = ObjectTypeAssociationIPv4
-	case dstAddr.Is6() && srcAddr.Is6():
+	case srcAddr.Is6():
 		objectType = ObjectTypeAssociationIPv6
 	default:
-		return nil, fmt.Errorf("invalid endpoints address (NewAssociationObject): src=%v dst=%v", srcAddr, dstAddr)
+		return nil, fmt.Errorf("invalid association source address (NewAssociationObject): src=%v", srcAddr)
 	}
 
 	o := &AssociationObject{
@@ -2257,10 +2258,6 @@ func NewAssociationObject(srcAddr, dstAddr netip.Addr, color, preference uint32,
 	}
 
 	if opts.pccType == JuniperLegacy {
-		if !dstAddr.Is4() {
-			return nil, fmt.Errorf("invalid endpoint address for JuniperLegacy (NewAssociationObject): only IPv4 is supported, got dst=%v", dstAddr)
-		}
-
 		o.AssocID = 0
 		o.AssocType = AssocTypeSRPolicyAssociationJuniper
 		associationObjectTLVs := []TLVInterface{
@@ -2293,7 +2290,9 @@ func NewAssociationObject(srcAddr, dstAddr netip.Addr, color, preference uint32,
 			&SRPolicyCandidatePathIdentifier{
 				ProtocolOrigin: ProtocolOriginPCEP, // this PCE originates the candidate path
 				OriginatorASN:  opts.originatorASN,
-				OriginatorAddr: dstAddr,
+				// Originator is the PCE's headend address, not the policy endpoint
+				// (RFC 9256 §2.6, RFC 9862 §4.2).
+				OriginatorAddr: srcAddr,
 				Discriminator:  1, // keep existing wire value
 			},
 			&SRPolicyCandidatePathPreference{

--- a/pkg/packet/pcep/object.go
+++ b/pkg/packet/pcep/object.go
@@ -1653,8 +1653,8 @@ func (o *SRv6EroSubobject) decodeSID(subobject []uint8, off int) (int, error) {
 		return off, errors.New("SRv6EroSubobject: truncated SID")
 	}
 
-	sid, _ := netip.AddrFromSlice(subobject[off : off+16])
-	o.Segment = table.NewSegmentSRv6(sid)
+	addr, _ := netip.AddrFromSlice(subobject[off : off+16])
+	o.Segment = table.NewSegmentSRv6(table.SRv6SID(addr))
 
 	return off + 16, nil
 }
@@ -1723,9 +1723,9 @@ func (o *SRv6EroSubobject) Serialize() ([]uint8, error) {
 
 	reserved := make([]uint8, 2)
 
-	behaviorBytes := Uint16ToByteSlice(o.Segment.Behavior())
+	behaviorBytes := Uint16ToByteSlice(o.Segment.BehaviorOrDerived())
 
-	byteSid := o.Segment.Sid.AsSlice()
+	byteSid := o.Segment.Sid.Addr().AsSlice()
 
 	byteNAI := o.Segment.LocalAddr.AsSlice()
 	if o.Segment.RemoteAddr.IsValid() {

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -28,7 +28,8 @@ const (
 // fakeSegment is used to test unsupported segment types.
 type fakeSegment struct{}
 
-func (fakeSegment) SidString() string { return "fake" }
+func (fakeSegment) SidString() string       { return "fake" }
+func (fakeSegment) Family() table.DataPlane { return table.DPUnspecified }
 
 func TestSREroSubobject_RoundTrip(t *testing.T) {
 	t.Parallel()
@@ -464,7 +465,7 @@ func TestSREroSubobject_DecodeFromBytes_TruncatedAfterHeader(t *testing.T) {
 func TestSRv6EroSubobject_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	sid := netip.MustParseAddr("fc00:0:1::")
+	sid := table.SRv6SID(netip.MustParseAddr("fc00:0:1::"))
 	local := netip.MustParseAddr(testIPv6Addr1)
 	remote := netip.MustParseAddr(testIPv6Addr2)
 
@@ -1316,7 +1317,7 @@ func TestNewSrpObject(t *testing.T) {
 			want: &pcep.SrpObject{ObjectType: pcep.ObjectTypeSRPSRP, SrpID: 2, TLVs: []pcep.TLVInterface{&pcep.PathSetupType{PathSetupType: pcep.PathSetupTypeSRTE}}},
 		},
 		"SRv6": {
-			segs: []table.Segment{table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::"))}, srpID: 3, remove: true,
+			segs: []table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00:0:1::")))}, srpID: 3, remove: true,
 			want: &pcep.SrpObject{ObjectType: pcep.ObjectTypeSRPSRP, RFlag: true, SrpID: 3, TLVs: []pcep.TLVInterface{&pcep.PathSetupType{PathSetupType: pcep.PathSetupTypeSRv6TE}}},
 		},
 		"InvalidSegmentType": {
@@ -1351,7 +1352,7 @@ func TestPathSetupTypeForSegments(t *testing.T) {
 		"NoSegments":         {nil, 0, false},
 		"UnknownSegmentType": {[]table.Segment{fakeSegment{}}, 0, false},
 		"SRMPLS":             {[]table.Segment{table.NewSegmentSRMPLS(16001)}, pcep.PathSetupTypeSRTE, true},
-		"SRv6":               {[]table.Segment{table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::"))}, pcep.PathSetupTypeSRv6TE, true},
+		"SRv6":               {[]table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00:0:1::")))}, pcep.PathSetupTypeSRv6TE, true},
 	}
 
 	for name, tt := range cases {
@@ -1499,7 +1500,7 @@ func TestNewEroSubobject(t *testing.T) {
 	t.Run("SRv6", func(t *testing.T) {
 		t.Parallel()
 
-		seg := table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::"))
+		seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00:0:1::")))
 		subo, err := pcep.NewEroSubobject(seg)
 		require.NoError(t, err)
 		assert.IsType(t, &pcep.SRv6EroSubobject{}, subo)
@@ -1516,7 +1517,7 @@ func TestNewEroSubobject(t *testing.T) {
 		t.Parallel()
 
 		seg := table.SegmentSRv6{
-			Sid:        netip.MustParseAddr("fc00:0:1::"),
+			Sid:        table.SRv6SID(netip.MustParseAddr("fc00:0:1::")),
 			LocalAddr:  netip.MustParseAddr("fe80::1"),
 			RemoteAddr: netip.MustParseAddr("fe80::2"),
 		}
@@ -1628,7 +1629,7 @@ func TestNAITypeSRv6_StringWithReference(t *testing.T) {
 func TestSRv6EroSubobject_ToSegment(t *testing.T) {
 	t.Parallel()
 
-	seg := table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::"))
+	seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00:0:1::")))
 	subo := &pcep.SRv6EroSubobject{Segment: seg}
 	assert.Equal(t, seg, subo.ToSegment())
 }
@@ -1660,7 +1661,7 @@ func TestSRv6EroSubobject_Serialize_UnknownBehavior(t *testing.T) {
 		SubobjectType: pcep.SubobjectTypeEROSRv6,
 		NAIType:       pcep.NAITypeSRv6Absent,
 		FFlag:         true,
-		Segment:       table.SegmentSRv6{Sid: netip.MustParseAddr("fc00:0:1::")},
+		Segment:       table.SegmentSRv6{Sid: table.SRv6SID(netip.MustParseAddr("fc00:0:1::"))},
 	}
 
 	b, err := o.Serialize()
@@ -1895,7 +1896,7 @@ func TestEroObject_Serialize_LenError_SRv6AbsentNAI(t *testing.T) {
 		SubobjectType: pcep.SubobjectTypeEROSRv6,
 		NAIType:       pcep.NAITypeSRv6Absent,
 		FFlag:         false,
-		Segment:       table.SegmentSRv6{Sid: netip.MustParseAddr("fc00:0:1::")},
+		Segment:       table.SegmentSRv6{Sid: table.SRv6SID(netip.MustParseAddr("fc00:0:1::"))},
 	}
 	o := pcep.EroObject{ObjectType: pcep.ObjectTypeEROExplicitRoute, EroSubobjects: []pcep.EroSubobject{badSubo}}
 
@@ -2073,7 +2074,7 @@ func TestSRv6EroSubobject_DecodeFromBytes_TruncatedAfterHeader(t *testing.T) {
 func TestNewSRv6EroSubobject_NAIFromSegment(t *testing.T) {
 	t.Parallel()
 
-	sid := netip.MustParseAddr("fc00:0:1::")
+	sid := table.SRv6SID(netip.MustParseAddr("fc00:0:1::"))
 	local := netip.MustParseAddr(testIPv6Addr1)
 	remote := netip.MustParseAddr(testIPv6Addr2)
 
@@ -2115,7 +2116,7 @@ func TestNewSRv6EroSubobject_NAIFromSegment(t *testing.T) {
 func TestNewSRv6EroSubobject_LinkLocalRejected(t *testing.T) {
 	t.Parallel()
 
-	sid := netip.MustParseAddr("fc00:0:1::")
+	sid := table.SRv6SID(netip.MustParseAddr("fc00:0:1::"))
 
 	cases := map[string]table.SegmentSRv6{
 		"LinkLocalAdjacency": {
@@ -2139,7 +2140,7 @@ func TestNewSRv6EroSubobject_LinkLocalRejected(t *testing.T) {
 func TestNewSRv6EroSubobject_AddressFamilyRejected(t *testing.T) {
 	t.Parallel()
 
-	sid := netip.MustParseAddr("fc00:0:1::")
+	sid := table.SRv6SID(netip.MustParseAddr("fc00:0:1::"))
 
 	cases := map[string]table.SegmentSRv6{
 		"IPv4LocalAddr": {
@@ -2166,7 +2167,7 @@ func TestNewSRv6EroSubobject_AddressFamilyRejected(t *testing.T) {
 func TestNewSRv6EroSubobject_StructureValidation(t *testing.T) {
 	t.Parallel()
 
-	sid := netip.MustParseAddr("fc00:0:1::")
+	sid := table.SRv6SID(netip.MustParseAddr("fc00:0:1::"))
 	local := netip.MustParseAddr(testIPv6Addr1)
 
 	t.Run("NilStructureIsAbsent", func(t *testing.T) {

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -50,6 +50,16 @@ func TestSREroSubobject_RoundTrip(t *testing.T) {
 
 		return seg
 	}
+	mkSRMPLSWithLinkLocalNAI := func(sid uint32, local, remote string, localIfaceID, remoteIfaceID uint32) table.SegmentSRMPLS {
+		seg := table.NewSegmentSRMPLS(sid)
+
+		seg.LocalAddr = netip.MustParseAddr(local)
+		seg.RemoteAddr = netip.MustParseAddr(remote)
+		seg.LocalIfaceID = &localIfaceID
+		seg.RemoteIfaceID = &remoteIfaceID
+
+		return seg
+	}
 
 	cases := map[string]pcep.SREroSubobject{
 		"NAIAbsent_LabelOnly": {
@@ -94,6 +104,12 @@ func TestSREroSubobject_RoundTrip(t *testing.T) {
 			NAIType:       pcep.NAITypeSRIPv6AdjacencyGlobal,
 			MFlag:         true,
 			Segment:       mkSRMPLSWithNAI(24002, testIPv6Addr1, testIPv6Addr2),
+		},
+		"IPv6AdjacencyLinkLocal": {
+			SubobjectType: pcep.SubobjectTypeEROSR,
+			NAIType:       pcep.NAITypeSRIPv6AdjacencyLinkLocal,
+			MFlag:         true,
+			Segment:       mkSRMPLSWithLinkLocalNAI(24003, "fe80::1", "fe80::2", 5, 7),
 		},
 		"IPv4Node_CFlag_MPLSStackAttrs": {
 			SubobjectType: pcep.SubobjectTypeEROSR,
@@ -181,6 +197,16 @@ func TestNewSREroSubobject_NAIFromSegment(t *testing.T) {
 		},
 		"LinkLocalRemoteOnly": {
 			seg: mk(testIPv6Addr1, "fe80::2"), wantErr: true,
+		},
+		"LinkLocalAdjacencyWithIfaceID": {
+			seg: func() table.SegmentSRMPLS {
+				seg := mk("fe80::1", "fe80::2")
+				localIfaceID, remoteIfaceID := uint32(1), uint32(2)
+				seg.LocalIfaceID, seg.RemoteIfaceID = &localIfaceID, &remoteIfaceID
+
+				return seg
+			}(),
+			wantNAIType: pcep.NAITypeSRIPv6AdjacencyLinkLocal, wantLength: 4 + 4 + 40,
 		},
 	}
 
@@ -278,6 +304,12 @@ func TestSREroSubobject_SerializeRejectsNAIMismatch(t *testing.T) {
 			pcep.NAITypeSRIPv6AdjacencyGlobal, testIPv4Addr1, testIPv4Addr2,
 		),
 		"UnsupportedNAIType": mkSubo(pcep.NAITypeSRUnnumberedAdjacency, testIPv4Addr1, testIPv4Addr2),
+		"LinkLocalAdjacencyWithIPv4Addrs": mkSubo(
+			pcep.NAITypeSRIPv6AdjacencyLinkLocal, testIPv4Addr1, testIPv4Addr2,
+		),
+		"LinkLocalAdjacencyWithoutIfaceIDs": mkSubo(
+			pcep.NAITypeSRIPv6AdjacencyLinkLocal, testIPv6Addr1, testIPv6Addr2,
+		),
 	}
 
 	for name, subo := range cases {
@@ -468,8 +500,18 @@ func TestSRv6EroSubobject_RoundTrip(t *testing.T) {
 	sid := table.SRv6SID(netip.MustParseAddr("fc00:0:1::"))
 	local := netip.MustParseAddr(testIPv6Addr1)
 	remote := netip.MustParseAddr(testIPv6Addr2)
+	linkLocalIfaceID := uint32(5)
+	linkLocalRemoteIfaceID := uint32(7)
 
 	cases := map[string]pcep.SRv6EroSubobject{
+		"IPv6AdjLinkLocal_ENDX": {
+			SubobjectType: pcep.SubobjectTypeEROSRv6,
+			NAIType:       pcep.NAITypeSRv6IPv6AdjacencyLinkLocal,
+			Segment: table.SegmentSRv6{
+				Sid: sid, LocalAddr: netip.MustParseAddr("fe80::1"), RemoteAddr: netip.MustParseAddr("fe80::2"),
+				LocalIfaceID: &linkLocalIfaceID, RemoteIfaceID: &linkLocalRemoteIfaceID,
+			},
+		},
 		"IPv6Node_END": {
 			SubobjectType: pcep.SubobjectTypeEROSRv6,
 			NAIType:       pcep.NAITypeSRv6IPv6Node,
@@ -1653,7 +1695,6 @@ func TestSRv6EroSubobject_Len_Errors(t *testing.T) {
 	}
 }
 
-// Serialize still requires LocalAddr even when the NAI is absent (F=1).
 func TestSRv6EroSubobject_Serialize_UnknownBehavior(t *testing.T) {
 	t.Parallel()
 
@@ -1668,6 +1709,53 @@ func TestSRv6EroSubobject_Serialize_UnknownBehavior(t *testing.T) {
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(b), 8)
 	assert.Equal(t, table.BehaviorOpaque, binary.BigEndian.Uint16(b[6:8]))
+}
+
+func TestSRv6EroSubobject_Serialize_LinkLocalAdjacency(t *testing.T) {
+	t.Parallel()
+
+	local, remote := netip.MustParseAddr("fe80::1"), netip.MustParseAddr("fe80::2")
+	localIfaceID, remoteIfaceID := uint32(5), uint32(7)
+
+	seg := table.SegmentSRv6{
+		Sid:           table.SRv6SID(netip.MustParseAddr("fc00:0:1::")),
+		LocalAddr:     local,
+		RemoteAddr:    remote,
+		LocalIfaceID:  &localIfaceID,
+		RemoteIfaceID: &remoteIfaceID,
+	}
+
+	subo, err := pcep.NewSRv6EroSubobject(seg)
+	require.NoError(t, err)
+
+	b, err := subo.Serialize()
+	require.NoError(t, err)
+
+	var decoded pcep.SRv6EroSubobject
+	require.NoError(t, decoded.DecodeFromBytes(b))
+	assert.Equal(t, local, decoded.Segment.LocalAddr)
+	assert.Equal(t, remote, decoded.Segment.RemoteAddr)
+	require.NotNil(t, decoded.Segment.LocalIfaceID)
+	assert.Equal(t, localIfaceID, *decoded.Segment.LocalIfaceID)
+	require.NotNil(t, decoded.Segment.RemoteIfaceID)
+	assert.Equal(t, remoteIfaceID, *decoded.Segment.RemoteIfaceID)
+}
+
+func TestSRv6EroSubobject_Serialize_LinkLocalMissingIfaceIDs(t *testing.T) {
+	t.Parallel()
+
+	o := &pcep.SRv6EroSubobject{
+		SubobjectType: pcep.SubobjectTypeEROSRv6,
+		NAIType:       pcep.NAITypeSRv6IPv6AdjacencyLinkLocal,
+		Segment: table.SegmentSRv6{
+			Sid:        table.SRv6SID(netip.MustParseAddr("fc00:0:1::")),
+			LocalAddr:  netip.MustParseAddr("fe80::1"),
+			RemoteAddr: netip.MustParseAddr("fe80::2"),
+		},
+	}
+
+	_, err := o.Serialize()
+	assert.Error(t, err)
 }
 
 func TestEndpointsObject_Len_Error(t *testing.T) {
@@ -1981,6 +2069,10 @@ func TestSRv6EroSubobject_DecodeFromBytes_LinkLocalAdjacency(t *testing.T) {
 	require.NoError(t, o.DecodeFromBytes(raw))
 	assert.Equal(t, local, o.Segment.LocalAddr)
 	assert.Equal(t, remote, o.Segment.RemoteAddr)
+	require.NotNil(t, o.Segment.LocalIfaceID)
+	assert.Equal(t, uint32(0), *o.Segment.LocalIfaceID)
+	require.NotNil(t, o.Segment.RemoteIfaceID)
+	assert.Equal(t, uint32(0), *o.Segment.RemoteIfaceID)
 
 	l, err := o.Len()
 	require.NoError(t, err)
@@ -2098,6 +2190,17 @@ func TestNewSRv6EroSubobject_NAIFromSegment(t *testing.T) {
 			seg:         table.SegmentSRv6{Sid: sid, LocalAddr: local, Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16}},
 			wantNAIType: pcep.NAITypeSRv6IPv6Node, wantTFlag: true,
 		},
+		"LinkLocalAdjacencyWithIfaceID": {
+			seg: func() table.SegmentSRv6 {
+				localIfaceID, remoteIfaceID := uint32(1), uint32(2)
+
+				return table.SegmentSRv6{
+					Sid: sid, LocalAddr: netip.MustParseAddr("fe80::1"), RemoteAddr: netip.MustParseAddr("fe80::2"),
+					LocalIfaceID: &localIfaceID, RemoteIfaceID: &remoteIfaceID,
+				}
+			}(),
+			wantNAIType: pcep.NAITypeSRv6IPv6AdjacencyLinkLocal,
+		},
 	}
 
 	for name, tt := range cases {
@@ -2151,6 +2254,12 @@ func TestNewSRv6EroSubobject_AddressFamilyRejected(t *testing.T) {
 		},
 		"RemoteAddrWithoutLocalAddr": {
 			Sid: sid, RemoteAddr: netip.MustParseAddr(testIPv6Addr2),
+		},
+		"IPv4MappedSid": {
+			Sid: table.SRv6SID(netip.MustParseAddr("::ffff:192.0.2.1")), LocalAddr: netip.MustParseAddr(testIPv6Addr1),
+		},
+		"IPv4Sid": {
+			Sid: table.SRv6SID(netip.MustParseAddr(testIPv4Addr1)), LocalAddr: netip.MustParseAddr(testIPv6Addr1),
 		},
 	}
 

--- a/pkg/packet/pcep/object_test.go
+++ b/pkg/packet/pcep/object_test.go
@@ -798,7 +798,7 @@ func TestNewAssociationObject_DefaultCandidatePathIdentifier(t *testing.T) {
 		0x0a, 0x00, 0x00, 0x00, // protocol=0x0a + mbz
 		0x00, 0x00, 0x00, 0x00, // ASN=0
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // originator addr padding
-		0xc0, 0x00, 0x02, 0x02, // dstAddr=192.0.2.2
+		0xc0, 0x00, 0x02, 0x01, // originator=srcAddr=192.0.2.1 (RFC 9256 §2.6, RFC 9862 §4.2)
 		0x00, 0x00, 0x00, 0x01, // discriminator=1
 		0x00, 0x3b, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, // SRPOLICY-CPATH-PREFERENCE TLV: preference=200
 	}
@@ -844,18 +844,6 @@ func TestNewAssociationObject_JuniperLegacy_OriginatorASN(t *testing.T) {
 			assert.Equal(t, tt.expectedASN, cpID.OriginatorASN)
 		})
 	}
-}
-
-// pcep.JuniperLegacy uses the IPv4 Extended Association ID TLV format.
-// IPv6 endpoints must be rejected during object construction.
-func TestNewAssociationObject_JuniperLegacy_RejectsIPv6(t *testing.T) {
-	t.Parallel()
-
-	srcAddr := netip.MustParseAddr(testIPv6Addr1)
-	dstAddr := netip.MustParseAddr(testIPv6Addr2)
-
-	_, err := pcep.NewAssociationObject(srcAddr, dstAddr, 100, 200, pcep.VendorSpecific(pcep.JuniperLegacy))
-	assert.Error(t, err)
 }
 
 // Verifies Juniper vendor-specific TLVs preserve typed fields and legacy wire format.
@@ -1882,8 +1870,9 @@ func TestAssociationObject_Serialize_ObjectLengthBoundary(t *testing.T) {
 func TestNewAssociationObject_MismatchedFamilies(t *testing.T) {
 	t.Parallel()
 
-	_, err := pcep.NewAssociationObject(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr(testIPv6Addr1), 100, 200)
-	assert.Error(t, err)
+	o, err := pcep.NewAssociationObject(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr(testIPv6Addr1), 100, 200)
+	require.NoError(t, err)
+	assert.Equal(t, pcep.ObjectTypeAssociationIPv4, o.ObjectType)
 }
 
 func TestNewAssociationObject_ObjectType(t *testing.T) {
@@ -1907,6 +1896,13 @@ func TestNewAssociationObject_ObjectType(t *testing.T) {
 			assert.Equal(t, tt.want, o.ObjectType)
 		})
 	}
+}
+
+func TestNewAssociationObject_InvalidSrcAddr(t *testing.T) {
+	t.Parallel()
+
+	_, err := pcep.NewAssociationObject(netip.Addr{}, netip.MustParseAddr("192.0.2.2"), 100, 200)
+	require.Error(t, err)
 }
 
 func TestAssociationObject_Endpoint(t *testing.T) {

--- a/pkg/packet/pcep/pcep_internal_test.go
+++ b/pkg/packet/pcep/pcep_internal_test.go
@@ -459,7 +459,7 @@ func TestEroObject_RoundTrip(t *testing.T) {
 		return subo
 	}
 	mkSRv6Ero := func(sidStr, localStr string) *SRv6EroSubobject {
-		seg := table.NewSegmentSRv6(netip.MustParseAddr(sidStr))
+		seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(sidStr)))
 		seg.LocalAddr = netip.MustParseAddr(localStr)
 		subo, err := NewSRv6EroSubobject(seg)
 		require.NoError(t, err)

--- a/pkg/packet/pcep/pcep_internal_test.go
+++ b/pkg/packet/pcep/pcep_internal_test.go
@@ -66,7 +66,7 @@ func TestNAITypeSR_naiLength(t *testing.T) {
 		"IPv4Adjacency":          {nt: NAITypeSRIPv4Adjacency, want: 8},
 		"IPv6AdjacencyGlobal":    {nt: NAITypeSRIPv6AdjacencyGlobal, want: 32},
 		"UnnumberedAdjacency":    {nt: NAITypeSRUnnumberedAdjacency, wantErr: true},
-		"IPv6AdjacencyLinkLocal": {nt: NAITypeSRIPv6AdjacencyLinkLocal, wantErr: true},
+		"IPv6AdjacencyLinkLocal": {nt: NAITypeSRIPv6AdjacencyLinkLocal, want: 40},
 		"Unknown":                {nt: NAITypeSR(0x07), wantErr: true},
 	}
 

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -608,15 +608,23 @@ func buildLsSrv6SID(s *table.LsSrv6SID) *pb.LsSrv6SID {
 		pbSID.MultiTopoIds = append(pbSID.MultiTopoIds, &pb.MultiTopoID{MultiTopoId: topoID})
 	}
 
-	if s.EndpointBehavior != (table.EndpointBehavior{}) {
-		pbSID.EndpointBehavior = &pb.EndpointBehavior{
-			Behavior:  uint32(s.EndpointBehavior.Behavior),
-			Flags:     uint32(s.EndpointBehavior.Flags),
-			Algorithm: uint32(s.EndpointBehavior.Algorithm),
-		}
-	}
+	pbSID.EndpointBehavior = buildEndpointBehavior(s.EndpointBehavior)
 
 	return pbSID
+}
+
+// buildEndpointBehavior returns nil for the zero value to distinguish an absent
+// behavior from the End behavior (0) on the wire.
+func buildEndpointBehavior(eb table.EndpointBehavior) *pb.EndpointBehavior {
+	if eb == (table.EndpointBehavior{}) {
+		return nil
+	}
+
+	return &pb.EndpointBehavior{
+		Behavior:  uint32(eb.Behavior),
+		Flags:     uint32(eb.Flags),
+		Algorithm: uint32(eb.Algorithm),
+	}
 }
 
 // buildSidStructure preserves SID Structure presence.
@@ -635,7 +643,8 @@ func buildSidStructure(s *table.SIDStructure) *pb.SidStructure {
 
 func convertSrv6EndXSID(sid *table.Srv6EndXSID) *pb.Srv6EndXSID {
 	pbSID := &pb.Srv6EndXSID{
-		EndpointBehavior: uint32(sid.EndpointBehavior),
+		EndpointBehavior: buildEndpointBehavior(sid.EndpointBehavior),
+		Weight:           uint32(sid.Weight),
 		Sids:             make([]*pb.SID, 0, len(sid.Sids)),
 		SidStructure:     buildSidStructure(sid.Srv6SIDStructure),
 	}

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -416,7 +416,7 @@ func convertLsLinks(links []*table.LsLink, lg *logger.Logger) []*pb.LsLink {
 
 	result := make([]*pb.LsLink, 0, len(links))
 	for _, link := range links {
-		if link == nil || link.LocalNode == nil || link.RemoteNode == nil {
+		if link == nil || link.Local.Node == nil || link.Remote.Node == nil {
 			lg.Debug("skip link with nil node", logger.Any("link", link))
 			continue
 		}
@@ -427,34 +427,43 @@ func convertLsLinks(links []*table.LsLink, lg *logger.Logger) []*pb.LsLink {
 	return result
 }
 
-// buildLsLink converts a single table.LsLink to protobuf LsLink.
+// The protobuf has no per-family address fields, so dual-stack links
+// report whichever address is available, preferring IPv4.
 func buildLsLink(link *table.LsLink) *pb.LsLink {
-	var localIP, remoteIP string
-
-	if link.LocalIP.IsValid() {
-		localIP = link.LocalIP.String()
-	}
-
-	if link.RemoteIP.IsValid() {
-		remoteIP = link.RemoteIP.String()
-	}
+	localIP := firstValidAddrString(link.Local.IPv4, link.Local.IPv6)
+	remoteIP := firstValidAddrString(link.Remote.IPv4, link.Remote.IPv6)
 
 	pbLink := &pb.LsLink{
-		LocalRouterId:  link.LocalNode.RouterID,
-		LocalAsn:       link.LocalNode.ASN,
+		LocalRouterId:  link.Local.Node.RouterID,
+		LocalAsn:       link.Local.Node.ASN,
 		LocalIp:        localIP,
-		RemoteRouterId: link.RemoteNode.RouterID,
-		RemoteAsn:      link.RemoteNode.ASN,
+		RemoteRouterId: link.Remote.Node.RouterID,
+		RemoteAsn:      link.Remote.Node.ASN,
 		RemoteIp:       remoteIP,
 		Metrics:        convertMetrics(link.Metrics),
-		AdjSid:         link.AdjSid,
 	}
 
-	if link.Srv6EndXSID != nil {
-		pbLink.Srv6EndXSid = convertSrv6EndXSID(link.Srv6EndXSID)
+	if len(link.AdjSids) > 0 {
+		pbLink.AdjSid = link.AdjSids[0].Sid
+	}
+
+	if len(link.Srv6EndXSIDs) > 0 && link.Srv6EndXSIDs[0] != nil {
+		pbLink.Srv6EndXSid = convertSrv6EndXSID(link.Srv6EndXSIDs[0])
 	}
 
 	return pbLink
+}
+
+func firstValidAddrString(v4, v6 netip.Addr) string {
+	if v4.IsValid() {
+		return v4.String()
+	}
+
+	if v6.IsValid() {
+		return v6.String()
+	}
+
+	return ""
 }
 
 // convertMetrics converts a slice of table.Metric to protobuf Metric.

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -81,7 +81,6 @@ func toPBSyncState(state SyncState) pb.LspDbSyncState {
 	}
 }
 
-// toPBSessionStats converts session counters and setup counters to protobuf.
 // Counters not applicable to Pola's PCE role are reported as 0.
 func toPBSessionStats(stats SessionStats, setupOK, setupFail uint64) *pb.SessionStats {
 	return &pb.SessionStats{
@@ -214,7 +213,6 @@ func capabilityType(t pcep.TLVType) pb.CapabilityType {
 	}
 }
 
-// buildPBSession converts a Session to its protobuf representation.
 // Stats is included only when requested.
 func (s *APIServer) buildPBSession(pcepSession *Session, includeStats bool) *pb.Session {
 	snap := pcepSession.snapshot()
@@ -297,6 +295,8 @@ func (s *APIServer) buildPBSRPolicy(pcepSession *Session, policy *table.SRPolicy
 
 	srPolicy.SrcRouterId = routerIDIndex[policy.SrcAddr]
 	srPolicy.DstRouterId = routerIDIndex[policy.DstAddr]
+	srPolicy.UnderlayFamily = toPBAddressFamily(policy.Plane.Family)
+	srPolicy.DataPlane = toPBDataPlane(policy.Plane.DataPlane)
 
 	for _, segment := range policy.SegmentList {
 		srPolicy.SegmentList = append(srPolicy.SegmentList, convertSegment(segment))
@@ -305,8 +305,6 @@ func (s *APIServer) buildPBSRPolicy(pcepSession *Session, policy *table.SRPolicy
 	return srPolicy
 }
 
-// buildPBSRPolicySession converts a Session and its SR Policies into the
-// lightweight SRPolicySession representation returned by GetSRPolicyList.
 func buildPBSRPolicySession(pcepSession *Session, policies []*pb.SRPolicy) *pb.SRPolicySession {
 	snap := pcepSession.snapshot()
 
@@ -315,6 +313,50 @@ func buildPBSRPolicySession(pcepSession *Session, policies []*pb.SRPolicy) *pb.S
 		State:      toPBSessionState(snap.state),
 		SyncState:  toPBSyncState(snap.syncState),
 		SrPolicies: policies,
+	}
+}
+
+func toPBAddressFamily(af table.AddressFamily) pb.AddressFamily {
+	switch af {
+	case table.AFIPv4:
+		return pb.AddressFamily_ADDRESS_FAMILY_IPV4
+	case table.AFIPv6:
+		return pb.AddressFamily_ADDRESS_FAMILY_IPV6
+	default:
+		return pb.AddressFamily_ADDRESS_FAMILY_UNSPECIFIED
+	}
+}
+
+func fromPBAddressFamily(af pb.AddressFamily) table.AddressFamily {
+	switch af {
+	case pb.AddressFamily_ADDRESS_FAMILY_IPV4:
+		return table.AFIPv4
+	case pb.AddressFamily_ADDRESS_FAMILY_IPV6:
+		return table.AFIPv6
+	default:
+		return table.AFUnspecified
+	}
+}
+
+func toPBDataPlane(dp table.DataPlane) pb.DataPlane {
+	switch dp {
+	case table.DPSRMPLS:
+		return pb.DataPlane_DATA_PLANE_SR_MPLS
+	case table.DPSRv6:
+		return pb.DataPlane_DATA_PLANE_SRV6
+	default:
+		return pb.DataPlane_DATA_PLANE_UNSPECIFIED
+	}
+}
+
+func fromPBDataPlane(dp pb.DataPlane) table.DataPlane {
+	switch dp {
+	case pb.DataPlane_DATA_PLANE_SR_MPLS:
+		return table.DPSRMPLS
+	case pb.DataPlane_DATA_PLANE_SRV6:
+		return table.DPSRv6
+	default:
+		return table.DPUnspecified
 	}
 }
 
@@ -374,6 +416,9 @@ func convertSegment(seg table.Segment) *pb.Segment {
 		if s := v.Structure; s != nil {
 			pbSeg.SidStructure = fmt.Sprintf("%d,%d,%d,%d", s.LocalBlock, s.LocalNode, s.LocalFunc, s.LocalArg)
 		}
+
+		pbSeg.Behavior = uint32(v.Behavior)
+		setPBIfaceIDs(pbSeg, v.LocalIfaceID, v.RemoteIfaceID)
 	case table.SegmentSRMPLS:
 		if v.LocalAddr.IsValid() {
 			pbSeg.LocalAddr = v.LocalAddr.String()
@@ -384,12 +429,22 @@ func convertSegment(seg table.Segment) *pb.Segment {
 		}
 
 		pbSeg.SidAbsent = v.SidAbsent
+		setPBIfaceIDs(pbSeg, v.LocalIfaceID, v.RemoteIfaceID)
 	}
 
 	return pbSeg
 }
 
-// convertLsNode converts a table.LsNode to a protobuf LsNode.
+func setPBIfaceIDs(pbSeg *pb.Segment, localIfaceID, remoteIfaceID *uint32) {
+	if localIfaceID != nil {
+		pbSeg.LocalIfaceId = new(*localIfaceID)
+	}
+
+	if remoteIfaceID != nil {
+		pbSeg.RemoteIfaceId = new(*remoteIfaceID)
+	}
+}
+
 func convertLsNode(lsNode *table.LsNode, lg *logger.Logger) *pb.LsNode {
 	if lsNode == nil {
 		return nil
@@ -408,7 +463,6 @@ func convertLsNode(lsNode *table.LsNode, lg *logger.Logger) *pb.LsNode {
 	}
 }
 
-// convertLsLinks converts a slice of table.LsLink to protobuf LsLink.
 func convertLsLinks(links []*table.LsLink, lg *logger.Logger) []*pb.LsLink {
 	if links == nil {
 		return nil
@@ -427,46 +481,51 @@ func convertLsLinks(links []*table.LsLink, lg *logger.Logger) []*pb.LsLink {
 	return result
 }
 
-// The protobuf has no per-family address fields, so dual-stack links
-// report whichever address is available, preferring IPv4.
 func buildLsLink(link *table.LsLink) *pb.LsLink {
-	localIP := firstValidAddrString(link.Local.IPv4, link.Local.IPv6)
-	remoteIP := firstValidAddrString(link.Remote.IPv4, link.Remote.IPv6)
-
 	pbLink := &pb.LsLink{
-		LocalRouterId:  link.Local.Node.RouterID,
-		LocalAsn:       link.Local.Node.ASN,
-		LocalIp:        localIP,
-		RemoteRouterId: link.Remote.Node.RouterID,
-		RemoteAsn:      link.Remote.Node.ASN,
-		RemoteIp:       remoteIP,
-		Metrics:        convertMetrics(link.Metrics),
+		Local:   buildLsLinkEndpoint(link.Local),
+		Remote:  buildLsLinkEndpoint(link.Remote),
+		Metrics: convertMetrics(link.Metrics),
 	}
 
-	if len(link.AdjSids) > 0 {
-		pbLink.AdjSid = link.AdjSids[0].Sid
+	for _, adjSID := range link.AdjSids {
+		pbLink.AdjSids = append(pbLink.AdjSids, &pb.AdjSid{
+			Family: toPBAddressFamily(adjSID.Family),
+			Sid:    adjSID.Sid,
+		})
 	}
 
-	if len(link.Srv6EndXSIDs) > 0 && link.Srv6EndXSIDs[0] != nil {
-		pbLink.Srv6EndXSid = convertSrv6EndXSID(link.Srv6EndXSIDs[0])
+	for _, endXSID := range link.Srv6EndXSIDs {
+		if endXSID != nil {
+			pbLink.Srv6EndXSids = append(pbLink.Srv6EndXSids, convertSrv6EndXSID(endXSID))
+		}
 	}
 
 	return pbLink
 }
 
-func firstValidAddrString(v4, v6 netip.Addr) string {
-	if v4.IsValid() {
-		return v4.String()
+// buildLsLinkEndpoint preserves each advertised address family independently.
+func buildLsLinkEndpoint(e table.LinkEndpoint) *pb.LsLinkEndpoint {
+	pbEndpoint := &pb.LsLinkEndpoint{
+		RouterId: e.Node.RouterID,
+		Asn:      e.Node.ASN,
 	}
 
-	if v6.IsValid() {
-		return v6.String()
+	if e.InterfaceID != nil {
+		pbEndpoint.InterfaceId = new(*e.InterfaceID)
 	}
 
-	return ""
+	if e.IPv4.IsValid() {
+		pbEndpoint.Ipv4 = e.IPv4.String()
+	}
+
+	if e.IPv6.IsValid() {
+		pbEndpoint.Ipv6 = e.IPv6.String()
+	}
+
+	return pbEndpoint
 }
 
-// convertMetrics converts a slice of table.Metric to protobuf Metric.
 func convertMetrics(metrics []*table.Metric) []*pb.Metric {
 	if metrics == nil {
 		return nil
@@ -484,7 +543,6 @@ func convertMetrics(metrics []*table.Metric) []*pb.Metric {
 	return result
 }
 
-// convertLsPrefixes converts a slice of table.LsPrefix to protobuf LsPrefix.
 func convertLsPrefixes(prefixes []*table.LsPrefix) []*pb.LsPrefix {
 	if prefixes == nil {
 		return nil
@@ -506,7 +564,6 @@ func convertLsPrefixes(prefixes []*table.LsPrefix) []*pb.LsPrefix {
 	return result
 }
 
-// convertLsSrv6SIDs converts a slice of table.LsSrv6SID to protobuf LsSrv6SID.
 func convertLsSrv6SIDs(sids []*table.LsSrv6SID) []*pb.LsSrv6SID {
 	if sids == nil {
 		return nil
@@ -522,7 +579,6 @@ func convertLsSrv6SIDs(sids []*table.LsSrv6SID) []*pb.LsSrv6SID {
 	return result
 }
 
-// buildLsSrv6SID converts a single table.LsSrv6SID to protobuf LsSrv6SID.
 func buildLsSrv6SID(s *table.LsSrv6SID) *pb.LsSrv6SID {
 	pbSID := &pb.LsSrv6SID{
 		Sids:         make([]*pb.SID, 0, len(s.Sids)),

--- a/pkg/server/grpc_convert.go
+++ b/pkg/server/grpc_convert.go
@@ -279,30 +279,53 @@ func (s *APIServer) buildPBSession(pcepSession *Session, includeStats bool) *pb.
 
 func (s *APIServer) buildPBSRPolicy(pcepSession *Session, policy *table.SRPolicy, routerIDIndex map[netip.Addr]string) *pb.SRPolicy {
 	srPolicy := &pb.SRPolicy{
-		PeerAddr:    pcepSession.peerAddr.AsSlice(),
-		SegmentList: make([]*pb.Segment, 0, len(policy.SegmentList)),
-		Color:       policy.Color,
-		Preference:  policy.Preference,
-		PolicyName:  policy.Name,
-		SrcAddr:     policy.SrcAddr.AsSlice(),
-		DstAddr:     policy.DstAddr.AsSlice(),
-		PlspId:      policy.PlspID,
-		LspId:       uint32(policy.LSPID),
-		State:       toPBPolicyState(policy.State),
-		Type:        toPBPolicyType(policy.Type),
-		Metric:      toPBMetricType(policy.Metric),
+		PeerAddr:         pcepSession.peerAddr.AsSlice(),
+		SegmentList:      make([]*pb.Segment, 0, len(policy.SegmentList)),
+		Color:            policy.Color,
+		PolicyName:       policy.Name,
+		Headend:          policy.Headend.AsSlice(),
+		Endpoint:         policy.Endpoint.AsSlice(),
+		PlspId:           policy.PlspID,
+		LspId:            uint32(policy.LSPID),
+		State:            toPBPolicyState(policy.State),
+		CandidatePath:    toPBCandidatePath(policy.CandidatePath),
+		HeadendRouterId:  routerIDIndex[policy.Headend],
+		EndpointRouterId: routerIDIndex[policy.Endpoint],
 	}
-
-	srPolicy.SrcRouterId = routerIDIndex[policy.SrcAddr]
-	srPolicy.DstRouterId = routerIDIndex[policy.DstAddr]
-	srPolicy.UnderlayFamily = toPBAddressFamily(policy.Plane.Family)
-	srPolicy.DataPlane = toPBDataPlane(policy.Plane.DataPlane)
 
 	for _, segment := range policy.SegmentList {
 		srPolicy.SegmentList = append(srPolicy.SegmentList, convertSegment(segment))
 	}
 
 	return srPolicy
+}
+
+func toPBCandidatePath(cp table.CandidatePath) *pb.CandidatePath {
+	pbCP := &pb.CandidatePath{Preference: cp.Preference}
+
+	switch {
+	case cp.Dynamic != nil:
+		pbCP.Path = &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+			Metric:         toPBMetricType(cp.Dynamic.Metric),
+			DataPlane:      toPBDataPlane(cp.Dynamic.Plane.DataPlane),
+			UnderlayFamily: toPBAddressFamily(cp.Dynamic.Plane.Family),
+		}}
+	case cp.Explicit != nil:
+		pbCP.Path = &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{
+			SegmentList: convertSegmentList(cp.Explicit.SegmentList),
+		}}
+	}
+
+	return pbCP
+}
+
+func convertSegmentList(segmentList []table.Segment) []*pb.Segment {
+	pbSegments := make([]*pb.Segment, 0, len(segmentList))
+	for _, segment := range segmentList {
+		pbSegments = append(pbSegments, convertSegment(segment))
+	}
+
+	return pbSegments
 }
 
 func buildPBSRPolicySession(pcepSession *Session, policies []*pb.SRPolicy) *pb.SRPolicySession {
@@ -357,17 +380,6 @@ func fromPBDataPlane(dp pb.DataPlane) table.DataPlane {
 		return table.DPSRv6
 	default:
 		return table.DPUnspecified
-	}
-}
-
-func toPBPolicyType(polType table.PolicyType) pb.SRPolicyType {
-	switch polType {
-	case table.PolicyTypeExplicit:
-		return pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT
-	case table.PolicyTypeDynamic:
-		return pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC
-	default:
-		return pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED
 	}
 }
 

--- a/pkg/server/grpc_convert_internal_test.go
+++ b/pkg/server/grpc_convert_internal_test.go
@@ -229,8 +229,17 @@ func TestBuildLsLink_LinkIPs(t *testing.T) {
 			t.Parallel()
 
 			link := table.NewLsLink(localNode, remoteNode)
-			link.LocalIP = tt.localIP
-			link.RemoteIP = tt.remoteIP
+			if tt.localIP.Is4() {
+				link.Local.IPv4 = tt.localIP
+			} else {
+				link.Local.IPv6 = tt.localIP
+			}
+
+			if tt.remoteIP.Is4() {
+				link.Remote.IPv4 = tt.remoteIP
+			} else {
+				link.Remote.IPv6 = tt.remoteIP
+			}
 
 			got := buildLsLink(link)
 
@@ -297,7 +306,9 @@ func TestGetTED_LinksWithoutIPsRoundTripToCLI(t *testing.T) {
 
 	for _, gotNode := range got.Nodes {
 		require.Len(t, gotNode.Links, 1)
-		assert.False(t, gotNode.Links[0].LocalIP.IsValid())
-		assert.False(t, gotNode.Links[0].RemoteIP.IsValid())
+		assert.False(t, gotNode.Links[0].Local.IPv4.IsValid())
+		assert.False(t, gotNode.Links[0].Local.IPv6.IsValid())
+		assert.False(t, gotNode.Links[0].Remote.IPv4.IsValid())
+		assert.False(t, gotNode.Links[0].Remote.IPv6.IsValid())
 	}
 }

--- a/pkg/server/grpc_convert_internal_test.go
+++ b/pkg/server/grpc_convert_internal_test.go
@@ -203,25 +203,29 @@ func TestBuildLsLink_LinkIPs(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		localIP      netip.Addr
-		remoteIP     netip.Addr
-		wantLocalIP  string
-		wantRemoteIP string
+		localIPv4    netip.Addr
+		localIPv6    netip.Addr
+		remoteIPv4   netip.Addr
+		wantLocalV4  string
+		wantLocalV6  string
+		wantRemoteV4 string
 	}{
 		{
 			name:         "valid IPs are stringified",
-			localIP:      netip.MustParseAddr("192.0.2.1"),
-			remoteIP:     netip.MustParseAddr("192.0.2.2"),
-			wantLocalIP:  "192.0.2.1",
-			wantRemoteIP: "192.0.2.2",
+			localIPv4:    netip.MustParseAddr("192.0.2.1"),
+			remoteIPv4:   netip.MustParseAddr("192.0.2.2"),
+			wantLocalV4:  "192.0.2.1",
+			wantRemoteV4: "192.0.2.2",
 		},
 		{
 			name: "absent IPs stay empty",
 		},
 		{
-			name:        "only the valid side is stringified",
-			localIP:     netip.MustParseAddr("2001:db8::1"),
-			wantLocalIP: "2001:db8::1",
+			name:        "each family round-trips independently",
+			localIPv4:   netip.MustParseAddr("192.0.2.1"),
+			localIPv6:   netip.MustParseAddr("2001:db8::1"),
+			wantLocalV4: "192.0.2.1",
+			wantLocalV6: "2001:db8::1",
 		},
 	}
 	for _, tt := range tests {
@@ -229,24 +233,62 @@ func TestBuildLsLink_LinkIPs(t *testing.T) {
 			t.Parallel()
 
 			link := table.NewLsLink(localNode, remoteNode)
-			if tt.localIP.Is4() {
-				link.Local.IPv4 = tt.localIP
-			} else {
-				link.Local.IPv6 = tt.localIP
-			}
-
-			if tt.remoteIP.Is4() {
-				link.Remote.IPv4 = tt.remoteIP
-			} else {
-				link.Remote.IPv6 = tt.remoteIP
-			}
+			link.Local.IPv4 = tt.localIPv4
+			link.Local.IPv6 = tt.localIPv6
+			link.Remote.IPv4 = tt.remoteIPv4
 
 			got := buildLsLink(link)
 
-			assert.Equal(t, tt.wantLocalIP, got.GetLocalIp())
-			assert.Equal(t, tt.wantRemoteIP, got.GetRemoteIp())
+			assert.Equal(t, tt.wantLocalV4, got.GetLocal().GetIpv4())
+			assert.Equal(t, tt.wantLocalV6, got.GetLocal().GetIpv6())
+			assert.Equal(t, tt.wantRemoteV4, got.GetRemote().GetIpv4())
+			assert.Empty(t, got.GetRemote().GetIpv6())
 		})
 	}
+}
+
+func TestToPBAddressFamily(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, pb.AddressFamily_ADDRESS_FAMILY_IPV4, toPBAddressFamily(table.AFIPv4))
+	assert.Equal(t, pb.AddressFamily_ADDRESS_FAMILY_IPV6, toPBAddressFamily(table.AFIPv6))
+	assert.Equal(t, pb.AddressFamily_ADDRESS_FAMILY_UNSPECIFIED, toPBAddressFamily(table.AFUnspecified))
+}
+
+func TestToPBDataPlane(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, pb.DataPlane_DATA_PLANE_SR_MPLS, toPBDataPlane(table.DPSRMPLS))
+	assert.Equal(t, pb.DataPlane_DATA_PLANE_SRV6, toPBDataPlane(table.DPSRv6))
+	assert.Equal(t, pb.DataPlane_DATA_PLANE_UNSPECIFIED, toPBDataPlane(table.DPUnspecified))
+}
+
+func TestSetPBIfaceIDs(t *testing.T) {
+	t.Parallel()
+
+	local := uint32(1)
+	remote := uint32(2)
+	pbSeg := &pb.Segment{}
+
+	setPBIfaceIDs(pbSeg, &local, &remote)
+
+	require.NotNil(t, pbSeg.LocalIfaceId)
+	require.NotNil(t, pbSeg.RemoteIfaceId)
+	assert.Equal(t, local, *pbSeg.LocalIfaceId)
+	assert.Equal(t, remote, *pbSeg.RemoteIfaceId)
+}
+
+func TestBuildLsLinkEndpoint_InterfaceID(t *testing.T) {
+	t.Parallel()
+
+	node := table.NewLsNode(65000, testRouterID1)
+	ifaceID := uint32(42)
+	endpoint := table.LinkEndpoint{Node: node, InterfaceID: &ifaceID}
+
+	pbEndpoint := buildLsLinkEndpoint(endpoint)
+
+	require.NotNil(t, pbEndpoint.InterfaceId)
+	assert.Equal(t, ifaceID, *pbEndpoint.InterfaceId)
 }
 
 type tedOnlyClient struct {
@@ -295,8 +337,10 @@ func TestGetTED_LinksWithoutIPsRoundTripToCLI(t *testing.T) {
 
 	for _, pbNode := range resp.GetNodes() {
 		for _, pbLink := range pbNode.GetLinks() {
-			assert.Empty(t, pbLink.GetLocalIp())
-			assert.Empty(t, pbLink.GetRemoteIp())
+			assert.Empty(t, pbLink.GetLocal().GetIpv4())
+			assert.Empty(t, pbLink.GetLocal().GetIpv6())
+			assert.Empty(t, pbLink.GetRemote().GetIpv4())
+			assert.Empty(t, pbLink.GetRemote().GetIpv6())
 		}
 	}
 

--- a/pkg/server/grpc_convert_internal_test.go
+++ b/pkg/server/grpc_convert_internal_test.go
@@ -274,8 +274,8 @@ func TestSetPBIfaceIDs(t *testing.T) {
 
 	require.NotNil(t, pbSeg.LocalIfaceId)
 	require.NotNil(t, pbSeg.RemoteIfaceId)
-	assert.Equal(t, local, *pbSeg.LocalIfaceId)
-	assert.Equal(t, remote, *pbSeg.RemoteIfaceId)
+	assert.Equal(t, local, pbSeg.GetLocalIfaceId())
+	assert.Equal(t, remote, pbSeg.GetRemoteIfaceId())
 }
 
 func TestBuildLsLinkEndpoint_InterfaceID(t *testing.T) {
@@ -288,7 +288,7 @@ func TestBuildLsLinkEndpoint_InterfaceID(t *testing.T) {
 	pbEndpoint := buildLsLinkEndpoint(endpoint)
 
 	require.NotNil(t, pbEndpoint.InterfaceId)
-	assert.Equal(t, ifaceID, *pbEndpoint.InterfaceId)
+	assert.Equal(t, ifaceID, pbEndpoint.GetInterfaceId())
 }
 
 type tedOnlyClient struct {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -415,13 +415,12 @@ func resolveDynamicPolicy(s *APIServer, req *pb.CreateSRPolicyRequest, spec tabl
 		return resolvedPath{}, err
 	}
 
-	headend, endpoint, err := spec.Resolve(ted, scope.Plane.Family)
+	headend, endpoint, err := spec.Resolve(ted)
 	if err != nil {
 		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "%s", err.Error())
 	}
 
-	// Endpoint and underlay families need not match; Pola aligns them by default
-	// for PCC interoperability, but cross-AF is supported (§1.3).
+	// Endpoint and underlay address families are independent; cross-AF policies are supported (§1.3).
 	if endpointFamily := table.FamilyOfAddr(endpoint); scope.Plane.Family.IsValid() && endpointFamily != scope.Plane.Family {
 		s.logger.Warn("cross address-family SR Policy",
 			logger.String("endpointFamily", endpointFamily.String()),
@@ -491,7 +490,7 @@ func resolveExplicitPolicy(s *APIServer, spec table.EndpointSpec, explicit *pb.E
 		}
 	}
 
-	headend, endpoint, err := spec.Resolve(ted, table.AFUnspecified)
+	headend, endpoint, err := spec.Resolve(ted)
 	if err != nil {
 		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "%s", err.Error())
 	}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -145,14 +145,6 @@ func serveGRPC(grpcServer *grpc.Server, lis net.Listener) error {
 	return nil
 }
 
-func validateCreateSRPolicy(req *pb.CreateSRPolicyRequest, disablePathCompute bool) error {
-	if disablePathCompute {
-		return validate(req.GetSrPolicy(), req.GetAsn(), ValidationAddDisablePathCompute)
-	}
-
-	return validate(req.GetSrPolicy(), req.GetAsn(), ValidationAdd)
-}
-
 func parseSidStructure(s string) (*table.SIDStructure, error) {
 	structure, err := table.ParseSIDStructure(s)
 	if err != nil {
@@ -283,26 +275,104 @@ func newEnrichedSegment(segment *pb.Segment, usidMode bool) (table.Segment, erro
 }
 
 type resolvedPath struct {
-	SegmentList []table.Segment
-	SrcAddr     netip.Addr
-	DstAddr     netip.Addr
-	SrcRouterID string
-	Metric      table.MetricType
-	// Plane is zero for explicit paths, which have no underlay plane.
-	Plane table.Plane
+	Headend       netip.Addr
+	Endpoint      netip.Addr
+	SegmentList   []table.Segment
+	CandidatePath table.CandidatePath
 }
 
-func resolvePath(s *APIServer, input *pb.CreateSRPolicyRequest, disablePathCompute bool) (resolvedPath, error) {
-	if disablePathCompute {
-		return resolvePathFromRequest(s, input)
+// endpointSpecFromPB extracts the endpoint specification from the request
+// (RFC 9256 §2.1), supporting address and router-ID forms.
+func endpointSpecFromPB(policy *pb.SRPolicy) (table.EndpointSpec, error) {
+	headend, err := addrFromOptionalSlice(policy.GetHeadend())
+	if err != nil {
+		return table.EndpointSpec{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid headend address: %v", policy.GetHeadend())
 	}
 
-	return resolvePathViaTED(s, input)
+	endpoint, err := addrFromOptionalSlice(policy.GetEndpoint())
+	if err != nil {
+		return table.EndpointSpec{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid endpoint address: %v", policy.GetEndpoint())
+	}
+
+	return table.EndpointSpec{
+		Headend:          headend,
+		Endpoint:         endpoint,
+		HeadendRouterID:  policy.GetHeadendRouterId(),
+		EndpointRouterID: policy.GetEndpointRouterId(),
+		Family:           fromPBAddressFamily(policy.GetEndpointFamily()),
+	}, nil
 }
 
-func resolvePathViaTED(s *APIServer, input *pb.CreateSRPolicyRequest) (resolvedPath, error) {
-	inputSRPolicy := input.GetSrPolicy()
+// addrFromOptionalSlice parses an optional IPv4 or IPv6 address.
+// An empty slice returns the zero address; an invalid non-empty slice returns an error.
+func addrFromOptionalSlice(b []byte) (netip.Addr, error) {
+	if len(b) == 0 {
+		return netip.Addr{}, nil
+	}
 
+	addr, ok := netip.AddrFromSlice(b)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", b)
+	}
+
+	return addr.Unmap(), nil
+}
+
+// resolvePreference normalizes the proto3 zero value to table.DefaultPreference (RFC 9256 §2.7).
+func resolvePreference(preference uint32) uint32 {
+	if preference == 0 {
+		return table.DefaultPreference
+	}
+
+	return preference
+}
+
+// resolvePolicy resolves a CreateSRPolicyRequest into a resolvedPath.
+func resolvePolicy(s *APIServer, req *pb.CreateSRPolicyRequest) (resolvedPath, error) {
+	policy := req.GetSrPolicy()
+
+	spec, err := endpointSpecFromPB(policy)
+	if err != nil {
+		return resolvedPath{}, err
+	}
+
+	preference := resolvePreference(policy.GetCandidatePath().GetPreference())
+
+	switch cp := policy.GetCandidatePath().GetPath().(type) {
+	case *pb.CandidatePath_Dynamic:
+		return resolveDynamicPolicy(s, req, spec, cp.Dynamic, preference)
+	case *pb.CandidatePath_Explicit:
+		return resolveExplicitPolicy(s, spec, cp.Explicit, preference)
+	default:
+		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "candidatePath must specify either dynamic or explicit")
+	}
+}
+
+// routerIDsForCSPF returns the router IDs CSPF needs.
+// Address-form endpoints are resolved via the TED and can still use dynamic paths (§3.6).
+func routerIDsForCSPF(ted *table.LsTED, spec table.EndpointSpec) (headendRouterID, endpointRouterID string, err error) {
+	if spec.UsesRouterID() {
+		return spec.HeadendRouterID, spec.EndpointRouterID, nil
+	}
+
+	if !spec.Headend.IsValid() || !spec.Endpoint.IsValid() {
+		return "", "", newStatus(codes.InvalidArgument, ReasonInvalidRequest, "either headend/endpoint or headendRouterId/endpointRouterId must be set")
+	}
+
+	headendRouterID, ok := ted.FindRouterIDByLoopback(spec.Headend)
+	if !ok {
+		return "", "", newStatus(codes.InvalidArgument, ReasonInvalidRequest, "headend address %s not found in TED", spec.Headend)
+	}
+
+	endpointRouterID, ok = ted.FindRouterIDByLoopback(spec.Endpoint)
+	if !ok {
+		return "", "", newStatus(codes.InvalidArgument, ReasonInvalidRequest, "endpoint address %s not found in TED", spec.Endpoint)
+	}
+
+	return headendRouterID, endpointRouterID, nil
+}
+
+func resolveDynamicPolicy(s *APIServer, req *pb.CreateSRPolicyRequest, spec table.EndpointSpec, dyn *pb.DynamicPath, preference uint32) (resolvedPath, error) {
 	ted := s.pce.TED()
 	if ted == nil {
 		return resolvedPath{}, newStatus(codes.FailedPrecondition, ReasonTEDDisabled, "ted is disabled")
@@ -318,74 +388,92 @@ func resolvePathViaTED(s *APIServer, input *pb.CreateSRPolicyRequest) (resolvedP
 			continue
 		}
 
-		if node.ASN != input.GetAsn() {
-			return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "request ASN %d does not match ted ASN %d", input.GetAsn(), node.ASN)
+		if node.ASN != req.GetAsn() {
+			return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "request ASN %d does not match ted ASN %d", req.GetAsn(), node.ASN)
 		}
 
 		break
 	}
 
-	srcAF, err := defaultLoopbackFamily(ted, inputSRPolicy.GetSrcRouterId())
+	headendRouterID, endpointRouterID, err := routerIDsForCSPF(ted, spec)
 	if err != nil {
 		return resolvedPath{}, err
 	}
 
-	srcAddr, err := getLoopbackAddr(ted, inputSRPolicy.GetSrcRouterId(), srcAF)
+	metricType, err := getMetricType(dyn.GetMetric())
 	if err != nil {
 		return resolvedPath{}, err
 	}
 
-	dstAF, err := defaultLoopbackFamily(ted, inputSRPolicy.GetDstRouterId())
+	scope, err := resolvePathScope(ted, headendRouterID, dyn.GetUnderlayFamily(), dyn.GetDataPlane())
 	if err != nil {
 		return resolvedPath{}, err
 	}
 
-	dstAddr, err := getLoopbackAddr(ted, inputSRPolicy.GetDstRouterId(), dstAF)
+	segmentList, err := computeDynamicSegmentList(headendRouterID, endpointRouterID, dyn.GetWaypoints(), metricType, scope, ted)
 	if err != nil {
 		return resolvedPath{}, err
 	}
 
-	result, err := getSegmentList(inputSRPolicy, ted, s.usidMode)
+	headend, endpoint, err := spec.Resolve(ted, scope.Plane.Family)
 	if err != nil {
-		return resolvedPath{}, err
+		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "%s", err.Error())
+	}
+
+	// Endpoint and underlay families need not match; Pola aligns them by default
+	// for PCC interoperability, but cross-AF is supported (§1.3).
+	if endpointFamily := table.FamilyOfAddr(endpoint); scope.Plane.Family.IsValid() && endpointFamily != scope.Plane.Family {
+		s.logger.Warn("cross address-family SR Policy",
+			logger.String("endpointFamily", endpointFamily.String()),
+			logger.String("underlayFamily", scope.Plane.Family.String()),
+			logger.String("policyName", req.GetSrPolicy().GetPolicyName()))
 	}
 
 	return resolvedPath{
-		SegmentList: result.SegmentList,
-		SrcAddr:     srcAddr,
-		DstAddr:     dstAddr,
-		SrcRouterID: inputSRPolicy.GetSrcRouterId(),
-		Metric:      result.Metric,
-		Plane:       result.Plane,
+		Headend:     headend,
+		Endpoint:    endpoint,
+		SegmentList: segmentList,
+		CandidatePath: table.CandidatePath{
+			Preference: preference,
+			Dynamic:    &table.DynamicPath{Metric: metricType, Plane: scope.Plane},
+		},
 	}, nil
 }
 
-func resolvePathFromRequest(s *APIServer, input *pb.CreateSRPolicyRequest) (resolvedPath, error) {
-	inputSRPolicy := input.GetSrPolicy()
+func computeDynamicSegmentList(headendRouterID, endpointRouterID string, pbWaypoints []*pb.Waypoint, metricType table.MetricType, scope cspf.PathScope, ted *table.LsTED) ([]table.Segment, error) {
+	if len(pbWaypoints) > 0 {
+		waypoints := make([]table.Waypoint, 0, len(pbWaypoints))
+		for _, w := range pbWaypoints {
+			waypoints = append(waypoints, table.Waypoint{
+				RouterID: w.GetRouterId(),
+				SID:      w.GetSid(), // optional
+			})
+		}
 
-	srcAddr, ok := netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
-	if !ok {
-		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
-			"invalid source address %v",
-			inputSRPolicy.GetSrcAddr(),
-		)
+		segs, err := cspf.WithLooseSourceRouting(headendRouterID, endpointRouterID, waypoints, metricType, scope, ted)
+		if err != nil {
+			return nil, statusFromCSPFError(err)
+		}
+
+		return segs, nil
 	}
 
-	srcAddr = srcAddr.Unmap()
-
-	dstAddr, ok := netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
-	if !ok {
-		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
-			"invalid destination address %v",
-			inputSRPolicy.GetDstAddr(),
-		)
+	segs, err := cspf.CSPF(headendRouterID, endpointRouterID, metricType, scope, ted)
+	if err != nil {
+		return nil, statusFromCSPFError(err)
 	}
 
-	dstAddr = dstAddr.Unmap()
+	return segs, nil
+}
+
+func resolveExplicitPolicy(s *APIServer, spec table.EndpointSpec, explicit *pb.ExplicitPath, preference uint32) (resolvedPath, error) {
+	if len(explicit.GetSegmentList()) == 0 {
+		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "candidatePath.explicit.segmentList must not be empty")
+	}
 
 	var segmentList []table.Segment
 
-	for _, segment := range inputSRPolicy.GetSegmentList() {
+	for _, segment := range explicit.GetSegmentList() {
 		seg, err := newEnrichedSegment(segment, s.usidMode)
 		if err != nil {
 			return resolvedPath{}, err
@@ -394,26 +482,32 @@ func resolvePathFromRequest(s *APIServer, input *pb.CreateSRPolicyRequest) (reso
 		segmentList = append(segmentList, seg)
 	}
 
-	return resolvedPath{SegmentList: segmentList, SrcAddr: srcAddr, DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, nil
-}
+	var ted *table.LsTED
 
-// resolveSRPolicyIntent resolves the candidate-path type and metric per RFC 9256 §2.4.2.
-func resolveSRPolicyIntent(inputSRPolicy *pb.SRPolicy, disablePathCompute bool, metricType table.MetricType) (table.PolicyType, table.MetricType, error) {
-	if disablePathCompute {
-		return table.PolicyTypeExplicit, table.UnspecifiedMetric, nil
+	if spec.UsesRouterID() {
+		ted = s.pce.TED()
+		if ted == nil {
+			return resolvedPath{}, newStatus(codes.FailedPrecondition, ReasonTEDDisabled, "ted is disabled")
+		}
 	}
 
-	switch inputSRPolicy.GetType() {
-	case pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT:
-		return table.PolicyTypeExplicit, table.UnspecifiedMetric, nil
-	case pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC:
-		return table.PolicyTypeDynamic, metricType, nil
-	default:
-		return "", table.UnspecifiedMetric, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "undefined SR Policy type")
+	headend, endpoint, err := spec.Resolve(ted, table.AFUnspecified)
+	if err != nil {
+		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "%s", err.Error())
 	}
+
+	return resolvedPath{
+		Headend:     headend,
+		Endpoint:    endpoint,
+		SegmentList: segmentList,
+		CandidatePath: table.CandidatePath{
+			Preference: preference,
+			Explicit:   &table.ExplicitPath{SegmentList: segmentList},
+		},
+	}, nil
 }
 
-func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, path resolvedPath, disablePathCompute bool) error {
+func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, path resolvedPath) error {
 	inputSRPolicy := input.GetSrPolicy()
 
 	pcepSession, err := getSyncedPCEPSession(s.pce, inputSRPolicy.GetPeerAddr())
@@ -421,24 +515,16 @@ func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, path res
 		return wrapStatusError(err, "failed to get synchronized PCEP session")
 	}
 
-	policyType, metricType, err := resolveSRPolicyIntent(inputSRPolicy, disablePathCompute, path.Metric)
-	if err != nil {
-		return wrapStatusError(err, "failed to resolve SR policy type")
-	}
-
 	srPolicy := table.SRPolicy{
-		Name:        inputSRPolicy.GetPolicyName(),
-		SegmentList: path.SegmentList,
-		SrcAddr:     path.SrcAddr,
-		DstAddr:     path.DstAddr,
-		Color:       inputSRPolicy.GetColor(),
-		Preference:  100,
-		Type:        policyType,
-		Metric:      metricType,
-		Plane:       path.Plane,
+		Name:          inputSRPolicy.GetPolicyName(),
+		SegmentList:   path.SegmentList,
+		Headend:       path.Headend,
+		Endpoint:      path.Endpoint,
+		Color:         inputSRPolicy.GetColor(),
+		CandidatePath: path.CandidatePath,
 	}
 
-	if id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), path.DstAddr); exists {
+	if id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), path.Endpoint); exists {
 		s.logger.Debug("Request to update SR Policy", logger.Uint32("plspID", id))
 
 		srPolicy.PlspID = id
@@ -458,12 +544,11 @@ func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, path res
 
 // CreateSRPolicy creates a new SR Policy.
 func (s *APIServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyRequest) (*pb.CreateSRPolicyResponse, error) {
-	disablePathCompute := req.GetDisablePathCompute()
-	if err := validateCreateSRPolicy(req, disablePathCompute); err != nil {
+	if err := validate(req.GetSrPolicy(), req.GetAsn(), ValidationAdd); err != nil {
 		return nil, wrapStatusError(err, "failed to validate SR policy creation")
 	}
 
-	path, err := resolvePath(s, req, disablePathCompute)
+	path, err := resolvePolicy(s, req)
 	if err != nil {
 		return nil, wrapStatusError(err, "failed to resolve SR policy path")
 	}
@@ -472,7 +557,7 @@ func (s *APIServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyRequ
 		return nil, err
 	}
 
-	if err := sendSRPolicyRequest(s, req, path, disablePathCompute); err != nil {
+	if err := sendSRPolicyRequest(s, req, path); err != nil {
 		return nil, wrapStatusError(err, "failed to send SR policy request")
 	}
 
@@ -480,14 +565,14 @@ func (s *APIServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyRequ
 }
 
 func validateEndpointFamilies(path resolvedPath) error {
-	srcFamily := table.FamilyOfAddr(path.SrcAddr)
-	dstFamily := table.FamilyOfAddr(path.DstAddr)
+	headendFamily := table.FamilyOfAddr(path.Headend)
+	endpointFamily := table.FamilyOfAddr(path.Endpoint)
 
-	if path.SrcAddr.IsValid() && path.DstAddr.IsValid() && srcFamily != dstFamily {
-		return fmt.Errorf("source and destination addresses must share an address family (src=%s dst=%s)", path.SrcAddr, path.DstAddr)
+	if path.Headend.IsValid() && path.Endpoint.IsValid() && headendFamily != endpointFamily {
+		return fmt.Errorf("headend and endpoint addresses must share an address family (headend=%s endpoint=%s)", path.Headend, path.Endpoint)
 	}
 
-	if srcFamily == table.AFIPv6 {
+	if headendFamily == table.AFIPv6 {
 		return nil
 	}
 
@@ -528,8 +613,7 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, path resolvedPat
 		return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "%s", err.Error())
 	}
 
-	// Skip TED lookup for dynamically computed paths.
-	if policy.GetType() == pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC && !req.GetDisablePathCompute() {
+	if path.CandidatePath.Dynamic != nil {
 		return nil
 	}
 
@@ -553,20 +637,13 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, path resolvedPat
 			"TED is enabled but empty (not yet synchronized), SID validation cannot be performed")
 	}
 
-	// Resolve source router ID for path traversal.
-	srcRouterID := path.SrcRouterID
-
-	if req.GetDisablePathCompute() {
-		var ok bool
-
-		srcRouterID, ok = ted.FindRouterIDByLoopback(path.SrcAddr)
-		if !ok {
-			return newStatus(codes.InvalidArgument, ReasonInvalidRequest,
-				"source address %s not found in TED", path.SrcAddr)
-		}
+	headendRouterID, ok := ted.FindRouterIDByLoopback(path.Headend)
+	if !ok {
+		return newStatus(codes.InvalidArgument, ReasonInvalidRequest,
+			"headend address %s not found in TED", path.Headend)
 	}
 
-	if err := table.ValidateExplicitPath(ted, srcRouterID, segmentList); err != nil {
+	if err := table.ValidateExplicitPath(ted, headendRouterID, segmentList); err != nil {
 		return newStatus(codes.FailedPrecondition, ReasonSIDValidationFailed, "SID validation failed: %s", err)
 	}
 
@@ -582,23 +659,11 @@ func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRe
 
 	inputSRPolicy := input.GetSrPolicy()
 
-	var (
-		srcAddr, dstAddr netip.Addr
-		segmentList      []table.Segment
-	)
+	var segmentList []table.Segment
 
-	if len(inputSRPolicy.GetSrcAddr()) > 0 {
-		var ok bool
-
-		srcAddr, ok = netip.AddrFromSlice(inputSRPolicy.GetSrcAddr())
-		if !ok {
-			return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid source address")
-		}
-	}
-
-	dstAddr, ok := netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
+	endpoint, ok := netip.AddrFromSlice(inputSRPolicy.GetEndpoint())
 	if !ok {
-		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid destination address")
+		return nil, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "invalid endpoint address")
 	}
 
 	for _, segment := range inputSRPolicy.GetSegmentList() {
@@ -619,15 +684,14 @@ func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRe
 	}
 
 	srPolicy := table.SRPolicy{
-		Name:        inputSRPolicy.GetPolicyName(),
-		SegmentList: segmentList,
-		SrcAddr:     srcAddr,
-		DstAddr:     dstAddr,
-		Color:       inputSRPolicy.GetColor(),
-		Preference:  100,
+		Name:          inputSRPolicy.GetPolicyName(),
+		SegmentList:   segmentList,
+		Endpoint:      endpoint,
+		Color:         inputSRPolicy.GetColor(),
+		CandidatePath: table.CandidatePath{Preference: table.DefaultPreference},
 	}
 
-	id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), dstAddr)
+	id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), endpoint)
 	if !exists {
 		return nil, newStatus(codes.NotFound, ReasonSRPolicyNotFound, "requested SR Policy not found")
 	}
@@ -719,10 +783,6 @@ func validate(inputSRPolicy *pb.SRPolicy, asn uint32, validationKind ValidationK
 		return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "validate error, input is nil")
 	}
 
-	if validationKind == ValidationAdd && asn == 0 {
-		return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "validate error, ASN must not be zero")
-	}
-
 	validateFunc, ok := validator[validationKind]
 	if !ok {
 		return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "validate error: unknown validation kind %q", validationKind)
@@ -741,14 +801,12 @@ type ValidationKind string
 const (
 	// ValidationAdd validates an SR Policy for creation.
 	ValidationAdd ValidationKind = "Add"
-	// ValidationAddDisablePathCompute validates an SR Policy for creation with path computation disabled.
-	ValidationAddDisablePathCompute ValidationKind = "AddDisablePathCompute"
 	// ValidationDelete validates an SR Policy for deletion.
 	ValidationDelete ValidationKind = "Delete"
 )
 
 var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
-	ValidationAdd: func(policy *pb.SRPolicy, _ uint32) error {
+	ValidationAdd: func(policy *pb.SRPolicy, asn uint32) error {
 		if policy.PeerAddr == nil {
 			return errors.New("policy.PeerAddr must not be nil")
 		}
@@ -757,36 +815,17 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 			return errors.New("policy.Color must not be zero")
 		}
 
-		if policy.GetSrcRouterId() == "" {
-			return errors.New("policy.SrcRouterId must not be empty")
+		if err := validateEndpointSpecInput(policy); err != nil {
+			return err
 		}
 
-		if policy.GetDstRouterId() == "" {
-			return errors.New("policy.DstRouterId must not be empty")
+		if policy.GetCandidatePath().GetPath() == nil {
+			return errors.New("policy.CandidatePath must specify either dynamic or explicit")
 		}
 
-		return nil
-	},
-
-	ValidationAddDisablePathCompute: func(policy *pb.SRPolicy, _ uint32) error {
-		if policy.PeerAddr == nil {
-			return errors.New("policy.PeerAddr must not be nil")
-		}
-
-		if policy.GetColor() == 0 {
-			return errors.New("policy.Color must not be zero")
-		}
-
-		if len(policy.GetSrcAddr()) == 0 {
-			return errors.New("policy.SrcAddr must not be empty")
-		}
-
-		if len(policy.GetDstAddr()) == 0 {
-			return errors.New("policy.DstAddr must not be empty")
-		}
-
-		if len(policy.GetSegmentList()) == 0 {
-			return errors.New("policy.SegmentList must not be empty")
+		usesRouterID := policy.GetHeadendRouterId() != "" || policy.GetEndpointRouterId() != ""
+		if (usesRouterID || policy.GetCandidatePath().GetDynamic() != nil) && asn == 0 {
+			return errors.New("policy.Asn must not be zero")
 		}
 
 		return nil
@@ -801,8 +840,8 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 			return errors.New("policy.Color must not be zero")
 		}
 
-		if len(policy.GetDstAddr()) == 0 {
-			return errors.New("policy.DstAddr must not be empty")
+		if len(policy.GetEndpoint()) == 0 {
+			return errors.New("policy.Endpoint must not be empty")
 		}
 
 		if policy.GetPolicyName() == "" {
@@ -811,6 +850,30 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 
 		return nil
 	},
+}
+
+// validateEndpointSpecInput requires exactly one endpoint form:
+// address or router ID.
+func validateEndpointSpecInput(policy *pb.SRPolicy) error {
+	usesAddr := len(policy.GetHeadend()) > 0 || len(policy.GetEndpoint()) > 0
+	usesRouterID := policy.GetHeadendRouterId() != "" || policy.GetEndpointRouterId() != ""
+
+	switch {
+	case usesAddr && usesRouterID:
+		return errors.New("headend/endpoint and headendRouterId/endpointRouterId are mutually exclusive")
+	case usesAddr:
+		if len(policy.GetHeadend()) == 0 || len(policy.GetEndpoint()) == 0 {
+			return errors.New("both policy.Headend and policy.Endpoint must be set")
+		}
+	case usesRouterID:
+		if policy.GetHeadendRouterId() == "" || policy.GetEndpointRouterId() == "" {
+			return errors.New("both policy.HeadendRouterId and policy.EndpointRouterId must be set")
+		}
+	default:
+		return errors.New("either headend/endpoint or headendRouterId/endpointRouterId must be set")
+	}
+
+	return nil
 }
 
 func sortSessionsByAddr(sessions []*Session) {
@@ -855,34 +918,6 @@ func tedNode(ted *table.LsTED, routerID string) (*table.LsNode, bool) {
 	}
 
 	return node, true
-}
-
-func defaultLoopbackFamily(ted *table.LsTED, routerID string) (table.AddressFamily, error) {
-	node, ok := tedNode(ted, routerID)
-	if !ok {
-		return table.AFUnspecified, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID %s", routerID)
-	}
-
-	af, err := node.DefaultLoopbackFamily()
-	if err != nil {
-		return table.AFUnspecified, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
-	}
-
-	return af, nil
-}
-
-func getLoopbackAddr(ted *table.LsTED, routerID string, af table.AddressFamily) (netip.Addr, error) {
-	node, ok := tedNode(ted, routerID)
-	if !ok {
-		return netip.Addr{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID %s", routerID)
-	}
-
-	addr, err := node.LoopbackAddr(af)
-	if err != nil {
-		return netip.Addr{}, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
-	}
-
-	return addr, nil
 }
 
 // resolvePlane resolves the requested underlay plane, defaulting to the
@@ -930,89 +965,6 @@ func resolvePathScope(ted *table.LsTED, routerID string, pbFamily pb.AddressFami
 	}
 
 	return cspf.PathScope{Plane: plane}, nil
-}
-
-// Plane is the zero value for explicit paths, which have no underlay plane.
-type segmentListResult struct {
-	SegmentList []table.Segment
-	Metric      table.MetricType
-	Plane       table.Plane
-}
-
-func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool) (segmentListResult, error) {
-	var segmentList []table.Segment
-
-	switch inputSRPolicy.GetType() {
-	case pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT:
-		if len(inputSRPolicy.GetSegmentList()) == 0 {
-			return segmentListResult{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no segments in SRPolicy input")
-		}
-
-		for _, segment := range inputSRPolicy.GetSegmentList() {
-			sid, err := newEnrichedSegment(segment, usidMode)
-			if err != nil {
-				return segmentListResult{}, err
-			}
-
-			segmentList = append(segmentList, sid)
-		}
-	case pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC:
-		return getDynamicSegmentList(inputSRPolicy, ted)
-	default:
-		return segmentListResult{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "undefined SR Policy type")
-	}
-
-	return segmentListResult{SegmentList: segmentList, Metric: table.UnspecifiedMetric}, nil
-}
-
-func getDynamicSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED) (segmentListResult, error) {
-	metricType, err := getMetricType(inputSRPolicy.GetMetric())
-	if err != nil {
-		return segmentListResult{}, err
-	}
-
-	scope, err := resolvePathScope(ted, inputSRPolicy.GetSrcRouterId(), inputSRPolicy.GetUnderlayFamily(), inputSRPolicy.GetDataPlane())
-	if err != nil {
-		return segmentListResult{}, err
-	}
-
-	pbWPs := inputSRPolicy.GetWaypoints()
-	if len(pbWPs) > 0 {
-		waypoints := make([]table.Waypoint, 0, len(pbWPs))
-		for _, w := range pbWPs {
-			waypoints = append(waypoints, table.Waypoint{
-				RouterID: w.GetRouterId(),
-				SID:      w.GetSid(), // optional
-			})
-		}
-
-		segs, err := cspf.WithLooseSourceRouting(
-			inputSRPolicy.GetSrcRouterId(),
-			inputSRPolicy.GetDstRouterId(),
-			waypoints,
-			metricType,
-			scope,
-			ted,
-		)
-		if err != nil {
-			return segmentListResult{}, statusFromCSPFError(err)
-		}
-
-		return segmentListResult{SegmentList: segs, Metric: metricType, Plane: scope.Plane}, nil
-	}
-
-	segs, err := cspf.CSPF(
-		inputSRPolicy.GetSrcRouterId(),
-		inputSRPolicy.GetDstRouterId(),
-		metricType,
-		scope,
-		ted,
-	)
-	if err != nil {
-		return segmentListResult{}, statusFromCSPFError(err)
-	}
-
-	return segmentListResult{SegmentList: segs, Metric: metricType, Plane: scope.Plane}, nil
 }
 
 func getMetricType(metricType pb.MetricType) (table.MetricType, error) {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -797,13 +797,19 @@ func tedNode(ted *table.LsTED, routerID string) (*table.LsNode, bool) {
 	return node, true
 }
 
+// The API does not yet accept an explicit address family for endpoint resolution.
 func getLoopbackAddr(ted *table.LsTED, routerID string) (netip.Addr, error) {
 	node, ok := tedNode(ted, routerID)
 	if !ok {
 		return netip.Addr{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID %s", routerID)
 	}
 
-	addr, err := node.LoopbackAddr()
+	af, err := node.DefaultLoopbackFamily()
+	if err != nil {
+		return netip.Addr{}, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
+	}
+
+	addr, err := node.LoopbackAddr(af)
 	if err != nil {
 		return netip.Addr{}, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
 	}
@@ -811,7 +817,6 @@ func getLoopbackAddr(ted *table.LsTED, routerID string) (netip.Addr, error) {
 	return addr, nil
 }
 
-// getSegmentList returns the segment list and resolved metric type.
 func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool) ([]table.Segment, table.MetricType, error) {
 	var segmentList []table.Segment
 
@@ -837,7 +842,6 @@ func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool)
 
 		pbWPs := inputSRPolicy.GetWaypoints()
 		if len(pbWPs) > 0 {
-			// Convert to table.Waypoint
 			waypoints := make([]table.Waypoint, 0, len(pbWPs))
 			for _, w := range pbWPs {
 				waypoints = append(waypoints, table.Waypoint{

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -153,8 +153,6 @@ func validateCreateSRPolicy(req *pb.CreateSRPolicyRequest, disablePathCompute bo
 	return validate(req.GetSrPolicy(), req.GetAsn(), ValidationAdd)
 }
 
-// parseSidStructure parses a comma-separated SID structure (e.g. "32,16,0,80").
-// It returns nil for empty input.
 func parseSidStructure(s string) (*table.SIDStructure, error) {
 	structure, err := table.ParseSIDStructure(s)
 	if err != nil {
@@ -164,7 +162,25 @@ func parseSidStructure(s string) (*table.SIDStructure, error) {
 	return structure, nil
 }
 
-// enrichSRv6Segment applies gRPC overrides to an SRv6 segment.
+// segmentIfaceIDs preserves "not advertised" (nil) versus "advertised as 0".
+func segmentIfaceIDs(segment *pb.Segment) (local, remote *uint32) {
+	if segment == nil {
+		return nil, nil
+	}
+
+	if segment.LocalIfaceId != nil {
+		v := segment.GetLocalIfaceId()
+		local = &v
+	}
+
+	if segment.RemoteIfaceId != nil {
+		v := segment.GetRemoteIfaceId()
+		remote = &v
+	}
+
+	return local, remote
+}
+
 func enrichSRv6Segment(srv6Seg table.SegmentSRv6, segment *pb.Segment, usidMode bool) (table.SegmentSRv6, error) {
 	if usidMode {
 		srv6Seg.USid = true
@@ -194,10 +210,19 @@ func enrichSRv6Segment(srv6Seg table.SegmentSRv6, segment *pb.Segment, usidMode 
 		srv6Seg.RemoteAddr = ra
 	}
 
+	if b := segment.GetBehavior(); b != 0 {
+		if b > math.MaxUint16 {
+			return srv6Seg, fmt.Errorf("invalid behavior %d for SID %s: exceeds a 16-bit endpoint behavior code", b, segment.GetSid())
+		}
+
+		srv6Seg.Behavior = uint16(b)
+	}
+
+	srv6Seg.LocalIfaceID, srv6Seg.RemoteIfaceID = segmentIfaceIDs(segment)
+
 	return srv6Seg, nil
 }
 
-// enrichSRMPLSSegment applies gRPC NAI information to an SR-MPLS segment.
 func enrichSRMPLSSegment(mplsSeg table.SegmentSRMPLS, segment *pb.Segment) (table.SegmentSRMPLS, error) {
 	if s := segment.GetLocalAddr(); s != "" {
 		la, err := netip.ParseAddr(s)
@@ -218,11 +243,11 @@ func enrichSRMPLSSegment(mplsSeg table.SegmentSRMPLS, segment *pb.Segment) (tabl
 	}
 
 	mplsSeg.SidAbsent = segment.GetSidAbsent()
+	mplsSeg.LocalIfaceID, mplsSeg.RemoteIfaceID = segmentIfaceIDs(segment)
 
 	return mplsSeg, nil
 }
 
-// newEnrichedSegment converts a gRPC Segment to a table.Segment.
 func newEnrichedSegment(segment *pb.Segment, usidMode bool) (table.Segment, error) {
 	seg, err := table.NewSegment(segment.GetSid())
 	if err != nil {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -817,6 +817,21 @@ func getLoopbackAddr(ted *table.LsTED, routerID string) (netip.Addr, error) {
 	return addr, nil
 }
 
+// The API does not yet accept an explicit underlay plane for path computation.
+func defaultPathScope(ted *table.LsTED, routerID string) (cspf.PathScope, error) {
+	node, ok := tedNode(ted, routerID)
+	if !ok {
+		return cspf.PathScope{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID %s", routerID)
+	}
+
+	plane, err := node.DefaultPlane()
+	if err != nil {
+		return cspf.PathScope{}, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
+	}
+
+	return cspf.PathScope{Plane: plane}, nil
+}
+
 func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool) ([]table.Segment, table.MetricType, error) {
 	var segmentList []table.Segment
 
@@ -835,39 +850,41 @@ func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool)
 			segmentList = append(segmentList, sid)
 		}
 	case pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC:
-		metricType, err := getMetricType(inputSRPolicy.GetMetric())
-		if err != nil {
-			return nil, table.UnspecifiedMetric, err
+		return getDynamicSegmentList(inputSRPolicy, ted)
+	default:
+		return nil, table.UnspecifiedMetric, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "undefined SR Policy type")
+	}
+
+	return segmentList, table.UnspecifiedMetric, nil
+}
+
+func getDynamicSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED) ([]table.Segment, table.MetricType, error) {
+	metricType, err := getMetricType(inputSRPolicy.GetMetric())
+	if err != nil {
+		return nil, table.UnspecifiedMetric, err
+	}
+
+	scope, err := defaultPathScope(ted, inputSRPolicy.GetSrcRouterId())
+	if err != nil {
+		return nil, table.UnspecifiedMetric, err
+	}
+
+	pbWPs := inputSRPolicy.GetWaypoints()
+	if len(pbWPs) > 0 {
+		waypoints := make([]table.Waypoint, 0, len(pbWPs))
+		for _, w := range pbWPs {
+			waypoints = append(waypoints, table.Waypoint{
+				RouterID: w.GetRouterId(),
+				SID:      w.GetSid(), // optional
+			})
 		}
 
-		pbWPs := inputSRPolicy.GetWaypoints()
-		if len(pbWPs) > 0 {
-			waypoints := make([]table.Waypoint, 0, len(pbWPs))
-			for _, w := range pbWPs {
-				waypoints = append(waypoints, table.Waypoint{
-					RouterID: w.GetRouterId(),
-					SID:      w.GetSid(), // optional
-				})
-			}
-
-			segs, err := cspf.WithLooseSourceRouting(
-				inputSRPolicy.GetSrcRouterId(),
-				inputSRPolicy.GetDstRouterId(),
-				waypoints,
-				metricType,
-				ted,
-			)
-			if err != nil {
-				return nil, table.UnspecifiedMetric, statusFromCSPFError(err)
-			}
-
-			return segs, metricType, nil
-		}
-
-		segs, err := cspf.CSPF(
+		segs, err := cspf.WithLooseSourceRouting(
 			inputSRPolicy.GetSrcRouterId(),
 			inputSRPolicy.GetDstRouterId(),
+			waypoints,
 			metricType,
+			scope,
 			ted,
 		)
 		if err != nil {
@@ -875,11 +892,20 @@ func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool)
 		}
 
 		return segs, metricType, nil
-	default:
-		return nil, table.UnspecifiedMetric, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "undefined SR Policy type")
 	}
 
-	return segmentList, table.UnspecifiedMetric, nil
+	segs, err := cspf.CSPF(
+		inputSRPolicy.GetSrcRouterId(),
+		inputSRPolicy.GetDstRouterId(),
+		metricType,
+		scope,
+		ted,
+	)
+	if err != nil {
+		return nil, table.UnspecifiedMetric, statusFromCSPFError(err)
+	}
+
+	return segs, metricType, nil
 }
 
 func getMetricType(metricType pb.MetricType) (table.MetricType, error) {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -263,6 +263,8 @@ type resolvedPath struct {
 	DstAddr     netip.Addr
 	SrcRouterID string
 	Metric      table.MetricType
+	// Plane is zero for explicit paths, which have no underlay plane.
+	Plane table.Plane
 }
 
 func resolvePath(s *APIServer, input *pb.CreateSRPolicyRequest, disablePathCompute bool) (resolvedPath, error) {
@@ -298,32 +300,41 @@ func resolvePathViaTED(s *APIServer, input *pb.CreateSRPolicyRequest) (resolvedP
 		break
 	}
 
-	srcAddr, err := getLoopbackAddr(ted, inputSRPolicy.GetSrcRouterId())
+	srcAF, err := defaultLoopbackFamily(ted, inputSRPolicy.GetSrcRouterId())
 	if err != nil {
 		return resolvedPath{}, err
 	}
 
-	dstAddr, err := getLoopbackAddr(ted, inputSRPolicy.GetDstRouterId())
+	srcAddr, err := getLoopbackAddr(ted, inputSRPolicy.GetSrcRouterId(), srcAF)
 	if err != nil {
 		return resolvedPath{}, err
 	}
 
-	segmentList, metricType, err := getSegmentList(inputSRPolicy, ted, s.usidMode)
+	dstAF, err := defaultLoopbackFamily(ted, inputSRPolicy.GetDstRouterId())
+	if err != nil {
+		return resolvedPath{}, err
+	}
+
+	dstAddr, err := getLoopbackAddr(ted, inputSRPolicy.GetDstRouterId(), dstAF)
+	if err != nil {
+		return resolvedPath{}, err
+	}
+
+	result, err := getSegmentList(inputSRPolicy, ted, s.usidMode)
 	if err != nil {
 		return resolvedPath{}, err
 	}
 
 	return resolvedPath{
-		SegmentList: segmentList,
+		SegmentList: result.SegmentList,
 		SrcAddr:     srcAddr,
 		DstAddr:     dstAddr,
 		SrcRouterID: inputSRPolicy.GetSrcRouterId(),
-		Metric:      metricType,
+		Metric:      result.Metric,
+		Plane:       result.Plane,
 	}, nil
 }
 
-// resolvePathFromRequest takes the SR Policy path directly from the request,
-// without consulting the TED.
 func resolvePathFromRequest(s *APIServer, input *pb.CreateSRPolicyRequest) (resolvedPath, error) {
 	inputSRPolicy := input.GetSrPolicy()
 
@@ -335,6 +346,8 @@ func resolvePathFromRequest(s *APIServer, input *pb.CreateSRPolicyRequest) (reso
 		)
 	}
 
+	srcAddr = srcAddr.Unmap()
+
 	dstAddr, ok := netip.AddrFromSlice(inputSRPolicy.GetDstAddr())
 	if !ok {
 		return resolvedPath{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
@@ -342,6 +355,8 @@ func resolvePathFromRequest(s *APIServer, input *pb.CreateSRPolicyRequest) (reso
 			inputSRPolicy.GetDstAddr(),
 		)
 	}
+
+	dstAddr = dstAddr.Unmap()
 
 	var segmentList []table.Segment
 
@@ -360,7 +375,6 @@ func resolvePathFromRequest(s *APIServer, input *pb.CreateSRPolicyRequest) (reso
 // resolveSRPolicyIntent resolves the candidate-path type and metric per RFC 9256 §2.4.2.
 func resolveSRPolicyIntent(inputSRPolicy *pb.SRPolicy, disablePathCompute bool, metricType table.MetricType) (table.PolicyType, table.MetricType, error) {
 	if disablePathCompute {
-		// disable_path_compute treats the given SegmentList as an explicit path.
 		return table.PolicyTypeExplicit, table.UnspecifiedMetric, nil
 	}
 
@@ -396,6 +410,7 @@ func sendSRPolicyRequest(s *APIServer, input *pb.CreateSRPolicyRequest, path res
 		Preference:  100,
 		Type:        policyType,
 		Metric:      metricType,
+		Plane:       path.Plane,
 	}
 
 	if id, exists := pcepSession.SearchPlspID(inputSRPolicy.GetColor(), path.DstAddr); exists {
@@ -439,6 +454,27 @@ func (s *APIServer) CreateSRPolicy(_ context.Context, req *pb.CreateSRPolicyRequ
 	return &pb.CreateSRPolicyResponse{}, nil
 }
 
+func validateEndpointFamilies(path resolvedPath) error {
+	srcFamily := table.FamilyOfAddr(path.SrcAddr)
+	dstFamily := table.FamilyOfAddr(path.DstAddr)
+
+	if path.SrcAddr.IsValid() && path.DstAddr.IsValid() && srcFamily != dstFamily {
+		return fmt.Errorf("source and destination addresses must share an address family (src=%s dst=%s)", path.SrcAddr, path.DstAddr)
+	}
+
+	if srcFamily == table.AFIPv6 {
+		return nil
+	}
+
+	for _, seg := range path.SegmentList {
+		if _, ok := seg.(table.SegmentSRv6); ok {
+			return errors.New("an SRv6 segment list requires IPv6 endpoints")
+		}
+	}
+
+	return nil
+}
+
 func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, path resolvedPath) error {
 	policy := req.GetSrPolicy()
 	segmentList := path.SegmentList
@@ -461,6 +497,10 @@ func (s *APIServer) validateSIDs(req *pb.CreateSRPolicyRequest, path resolvedPat
 
 	if table.HasMixedSegmentTypes(segmentList) {
 		return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "segment list contains mixed SR-MPLS and SRv6 SIDs")
+	}
+
+	if err := validateEndpointFamilies(path); err != nil {
+		return newStatus(codes.InvalidArgument, ReasonInvalidRequest, "%s", err.Error())
 	}
 
 	// Skip TED lookup for dynamically computed paths.
@@ -577,7 +617,6 @@ func (s *APIServer) DeleteSRPolicy(_ context.Context, input *pb.DeleteSRPolicyRe
 	return &pb.DeleteSRPolicyResponse{}, nil
 }
 
-// srPolicyListFilter validates and parses the session filter.
 func srPolicyListFilter(req *pb.GetSRPolicyListRequest) (netip.Addr, error) {
 	var filterAddr netip.Addr
 
@@ -749,14 +788,12 @@ var validator = map[ValidationKind]func(policy *pb.SRPolicy, asn uint32) error{
 	},
 }
 
-// sortSessionsByAddr orders sessions by peer address.
 func sortSessionsByAddr(sessions []*Session) {
 	slices.SortFunc(sessions, func(a, b *Session) int {
 		return a.peerAddr.Compare(b.peerAddr)
 	})
 }
 
-// resolveSession resolves the PCEP session a request targets.
 // RFC 5440 §7.15 allows at most one session per peer.
 func resolveSession(pce *Server, addr []byte, requireSynced bool) (*Session, error) {
 	peerAddr, ok := netip.AddrFromSlice(addr)
@@ -778,12 +815,10 @@ func resolveSession(pce *Server, addr []byte, requireSynced bool) (*Session, err
 	return pcepSession, nil
 }
 
-// getSyncedPCEPSession resolves the synced PCEP session a write request targets.
 func getSyncedPCEPSession(pce *Server, addr []byte) (*Session, error) {
 	return resolveSession(pce, addr, true)
 }
 
-// tedNode returns the non-nil node for routerID.
 func tedNode(ted *table.LsTED, routerID string) (*table.LsNode, bool) {
 	if ted == nil {
 		return nil, false
@@ -797,16 +832,24 @@ func tedNode(ted *table.LsTED, routerID string) (*table.LsNode, bool) {
 	return node, true
 }
 
-// The API does not yet accept an explicit address family for endpoint resolution.
-func getLoopbackAddr(ted *table.LsTED, routerID string) (netip.Addr, error) {
+func defaultLoopbackFamily(ted *table.LsTED, routerID string) (table.AddressFamily, error) {
 	node, ok := tedNode(ted, routerID)
 	if !ok {
-		return netip.Addr{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID %s", routerID)
+		return table.AFUnspecified, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID %s", routerID)
 	}
 
 	af, err := node.DefaultLoopbackFamily()
 	if err != nil {
-		return netip.Addr{}, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
+		return table.AFUnspecified, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
+	}
+
+	return af, nil
+}
+
+func getLoopbackAddr(ted *table.LsTED, routerID string, af table.AddressFamily) (netip.Addr, error) {
+	node, ok := tedNode(ted, routerID)
+	if !ok {
+		return netip.Addr{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID %s", routerID)
 	}
 
 	addr, err := node.LoopbackAddr(af)
@@ -817,34 +860,73 @@ func getLoopbackAddr(ted *table.LsTED, routerID string) (netip.Addr, error) {
 	return addr, nil
 }
 
-// The API does not yet accept an explicit underlay plane for path computation.
-func defaultPathScope(ted *table.LsTED, routerID string) (cspf.PathScope, error) {
+// resolvePlane resolves the requested underlay plane, defaulting to the
+// node's unique viable plane when unspecified.
+func resolvePlane(node *table.LsNode, pbFamily pb.AddressFamily, pbDataPlane pb.DataPlane) (table.Plane, error) {
+	family := fromPBAddressFamily(pbFamily)
+	dataPlane := fromPBDataPlane(pbDataPlane)
+
+	if family.IsValid() && dataPlane != table.DPUnspecified {
+		plane := table.Plane{Family: family, DataPlane: dataPlane}
+		if err := plane.Validate(); err != nil {
+			return table.Plane{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "%s", err.Error())
+		}
+
+		return plane, nil
+	}
+
+	plane, err := node.DefaultPlane()
+	if err != nil {
+		return table.Plane{}, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
+	}
+
+	if family.IsValid() && plane.Family != family {
+		return table.Plane{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
+			"node's unique viable plane uses address family %s, which does not match the requested underlay family %s", plane.Family, family)
+	}
+
+	if dataPlane != table.DPUnspecified && plane.DataPlane != dataPlane {
+		return table.Plane{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest,
+			"node's unique viable plane uses data plane %s, which does not match the requested data plane %s", plane.DataPlane, dataPlane)
+	}
+
+	return plane, nil
+}
+
+func resolvePathScope(ted *table.LsTED, routerID string, pbFamily pb.AddressFamily, pbDataPlane pb.DataPlane) (cspf.PathScope, error) {
 	node, ok := tedNode(ted, routerID)
 	if !ok {
 		return cspf.PathScope{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID %s", routerID)
 	}
 
-	plane, err := node.DefaultPlane()
+	plane, err := resolvePlane(node, pbFamily, pbDataPlane)
 	if err != nil {
-		return cspf.PathScope{}, newStatus(codes.FailedPrecondition, ReasonTEDDataIncomplete, "%s", err.Error())
+		return cspf.PathScope{}, err
 	}
 
 	return cspf.PathScope{Plane: plane}, nil
 }
 
-func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool) ([]table.Segment, table.MetricType, error) {
+// Plane is the zero value for explicit paths, which have no underlay plane.
+type segmentListResult struct {
+	SegmentList []table.Segment
+	Metric      table.MetricType
+	Plane       table.Plane
+}
+
+func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool) (segmentListResult, error) {
 	var segmentList []table.Segment
 
 	switch inputSRPolicy.GetType() {
 	case pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT:
 		if len(inputSRPolicy.GetSegmentList()) == 0 {
-			return nil, table.UnspecifiedMetric, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no segments in SRPolicy input")
+			return segmentListResult{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "no segments in SRPolicy input")
 		}
 
 		for _, segment := range inputSRPolicy.GetSegmentList() {
 			sid, err := newEnrichedSegment(segment, usidMode)
 			if err != nil {
-				return nil, table.UnspecifiedMetric, err
+				return segmentListResult{}, err
 			}
 
 			segmentList = append(segmentList, sid)
@@ -852,21 +934,21 @@ func getSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED, usidMode bool)
 	case pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC:
 		return getDynamicSegmentList(inputSRPolicy, ted)
 	default:
-		return nil, table.UnspecifiedMetric, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "undefined SR Policy type")
+		return segmentListResult{}, newStatus(codes.InvalidArgument, ReasonInvalidRequest, "undefined SR Policy type")
 	}
 
-	return segmentList, table.UnspecifiedMetric, nil
+	return segmentListResult{SegmentList: segmentList, Metric: table.UnspecifiedMetric}, nil
 }
 
-func getDynamicSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED) ([]table.Segment, table.MetricType, error) {
+func getDynamicSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED) (segmentListResult, error) {
 	metricType, err := getMetricType(inputSRPolicy.GetMetric())
 	if err != nil {
-		return nil, table.UnspecifiedMetric, err
+		return segmentListResult{}, err
 	}
 
-	scope, err := defaultPathScope(ted, inputSRPolicy.GetSrcRouterId())
+	scope, err := resolvePathScope(ted, inputSRPolicy.GetSrcRouterId(), inputSRPolicy.GetUnderlayFamily(), inputSRPolicy.GetDataPlane())
 	if err != nil {
-		return nil, table.UnspecifiedMetric, err
+		return segmentListResult{}, err
 	}
 
 	pbWPs := inputSRPolicy.GetWaypoints()
@@ -888,10 +970,10 @@ func getDynamicSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED) ([]tabl
 			ted,
 		)
 		if err != nil {
-			return nil, table.UnspecifiedMetric, statusFromCSPFError(err)
+			return segmentListResult{}, statusFromCSPFError(err)
 		}
 
-		return segs, metricType, nil
+		return segmentListResult{SegmentList: segs, Metric: metricType, Plane: scope.Plane}, nil
 	}
 
 	segs, err := cspf.CSPF(
@@ -902,10 +984,10 @@ func getDynamicSegmentList(inputSRPolicy *pb.SRPolicy, ted *table.LsTED) ([]tabl
 		ted,
 	)
 	if err != nil {
-		return nil, table.UnspecifiedMetric, statusFromCSPFError(err)
+		return segmentListResult{}, statusFromCSPFError(err)
 	}
 
-	return segs, metricType, nil
+	return segmentListResult{SegmentList: segs, Metric: metricType, Plane: scope.Plane}, nil
 }
 
 func getMetricType(metricType pb.MetricType) (table.MetricType, error) {
@@ -923,7 +1005,6 @@ func getMetricType(metricType pb.MetricType) (table.MetricType, error) {
 	}
 }
 
-// sessionListFilter validates and parses the peer address filter.
 func sessionListFilter(req *pb.GetSessionListRequest) (netip.Addr, error) {
 	var filterAddr netip.Addr
 

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -330,14 +330,11 @@ func newTestAPIServer(ted *table.LsTED) *APIServer {
 	}
 }
 
-func explicitPolicyRequest(noSIDValidate bool, sid string) *pb.CreateSRPolicyRequest {
+func explicitPolicyRequest(noSIDValidate bool, _ string) *pb.CreateSRPolicyRequest {
 	return &pb.CreateSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
-			Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-			PolicyName:  testSRPolicyName,
-			Color:       100,
-			SrcRouterId: testRouterID1,
-			SegmentList: []*pb.Segment{{Sid: sid}},
+			PolicyName: testSRPolicyName,
+			Color:      100,
 		},
 		NoSidValidate: noSIDValidate,
 	}
@@ -346,7 +343,6 @@ func explicitPolicyRequest(noSIDValidate bool, sid string) *pb.CreateSRPolicyReq
 func dynamicPolicyRequest() *pb.CreateSRPolicyRequest {
 	return &pb.CreateSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
-			Type:       pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
 			PolicyName: testSRPolicyName,
 			Color:      100,
 		},
@@ -371,34 +367,9 @@ func TestValidateSIDs_DynamicPathSkipsCheck(t *testing.T) {
 	req := dynamicPolicyRequest()
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList})
+	path := resolvedPath{SegmentList: segmentList, CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}}}
+	err := s.validateSIDs(req, path)
 	assert.NoError(t, err, "expected a dynamic path to skip the check")
-}
-
-func TestValidateSIDs_DynamicWithDisablePathComputeIsStillValidated(t *testing.T) {
-	t.Parallel()
-
-	node := &table.LsNode{
-		RouterID:  testRouterID1,
-		SrgbBegin: 16000,
-		Prefixes: []*table.LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
-		},
-	}
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
-	s := newTestAPIServer(ted)
-
-	req := dynamicPolicyRequest()
-	req.DisablePathCompute = true
-	req.SrPolicy.SegmentList = []*pb.Segment{{Sid: "16099"}}
-	req.SrPolicy.SrcAddr = netip.MustParseAddr("10.0.0.1").AsSlice()
-	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
-	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
-
-	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.0.0.1")})
-	st, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.FailedPrecondition, st.Code())
 }
 
 func TestValidateSIDs_NoTED(t *testing.T) {
@@ -408,7 +379,7 @@ func TestValidateSIDs_NoTED(t *testing.T) {
 	req := explicitPolicyRequest(false, "16003")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcRouterID: testRouterID1})
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, Headend: netip.MustParseAddr("10.0.0.1")})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
@@ -422,7 +393,7 @@ func TestValidateSIDs_TEDEmpty(t *testing.T) {
 	req := explicitPolicyRequest(false, "16003")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcRouterID: testRouterID1})
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, Headend: netip.MustParseAddr("10.0.0.1")})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
@@ -445,40 +416,14 @@ func TestValidateSIDs_MissingSID(t *testing.T) {
 	req := explicitPolicyRequest(false, "16099")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
 
-	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcRouterID: testRouterID1})
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, Headend: netip.MustParseAddr("10.0.0.1")})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
 	assert.Contains(t, st.Message(), "hop 1", "expected the missing hop to be listed")
 }
 
-func TestValidateSIDs_EndpointFormIsStillValidated(t *testing.T) {
-	t.Parallel()
-
-	node := &table.LsNode{
-		RouterID:  testRouterID1,
-		SrgbBegin: 16000,
-		Prefixes: []*table.LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
-		},
-	}
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node}}
-	s := newTestAPIServer(ted)
-
-	req := explicitPolicyRequest(false, "16099")
-	req.DisablePathCompute = true
-	req.SrPolicy.SrcAddr = netip.MustParseAddr("10.0.0.1").AsSlice()
-	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
-	segmentList := []table.Segment{table.NewSegmentSRMPLS(16099)}
-
-	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.0.0.1")})
-	st, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.FailedPrecondition, st.Code())
-	assert.Contains(t, st.Message(), "hop 1", "expected the missing hop to be listed")
-}
-
-func TestValidateSIDs_DisablePathComputeSourceAddressNotFound(t *testing.T) {
+func TestValidateSIDs_HeadendAddressNotFoundInTED(t *testing.T) {
 	t.Parallel()
 
 	node := &table.LsNode{
@@ -492,16 +437,13 @@ func TestValidateSIDs_DisablePathComputeSourceAddressNotFound(t *testing.T) {
 	s := newTestAPIServer(ted)
 
 	req := explicitPolicyRequest(false, "16003")
-	req.DisablePathCompute = true
-	req.SrPolicy.SrcAddr = netip.MustParseAddr("10.0.0.9").AsSlice()
-	req.SrPolicy.DstAddr = netip.MustParseAddr("10.0.0.2").AsSlice()
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.0.0.9")})
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, Headend: netip.MustParseAddr("10.0.0.9")})
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
-	assert.Contains(t, st.Message(), "source address 10.0.0.9 not found in TED")
+	assert.Contains(t, st.Message(), "headend address 10.0.0.9 not found in TED")
 }
 
 func TestValidateSIDs_LabelOutOfRangeIsRejectedEvenWithNoSidValidate(t *testing.T) {
@@ -548,7 +490,7 @@ func TestValidateSIDs_AllKnownSucceeds(t *testing.T) {
 	req := explicitPolicyRequest(false, "16003")
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, SrcRouterID: testRouterID1})
+	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList, Headend: netip.MustParseAddr("10.0.0.1")})
 	assert.NoError(t, err)
 }
 
@@ -598,29 +540,29 @@ func TestValidateEndpointFamilies(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "both unset is not second-guessed", path: resolvedPath{}},
-		{name: "matching IPv4 endpoints", path: resolvedPath{SrcAddr: ipv4, DstAddr: ipv4Other}},
-		{name: "matching IPv6 endpoints", path: resolvedPath{SrcAddr: ipv6, DstAddr: ipv6}},
+		{name: "matching IPv4 endpoints", path: resolvedPath{Headend: ipv4, Endpoint: ipv4Other}},
+		{name: "matching IPv6 endpoints", path: resolvedPath{Headend: ipv6, Endpoint: ipv6}},
 		{
 			name:    "mismatched endpoint families",
-			path:    resolvedPath{SrcAddr: ipv4, DstAddr: ipv6},
+			path:    resolvedPath{Headend: ipv4, Endpoint: ipv6},
 			wantErr: true,
 		},
 		{
 			name:    "SRv6 segment list with an IPv4 endpoint",
-			path:    resolvedPath{SrcAddr: ipv4, DstAddr: ipv4Other, SegmentList: srv6Segs},
+			path:    resolvedPath{Headend: ipv4, Endpoint: ipv4Other, SegmentList: srv6Segs},
 			wantErr: true,
 		},
 		{
 			name: "SRv6 segment list with an IPv6 endpoint",
-			path: resolvedPath{SrcAddr: ipv6, DstAddr: ipv6, SegmentList: srv6Segs},
+			path: resolvedPath{Headend: ipv6, Endpoint: ipv6, SegmentList: srv6Segs},
 		},
 		{
 			name: "SR-MPLS segment list with an IPv4 endpoint",
-			path: resolvedPath{SrcAddr: ipv4, DstAddr: ipv4Other, SegmentList: srmplsSegs},
+			path: resolvedPath{Headend: ipv4, Endpoint: ipv4Other, SegmentList: srmplsSegs},
 		},
 		{
 			name:    "SRv6 segment past the first position with an IPv4 endpoint",
-			path:    resolvedPath{SrcAddr: ipv4, DstAddr: ipv4Other, SegmentList: append(append([]table.Segment{}, srmplsSegs...), srv6Segs...)},
+			path:    resolvedPath{Headend: ipv4, Endpoint: ipv4Other, SegmentList: append(append([]table.Segment{}, srmplsSegs...), srv6Segs...)},
 			wantErr: true,
 		},
 	}
@@ -644,11 +586,10 @@ func TestValidateSIDs_SRv6SegmentListWithIPv4EndpointIsRejected(t *testing.T) {
 
 	s := newTestAPIServer(nil)
 	req := explicitPolicyRequest(true, testSRv6SID1)
-	req.DisablePathCompute = true
 	path := resolvedPath{
 		SegmentList: []table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1)))},
-		SrcAddr:     netip.MustParseAddr(testAddrA),
-		DstAddr:     netip.MustParseAddr(testAddrB),
+		Headend:     netip.MustParseAddr(testAddrA),
+		Endpoint:    netip.MustParseAddr(testAddrB),
 	}
 
 	err := s.validateSIDs(req, path)
@@ -1124,8 +1065,8 @@ func TestGetSRPolicyList_FillsMissingFieldsAndOrdersDeterministically(t *testing
 	assert.Equal(t, uint32(2), policy.GetPlspId())
 	assert.Equal(t, uint32(7), policy.GetLspId())
 	assert.Equal(t, pb.SRPolicyState_SR_POLICY_STATE_ACTIVE, policy.GetState())
-	assert.Equal(t, "0000.0aff.0001", policy.GetSrcRouterId())
-	assert.Empty(t, policy.GetDstRouterId(), "no TED node owns the destination address")
+	assert.Equal(t, "0000.0aff.0001", policy.GetHeadendRouterId())
+	assert.Empty(t, policy.GetEndpointRouterId(), "no TED node owns the endpoint address")
 }
 
 func TestGetSRPolicyList_IncludesUnsyncedSessions(t *testing.T) {
@@ -1191,82 +1132,29 @@ func TestGetSRPolicyList_RejectsInvalidSessionFilter(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
-func TestResolveSRPolicyIntent(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name               string
-		policy             *pb.SRPolicy
-		disablePathCompute bool
-		metricType         table.MetricType
-		wantType           table.PolicyType
-		wantMetric         table.MetricType
-		wantErr            bool
-	}{
-		{
-			name:               "disable_path_compute is always explicit regardless of Type",
-			policy:             &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC},
-			disablePathCompute: true,
-			metricType:         table.TEMetric,
-			wantType:           table.PolicyTypeExplicit,
-			wantMetric:         table.UnspecifiedMetric,
-		},
-		{
-			name:       "explicit path has no metric",
-			policy:     &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT},
-			metricType: table.TEMetric,
-			wantType:   table.PolicyTypeExplicit,
-			wantMetric: table.UnspecifiedMetric,
-		},
-		{
-			name:       "dynamic path passes through the already-resolved metric",
-			policy:     &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC},
-			metricType: table.TEMetric,
-			wantType:   table.PolicyTypeDynamic,
-			wantMetric: table.TEMetric,
-		},
-		{
-			name:    "unspecified type is an error",
-			policy:  &pb.SRPolicy{},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			gotType, gotMetric, err := resolveSRPolicyIntent(tt.policy, tt.disablePathCompute, tt.metricType)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantType, gotType)
-			assert.Equal(t, tt.wantMetric, gotMetric)
-		})
-	}
-}
-
-func TestGetSRPolicyList_RoundTripsTypeAndMetric(t *testing.T) {
+func TestGetSRPolicyList_RoundTripsCandidatePathAndMetric(t *testing.T) {
 	t.Parallel()
 
 	seg, err := table.NewSegment("16003")
 	require.NoError(t, err)
 
 	knownPolicy := table.NewSRPolicy(1, "policy-known", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 100, 100, 0, table.PolicyUp)
-	knownPolicy.Type = table.PolicyTypeDynamic
-	knownPolicy.Metric = table.DelayMetric
+	knownPolicy.CandidatePath.Dynamic = &table.DynamicPath{
+		Metric: table.DelayMetric,
+		Plane:  table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS},
+	}
 
 	unknownPolicy := table.NewSRPolicy(2, "policy-unknown", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 200, 100, 0, table.PolicyUp)
+
+	explicitPolicy := table.NewSRPolicy(3, "policy-explicit", []table.Segment{seg}, netip.Addr{}, netip.Addr{}, 300, 100, 0, table.PolicyUp)
+	explicitPolicy.CandidatePath.Explicit = &table.ExplicitPath{SegmentList: []table.Segment{seg}}
 
 	s := &APIServer{
 		pce: &Server{sessionList: []*Session{
 			{
 				peerAddr:   netip.MustParseAddr("10.0.0.1"),
 				syncState:  SyncStateFinished,
-				srPolicies: []*table.SRPolicy{knownPolicy, unknownPolicy},
+				srPolicies: []*table.SRPolicy{knownPolicy, unknownPolicy, explicitPolicy},
 			},
 		}},
 		logger: logger.NewNop(),
@@ -1275,7 +1163,7 @@ func TestGetSRPolicyList_RoundTripsTypeAndMetric(t *testing.T) {
 	resp, err := s.GetSRPolicyList(context.Background(), &pb.GetSRPolicyListRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.GetSessions(), 1)
-	require.Len(t, resp.GetSessions()[0].GetSrPolicies(), 2)
+	require.Len(t, resp.GetSessions()[0].GetSrPolicies(), 3)
 
 	byColor := map[uint32]*pb.SRPolicy{}
 	for _, p := range resp.GetSessions()[0].GetSrPolicies() {
@@ -1284,13 +1172,18 @@ func TestGetSRPolicyList_RoundTripsTypeAndMetric(t *testing.T) {
 
 	known := byColor[100]
 	require.NotNil(t, known)
-	assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, known.GetType())
-	assert.Equal(t, pb.MetricType_METRIC_TYPE_DELAY, known.GetMetric())
+	require.NotNil(t, known.GetCandidatePath().GetDynamic(), "expected a dynamic candidate path to round-trip")
+	assert.Equal(t, pb.MetricType_METRIC_TYPE_DELAY, known.GetCandidatePath().GetDynamic().GetMetric())
 
 	unknown := byColor[200]
 	require.NotNil(t, unknown)
-	assert.Equal(t, pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED, unknown.GetType())
-	assert.Equal(t, pb.MetricType_METRIC_TYPE_UNSPECIFIED, unknown.GetMetric())
+	assert.Nil(t, unknown.GetCandidatePath().GetPath(), "a policy with an unknown candidate path kind must round-trip with neither dynamic nor explicit set")
+
+	explicit := byColor[300]
+	require.NotNil(t, explicit)
+	require.NotNil(t, explicit.GetCandidatePath().GetExplicit(), "expected an explicit candidate path to round-trip")
+	require.Len(t, explicit.GetCandidatePath().GetExplicit().GetSegmentList(), 1)
+	assert.Equal(t, convertSegment(seg).GetSid(), explicit.GetCandidatePath().GetExplicit().GetSegmentList()[0].GetSid())
 }
 
 func TestConvertSegment_CarriesSRv6NAIAndStructure(t *testing.T) {
@@ -1435,7 +1328,7 @@ func TestSessionList_ConcurrentAccess(t *testing.T) {
 	<-done
 }
 
-func TestDeleteSRPolicy_SrcAddrOmitted(t *testing.T) {
+func TestDeleteSRPolicy_HeadendOmitted(t *testing.T) {
 	t.Parallel()
 
 	server, client := newTCPConnPair(t)
@@ -1444,17 +1337,17 @@ func TestDeleteSRPolicy_SrcAddrOmitted(t *testing.T) {
 	})
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	dstAddr := netip.MustParseAddr("10.255.0.2")
+	endpoint := netip.MustParseAddr("10.255.0.2")
 
 	ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 	ss.syncState = SyncStateFinished
 	ss.srPolicies = []*table.SRPolicy{
 		{
-			PlspID:     1,
-			Name:       testSRPolicyName,
-			DstAddr:    dstAddr,
-			Color:      100,
-			Preference: 100,
+			PlspID:        1,
+			Name:          testSRPolicyName,
+			Endpoint:      endpoint,
+			Color:         100,
+			CandidatePath: table.CandidatePath{Preference: 100},
 		},
 	}
 
@@ -1464,7 +1357,7 @@ func TestDeleteSRPolicy_SrcAddrOmitted(t *testing.T) {
 	req := &pb.DeleteSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
 			PeerAddr:   peerAddr.AsSlice(),
-			DstAddr:    dstAddr.AsSlice(),
+			Endpoint:   endpoint.AsSlice(),
 			Color:      100,
 			PolicyName: testSRPolicyName,
 		},
@@ -1474,7 +1367,7 @@ func TestDeleteSRPolicy_SrcAddrOmitted(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestGetSegmentList_DynamicHopcountPrefersFewerHops(t *testing.T) {
+func TestComputeDynamicSegmentList_HopcountPrefersFewerHops(t *testing.T) {
 	t.Parallel()
 
 	mkNode := func(routerID string, sidIndex uint32) *table.LsNode {
@@ -1494,25 +1387,18 @@ func TestGetSegmentList_DynamicHopcountPrefersFewerHops(t *testing.T) {
 	nodeB.Links = []*table.LsLink{testIPv4Link(nodeB, nodeD)}
 
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"A": nodeA, "B": nodeB, "D": nodeD}}
+	scope := cspf.PathScope{Plane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS}}
 
-	srPolicy := &pb.SRPolicy{
-		Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-		SrcRouterId: "A",
-		DstRouterId: "D",
-		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
-	}
-
-	result, err := getSegmentList(srPolicy, ted, false)
+	segs, err := computeDynamicSegmentList("A", "D", nil, table.HopcountMetric, scope, ted)
 	require.NoError(t, err)
-	assert.Equal(t, table.HopcountMetric, result.Metric)
-	require.Len(t, result.SegmentList, 1, "expected the direct 1-hop path over the 2-hop detour")
+	require.Len(t, segs, 1, "expected the direct 1-hop path over the 2-hop detour")
 
-	mplsSeg, ok := result.SegmentList[0].(table.SegmentSRMPLS)
-	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", result.SegmentList[0])
+	mplsSeg, ok := segs[0].(table.SegmentSRMPLS)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", segs[0])
 	assert.Equal(t, uint32(16004), mplsSeg.Sid)
 }
 
-func TestGetSegmentList_DynamicWithWaypointsForcesTransit(t *testing.T) {
+func TestComputeDynamicSegmentList_WithWaypointsForcesTransit(t *testing.T) {
 	t.Parallel()
 
 	mkNode := func(routerID string, sidIndex uint32) *table.LsNode {
@@ -1531,116 +1417,214 @@ func TestGetSegmentList_DynamicWithWaypointsForcesTransit(t *testing.T) {
 	nodeA.Links = []*table.LsLink{testIPv4Link(nodeA, nodeD), testIPv4Link(nodeA, nodeB)}
 	nodeB.Links = []*table.LsLink{testIPv4Link(nodeB, nodeD)}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"A": nodeA, "B": nodeB, "D": nodeD}}
+	scope := cspf.PathScope{Plane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS}}
 
-	srPolicy := &pb.SRPolicy{
-		Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-		SrcRouterId: "A",
-		DstRouterId: "D",
-		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
-		Waypoints:   []*pb.Waypoint{{RouterId: "B"}},
-	}
-
-	result, err := getSegmentList(srPolicy, ted, false)
+	segs, err := computeDynamicSegmentList("A", "D", []*pb.Waypoint{{RouterId: "B"}}, table.HopcountMetric, scope, ted)
 	require.NoError(t, err)
-	assert.Equal(t, table.HopcountMetric, result.Metric)
-	require.Len(t, result.SegmentList, 2, "expected the direct 1-hop A-D path to be overridden by the B waypoint")
+	require.Len(t, segs, 2, "expected the direct 1-hop A-D path to be overridden by the B waypoint")
 
-	firstHop, ok := result.SegmentList[0].(table.SegmentSRMPLS)
-	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", result.SegmentList[0])
+	firstHop, ok := segs[0].(table.SegmentSRMPLS)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", segs[0])
 	assert.Equal(t, uint32(16002), firstHop.Sid, "first hop must be the waypoint node B")
 
-	secondHop, ok := result.SegmentList[1].(table.SegmentSRMPLS)
-	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", result.SegmentList[1])
+	secondHop, ok := segs[1].(table.SegmentSRMPLS)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", segs[1])
 	assert.Equal(t, uint32(16004), secondHop.Sid, "second hop must be the destination node D")
 }
 
-func TestGetSegmentList_Explicit(t *testing.T) {
+func TestResolveExplicitPolicy(t *testing.T) {
 	t.Parallel()
 
+	t.Run("converts every segment", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestAPIServer(nil)
+		spec := table.EndpointSpec{Headend: netip.MustParseAddr(testAddrA), Endpoint: netip.MustParseAddr(testAddrB)}
+		explicit := &pb.ExplicitPath{SegmentList: []*pb.Segment{{Sid: "16003"}, {Sid: "16004"}}}
+
+		path, err := resolveExplicitPolicy(s, spec, explicit, 100)
+		require.NoError(t, err)
+		assert.Len(t, path.SegmentList, 2)
+		require.NotNil(t, path.CandidatePath.Explicit)
+		assert.Len(t, path.CandidatePath.Explicit.SegmentList, 2)
+		assert.Equal(t, uint32(100), path.CandidatePath.Preference)
+	})
+
+	t.Run("empty segment list is an error", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestAPIServer(nil)
+		spec := table.EndpointSpec{Headend: netip.MustParseAddr(testAddrA), Endpoint: netip.MustParseAddr(testAddrB)}
+
+		_, err := resolveExplicitPolicy(s, spec, &pb.ExplicitPath{}, 100)
+		assert.ErrorContains(t, err, "segmentList must not be empty")
+	})
+
+	t.Run("malformed segment SID propagates the error", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestAPIServer(nil)
+		spec := table.EndpointSpec{Headend: netip.MustParseAddr(testAddrA), Endpoint: netip.MustParseAddr(testAddrB)}
+		explicit := &pb.ExplicitPath{SegmentList: []*pb.Segment{{Sid: invalidSidStr}}}
+
+		_, err := resolveExplicitPolicy(s, spec, explicit, 100)
+		assert.Error(t, err)
+	})
+
+	t.Run("router ID form resolves loopbacks via the TED", func(t *testing.T) {
+		t.Parallel()
+
+		srcNode := &table.LsNode{RouterID: "r1", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}}}
+		dstNode := &table.LsNode{RouterID: "r2", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.2/32")}}}
+		ted := &table.LsTED{Nodes: map[string]*table.LsNode{"r1": srcNode, "r2": dstNode}}
+		s := newTestAPIServer(ted)
+		spec := table.EndpointSpec{HeadendRouterID: "r1", EndpointRouterID: "r2"}
+		explicit := &pb.ExplicitPath{SegmentList: []*pb.Segment{{Sid: "16003"}}}
+
+		path, err := resolveExplicitPolicy(s, spec, explicit, 100)
+		require.NoError(t, err)
+		assert.Equal(t, "10.0.0.1", path.Headend.String())
+		assert.Equal(t, "10.0.0.2", path.Endpoint.String())
+	})
+
+	t.Run("router ID form requires the TED", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestAPIServer(nil)
+		spec := table.EndpointSpec{HeadendRouterID: "r1", EndpointRouterID: "r2"}
+		explicit := &pb.ExplicitPath{SegmentList: []*pb.Segment{{Sid: "16003"}}}
+
+		_, err := resolveExplicitPolicy(s, spec, explicit, 100)
+		assert.ErrorContains(t, err, "ted is disabled")
+	})
+
+	t.Run("unknown headend router ID", func(t *testing.T) {
+		t.Parallel()
+
+		dstNode := &table.LsNode{RouterID: "r2", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.2/32")}}}
+		ted := &table.LsTED{Nodes: map[string]*table.LsNode{"r2": dstNode}}
+		s := newTestAPIServer(ted)
+		spec := table.EndpointSpec{HeadendRouterID: "missing", EndpointRouterID: "r2"}
+		explicit := &pb.ExplicitPath{SegmentList: []*pb.Segment{{Sid: "16003"}}}
+
+		_, err := resolveExplicitPolicy(s, spec, explicit, 100)
+		assert.ErrorContains(t, err, "no node with router ID missing")
+	})
+
+	t.Run("unknown endpoint router ID", func(t *testing.T) {
+		t.Parallel()
+
+		srcNode := &table.LsNode{RouterID: "r1", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}}}
+		ted := &table.LsTED{Nodes: map[string]*table.LsNode{"r1": srcNode}}
+		s := newTestAPIServer(ted)
+		spec := table.EndpointSpec{HeadendRouterID: "r1", EndpointRouterID: "missing"}
+		explicit := &pb.ExplicitPath{SegmentList: []*pb.Segment{{Sid: "16003"}}}
+
+		_, err := resolveExplicitPolicy(s, spec, explicit, 100)
+		assert.ErrorContains(t, err, "no node with router ID missing")
+	})
+
+	// netip.AddrFromSlice silently zeroes malformed addresses; verify that this
+	// surfaces as an incomplete address-form spec.
+	t.Run("malformed headend address surfaces as an incomplete address form", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestAPIServer(nil)
+		spec := table.EndpointSpec{Endpoint: netip.MustParseAddr(testAddrB)}
+		explicit := &pb.ExplicitPath{SegmentList: []*pb.Segment{{Sid: "16003"}}}
+
+		_, err := resolveExplicitPolicy(s, spec, explicit, 100)
+		assert.ErrorContains(t, err, "both headend and endpoint must be set")
+	})
+}
+
+func TestResolvePolicy_UndefinedCandidatePath(t *testing.T) {
+	t.Parallel()
+
+	s := newTestAPIServer(nil)
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{}}
+
+	_, err := resolvePolicy(s, req)
+	assert.ErrorContains(t, err, "candidatePath must specify either dynamic or explicit")
+}
+
+// Malformed address slices must be rejected explicitly rather than silently
+// treated as absent addresses.
+func TestResolvePolicy_MalformedEndpointAddress(t *testing.T) {
+	t.Parallel()
+
+	s := newTestAPIServer(nil)
+
 	tests := []struct {
-		name    string
-		policy  *pb.SRPolicy
-		wantErr bool
-		wantLen int
+		name string
+		req  *pb.CreateSRPolicyRequest
+		want string
 	}{
 		{
-			name:    "converts every segment",
-			policy:  &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, SegmentList: []*pb.Segment{{Sid: "16003"}, {Sid: "16004"}}},
-			wantLen: 2,
+			name: "malformed headend",
+			req: &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{
+				Headend: []byte{1, 2, 3}, Endpoint: netip.MustParseAddr(testAddrB).AsSlice(),
+			}},
+			want: "invalid headend address",
 		},
 		{
-			name:    "empty segment list is an error",
-			policy:  &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT},
-			wantErr: true,
-		},
-		{
-			name:    "malformed segment SID propagates the error",
-			policy:  &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, SegmentList: []*pb.Segment{{Sid: invalidSidStr}}},
-			wantErr: true,
+			name: "malformed endpoint",
+			req: &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{
+				Headend: netip.MustParseAddr(testAddrA).AsSlice(), Endpoint: []byte{1, 2, 3},
+			}},
+			want: "invalid endpoint address",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := getSegmentList(tt.policy, &table.LsTED{}, false)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, table.UnspecifiedMetric, result.Metric)
-			assert.Len(t, result.SegmentList, tt.wantLen)
+			_, err := resolvePolicy(s, tt.req)
+			assert.ErrorContains(t, err, tt.want)
 		})
 	}
 }
 
-func TestGetSegmentList_DynamicMetricError(t *testing.T) {
+func TestResolveDynamicPolicy_MetricError(t *testing.T) {
 	t.Parallel()
 
-	policy := &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, Metric: pb.MetricType_METRIC_TYPE_UNSPECIFIED}
-	_, err := getSegmentList(policy, &table.LsTED{Nodes: map[string]*table.LsNode{}}, false)
+	node := &table.LsNode{
+		RouterID: "A", SrgbBegin: 16000, SrgbEnd: 17000,
+		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 1, HasSidIndex: true}},
+	}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"A": node}}
+	s := newTestAPIServer(ted)
+	spec := table.EndpointSpec{HeadendRouterID: "A", EndpointRouterID: "D"}
+	dyn := &pb.DynamicPath{Metric: pb.MetricType_METRIC_TYPE_UNSPECIFIED}
+
+	_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{}, spec, dyn, 100)
 	assert.Error(t, err, "expected an unresolvable metric to be rejected before CSPF runs")
 }
 
-func TestGetSegmentList_UndefinedType(t *testing.T) {
+func TestResolveDynamicPolicy_UnknownHeadendRouterID(t *testing.T) {
 	t.Parallel()
 
-	_, err := getSegmentList(&pb.SRPolicy{}, &table.LsTED{}, false)
-	assert.Error(t, err)
+	otherNode := &table.LsNode{RouterID: "other"}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"other": otherNode}}
+	s := newTestAPIServer(ted)
+	spec := table.EndpointSpec{HeadendRouterID: "unknown", EndpointRouterID: "D"}
+	dyn := &pb.DynamicPath{Metric: pb.MetricType_METRIC_TYPE_HOPCOUNT}
+
+	_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{}, spec, dyn, 100)
+	assert.ErrorContains(t, err, "no node with router ID unknown")
 }
 
-func TestGetSegmentList_DynamicUnknownSrcRouterID(t *testing.T) {
+func TestResolveDynamicPolicy_HeadendWithoutViablePlane(t *testing.T) {
 	t.Parallel()
 
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
-	srPolicy := &pb.SRPolicy{
-		Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-		SrcRouterId: "unknown",
-		DstRouterId: "D",
-		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
-	}
-
-	_, err := getSegmentList(srPolicy, ted, false)
-	assert.Error(t, err, "expected an unresolvable SrcRouterId to be rejected before CSPF runs")
-}
-
-func TestGetSegmentList_DynamicSrcNodeWithoutViablePlane(t *testing.T) {
-	t.Parallel()
-
-	nodeA := &table.LsNode{RouterID: "A"} // no Prefixes and no SRv6SIDs: no candidate plane
+	nodeA := &table.LsNode{RouterID: "A"}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"A": nodeA}}
-	srPolicy := &pb.SRPolicy{
-		Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-		SrcRouterId: "A",
-		DstRouterId: "D",
-		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
-	}
+	s := newTestAPIServer(ted)
+	spec := table.EndpointSpec{HeadendRouterID: "A", EndpointRouterID: "D"}
+	dyn := &pb.DynamicPath{Metric: pb.MetricType_METRIC_TYPE_HOPCOUNT}
 
-	_, err := getSegmentList(srPolicy, ted, false)
-	assert.Error(t, err, "expected a source node without a Node SID to be rejected before CSPF runs")
+	_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{}, spec, dyn, 100)
+	assert.Error(t, err, "expected a headend node without a Node SID to be rejected before CSPF runs")
 }
 
 func TestGetMetricType(t *testing.T) {
@@ -1685,26 +1669,6 @@ func TestGetMetricType(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestToPBPolicyType(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		in   table.PolicyType
-		want pb.SRPolicyType
-	}{
-		{name: "explicit", in: table.PolicyTypeExplicit, want: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT},
-		{name: "dynamic", in: table.PolicyTypeDynamic, want: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC},
-		{name: "unrecognized maps to unspecified", in: table.PolicyType("bogus"), want: pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, toPBPolicyType(tt.in))
 		})
 	}
 }
@@ -1806,62 +1770,44 @@ func TestNewAPIServer(t *testing.T) {
 	assert.True(t, ok, "expected the PCE service to be registered with the gRPC server")
 }
 
-func TestValidateCreateSRPolicy(t *testing.T) {
+func TestValidateEndpointSpecInput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name               string
-		req                *pb.CreateSRPolicyRequest
-		disablePathCompute bool
-		wantErr            bool
+		name    string
+		policy  *pb.SRPolicy
+		wantErr string
 	}{
 		{
-			name: "path-compute request valid",
-			req: &pb.CreateSRPolicyRequest{
-				Asn: 65000,
-				SrPolicy: &pb.SRPolicy{
-					PeerAddr:    netip.MustParseAddr("10.0.0.1").AsSlice(),
-					Color:       100,
-					SrcRouterId: "r1",
-					DstRouterId: "r2",
-				},
-			},
+			name:   "address form valid",
+			policy: &pb.SRPolicy{Headend: netip.MustParseAddr("10.0.0.1").AsSlice(), Endpoint: netip.MustParseAddr("10.0.0.2").AsSlice()},
 		},
 		{
-			name: "path-compute request missing router IDs",
-			req: &pb.CreateSRPolicyRequest{
-				Asn:      65000,
-				SrPolicy: &pb.SRPolicy{PeerAddr: netip.MustParseAddr("10.0.0.1").AsSlice(), Color: 100},
-			},
-			wantErr: true,
+			name:   "router ID form valid",
+			policy: &pb.SRPolicy{HeadendRouterId: "r1", EndpointRouterId: "r2"},
 		},
 		{
-			name: "disable_path_compute request valid",
-			req: &pb.CreateSRPolicyRequest{
-				SrPolicy: &pb.SRPolicy{
-					PeerAddr:    netip.MustParseAddr("10.0.0.1").AsSlice(),
-					Color:       100,
-					SrcAddr:     netip.MustParseAddr("10.0.0.1").AsSlice(),
-					DstAddr:     netip.MustParseAddr("10.0.0.2").AsSlice(),
-					SegmentList: []*pb.Segment{{Sid: "16003"}},
-				},
-				DisablePathCompute: true,
+			name: "both forms set is rejected",
+			policy: &pb.SRPolicy{
+				Headend: netip.MustParseAddr("10.0.0.1").AsSlice(), Endpoint: netip.MustParseAddr("10.0.0.2").AsSlice(),
+				HeadendRouterId: "r1", EndpointRouterId: "r2",
 			},
-			disablePathCompute: true,
+			wantErr: "mutually exclusive",
 		},
 		{
-			name: "disable_path_compute request missing segment list",
-			req: &pb.CreateSRPolicyRequest{
-				SrPolicy: &pb.SRPolicy{
-					PeerAddr: netip.MustParseAddr("10.0.0.1").AsSlice(),
-					Color:    100,
-					SrcAddr:  netip.MustParseAddr("10.0.0.1").AsSlice(),
-					DstAddr:  netip.MustParseAddr("10.0.0.2").AsSlice(),
-				},
-				DisablePathCompute: true,
-			},
-			disablePathCompute: true,
-			wantErr:            true,
+			name:    "address form missing endpoint",
+			policy:  &pb.SRPolicy{Headend: netip.MustParseAddr("10.0.0.1").AsSlice()},
+			wantErr: "both policy.Headend and policy.Endpoint must be set",
+		},
+		{
+			name:    "router ID form missing endpoint router ID",
+			policy:  &pb.SRPolicy{HeadendRouterId: "r1"},
+			wantErr: "both policy.HeadendRouterId and policy.EndpointRouterId must be set",
+		},
+		{
+			name:    "neither form set",
+			policy:  &pb.SRPolicy{},
+			wantErr: "either headend/endpoint or headendRouterId/endpointRouterId must be set",
 		},
 	}
 
@@ -1869,72 +1815,15 @@ func TestValidateCreateSRPolicy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateCreateSRPolicy(tt.req, tt.disablePathCompute)
-			if tt.wantErr {
-				assert.Error(t, err)
+			err := validateEndpointSpecInput(tt.policy)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
-}
-
-func TestGetLoopbackAddr(t *testing.T) {
-	t.Parallel()
-
-	node := &table.LsNode{
-		RouterID: "r1",
-		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}},
-	}
-	noLoopbackNode := &table.LsNode{
-		RouterID: "r2",
-		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.0/24")}},
-	}
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node, noLoopbackNode.RouterID: noLoopbackNode, "r3": nil}}
-
-	addr, err := getLoopbackAddr(ted, "r1", table.AFIPv4)
-	require.NoError(t, err)
-	assert.Equal(t, "10.0.0.1", addr.String())
-
-	_, err = getLoopbackAddr(ted, "missing", table.AFIPv4)
-	require.ErrorContains(t, err, "no node with router ID missing")
-
-	_, err = getLoopbackAddr(ted, "r2", table.AFIPv4)
-	require.Error(t, err, "expected an error for a node without a loopback address")
-
-	_, err = getLoopbackAddr(ted, "r3", table.AFIPv4)
-	require.ErrorContains(t, err, "no node with router ID r3")
-
-	_, err = getLoopbackAddr(nil, "r1", table.AFIPv4)
-	assert.ErrorContains(t, err, "no node with router ID r1")
-}
-
-func TestDefaultLoopbackFamily(t *testing.T) {
-	t.Parallel()
-
-	node := &table.LsNode{
-		RouterID: "r1",
-		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}},
-	}
-	dualStackNode := &table.LsNode{
-		RouterID: "r2",
-		Prefixes: []*table.LsPrefix{
-			{Prefix: netip.MustParsePrefix("10.0.0.2/32")},
-			{Prefix: netip.MustParsePrefix("2001:db8::2/128")},
-		},
-	}
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node, dualStackNode.RouterID: dualStackNode}}
-
-	af, err := defaultLoopbackFamily(ted, "r1")
-	require.NoError(t, err)
-	assert.Equal(t, table.AFIPv4, af)
-
-	_, err = defaultLoopbackFamily(ted, "r2")
-	require.Error(t, err, "expected a node with loopbacks in multiple families to require an explicit family")
-
-	_, err = defaultLoopbackFamily(ted, "missing")
-	require.ErrorContains(t, err, "no node with router ID missing")
 }
 
 func TestResolvePlane(t *testing.T) {
@@ -2210,33 +2099,31 @@ func TestNewEnrichedSegmentSRMPLS_SubobjectValidationErrors(t *testing.T) {
 	}
 }
 
-func TestResolvePath_PathCompute(t *testing.T) {
+func TestResolveDynamicPolicy_TEDAvailability(t *testing.T) {
 	t.Parallel()
 
-	srcNode := &table.LsNode{ASN: 65000, RouterID: "r1", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}}}
-	dstNode := &table.LsNode{ASN: 65000, RouterID: "r2", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.2/32")}}}
-	ted := &table.LsTED{Nodes: map[string]*table.LsNode{srcNode.RouterID: srcNode, dstNode.RouterID: dstNode}}
-
-	explicitReq := func() *pb.CreateSRPolicyRequest {
-		return &pb.CreateSRPolicyRequest{
-			Asn: 65000,
-			SrPolicy: &pb.SRPolicy{
-				Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-				SrcRouterId: "r1",
-				DstRouterId: "r2",
-				SegmentList: []*pb.Segment{{Sid: "16003"}},
-			},
-		}
+	srcNode := &table.LsNode{
+		ASN: 65000, RouterID: "r1", SrgbBegin: 16000, SrgbEnd: 17000,
+		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 1, HasSidIndex: true}},
 	}
+	dstNode := &table.LsNode{
+		ASN: 65000, RouterID: "r2", SrgbBegin: 16000, SrgbEnd: 17000,
+		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.2/32"), SidIndex: 2, HasSidIndex: true}},
+	}
+	srcNode.Links = []*table.LsLink{testIPv4Link(srcNode, dstNode)}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"r1": srcNode, "r2": dstNode}}
 
-	t.Run("success resolves loopbacks and segments", func(t *testing.T) {
+	spec := table.EndpointSpec{HeadendRouterID: "r1", EndpointRouterID: "r2"}
+	dyn := &pb.DynamicPath{Metric: pb.MetricType_METRIC_TYPE_HOPCOUNT}
+
+	t.Run("success resolves loopbacks and computes a segment list", func(t *testing.T) {
 		t.Parallel()
 
 		s := newTestAPIServer(ted)
-		path, err := resolvePath(s, explicitReq(), false)
+		path, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{Asn: 65000}, spec, dyn, 100)
 		require.NoError(t, err)
-		assert.Equal(t, "10.0.0.1", path.SrcAddr.String())
-		assert.Equal(t, "10.0.0.2", path.DstAddr.String())
+		assert.Equal(t, "10.0.0.1", path.Headend.String())
+		assert.Equal(t, "10.0.0.2", path.Endpoint.String())
 		assert.Len(t, path.SegmentList, 1)
 	})
 
@@ -2244,7 +2131,7 @@ func TestResolvePath_PathCompute(t *testing.T) {
 		t.Parallel()
 
 		s := newTestAPIServer(nil)
-		_, err := resolvePath(s, explicitReq(), false)
+		_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{Asn: 65000}, spec, dyn, 100)
 		assert.ErrorContains(t, err, "ted is disabled")
 	})
 
@@ -2252,7 +2139,7 @@ func TestResolvePath_PathCompute(t *testing.T) {
 		t.Parallel()
 
 		s := newTestAPIServer(&table.LsTED{Nodes: map[string]*table.LsNode{}})
-		_, err := resolvePath(s, explicitReq(), false)
+		_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{Asn: 65000}, spec, dyn, 100)
 		assert.ErrorContains(t, err, "no node in TED")
 	})
 
@@ -2260,18 +2147,16 @@ func TestResolvePath_PathCompute(t *testing.T) {
 		t.Parallel()
 
 		s := newTestAPIServer(ted)
-		req := explicitReq()
-		req.Asn = 1
-		_, err := resolvePath(s, req, false)
+		_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{Asn: 1}, spec, dyn, 100)
 		assert.ErrorContains(t, err, "does not match ted ASN")
 	})
 
 	t.Run("nil TED entry is skipped by the ASN check", func(t *testing.T) {
 		t.Parallel()
 
-		nodes := map[string]*table.LsNode{srcNode.RouterID: srcNode, dstNode.RouterID: dstNode, "r0": nil}
+		nodes := map[string]*table.LsNode{"r1": srcNode, "r2": dstNode, "r0": nil}
 		s := newTestAPIServer(&table.LsTED{Nodes: nodes})
-		_, err := resolvePath(s, explicitReq(), false)
+		_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{Asn: 65000}, spec, dyn, 100)
 		require.NoError(t, err)
 	})
 
@@ -2279,95 +2164,98 @@ func TestResolvePath_PathCompute(t *testing.T) {
 		t.Parallel()
 
 		s := newTestAPIServer(&table.LsTED{Nodes: map[string]*table.LsNode{"r0": nil}})
-		_, err := resolvePath(s, explicitReq(), false)
+		_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{Asn: 65000}, spec, dyn, 100)
 		assert.ErrorContains(t, err, "no node with router ID r1")
 	})
 
-	t.Run("unknown source router ID", func(t *testing.T) {
+	t.Run("endpoint resolution failure after a successful CSPF run is propagated", func(t *testing.T) {
 		t.Parallel()
 
+		// Ensure errors from final endpoint resolution are not masked by CSPF.
 		s := newTestAPIServer(ted)
-		req := explicitReq()
-		req.SrPolicy.SrcRouterId = "missing"
-		_, err := resolvePath(s, req, false)
-		assert.ErrorContains(t, err, "no node with router ID missing")
+		mixedSpec := spec
+		mixedSpec.Headend = netip.MustParseAddr("10.0.0.1")
+		mixedSpec.Endpoint = netip.MustParseAddr("10.0.0.2")
+
+		_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{Asn: 65000}, mixedSpec, dyn, 100)
+		assert.ErrorContains(t, err, "mutually exclusive")
 	})
 
-	t.Run("unknown destination router ID", func(t *testing.T) {
+	t.Run("address form that resolves to no TED router ID is propagated", func(t *testing.T) {
 		t.Parallel()
 
 		s := newTestAPIServer(ted)
-		req := explicitReq()
-		req.SrPolicy.DstRouterId = "missing"
-		_, err := resolvePath(s, req, false)
-		assert.ErrorContains(t, err, "no node with router ID missing")
-	})
+		addrSpec := table.EndpointSpec{Headend: netip.MustParseAddr("192.0.2.1"), Endpoint: netip.MustParseAddr("10.0.0.2")}
 
-	t.Run("segment list resolution error propagates", func(t *testing.T) {
-		t.Parallel()
-
-		s := newTestAPIServer(ted)
-		req := explicitReq()
-		req.SrPolicy.SegmentList = nil
-		_, err := resolvePath(s, req, false)
-		assert.ErrorContains(t, err, "no segments in SRPolicy input")
+		_, err := resolveDynamicPolicy(s, &pb.CreateSRPolicyRequest{Asn: 65000}, addrSpec, dyn, 100)
+		assert.ErrorContains(t, err, "headend address 192.0.2.1 not found in TED")
 	})
 }
 
-func TestResolvePath_DisablePathCompute(t *testing.T) {
+func TestRouterIDsForCSPF(t *testing.T) {
 	t.Parallel()
 
-	disabledReq := func() *pb.CreateSRPolicyRequest {
-		return &pb.CreateSRPolicyRequest{
-			DisablePathCompute: true,
-			SrPolicy: &pb.SRPolicy{
-				SrcAddr:     netip.MustParseAddr("10.0.0.1").AsSlice(),
-				DstAddr:     netip.MustParseAddr("10.0.0.2").AsSlice(),
-				SegmentList: []*pb.Segment{{Sid: "16003"}},
-			},
-		}
-	}
+	nodeA := &table.LsNode{RouterID: "r1", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}}}
+	nodeB := &table.LsNode{RouterID: "r2", Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.2/32")}}}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"r1": nodeA, "r2": nodeB}}
 
-	t.Run("success uses the request addresses and segments verbatim", func(t *testing.T) {
+	t.Run("router ID form returns the router IDs as-is", func(t *testing.T) {
 		t.Parallel()
 
-		s := newTestAPIServer(nil)
-		path, err := resolvePath(s, disabledReq(), true)
+		spec := table.EndpointSpec{HeadendRouterID: "r1", EndpointRouterID: "r2"}
+		headendRouterID, endpointRouterID, err := routerIDsForCSPF(ted, spec)
 		require.NoError(t, err)
-		assert.Equal(t, "10.0.0.1", path.SrcAddr.String())
-		assert.Equal(t, "10.0.0.2", path.DstAddr.String())
-		assert.Len(t, path.SegmentList, 1)
+		assert.Equal(t, "r1", headendRouterID)
+		assert.Equal(t, "r2", endpointRouterID)
 	})
 
-	t.Run("malformed source address", func(t *testing.T) {
+	t.Run("neither form is set", func(t *testing.T) {
 		t.Parallel()
 
-		s := newTestAPIServer(nil)
-		req := disabledReq()
-		req.SrPolicy.SrcAddr = []byte{1, 2, 3}
-		_, err := resolvePath(s, req, true)
-		assert.ErrorContains(t, err, "invalid source address")
+		_, _, err := routerIDsForCSPF(ted, table.EndpointSpec{})
+		assert.ErrorContains(t, err, "either headend/endpoint or headendRouterId/endpointRouterId must be set")
 	})
 
-	t.Run("malformed destination address", func(t *testing.T) {
+	t.Run("headend address not found in TED", func(t *testing.T) {
 		t.Parallel()
 
-		s := newTestAPIServer(nil)
-		req := disabledReq()
-		req.SrPolicy.DstAddr = []byte{1, 2, 3}
-		_, err := resolvePath(s, req, true)
-		assert.ErrorContains(t, err, "invalid destination address")
+		spec := table.EndpointSpec{Headend: netip.MustParseAddr("192.0.2.1"), Endpoint: netip.MustParseAddr("10.0.0.2")}
+		_, _, err := routerIDsForCSPF(ted, spec)
+		assert.ErrorContains(t, err, "headend address 192.0.2.1 not found in TED")
 	})
 
-	t.Run("malformed segment SID", func(t *testing.T) {
+	t.Run("endpoint address not found in TED", func(t *testing.T) {
 		t.Parallel()
 
-		s := newTestAPIServer(nil)
-		req := disabledReq()
-		req.SrPolicy.SegmentList = []*pb.Segment{{Sid: invalidSidStr}}
-		_, err := resolvePath(s, req, true)
-		assert.Error(t, err)
+		spec := table.EndpointSpec{Headend: netip.MustParseAddr("10.0.0.1"), Endpoint: netip.MustParseAddr("192.0.2.2")}
+		_, _, err := routerIDsForCSPF(ted, spec)
+		assert.ErrorContains(t, err, "endpoint address 192.0.2.2 not found in TED")
 	})
+
+	t.Run("address form resolves both router IDs via the TED", func(t *testing.T) {
+		t.Parallel()
+
+		spec := table.EndpointSpec{Headend: netip.MustParseAddr("10.0.0.1"), Endpoint: netip.MustParseAddr("10.0.0.2")}
+		headendRouterID, endpointRouterID, err := routerIDsForCSPF(ted, spec)
+		require.NoError(t, err)
+		assert.Equal(t, "r1", headendRouterID)
+		assert.Equal(t, "r2", endpointRouterID)
+	})
+}
+
+func TestResolvePreference(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, table.DefaultPreference, resolvePreference(0))
+	assert.Equal(t, uint32(200), resolvePreference(200))
+}
+
+func TestSegmentIfaceIDs_NilSegment(t *testing.T) {
+	t.Parallel()
+
+	local, remote := segmentIfaceIDs(nil)
+	assert.Nil(t, local)
+	assert.Nil(t, remote)
 }
 
 func TestCreateSRPolicy(t *testing.T) {
@@ -2384,13 +2272,14 @@ func TestCreateSRPolicy(t *testing.T) {
 		return &pb.CreateSRPolicyRequest{
 			Asn: 65000,
 			SrPolicy: &pb.SRPolicy{
-				Type:        pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
-				PolicyName:  testSRPolicyName,
-				Color:       100,
-				PeerAddr:    netip.MustParseAddr("10.0.255.1").AsSlice(),
-				SrcRouterId: "r1",
-				DstRouterId: "r2",
-				SegmentList: []*pb.Segment{{Sid: "16003"}},
+				PolicyName:       testSRPolicyName,
+				Color:            100,
+				PeerAddr:         netip.MustParseAddr("10.0.255.1").AsSlice(),
+				HeadendRouterId:  "r1",
+				EndpointRouterId: "r2",
+				CandidatePath: &pb.CandidatePath{Path: &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{
+					SegmentList: []*pb.Segment{{Sid: "16003"}},
+				}}},
 			},
 			NoSidValidate: true,
 		}
@@ -2420,7 +2309,7 @@ func TestCreateSRPolicy(t *testing.T) {
 		s := newTestAPIServer(ted)
 		req := baseReq()
 		req.NoSidValidate = false
-		req.SrPolicy.SegmentList = []*pb.Segment{{Sid: "16099"}}
+		req.SrPolicy.CandidatePath.GetExplicit().SegmentList = []*pb.Segment{{Sid: "16099"}}
 		_, err := s.CreateSRPolicy(context.Background(), req)
 		st, ok := status.FromError(err)
 		require.True(t, ok)
@@ -2585,15 +2474,16 @@ func TestCreateSRPolicy_EndpointFamilyIndependentOfUnderlayPlane(t *testing.T) {
 		req := &pb.CreateSRPolicyRequest{
 			Asn: 1,
 			SrPolicy: &pb.SRPolicy{
-				Type:           pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-				PolicyName:     testSRPolicyName,
-				Color:          100,
-				PeerAddr:       peerAddr.AsSlice(),
-				SrcRouterId:    "A",
-				DstRouterId:    "B",
-				Metric:         pb.MetricType_METRIC_TYPE_TE,
-				UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
-				DataPlane:      pb.DataPlane_DATA_PLANE_SR_MPLS,
+				PolicyName:       testSRPolicyName,
+				Color:            100,
+				PeerAddr:         peerAddr.AsSlice(),
+				HeadendRouterId:  "A",
+				EndpointRouterId: "B",
+				CandidatePath: &pb.CandidatePath{Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+					Metric:         pb.MetricType_METRIC_TYPE_TE,
+					UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
+					DataPlane:      pb.DataPlane_DATA_PLANE_SR_MPLS,
+				}}},
 			},
 		}
 
@@ -2646,15 +2536,16 @@ func TestCreateSRPolicy_EndpointFamilyIndependentOfUnderlayPlane(t *testing.T) {
 		req := &pb.CreateSRPolicyRequest{
 			Asn: 1,
 			SrPolicy: &pb.SRPolicy{
-				Type:           pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
-				PolicyName:     testSRPolicyName,
-				Color:          100,
-				PeerAddr:       peerAddr.AsSlice(),
-				SrcRouterId:    "C",
-				DstRouterId:    "D",
-				Metric:         pb.MetricType_METRIC_TYPE_TE,
-				UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV4,
-				DataPlane:      pb.DataPlane_DATA_PLANE_SR_MPLS,
+				PolicyName:       testSRPolicyName,
+				Color:            100,
+				PeerAddr:         peerAddr.AsSlice(),
+				HeadendRouterId:  "C",
+				EndpointRouterId: "D",
+				CandidatePath: &pb.CandidatePath{Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+					Metric:         pb.MetricType_METRIC_TYPE_TE,
+					UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV4,
+					DataPlane:      pb.DataPlane_DATA_PLANE_SR_MPLS,
+				}}},
 			},
 		}
 
@@ -2688,14 +2579,15 @@ func TestCreateSRPolicy_SRv6WithoutLocalAddr(t *testing.T) {
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
 
 	req := &pb.CreateSRPolicyRequest{
-		DisablePathCompute: true,
 		SrPolicy: &pb.SRPolicy{
-			PolicyName:  testSRPolicyName,
-			Color:       100,
-			PeerAddr:    netip.MustParseAddr("10.0.255.1").AsSlice(),
-			SrcAddr:     netip.MustParseAddr("2001:db8:e::1").AsSlice(),
-			DstAddr:     netip.MustParseAddr("2001:db8:e::2").AsSlice(),
-			SegmentList: []*pb.Segment{{Sid: testSRv6SID1}},
+			PolicyName: testSRPolicyName,
+			Color:      100,
+			PeerAddr:   netip.MustParseAddr("10.0.255.1").AsSlice(),
+			Headend:    netip.MustParseAddr("2001:db8:e::1").AsSlice(),
+			Endpoint:   netip.MustParseAddr("2001:db8:e::2").AsSlice(),
+			CandidatePath: &pb.CandidatePath{Path: &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{
+				SegmentList: []*pb.Segment{{Sid: testSRv6SID1}},
+			}}},
 		},
 		NoSidValidate: true,
 	}
@@ -2733,21 +2625,30 @@ func TestCreateSRPolicy_StatusCodes(t *testing.T) {
 		return &pb.CreateSRPolicyRequest{
 			Asn: 65000,
 			SrPolicy: &pb.SRPolicy{
-				Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT, PolicyName: testSRPolicyName, Color: 100,
-				PeerAddr:    netip.MustParseAddr("10.0.255.1").AsSlice(),
-				SrcRouterId: "r1", DstRouterId: "r2",
-				SegmentList: []*pb.Segment{{Sid: "16002"}},
+				PolicyName: testSRPolicyName, Color: 100,
+				PeerAddr:         netip.MustParseAddr("10.0.255.1").AsSlice(),
+				HeadendRouterId:  "r1",
+				EndpointRouterId: "r2",
+				CandidatePath: &pb.CandidatePath{Path: &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{
+					SegmentList: []*pb.Segment{{Sid: "16002"}},
+				}}},
 			},
 			NoSidValidate: true,
 		}
 	}
 	dynamicReq := func() *pb.CreateSRPolicyRequest {
 		req := explicitReq()
-		req.SrPolicy.Type = pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC
-		req.SrPolicy.Metric = pb.MetricType_METRIC_TYPE_IGP
-		req.SrPolicy.SegmentList = nil
+		req.SrPolicy.CandidatePath = &pb.CandidatePath{Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{
+			Metric: pb.MetricType_METRIC_TYPE_IGP,
+		}}}
 
 		return req
+	}
+	dyn := func(r *pb.CreateSRPolicyRequest) *pb.DynamicPath {
+		return r.GetSrPolicy().GetCandidatePath().GetDynamic()
+	}
+	explicit := func(r *pb.CreateSRPolicyRequest) *pb.ExplicitPath {
+		return r.GetSrPolicy().GetCandidatePath().GetExplicit()
 	}
 
 	tests := []struct {
@@ -2760,7 +2661,7 @@ func TestCreateSRPolicy_StatusCodes(t *testing.T) {
 	}{
 		{
 			"ASN is zero", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); r.Asn = 0; return r },
-			codes.InvalidArgument, ReasonInvalidRequest, "ASN must not be zero",
+			codes.InvalidArgument, ReasonInvalidRequest, "policy.Asn must not be zero",
 		},
 		{
 			"color is zero", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); r.SrPolicy.Color = 0; return r },
@@ -2771,64 +2672,64 @@ func TestCreateSRPolicy_StatusCodes(t *testing.T) {
 			codes.InvalidArgument, ReasonInvalidRequest, "policy.PeerAddr must not be nil",
 		},
 		{
-			"request ASN does not match the TED", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); r.Asn = 65001; return r },
+			"request ASN does not match the TED", true, func() *pb.CreateSRPolicyRequest { r := dynamicReq(); r.Asn = 65001; return r },
 			codes.InvalidArgument, ReasonInvalidRequest, "does not match ted ASN",
 		},
 		{
-			"source router ID is not in the TED", true, func() *pb.CreateSRPolicyRequest { r := dynamicReq(); r.SrPolicy.SrcRouterId = "r9"; return r },
+			"headend router ID is not in the TED", true, func() *pb.CreateSRPolicyRequest { r := dynamicReq(); r.SrPolicy.HeadendRouterId = "r9"; return r },
 			codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID r9",
 		},
 		{
-			"destination router ID is not in the TED", true, func() *pb.CreateSRPolicyRequest { r := dynamicReq(); r.SrPolicy.DstRouterId = "r9"; return r },
-			codes.InvalidArgument, ReasonInvalidRequest, "no node with router ID r9",
+			"endpoint router ID is not in the TED", true, func() *pb.CreateSRPolicyRequest { r := dynamicReq(); r.SrPolicy.EndpointRouterId = "r9"; return r },
+			codes.InvalidArgument, ReasonInvalidRequest, "destination router r9 not found in TED",
 		},
 		{"waypoint router ID is not in the TED", true, func() *pb.CreateSRPolicyRequest {
 			r := dynamicReq()
-			r.SrPolicy.Waypoints = []*pb.Waypoint{{RouterId: "r9"}}
+			dyn(r).Waypoints = []*pb.Waypoint{{RouterId: "r9"}}
 
 			return r
 		}, codes.InvalidArgument, ReasonInvalidRequest, "waypoint router r9 not found in TED"},
 		{"waypoint SID is malformed", true, func() *pb.CreateSRPolicyRequest {
 			r := dynamicReq()
-			r.SrPolicy.Waypoints = []*pb.Waypoint{{RouterId: "r2", Sid: "not-an-address"}}
+			dyn(r).Waypoints = []*pb.Waypoint{{RouterId: "r2", Sid: "not-an-address"}}
 
 			return r
 		}, codes.InvalidArgument, ReasonInvalidRequest, "failed to build segment for waypoint r2"},
 		{"dynamic policy without a metric", true, func() *pb.CreateSRPolicyRequest {
 			r := dynamicReq()
-			r.SrPolicy.Metric = pb.MetricType_METRIC_TYPE_UNSPECIFIED
+			dyn(r).Metric = pb.MetricType_METRIC_TYPE_UNSPECIFIED
 
 			return r
 		}, codes.InvalidArgument, ReasonInvalidRequest, "unknown metric type"},
 		{"dynamic policy with a metric outside the enum", true, func() *pb.CreateSRPolicyRequest {
 			r := dynamicReq()
-			r.SrPolicy.Metric = pb.MetricType(99)
+			dyn(r).Metric = pb.MetricType(99)
 
 			return r
 		}, codes.InvalidArgument, ReasonInvalidRequest, "unknown metric type"},
 		{
-			"policy type is unset", true, func() *pb.CreateSRPolicyRequest {
+			"candidate path is unset", true, func() *pb.CreateSRPolicyRequest {
 				r := explicitReq()
-				r.SrPolicy.Type = pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED
+				r.SrPolicy.CandidatePath = nil
 
 				return r
 			},
-			codes.InvalidArgument, ReasonInvalidRequest, "undefined SR Policy type",
+			codes.InvalidArgument, ReasonInvalidRequest, "policy.CandidatePath must specify either dynamic or explicit",
 		},
 		{
-			"explicit policy with an empty segment list", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); r.SrPolicy.SegmentList = nil; return r },
-			codes.InvalidArgument, ReasonInvalidRequest, "no segments in SRPolicy input",
+			"explicit policy with an empty segment list", true, func() *pb.CreateSRPolicyRequest { r := explicitReq(); explicit(r).SegmentList = nil; return r },
+			codes.InvalidArgument, ReasonInvalidRequest, "candidatePath.explicit.segmentList must not be empty",
 		},
 		{"explicit policy with a malformed SID", true, func() *pb.CreateSRPolicyRequest {
 			r := explicitReq()
-			r.SrPolicy.SegmentList = []*pb.Segment{{Sid: invalidSidStr}}
+			explicit(r).SegmentList = []*pb.Segment{{Sid: invalidSidStr}}
 
 			return r
 		}, codes.InvalidArgument, ReasonInvalidRequest, "invalid SID"},
 		{"SID is not present in the TED", true, func() *pb.CreateSRPolicyRequest {
 			r := explicitReq()
 			r.NoSidValidate = false
-			r.SrPolicy.SegmentList = []*pb.Segment{{Sid: "16099"}}
+			explicit(r).SegmentList = []*pb.Segment{{Sid: "16099"}}
 
 			return r
 		}, codes.FailedPrecondition, "SID_VALIDATION_FAILED", "SID validation failed"},
@@ -2836,12 +2737,12 @@ func TestCreateSRPolicy_StatusCodes(t *testing.T) {
 		// FailedPrecondition: request is well formed, PCE/TED state cannot satisfy it.
 		{"TED is disabled", false, explicitReq, codes.FailedPrecondition, "TED_DISABLED", "ted is disabled"},
 		{
-			"destination is unreachable", true, func() *pb.CreateSRPolicyRequest { r := dynamicReq(); r.SrPolicy.DstRouterId = "r3"; return r },
+			"destination is unreachable", true, func() *pb.CreateSRPolicyRequest { r := dynamicReq(); r.SrPolicy.EndpointRouterId = "r3"; return r },
 			codes.FailedPrecondition, "DESTINATION_UNREACHABLE", "next node not found",
 		},
 		{"requested metric is not carried by a traversed link", true, func() *pb.CreateSRPolicyRequest {
 			r := dynamicReq()
-			r.SrPolicy.Metric = pb.MetricType_METRIC_TYPE_TE
+			dyn(r).Metric = pb.MetricType_METRIC_TYPE_TE
 
 			return r
 		}, codes.FailedPrecondition, "METRIC_NOT_CARRIED", "metric METRIC_TYPE_TE not defined"},
@@ -2882,12 +2783,12 @@ func TestDeleteSRPolicy(t *testing.T) {
 	t.Parallel()
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	dstAddr := netip.MustParseAddr("10.255.0.2")
+	endpoint := netip.MustParseAddr("10.255.0.2")
 
 	validPolicy := func() *pb.SRPolicy {
 		return &pb.SRPolicy{
 			PeerAddr:   peerAddr.AsSlice(),
-			DstAddr:    dstAddr.AsSlice(),
+			Endpoint:   endpoint.AsSlice(),
 			Color:      100,
 			PolicyName: testSRPolicyName,
 		}
@@ -2902,25 +2803,14 @@ func TestDeleteSRPolicy(t *testing.T) {
 		assert.Nil(t, resp)
 	})
 
-	t.Run("malformed source address", func(t *testing.T) {
+	t.Run("malformed endpoint address", func(t *testing.T) {
 		t.Parallel()
 
 		s := &APIServer{logger: logger.NewNop()}
 		policy := validPolicy()
-		policy.SrcAddr = []byte{1, 2, 3}
+		policy.Endpoint = []byte{1, 2, 3}
 		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: policy})
-		require.ErrorContains(t, err, "invalid source address")
-		assert.Nil(t, resp)
-	})
-
-	t.Run("malformed destination address", func(t *testing.T) {
-		t.Parallel()
-
-		s := &APIServer{logger: logger.NewNop()}
-		policy := validPolicy()
-		policy.DstAddr = []byte{1, 2, 3}
-		resp, err := s.DeleteSRPolicy(context.Background(), &pb.DeleteSRPolicyRequest{SrPolicy: policy})
-		require.ErrorContains(t, err, "invalid destination address")
+		require.ErrorContains(t, err, "invalid endpoint address")
 		assert.Nil(t, resp)
 	})
 
@@ -2977,7 +2867,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 
 		ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 		ss.syncState = SyncStateFinished
-		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: testSRPolicyName, DstAddr: dstAddr, Color: 100, Preference: 100}}
+		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: testSRPolicyName, Endpoint: endpoint, Color: 100, CandidatePath: table.CandidatePath{Preference: 100}}}
 
 		require.NoError(t, server.Close(), "failed to close server connection")
 
@@ -2997,7 +2887,7 @@ func TestDeleteSRPolicy(t *testing.T) {
 
 		ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 		ss.syncState = SyncStateFinished
-		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: testSRPolicyName, DstAddr: dstAddr, Color: 100, Preference: 100}}
+		ss.srPolicies = []*table.SRPolicy{{PlspID: 1, Name: testSRPolicyName, Endpoint: endpoint, Color: 100, CandidatePath: table.CandidatePath{Preference: 100}}}
 		ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
 			[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
@@ -3018,8 +2908,16 @@ func TestValidate_NilPolicy(t *testing.T) {
 func TestValidate_AddRequiresNonZeroASN(t *testing.T) {
 	t.Parallel()
 
-	policy := &pb.SRPolicy{PeerAddr: []byte{10, 0, 0, 1}, Color: 100, SrcRouterId: "r1", DstRouterId: "r2"}
-	assert.ErrorContains(t, validate(policy, 0, ValidationAdd), "ASN must not be zero")
+	policy := &pb.SRPolicy{
+		PeerAddr:         []byte{10, 0, 0, 1},
+		Color:            100,
+		HeadendRouterId:  "r1",
+		EndpointRouterId: "r2",
+		CandidatePath: &pb.CandidatePath{Path: &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{
+			SegmentList: []*pb.Segment{{Sid: "16003"}},
+		}}},
+	}
+	assert.ErrorContains(t, validate(policy, 0, ValidationAdd), "policy.Asn must not be zero")
 }
 
 func TestValidate_UnknownKind(t *testing.T) {
@@ -3033,7 +2931,11 @@ func TestValidate_Add(t *testing.T) {
 	t.Parallel()
 
 	full := func() *pb.SRPolicy {
-		return &pb.SRPolicy{PeerAddr: []byte{10, 0, 0, 1}, Color: 100, SrcRouterId: "r1", DstRouterId: "r2"}
+		return &pb.SRPolicy{
+			PeerAddr: []byte{10, 0, 0, 1}, Color: 100,
+			HeadendRouterId: "r1", EndpointRouterId: "r2",
+			CandidatePath: &pb.CandidatePath{Path: &pb.CandidatePath_Dynamic{Dynamic: &pb.DynamicPath{}}},
+		}
 	}
 
 	tests := []struct {
@@ -3044,8 +2946,16 @@ func TestValidate_Add(t *testing.T) {
 		{name: "valid"},
 		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PeerAddr = nil }, wantErr: "policy.PeerAddr must not be nil"},
 		{name: "zero color", mutate: func(p *pb.SRPolicy) { p.Color = 0 }, wantErr: wantErrColorZero},
-		{name: "missing source router ID", mutate: func(p *pb.SRPolicy) { p.SrcRouterId = "" }, wantErr: "SrcRouterId must not be empty"},
-		{name: "missing destination router ID", mutate: func(p *pb.SRPolicy) { p.DstRouterId = "" }, wantErr: "DstRouterId must not be empty"},
+		{
+			name:    "missing headend router ID",
+			mutate:  func(p *pb.SRPolicy) { p.HeadendRouterId = "" },
+			wantErr: "both policy.HeadendRouterId and policy.EndpointRouterId must be set",
+		},
+		{
+			name:    "missing endpoint router ID",
+			mutate:  func(p *pb.SRPolicy) { p.EndpointRouterId = "" },
+			wantErr: "both policy.HeadendRouterId and policy.EndpointRouterId must be set",
+		},
 	}
 
 	for _, tt := range tests {
@@ -3068,16 +2978,18 @@ func TestValidate_Add(t *testing.T) {
 	}
 }
 
-func TestValidate_AddDisablePathCompute(t *testing.T) {
+func TestValidate_AddAddressForm(t *testing.T) {
 	t.Parallel()
 
 	full := func() *pb.SRPolicy {
 		return &pb.SRPolicy{
-			PeerAddr:    []byte{10, 0, 0, 1},
-			Color:       100,
-			SrcAddr:     []byte{10, 0, 0, 1},
-			DstAddr:     []byte{10, 0, 0, 2},
-			SegmentList: []*pb.Segment{{Sid: "16003"}},
+			PeerAddr: []byte{10, 0, 0, 1},
+			Color:    100,
+			Headend:  []byte{10, 0, 0, 1},
+			Endpoint: []byte{10, 0, 0, 2},
+			CandidatePath: &pb.CandidatePath{Path: &pb.CandidatePath_Explicit{Explicit: &pb.ExplicitPath{
+				SegmentList: []*pb.Segment{{Sid: "16003"}},
+			}}},
 		}
 	}
 
@@ -3089,9 +3001,14 @@ func TestValidate_AddDisablePathCompute(t *testing.T) {
 		{name: "valid"},
 		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PeerAddr = nil }, wantErr: "policy.PeerAddr must not be nil"},
 		{name: "zero color", mutate: func(p *pb.SRPolicy) { p.Color = 0 }, wantErr: wantErrColorZero},
-		{name: "missing source address", mutate: func(p *pb.SRPolicy) { p.SrcAddr = nil }, wantErr: "SrcAddr must not be empty"},
-		{name: "missing destination address", mutate: func(p *pb.SRPolicy) { p.DstAddr = nil }, wantErr: "DstAddr must not be empty"},
-		{name: "missing segment list", mutate: func(p *pb.SRPolicy) { p.SegmentList = nil }, wantErr: "SegmentList must not be empty"},
+		{name: "missing headend address", mutate: func(p *pb.SRPolicy) { p.Headend = nil }, wantErr: "both policy.Headend and policy.Endpoint must be set"},
+		{name: "missing endpoint address", mutate: func(p *pb.SRPolicy) { p.Endpoint = nil }, wantErr: "both policy.Headend and policy.Endpoint must be set"},
+		{
+			name:    "both address and router ID forms set",
+			mutate:  func(p *pb.SRPolicy) { p.HeadendRouterId = "r1"; p.EndpointRouterId = "r2" },
+			wantErr: "mutually exclusive",
+		},
+		{name: "candidate path missing", mutate: func(p *pb.SRPolicy) { p.CandidatePath = nil }, wantErr: "policy.CandidatePath must specify either dynamic or explicit"},
 	}
 
 	for _, tt := range tests {
@@ -3103,7 +3020,7 @@ func TestValidate_AddDisablePathCompute(t *testing.T) {
 				tt.mutate(policy)
 			}
 
-			err := validate(policy, 65000, ValidationAddDisablePathCompute)
+			err := validate(policy, 0, ValidationAdd)
 			if tt.wantErr == "" {
 				assert.NoError(t, err)
 				return
@@ -3121,7 +3038,7 @@ func TestValidate_Delete(t *testing.T) {
 		return &pb.SRPolicy{
 			PeerAddr:   []byte{10, 0, 0, 1},
 			Color:      100,
-			DstAddr:    []byte{10, 0, 0, 2},
+			Endpoint:   []byte{10, 0, 0, 2},
 			PolicyName: testSRPolicyName,
 		}
 	}
@@ -3134,7 +3051,7 @@ func TestValidate_Delete(t *testing.T) {
 		{name: "valid"},
 		{name: "missing PCEP session address", mutate: func(p *pb.SRPolicy) { p.PeerAddr = nil }, wantErr: "policy.PeerAddr must not be nil"},
 		{name: "zero color", mutate: func(p *pb.SRPolicy) { p.Color = 0 }, wantErr: wantErrColorZero},
-		{name: "missing destination address", mutate: func(p *pb.SRPolicy) { p.DstAddr = nil }, wantErr: "DstAddr must not be empty"},
+		{name: "missing endpoint address", mutate: func(p *pb.SRPolicy) { p.Endpoint = nil }, wantErr: "policy.Endpoint must not be empty"},
 		{name: "missing policy name", mutate: func(p *pb.SRPolicy) { p.PolicyName = "" }, wantErr: "PolicyName must not be empty"},
 	}
 
@@ -3164,20 +3081,8 @@ func TestSendSRPolicyRequest_GetSyncedPCEPSessionError(t *testing.T) {
 	s := &APIServer{pce: &Server{}, logger: logger.NewNop()}
 	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: netip.MustParseAddr("10.0.255.1").AsSlice()}}
 
-	err := sendSRPolicyRequest(s, req, resolvedPath{}, false)
+	err := sendSRPolicyRequest(s, req, resolvedPath{})
 	assert.ErrorContains(t, err, "failed to get synchronized PCEP session")
-}
-
-func TestSendSRPolicyRequest_ResolveIntentError(t *testing.T) {
-	t.Parallel()
-
-	peerAddr := netip.MustParseAddr("10.0.255.1")
-	ss := &Session{peerAddr: peerAddr, syncState: SyncStateFinished}
-	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Type: pb.SRPolicyType_SR_POLICY_TYPE_UNSPECIFIED}}
-
-	err := sendSRPolicyRequest(s, req, resolvedPath{}, false)
-	assert.ErrorContains(t, err, "failed to resolve SR policy type")
 }
 
 func TestSendSRPolicyRequest_CreatesNewPolicy(t *testing.T) {
@@ -3189,17 +3094,25 @@ func TestSendSRPolicyRequest_CreatesNewPolicy(t *testing.T) {
 	})
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	dstAddr := netip.MustParseAddr("10.255.0.2")
+	endpoint := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 	ss.syncState = SyncStateFinished
 	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
 		[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	require.NoError(t, sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false))
+	path := resolvedPath{
+		SegmentList: segmentList,
+		Headend:     netip.MustParseAddr("10.255.0.1"),
+		Endpoint:    endpoint,
+		CandidatePath: table.CandidatePath{
+			Explicit: &table.ExplicitPath{SegmentList: segmentList},
+		},
+	}
+	require.NoError(t, sendSRPolicyRequest(s, req, path))
 	assert.NoError(t, readPCEPMessage(client), "expected a well-framed PCInitiate message on the wire")
 }
 
@@ -3212,18 +3125,26 @@ func TestSendSRPolicyRequest_UpdatesExistingPolicy(t *testing.T) {
 	})
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	dstAddr := netip.MustParseAddr("10.255.0.2")
+	endpoint := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 	ss.syncState = SyncStateFinished
-	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, DstAddr: dstAddr}}
+	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, Endpoint: endpoint}}
 	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
 		[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	require.NoError(t, sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false))
+	path := resolvedPath{
+		SegmentList: segmentList,
+		Headend:     netip.MustParseAddr("10.255.0.1"),
+		Endpoint:    endpoint,
+		CandidatePath: table.CandidatePath{
+			Explicit: &table.ExplicitPath{SegmentList: segmentList},
+		},
+	}
+	require.NoError(t, sendSRPolicyRequest(s, req, path))
 	assert.NoError(t, readPCEPMessage(client), "expected a well-framed PCUpdate message on the wire")
 }
 
@@ -3236,18 +3157,26 @@ func TestSendSRPolicyRequest_UpdateSendFailure(t *testing.T) {
 	})
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	dstAddr := netip.MustParseAddr("10.255.0.2")
+	endpoint := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 	ss.syncState = SyncStateFinished
-	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, DstAddr: dstAddr}}
+	ss.srPolicies = []*table.SRPolicy{{PlspID: 7, Color: 100, Endpoint: endpoint}}
 
 	require.NoError(t, server.Close(), "failed to close server connection")
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false)
+	path := resolvedPath{
+		SegmentList: segmentList,
+		Headend:     netip.MustParseAddr("10.255.0.1"),
+		Endpoint:    endpoint,
+		CandidatePath: table.CandidatePath{
+			Explicit: &table.ExplicitPath{SegmentList: segmentList},
+		},
+	}
+	err := sendSRPolicyRequest(s, req, path)
 	require.ErrorContains(t, err, "failed to send PC update")
 	assert.Equal(t, ReasonPCEPRequestFailed, errInfoReason(t, err))
 }
@@ -3261,17 +3190,25 @@ func TestSendSRPolicyRequest_CreateSendFailure(t *testing.T) {
 	})
 
 	peerAddr := netip.MustParseAddr("10.0.255.1")
-	dstAddr := netip.MustParseAddr("10.255.0.2")
+	endpoint := netip.MustParseAddr("10.255.0.2")
 	ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
 	ss.syncState = SyncStateFinished
 
 	require.NoError(t, server.Close(), "failed to close server connection")
 
 	s := &APIServer{pce: &Server{sessionList: []*Session{ss}}, logger: logger.NewNop()}
-	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100, Type: pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT}}
+	req := &pb.CreateSRPolicyRequest{SrPolicy: &pb.SRPolicy{PeerAddr: peerAddr.AsSlice(), Color: 100}}
 	segmentList := []table.Segment{table.NewSegmentSRMPLS(16003)}
 
-	err := sendSRPolicyRequest(s, req, resolvedPath{SegmentList: segmentList, SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, false)
+	path := resolvedPath{
+		SegmentList: segmentList,
+		Headend:     netip.MustParseAddr("10.255.0.1"),
+		Endpoint:    endpoint,
+		CandidatePath: table.CandidatePath{
+			Explicit: &table.ExplicitPath{SegmentList: segmentList},
+		},
+	}
+	err := sendSRPolicyRequest(s, req, path)
 	require.ErrorContains(t, err, "failed to request SR policy creation")
 	assert.Equal(t, ReasonPCEPRequestFailed, errInfoReason(t, err))
 }

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -218,6 +218,14 @@ func TestCreateEroFromSegmentListWithNAI(t *testing.T) {
 	assert.Equal(t, seg.LocalAddr.AsSlice(), raw[8:12], "NAI")
 }
 
+func testIPv4Link(local, remote *table.LsNode) *table.LsLink {
+	link := table.NewLsLink(local, remote)
+	link.Local.IPv4 = netip.MustParseAddr("192.0.2.101")
+	link.Remote.IPv4 = netip.MustParseAddr("192.0.2.102")
+
+	return link
+}
+
 func newTestAPIServer(ted *table.LsTED) *APIServer {
 	return &APIServer{
 		pce:    &Server{ted: ted},
@@ -1310,8 +1318,8 @@ func TestGetSegmentList_DynamicHopcountPrefersFewerHops(t *testing.T) {
 	nodeA := mkNode("A", 1)
 	nodeB := mkNode("B", 2)
 	nodeD := mkNode("D", 4)
-	nodeA.Links = []*table.LsLink{table.NewLsLink(nodeA, nodeD), table.NewLsLink(nodeA, nodeB)}
-	nodeB.Links = []*table.LsLink{table.NewLsLink(nodeB, nodeD)}
+	nodeA.Links = []*table.LsLink{testIPv4Link(nodeA, nodeD), testIPv4Link(nodeA, nodeB)}
+	nodeB.Links = []*table.LsLink{testIPv4Link(nodeB, nodeD)}
 
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"A": nodeA, "B": nodeB, "D": nodeD}}
 
@@ -1348,8 +1356,8 @@ func TestGetSegmentList_DynamicWithWaypointsForcesTransit(t *testing.T) {
 	nodeA := mkNode("A", 1)
 	nodeB := mkNode("B", 2)
 	nodeD := mkNode("D", 4)
-	nodeA.Links = []*table.LsLink{table.NewLsLink(nodeA, nodeD), table.NewLsLink(nodeA, nodeB)}
-	nodeB.Links = []*table.LsLink{table.NewLsLink(nodeB, nodeD)}
+	nodeA.Links = []*table.LsLink{testIPv4Link(nodeA, nodeD), testIPv4Link(nodeA, nodeB)}
+	nodeB.Links = []*table.LsLink{testIPv4Link(nodeB, nodeD)}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"A": nodeA, "B": nodeB, "D": nodeD}}
 
 	srPolicy := &pb.SRPolicy{
@@ -1430,6 +1438,37 @@ func TestGetSegmentList_UndefinedType(t *testing.T) {
 
 	_, _, err := getSegmentList(&pb.SRPolicy{}, &table.LsTED{}, false)
 	assert.Error(t, err)
+}
+
+func TestGetSegmentList_DynamicUnknownSrcRouterID(t *testing.T) {
+	t.Parallel()
+
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+	srPolicy := &pb.SRPolicy{
+		Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
+		SrcRouterId: "unknown",
+		DstRouterId: "D",
+		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
+	}
+
+	_, _, err := getSegmentList(srPolicy, ted, false)
+	assert.Error(t, err, "expected an unresolvable SrcRouterId to be rejected before CSPF runs")
+}
+
+func TestGetSegmentList_DynamicSrcNodeWithoutViablePlane(t *testing.T) {
+	t.Parallel()
+
+	nodeA := &table.LsNode{RouterID: "A"} // no Prefixes and no SRv6SIDs: no candidate plane
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{"A": nodeA}}
+	srPolicy := &pb.SRPolicy{
+		Type:        pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
+		SrcRouterId: "A",
+		DstRouterId: "D",
+		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
+	}
+
+	_, _, err := getSegmentList(srPolicy, ted, false)
+	assert.Error(t, err, "expected a source node without a Node SID to be rejected before CSPF runs")
 }
 
 func TestGetMetricType(t *testing.T) {
@@ -2213,10 +2252,10 @@ func TestCreateSRPolicy_StatusCodes(t *testing.T) {
 			}
 		}
 		r1, r2, r3 := mk("r1", "10.0.0.1", 1), mk("r2", "10.0.0.2", 2), mk("r3", "10.0.0.3", 3)
-		link := table.NewLsLink(r1, r2)
+		link := testIPv4Link(r1, r2)
 		link.Metrics = []*table.Metric{table.NewMetric(table.IGPMetric, 10)}
 		r1.Links = append(r1.Links, link)
-		reverseLink := table.NewLsLink(r2, r1)
+		reverseLink := testIPv4Link(r2, r1)
 		reverseLink.Metrics = []*table.Metric{table.NewMetric(table.IGPMetric, 10)}
 		r2.Links = append(r2.Links, reverseLink)
 

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -486,6 +486,81 @@ func TestValidateSIDs_MixedSegmentTypesAreRejected(t *testing.T) {
 	assert.Contains(t, st.Message(), "mixed SR-MPLS and SRv6 SIDs")
 }
 
+func TestValidateEndpointFamilies(t *testing.T) {
+	t.Parallel()
+
+	ipv4 := netip.MustParseAddr("10.0.0.1")
+	ipv4Other := netip.MustParseAddr("10.0.0.2")
+	ipv6 := netip.MustParseAddr("2001:db8::1")
+	srv6Segs := []table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1)))}
+	srmplsSegs := []table.Segment{table.NewSegmentSRMPLS(16003)}
+
+	tests := []struct {
+		name    string
+		path    resolvedPath
+		wantErr bool
+	}{
+		{name: "both unset is not second-guessed", path: resolvedPath{}},
+		{name: "matching IPv4 endpoints", path: resolvedPath{SrcAddr: ipv4, DstAddr: ipv4Other}},
+		{name: "matching IPv6 endpoints", path: resolvedPath{SrcAddr: ipv6, DstAddr: ipv6}},
+		{
+			name:    "mismatched endpoint families",
+			path:    resolvedPath{SrcAddr: ipv4, DstAddr: ipv6},
+			wantErr: true,
+		},
+		{
+			name:    "SRv6 segment list with an IPv4 endpoint",
+			path:    resolvedPath{SrcAddr: ipv4, DstAddr: ipv4Other, SegmentList: srv6Segs},
+			wantErr: true,
+		},
+		{
+			name: "SRv6 segment list with an IPv6 endpoint",
+			path: resolvedPath{SrcAddr: ipv6, DstAddr: ipv6, SegmentList: srv6Segs},
+		},
+		{
+			name: "SR-MPLS segment list with an IPv4 endpoint",
+			path: resolvedPath{SrcAddr: ipv4, DstAddr: ipv4Other, SegmentList: srmplsSegs},
+		},
+		{
+			name:    "SRv6 segment past the first position with an IPv4 endpoint",
+			path:    resolvedPath{SrcAddr: ipv4, DstAddr: ipv4Other, SegmentList: append(append([]table.Segment{}, srmplsSegs...), srv6Segs...)},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateEndpointFamilies(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateSIDs_SRv6SegmentListWithIPv4EndpointIsRejected(t *testing.T) {
+	t.Parallel()
+
+	s := newTestAPIServer(nil)
+	req := explicitPolicyRequest(true, testSRv6SID1)
+	req.DisablePathCompute = true
+	path := resolvedPath{
+		SegmentList: []table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1)))},
+		SrcAddr:     netip.MustParseAddr(testAddrA),
+		DstAddr:     netip.MustParseAddr(testAddrB),
+	}
+
+	err := s.validateSIDs(req, path)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "SRv6 segment list requires IPv6 endpoints")
+}
+
 func TestServe_InvalidAddress(t *testing.T) {
 	t.Parallel()
 
@@ -1330,13 +1405,13 @@ func TestGetSegmentList_DynamicHopcountPrefersFewerHops(t *testing.T) {
 		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
 	}
 
-	segmentList, metricType, err := getSegmentList(srPolicy, ted, false)
+	result, err := getSegmentList(srPolicy, ted, false)
 	require.NoError(t, err)
-	assert.Equal(t, table.HopcountMetric, metricType)
-	require.Len(t, segmentList, 1, "expected the direct 1-hop path over the 2-hop detour")
+	assert.Equal(t, table.HopcountMetric, result.Metric)
+	require.Len(t, result.SegmentList, 1, "expected the direct 1-hop path over the 2-hop detour")
 
-	mplsSeg, ok := segmentList[0].(table.SegmentSRMPLS)
-	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", segmentList[0])
+	mplsSeg, ok := result.SegmentList[0].(table.SegmentSRMPLS)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", result.SegmentList[0])
 	assert.Equal(t, uint32(16004), mplsSeg.Sid)
 }
 
@@ -1368,17 +1443,17 @@ func TestGetSegmentList_DynamicWithWaypointsForcesTransit(t *testing.T) {
 		Waypoints:   []*pb.Waypoint{{RouterId: "B"}},
 	}
 
-	segmentList, metricType, err := getSegmentList(srPolicy, ted, false)
+	result, err := getSegmentList(srPolicy, ted, false)
 	require.NoError(t, err)
-	assert.Equal(t, table.HopcountMetric, metricType)
-	require.Len(t, segmentList, 2, "expected the direct 1-hop A-D path to be overridden by the B waypoint")
+	assert.Equal(t, table.HopcountMetric, result.Metric)
+	require.Len(t, result.SegmentList, 2, "expected the direct 1-hop A-D path to be overridden by the B waypoint")
 
-	firstHop, ok := segmentList[0].(table.SegmentSRMPLS)
-	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", segmentList[0])
+	firstHop, ok := result.SegmentList[0].(table.SegmentSRMPLS)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", result.SegmentList[0])
 	assert.Equal(t, uint32(16002), firstHop.Sid, "first hop must be the waypoint node B")
 
-	secondHop, ok := segmentList[1].(table.SegmentSRMPLS)
-	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", segmentList[1])
+	secondHop, ok := result.SegmentList[1].(table.SegmentSRMPLS)
+	require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", result.SegmentList[1])
 	assert.Equal(t, uint32(16004), secondHop.Sid, "second hop must be the destination node D")
 }
 
@@ -1412,15 +1487,15 @@ func TestGetSegmentList_Explicit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, metricType, err := getSegmentList(tt.policy, &table.LsTED{}, false)
+			result, err := getSegmentList(tt.policy, &table.LsTED{}, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, table.UnspecifiedMetric, metricType)
-			assert.Len(t, got, tt.wantLen)
+			assert.Equal(t, table.UnspecifiedMetric, result.Metric)
+			assert.Len(t, result.SegmentList, tt.wantLen)
 		})
 	}
 }
@@ -1429,14 +1504,14 @@ func TestGetSegmentList_DynamicMetricError(t *testing.T) {
 	t.Parallel()
 
 	policy := &pb.SRPolicy{Type: pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC, Metric: pb.MetricType_METRIC_TYPE_UNSPECIFIED}
-	_, _, err := getSegmentList(policy, &table.LsTED{Nodes: map[string]*table.LsNode{}}, false)
+	_, err := getSegmentList(policy, &table.LsTED{Nodes: map[string]*table.LsNode{}}, false)
 	assert.Error(t, err, "expected an unresolvable metric to be rejected before CSPF runs")
 }
 
 func TestGetSegmentList_UndefinedType(t *testing.T) {
 	t.Parallel()
 
-	_, _, err := getSegmentList(&pb.SRPolicy{}, &table.LsTED{}, false)
+	_, err := getSegmentList(&pb.SRPolicy{}, &table.LsTED{}, false)
 	assert.Error(t, err)
 }
 
@@ -1451,7 +1526,7 @@ func TestGetSegmentList_DynamicUnknownSrcRouterID(t *testing.T) {
 		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
 	}
 
-	_, _, err := getSegmentList(srPolicy, ted, false)
+	_, err := getSegmentList(srPolicy, ted, false)
 	assert.Error(t, err, "expected an unresolvable SrcRouterId to be rejected before CSPF runs")
 }
 
@@ -1467,7 +1542,7 @@ func TestGetSegmentList_DynamicSrcNodeWithoutViablePlane(t *testing.T) {
 		Metric:      pb.MetricType_METRIC_TYPE_HOPCOUNT,
 	}
 
-	_, _, err := getSegmentList(srPolicy, ted, false)
+	_, err := getSegmentList(srPolicy, ted, false)
 	assert.Error(t, err, "expected a source node without a Node SID to be rejected before CSPF runs")
 }
 
@@ -1721,21 +1796,135 @@ func TestGetLoopbackAddr(t *testing.T) {
 	}
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node, noLoopbackNode.RouterID: noLoopbackNode, "r3": nil}}
 
-	addr, err := getLoopbackAddr(ted, "r1")
+	addr, err := getLoopbackAddr(ted, "r1", table.AFIPv4)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.1", addr.String())
 
-	_, err = getLoopbackAddr(ted, "missing")
+	_, err = getLoopbackAddr(ted, "missing", table.AFIPv4)
 	require.ErrorContains(t, err, "no node with router ID missing")
 
-	_, err = getLoopbackAddr(ted, "r2")
+	_, err = getLoopbackAddr(ted, "r2", table.AFIPv4)
 	require.Error(t, err, "expected an error for a node without a loopback address")
 
-	_, err = getLoopbackAddr(ted, "r3")
+	_, err = getLoopbackAddr(ted, "r3", table.AFIPv4)
 	require.ErrorContains(t, err, "no node with router ID r3")
 
-	_, err = getLoopbackAddr(nil, "r1")
+	_, err = getLoopbackAddr(nil, "r1", table.AFIPv4)
 	assert.ErrorContains(t, err, "no node with router ID r1")
+}
+
+func TestDefaultLoopbackFamily(t *testing.T) {
+	t.Parallel()
+
+	node := &table.LsNode{
+		RouterID: "r1",
+		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}},
+	}
+	dualStackNode := &table.LsNode{
+		RouterID: "r2",
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.2/32")},
+			{Prefix: netip.MustParsePrefix("2001:db8::2/128")},
+		},
+	}
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{node.RouterID: node, dualStackNode.RouterID: dualStackNode}}
+
+	af, err := defaultLoopbackFamily(ted, "r1")
+	require.NoError(t, err)
+	assert.Equal(t, table.AFIPv4, af)
+
+	_, err = defaultLoopbackFamily(ted, "r2")
+	require.Error(t, err, "expected a node with loopbacks in multiple families to require an explicit family")
+
+	_, err = defaultLoopbackFamily(ted, "missing")
+	require.ErrorContains(t, err, "no node with router ID missing")
+}
+
+func TestResolvePlane(t *testing.T) {
+	t.Parallel()
+
+	srMPLSNode := &table.LsNode{
+		RouterID: "r1", SrgbBegin: 16000, SrgbEnd: 17000,
+		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 1, HasSidIndex: true}},
+	}
+
+	dualPlaneNode := &table.LsNode{
+		RouterID: "r2", SrgbBegin: 16000, SrgbEnd: 17000,
+		Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.2/32"), SidIndex: 2, HasSidIndex: true}},
+		SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{testSRv6SID1}}},
+	}
+
+	tests := []struct {
+		name      string
+		node      *table.LsNode
+		family    pb.AddressFamily
+		dataPlane pb.DataPlane
+		wantPlane table.Plane
+		wantErr   string
+	}{
+		{
+			name:      "both unspecified defaults to the node's unique viable plane",
+			node:      srMPLSNode,
+			wantPlane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS},
+		},
+		{
+			name:      "explicit plane is used verbatim",
+			node:      dualPlaneNode,
+			family:    pb.AddressFamily_ADDRESS_FAMILY_IPV6,
+			dataPlane: pb.DataPlane_DATA_PLANE_SRV6,
+			wantPlane: table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRv6},
+		},
+		{
+			name:      "explicit invalid combination is rejected",
+			node:      dualPlaneNode,
+			family:    pb.AddressFamily_ADDRESS_FAMILY_IPV4,
+			dataPlane: pb.DataPlane_DATA_PLANE_SRV6,
+			wantErr:   "SRv6 requires IPv6",
+		},
+		{
+			name:    "ambiguous node without an explicit plane is rejected",
+			node:    dualPlaneNode,
+			wantErr: "explicit plane is required",
+		},
+		{
+			name:      "family alone is cross-checked against the node's unique plane",
+			node:      srMPLSNode,
+			family:    pb.AddressFamily_ADDRESS_FAMILY_IPV4,
+			wantPlane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS},
+		},
+		{
+			name:    "family alone mismatching the node's unique plane is rejected",
+			node:    srMPLSNode,
+			family:  pb.AddressFamily_ADDRESS_FAMILY_IPV6,
+			wantErr: "does not match the requested underlay family",
+		},
+		{
+			name:      "data plane alone is cross-checked against the node's unique plane",
+			node:      srMPLSNode,
+			dataPlane: pb.DataPlane_DATA_PLANE_SR_MPLS,
+			wantPlane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS},
+		},
+		{
+			name:      "data plane alone mismatching the node's unique plane is rejected",
+			node:      srMPLSNode,
+			dataPlane: pb.DataPlane_DATA_PLANE_SRV6,
+			wantErr:   "does not match the requested data plane",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			plane, err := resolvePlane(tt.node, tt.family, tt.dataPlane)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPlane, plane)
+		})
+	}
 }
 
 func TestGetSyncedPCEPSession(t *testing.T) {
@@ -2169,7 +2358,6 @@ func TestCreateSRPolicy(t *testing.T) {
 	})
 }
 
-// readEROBehavior reads a PCEP message and returns the behavior from its first ERO subobject.
 func readEROBehavior(t *testing.T, r io.Reader) uint16 {
 	t.Helper()
 
@@ -2204,6 +2392,188 @@ func readEROBehavior(t *testing.T, r io.Reader) uint16 {
 	return 0
 }
 
+// pcepWireObject represents a decoded PCEP object for wire-level test inspection.
+// It retains fields not represented by table.SRPolicy.
+type pcepWireObject struct {
+	Class pcep.ObjectClass
+	Type  uint8
+	Body  []byte
+}
+
+func readPCEPObjects(t *testing.T, r io.Reader) []pcepWireObject {
+	t.Helper()
+
+	headerBytes := make([]byte, pcep.CommonHeaderLength)
+	_, err := io.ReadFull(r, headerBytes)
+	require.NoError(t, err)
+
+	var header pcep.CommonHeader
+	require.NoError(t, header.DecodeFromBytes(headerBytes))
+
+	body := make([]byte, int(header.MessageLength)-int(pcep.CommonHeaderLength))
+	_, err = io.ReadFull(r, body)
+	require.NoError(t, err)
+
+	const objectHeaderLength = 4
+
+	var objs []pcepWireObject
+
+	for len(body) > 0 {
+		var objHeader pcep.CommonObjectHeader
+		require.NoError(t, objHeader.DecodeFromBytes(body))
+
+		objs = append(objs, pcepWireObject{
+			Class: objHeader.ObjectClass,
+			Type:  uint8(objHeader.ObjectType),
+			Body:  body[objectHeaderLength:objHeader.ObjectLength],
+		})
+		body = body[objHeader.ObjectLength:]
+	}
+
+	return objs
+}
+
+func findPCEPObject(t *testing.T, objs []pcepWireObject, class pcep.ObjectClass) pcepWireObject {
+	t.Helper()
+
+	for _, obj := range objs {
+		if obj.Class == class {
+			return obj
+		}
+	}
+
+	t.Fatalf("no object of class %v found in PCEP message", class)
+
+	return pcepWireObject{}
+}
+
+func TestCreateSRPolicy_EndpointFamilyIndependentOfUnderlayPlane(t *testing.T) {
+	t.Parallel()
+
+	t.Run("IPv4 endpoint over an IPv6 SR-MPLS underlay", func(t *testing.T) {
+		t.Parallel()
+
+		// Use a non-/128 IPv6 Prefix-SID so the loopback family remains unambiguous.
+		srcNode := &table.LsNode{
+			ASN: 1, RouterID: "A", SrgbBegin: 16000, SrgbEnd: 17000,
+			Prefixes: []*table.LsPrefix{
+				{Prefix: netip.MustParsePrefix("10.0.0.1/32")},
+				{Prefix: netip.MustParsePrefix("2001:db8:a::/64"), SidIndex: 1, HasSidIndex: true},
+			},
+		}
+		dstNode := &table.LsNode{
+			ASN: 1, RouterID: "B", SrgbBegin: 16000, SrgbEnd: 17000,
+			Prefixes: []*table.LsPrefix{
+				{Prefix: netip.MustParsePrefix("10.0.0.2/32")},
+				{Prefix: netip.MustParsePrefix("2001:db8:b::/64"), SidIndex: 2, HasSidIndex: true},
+			},
+		}
+		link := table.NewLsLink(srcNode, dstNode)
+		link.Local.IPv6, link.Remote.IPv6 = netip.MustParseAddr("2001:db8:ab::1"), netip.MustParseAddr("2001:db8:ab::2")
+		link.Metrics = []*table.Metric{table.NewMetric(table.TEMetric, 10)}
+		srcNode.AddLink(link)
+		ted := &table.LsTED{Nodes: map[string]*table.LsNode{"A": srcNode, "B": dstNode}}
+
+		server, client := newTCPConnPair(t)
+		t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+		peerAddr := netip.MustParseAddr("10.0.255.1")
+		ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
+		ss.syncState = SyncStateFinished
+		ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+			[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
+
+		s := &APIServer{pce: &Server{ted: ted, sessionList: []*Session{ss}}, logger: logger.NewNop()}
+
+		req := &pb.CreateSRPolicyRequest{
+			Asn: 1,
+			SrPolicy: &pb.SRPolicy{
+				Type:           pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
+				PolicyName:     testSRPolicyName,
+				Color:          100,
+				PeerAddr:       peerAddr.AsSlice(),
+				SrcRouterId:    "A",
+				DstRouterId:    "B",
+				Metric:         pb.MetricType_METRIC_TYPE_TE,
+				UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV6,
+				DataPlane:      pb.DataPlane_DATA_PLANE_SR_MPLS,
+			},
+		}
+
+		_, err := s.CreateSRPolicy(context.Background(), req)
+		require.NoError(t, err)
+
+		objs := readPCEPObjects(t, client)
+		endpoints := findPCEPObject(t, objs, pcep.ObjectClassEndpoints)
+		assert.Equal(t, uint8(pcep.ObjectTypeEndpointIPv4), endpoints.Type)
+
+		ero := findPCEPObject(t, objs, pcep.ObjectClassERO)
+		require.NotEmpty(t, ero.Body)
+		assert.Equal(t, uint8(pcep.SubobjectTypeEROSR), ero.Body[0]&0x7f)
+	})
+
+	t.Run("IPv6 endpoint over an IPv4 SR-MPLS underlay", func(t *testing.T) {
+		t.Parallel()
+
+		srcNode := &table.LsNode{
+			ASN: 1, RouterID: "C", SrgbBegin: 16000, SrgbEnd: 17000,
+			Prefixes: []*table.LsPrefix{
+				{Prefix: netip.MustParsePrefix("2001:db8:c::1/128")},
+				{Prefix: netip.MustParsePrefix("10.0.1.0/24"), SidIndex: 1, HasSidIndex: true},
+			},
+		}
+		dstNode := &table.LsNode{
+			ASN: 1, RouterID: "D", SrgbBegin: 16000, SrgbEnd: 17000,
+			Prefixes: []*table.LsPrefix{
+				{Prefix: netip.MustParsePrefix("2001:db8:d::1/128")},
+				{Prefix: netip.MustParsePrefix("10.0.2.0/24"), SidIndex: 2, HasSidIndex: true},
+			},
+		}
+		link := table.NewLsLink(srcNode, dstNode)
+		link.Local.IPv4, link.Remote.IPv4 = netip.MustParseAddr("10.0.1.1"), netip.MustParseAddr("10.0.2.1")
+		link.Metrics = []*table.Metric{table.NewMetric(table.TEMetric, 10)}
+		srcNode.AddLink(link)
+		ted := &table.LsTED{Nodes: map[string]*table.LsNode{"C": srcNode, "D": dstNode}}
+
+		server, client := newTCPConnPair(t)
+		t.Cleanup(func() { assert.NoError(t, client.Close()) })
+
+		peerAddr := netip.MustParseAddr("10.0.255.1")
+		ss := NewSession(testLocalOpen(1), peerAddr, server, logger.NewNop(), nil, 0)
+		ss.syncState = SyncStateFinished
+		ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+			[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
+
+		s := &APIServer{pce: &Server{ted: ted, sessionList: []*Session{ss}}, logger: logger.NewNop()}
+
+		req := &pb.CreateSRPolicyRequest{
+			Asn: 1,
+			SrPolicy: &pb.SRPolicy{
+				Type:           pb.SRPolicyType_SR_POLICY_TYPE_DYNAMIC,
+				PolicyName:     testSRPolicyName,
+				Color:          100,
+				PeerAddr:       peerAddr.AsSlice(),
+				SrcRouterId:    "C",
+				DstRouterId:    "D",
+				Metric:         pb.MetricType_METRIC_TYPE_TE,
+				UnderlayFamily: pb.AddressFamily_ADDRESS_FAMILY_IPV4,
+				DataPlane:      pb.DataPlane_DATA_PLANE_SR_MPLS,
+			},
+		}
+
+		_, err := s.CreateSRPolicy(context.Background(), req)
+		require.NoError(t, err)
+
+		objs := readPCEPObjects(t, client)
+		endpoints := findPCEPObject(t, objs, pcep.ObjectClassEndpoints)
+		assert.Equal(t, uint8(pcep.ObjectTypeEndpointIPv6), endpoints.Type, "endpoint family must stay IPv6 even though the underlay plane is IPv4/SR-MPLS")
+
+		ero := findPCEPObject(t, objs, pcep.ObjectClassERO)
+		require.NotEmpty(t, ero.Body)
+		assert.Equal(t, uint8(pcep.SubobjectTypeEROSR), ero.Body[0]&0x7f, "ERO must carry the SR-MPLS segment CSPF computed")
+	})
+}
+
 func TestCreateSRPolicy_SRv6WithoutLocalAddr(t *testing.T) {
 	t.Parallel()
 
@@ -2226,8 +2596,8 @@ func TestCreateSRPolicy_SRv6WithoutLocalAddr(t *testing.T) {
 			PolicyName:  testSRPolicyName,
 			Color:       100,
 			PeerAddr:    netip.MustParseAddr("10.0.255.1").AsSlice(),
-			SrcAddr:     netip.MustParseAddr("10.0.0.1").AsSlice(),
-			DstAddr:     netip.MustParseAddr("10.0.0.2").AsSlice(),
+			SrcAddr:     netip.MustParseAddr("2001:db8:e::1").AsSlice(),
+			DstAddr:     netip.MustParseAddr("2001:db8:e::2").AsSlice(),
 			SegmentList: []*pb.Segment{{Sid: testSRv6SID1}},
 		},
 		NoSidValidate: true,
@@ -3123,21 +3493,19 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 		SrgbEnd:    17000,
 		Links: []*pb.LsLink{
 			{
-				LocalRouterId:  testRouterID1,
-				LocalAsn:       65000,
-				LocalIp:        "192.0.2.1",
-				RemoteRouterId: testRouterID2,
-				RemoteAsn:      65000,
-				RemoteIp:       "192.0.2.2",
+				Local:  &pb.LsLinkEndpoint{RouterId: testRouterID1, Asn: 65000, Ipv4: "192.0.2.1"},
+				Remote: &pb.LsLinkEndpoint{RouterId: testRouterID2, Asn: 65000, Ipv4: "192.0.2.2"},
 				Metrics: []*pb.Metric{
 					{Type: pb.MetricType_METRIC_TYPE_IGP, Value: 10},
 					{Type: pb.MetricType_METRIC_TYPE_TE, Value: 20},
 				},
-				AdjSid: 24001,
-				Srv6EndXSid: &pb.Srv6EndXSID{
-					EndpointBehavior: uint32(table.BehaviorENDX),
-					Sids:             []*pb.SID{{Sid: testSRv6SID1}},
-					SidStructure:     &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+				AdjSids: []*pb.AdjSid{{Family: pb.AddressFamily_ADDRESS_FAMILY_UNSPECIFIED, Sid: 24001}},
+				Srv6EndXSids: []*pb.Srv6EndXSID{
+					{
+						EndpointBehavior: uint32(table.BehaviorENDX),
+						Sids:             []*pb.SID{{Sid: testSRv6SID1}},
+						SidStructure:     &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+					},
 				},
 			},
 		},

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -468,7 +468,7 @@ func TestValidateSIDs_MixedSegmentTypesAreRejected(t *testing.T) {
 	req := explicitPolicyRequest(true, "16099")
 	segmentList := []table.Segment{
 		table.NewSegmentSRMPLS(16099),
-		table.SegmentSRv6{Sid: netip.MustParseAddr("2001:db8::1")},
+		table.SegmentSRv6{Sid: table.SRv6SID(netip.MustParseAddr("2001:db8::1"))},
 	}
 
 	err := s.validateSIDs(req, resolvedPath{SegmentList: segmentList})
@@ -1118,7 +1118,7 @@ func TestConvertSegment_CarriesSRv6NAIAndStructure(t *testing.T) {
 
 	sid := netip.MustParseAddr("2001:db8:1005::")
 	seg := table.SegmentSRv6{
-		Sid:        sid,
+		Sid:        table.SRv6SID(sid),
 		LocalAddr:  netip.MustParseAddr("2001:db8::5"),
 		RemoteAddr: netip.MustParseAddr("2001:db8::6"),
 		Structure:  &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80},
@@ -3022,22 +3022,22 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 	remote := &table.LsNode{ASN: 65000, RouterID: testRouterID2}
 
 	link := table.NewLsLink(node, remote)
-	link.LocalIP = netip.MustParseAddr("192.0.2.1")
-	link.RemoteIP = netip.MustParseAddr("192.0.2.2")
-	link.AdjSid = 24001
+	link.Local.IPv4 = netip.MustParseAddr("192.0.2.1")
+	link.Remote.IPv4 = netip.MustParseAddr("192.0.2.2")
+	link.AdjSids = []table.AdjSID{{Family: table.AFUnspecified, Sid: 24001}}
 	link.Metrics = []*table.Metric{
 		nil,
 		table.NewMetric(table.IGPMetric, 10),
 		table.NewMetric(table.TEMetric, 20),
 	}
-	link.Srv6EndXSID = &table.Srv6EndXSID{
+	link.Srv6EndXSIDs = []*table.Srv6EndXSID{{
 		EndpointBehavior: table.BehaviorENDX,
 		Sids:             []string{testSRv6SID1, ""},
 		Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
-	}
+	}}
 	node.Links = []*table.LsLink{
 		link,
-		{LocalNode: node, RemoteNode: nil},
+		{Local: table.LinkEndpoint{Node: node}},
 		nil,
 	}
 

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -3474,7 +3474,10 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 		table.NewMetric(table.TEMetric, 20),
 	}
 	link.Srv6EndXSIDs = []*table.Srv6EndXSID{{
-		EndpointBehavior: table.BehaviorENDX,
+		EndpointBehavior: table.EndpointBehavior{
+			Behavior: table.BehaviorENDX, Flags: 0xC0, Algorithm: 128,
+		},
+		Weight:           7,
 		Sids:             []string{testSRv6SID1, ""},
 		Srv6SIDStructure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 	}}
@@ -3536,9 +3539,12 @@ func TestGetTED_ConvertsFullNode(t *testing.T) {
 				AdjSids: []*pb.AdjSid{{Family: pb.AddressFamily_ADDRESS_FAMILY_UNSPECIFIED, Sid: 24001}},
 				Srv6EndXSids: []*pb.Srv6EndXSID{
 					{
-						EndpointBehavior: uint32(table.BehaviorENDX),
-						Sids:             []*pb.SID{{Sid: testSRv6SID1}},
-						SidStructure:     &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
+						EndpointBehavior: &pb.EndpointBehavior{
+							Behavior: uint32(table.BehaviorENDX), Flags: 0xC0, Algorithm: 128,
+						},
+						Weight:       7,
+						Sids:         []*pb.SID{{Sid: testSRv6SID1}},
+						SidStructure: &pb.SidStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16, LocalArg: 0},
 					},
 				},
 			},

--- a/pkg/server/grpc_server_internal_test.go
+++ b/pkg/server/grpc_server_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/netip"
 	"strconv"
@@ -104,12 +105,16 @@ func TestStatusFromCSPFError(t *testing.T) {
 func TestNewEnrichedSegmentSRMPLS(t *testing.T) {
 	t.Parallel()
 
+	linkLocalIfaceID, linkRemoteIfaceID := uint32(5), uint32(9)
+
 	tests := []struct {
-		name       string
-		segment    *pb.Segment
-		wantLocal  string
-		wantRemote string
-		wantErr    bool
+		name              string
+		segment           *pb.Segment
+		wantLocal         string
+		wantRemote        string
+		wantLocalIfaceID  *uint32
+		wantRemoteIfaceID *uint32
+		wantErr           bool
 	}{
 		{
 			name:    "no addresses",
@@ -125,6 +130,20 @@ func TestNewEnrichedSegmentSRMPLS(t *testing.T) {
 			segment:    &pb.Segment{Sid: "24001", LocalAddr: testAddrA, RemoteAddr: testAddrB},
 			wantLocal:  testAddrA,
 			wantRemote: testAddrB,
+		},
+		{
+			name: "link-local adjacency NAI with interface IDs",
+			segment: &pb.Segment{
+				Sid:           "24002",
+				LocalAddr:     "fe80::1",
+				RemoteAddr:    "fe80::2",
+				LocalIfaceId:  &linkLocalIfaceID,
+				RemoteIfaceId: &linkRemoteIfaceID,
+			},
+			wantLocal:         "fe80::1",
+			wantRemote:        "fe80::2",
+			wantLocalIfaceID:  &linkLocalIfaceID,
+			wantRemoteIfaceID: &linkRemoteIfaceID,
 		},
 		{
 			name:    "malformed localAddr",
@@ -154,6 +173,8 @@ func TestNewEnrichedSegmentSRMPLS(t *testing.T) {
 			require.Truef(t, ok, "segment type: got %T, want table.SegmentSRMPLS", seg)
 			assert.Equal(t, tt.wantLocal, addrString(mplsSeg.LocalAddr), "LocalAddr")
 			assert.Equal(t, tt.wantRemote, addrString(mplsSeg.RemoteAddr), "RemoteAddr")
+			assert.Equal(t, tt.wantLocalIfaceID, mplsSeg.LocalIfaceID, "LocalIfaceID")
+			assert.Equal(t, tt.wantRemoteIfaceID, mplsSeg.RemoteIfaceID, "RemoteIfaceID")
 		})
 	}
 }
@@ -161,11 +182,15 @@ func TestNewEnrichedSegmentSRMPLS(t *testing.T) {
 func TestNewEnrichedSegmentSRv6(t *testing.T) {
 	t.Parallel()
 
+	localIfaceID, remoteIfaceID := uint32(3), uint32(4)
 	segment := &pb.Segment{
-		Sid:          testSRv6SID2,
-		LocalAddr:    "2001:db8::5",
-		RemoteAddr:   "2001:db8::6",
-		SidStructure: "32,16,0,80",
+		Sid:           testSRv6SID2,
+		LocalAddr:     "2001:db8::5",
+		RemoteAddr:    "2001:db8::6",
+		SidStructure:  "32,16,0,80",
+		Behavior:      uint32(table.BehaviorENDX),
+		LocalIfaceId:  &localIfaceID,
+		RemoteIfaceId: &remoteIfaceID,
 	}
 
 	for _, usidMode := range []bool{false, true} {
@@ -179,7 +204,19 @@ func TestNewEnrichedSegmentSRv6(t *testing.T) {
 		assert.Equal(t, "2001:db8::6", addrString(srv6Seg.RemoteAddr), "RemoteAddr")
 		assert.Equal(t, &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}, srv6Seg.Structure, "Structure")
 		assert.Equalf(t, usidMode, srv6Seg.USid, "USid with usidMode=%v", usidMode)
+		assert.Equal(t, table.BehaviorENDX, srv6Seg.Behavior, "Behavior")
+		assert.Equal(t, &localIfaceID, srv6Seg.LocalIfaceID, "LocalIfaceID")
+		assert.Equal(t, &remoteIfaceID, srv6Seg.RemoteIfaceID, "RemoteIfaceID")
 	}
+}
+
+func TestNewEnrichedSegmentSRv6_BehaviorOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	segment := &pb.Segment{Sid: testSRv6SID1, Behavior: uint32(math.MaxUint16) + 1}
+
+	_, err := newEnrichedSegment(segment, false)
+	assert.Error(t, err, "expected an error for a behavior code that does not fit in 16 bits")
 }
 
 func TestNewEnrichedSegmentInvalidSID(t *testing.T) {
@@ -216,6 +253,66 @@ func TestCreateEroFromSegmentListWithNAI(t *testing.T) {
 	assert.Equalf(t, uint8(0x01), nt, "NAI type: got 0x%02x, want 0x01 (IPv4 node ID)", nt)
 	assert.Zero(t, raw[3]&0x08, "F flag is set even though the NAI is present")
 	assert.Equal(t, seg.LocalAddr.AsSlice(), raw[8:12], "NAI")
+}
+
+func TestNewEnrichedSegmentToEro_SRMPLSLinkLocalNAI(t *testing.T) {
+	t.Parallel()
+
+	localIfaceID, remoteIfaceID := uint32(5), uint32(9)
+	seg, err := newEnrichedSegment(&pb.Segment{
+		Sid:           "24003",
+		LocalAddr:     "fe80::1",
+		RemoteAddr:    "fe80::2",
+		LocalIfaceId:  &localIfaceID,
+		RemoteIfaceId: &remoteIfaceID,
+	}, false)
+	require.NoError(t, err)
+
+	ero, err := createEroFromSegmentList([]table.Segment{seg})
+	require.NoError(t, err)
+	require.Len(t, ero.EroSubobjects, 1)
+
+	raw, err := ero.EroSubobjects[0].Serialize()
+	require.NoError(t, err)
+
+	nt := raw[2] >> 4
+	assert.Equalf(t, uint8(0x06), nt, "NAI type: got 0x%02x, want 0x06 (IPv6 link-local adjacency)", nt)
+
+	require.Len(t, raw, 48)
+	assert.Equal(t, netip.MustParseAddr("fe80::1").AsSlice(), raw[8:24], "local NAI address")
+	assert.Equal(t, localIfaceID, binary.BigEndian.Uint32(raw[24:28]), "local interface ID")
+	assert.Equal(t, netip.MustParseAddr("fe80::2").AsSlice(), raw[28:44], "remote NAI address")
+	assert.Equal(t, remoteIfaceID, binary.BigEndian.Uint32(raw[44:48]), "remote interface ID")
+}
+
+func TestNewEnrichedSegmentToEro_SRv6LinkLocalNAI(t *testing.T) {
+	t.Parallel()
+
+	localIfaceID, remoteIfaceID := uint32(3), uint32(4)
+	seg, err := newEnrichedSegment(&pb.Segment{
+		Sid:           testSRv6SID1,
+		LocalAddr:     "fe80::1",
+		RemoteAddr:    "fe80::2",
+		LocalIfaceId:  &localIfaceID,
+		RemoteIfaceId: &remoteIfaceID,
+	}, false)
+	require.NoError(t, err)
+
+	ero, err := createEroFromSegmentList([]table.Segment{seg})
+	require.NoError(t, err)
+	require.Len(t, ero.EroSubobjects, 1)
+
+	raw, err := ero.EroSubobjects[0].Serialize()
+	require.NoError(t, err)
+
+	nt := raw[2] >> 4
+	assert.Equalf(t, uint8(0x06), nt, "NAI type: got 0x%02x, want 0x06 (IPv6 link-local adjacency)", nt)
+
+	require.Len(t, raw, 64)
+	assert.Equal(t, netip.MustParseAddr("fe80::1").AsSlice(), raw[24:40], "local NAI address")
+	assert.Equal(t, localIfaceID, binary.BigEndian.Uint32(raw[40:44]), "local interface ID")
+	assert.Equal(t, netip.MustParseAddr("fe80::2").AsSlice(), raw[44:60], "remote NAI address")
+	assert.Equal(t, remoteIfaceID, binary.BigEndian.Uint32(raw[60:64]), "remote interface ID")
 }
 
 func testIPv4Link(local, remote *table.LsNode) *table.LsLink {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -283,7 +283,9 @@ func parseRemoteAddr(tcpConn *net.TCPConn) (netip.Addr, error) {
 		return netip.Addr{}, fmt.Errorf("failed to parse remote address %s: %w", remoteAddrStr, err)
 	}
 
-	return addrPort.Addr(), nil
+	// A dual-stack listener reports IPv4 peers as IPv4-mapped IPv6; normalize
+	// so session lookups use a consistent address representation.
+	return addrPort.Addr().Unmap(), nil
 }
 
 // Serve starts the PCEP server on the specified address and port.

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -1707,7 +1707,18 @@ func (ss *Session) computePathFromTED(sr *pcep.StateReport) ([]table.Segment, er
 		logger.String("dstRouterID", dstRouterID),
 		logger.String("metricType", metricType.String()))
 
-	segmentList, err := cspf.CSPF(srcRouterID, dstRouterID, metricType, ss.ted)
+	// The API does not yet accept an explicit underlay plane for path computation.
+	srcNode, ok := tedNode(ss.ted, srcRouterID)
+	if !ok {
+		return nil, fmt.Errorf("no node with router ID %s", srcRouterID)
+	}
+
+	plane, err := srcNode.DefaultPlane()
+	if err != nil {
+		return nil, fmt.Errorf("get default plane: %w", err)
+	}
+
+	segmentList, err := cspf.CSPF(srcRouterID, dstRouterID, metricType, cspf.PathScope{Plane: plane}, ss.ted)
 	if err != nil {
 		return nil, fmt.Errorf("CSPF computation failed: %w", err)
 	}

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -256,14 +256,13 @@ type Session struct {
 
 // srPolicyIntent stores policy information not reported by PCEP.
 type srPolicyIntent struct {
-	polType   table.PolicyType
-	metric    table.MetricType
-	expiresAt time.Time
+	candidatePath table.CandidatePath
+	expiresAt     time.Time
 }
 
 // rememberSRPolicyIntent records the intent for an SRP-ID.
 // SRP-ID 0 is reserved for unsolicited PCRpt messages and is ignored.
-func (ss *Session) rememberSRPolicyIntent(srpID uint32, polType table.PolicyType, metric table.MetricType) {
+func (ss *Session) rememberSRPolicyIntent(srpID uint32, candidatePath table.CandidatePath) {
 	if srpID == 0 {
 		return
 	}
@@ -275,7 +274,7 @@ func (ss *Session) rememberSRPolicyIntent(srpID uint32, polType table.PolicyType
 		ss.srPolicyIntents = make(map[uint32]srPolicyIntent)
 	}
 
-	ss.srPolicyIntents[srpID] = srPolicyIntent{polType: polType, metric: metric, expiresAt: time.Now().Add(ss.srPolicyIntentTTL)}
+	ss.srPolicyIntents[srpID] = srPolicyIntent{candidatePath: candidatePath, expiresAt: time.Now().Add(ss.srPolicyIntentTTL)}
 }
 
 func (ss *Session) srPolicyIntentExists(srpID uint32) bool {
@@ -1889,8 +1888,7 @@ func firstPathSetupTypeCapability(caps []pcep.CapabilityInterface) *pcep.PathSet
 }
 
 // peerSupportsPST reports whether the peer supports the given path setup type.
-// PATH-SETUP-TYPE-CAPABILITY takes precedence; otherwise, legacy SR-CAPABILITY-TLV
-// implies PSTs 0 and 1, and its absence implies PST=0 (RFC 8408 §3, RFC 8664 Appendix A).
+// Legacy SR-CAPABILITY-TLV provides the fallback behavior (RFC 8408 §3, RFC 8664 Appendix A).
 func peerSupportsPST(caps []pcep.CapabilityInterface, pst pcep.Pst) bool {
 	if pstCap := firstPathSetupTypeCapability(caps); pstCap != nil {
 		return pstCap.HasPathSetupType(pst)
@@ -1904,9 +1902,7 @@ func peerSupportsPST(caps []pcep.CapabilityInterface, pst pcep.Pst) bool {
 }
 
 // peerMaxSIDs returns the advertised SID depth for the given path setup type.
-// PATH-SETUP-TYPE-CAPABILITY takes precedence; otherwise, the top-level capability
-// is used as a legacy fallback for SRTE (RFC 8408 §3, RFC 8664 Appendix A).
-// An unlisted PST has no advertised SID depth (RFC 8664 §5.1, RFC 9603 §5.1).
+// The top-level capability is a legacy fallback for SRTE (RFC 8664 Appendix A).
 func peerMaxSIDs(caps []pcep.CapabilityInterface, pst pcep.Pst) (maxSIDs uint8, ok bool) {
 	if pstCap := firstPathSetupTypeCapability(caps); pstCap != nil {
 		if !pstCap.HasPathSetupType(pst) {
@@ -1927,7 +1923,6 @@ func peerMaxSIDs(caps []pcep.CapabilityInterface, pst pcep.Pst) (maxSIDs uint8, 
 	return 0, false
 }
 
-// validatePathSetupTypeForPeer rejects segment lists with unsupported path setup types.
 func (ss *Session) validatePathSetupTypeForPeer(segmentList []table.Segment) error {
 	pst, ok := pcep.PathSetupTypeForSegments(segmentList)
 	if !ok {
@@ -1937,6 +1932,15 @@ func (ss *Session) validatePathSetupTypeForPeer(segmentList []table.Segment) err
 
 	if !peerSupportsPST(ss.ReceivedCapabilities(), pst) {
 		return fmt.Errorf("the PCC did not advertise the path setup type this segment list requires: %s", pst)
+	}
+
+	return nil
+}
+
+// Juniper legacy SR Policy encoding supports only IPv4 endpoints, even on IPv6 PCEP sessions (RFC 8697).
+func (ss *Session) validateEndpointFamilyForPeer(endpoint netip.Addr) error {
+	if ss.pccType == pcep.JuniperLegacy && !endpoint.Is4() {
+		return fmt.Errorf("the PCC uses Juniper legacy SR Policy encoding, which only supports IPv4 endpoints: got %s", endpoint)
 	}
 
 	return nil
@@ -2025,7 +2029,7 @@ func nextUnusedSRPID(
 }
 
 // allocateSRPID allocates an unused SRP-ID and records its intent.
-func (ss *Session) allocateSRPID(polType table.PolicyType, metric table.MetricType) (uint32, error) {
+func (ss *Session) allocateSRPID(candidatePath table.CandidatePath) (uint32, error) {
 	ss.srpIDMu.Lock()
 	defer ss.srpIDMu.Unlock()
 
@@ -2035,7 +2039,7 @@ func (ss *Session) allocateSRPID(polType table.PolicyType, metric table.MetricTy
 	}
 
 	ss.srpIDHead = nextHead
-	ss.rememberSRPolicyIntent(srpID, polType, metric)
+	ss.rememberSRPolicyIntent(srpID, candidatePath)
 
 	return srpID, nil
 }
@@ -2052,7 +2056,13 @@ func (ss *Session) SendPCInitiate(srPolicy table.SRPolicy, lspDelete bool) error
 		return fmt.Errorf("cannot %s SR policy %q: %w", action, srPolicy.Name, err)
 	}
 
-	srpID, err := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
+	if !lspDelete {
+		if err := ss.validateEndpointFamilyForPeer(srPolicy.Endpoint); err != nil {
+			return fmt.Errorf("cannot %s SR policy %q: %w", action, srPolicy.Name, err)
+		}
+	}
+
+	srpID, err := ss.allocateSRPID(srPolicy.CandidatePath)
 	if err != nil {
 		return err
 	}
@@ -2087,7 +2097,7 @@ func (ss *Session) SendPCUpdate(srPolicy table.SRPolicy) error {
 		return fmt.Errorf("cannot update SR policy %q: %w", srPolicy.Name, err)
 	}
 
-	srpID, err := ss.allocateSRPID(srPolicy.Type, srPolicy.Metric)
+	srpID, err := ss.allocateSRPID(srPolicy.CandidatePath)
 	if err != nil {
 		return err
 	}
@@ -2206,8 +2216,7 @@ func (ss *Session) updateOrCreatePolicy(sr *pcep.StateReport, segmentList []tabl
 			})
 
 			if intent, ok := ss.takeSRPolicyIntent(sr.SrpObject.SrpID); ok {
-				p.Type = intent.polType
-				p.Metric = intent.metric
+				p.CandidatePath = intent.candidatePath
 			}
 		}
 
@@ -2236,8 +2245,7 @@ func (ss *Session) updateOrCreatePolicy(sr *pcep.StateReport, segmentList []tabl
 
 	p := table.NewSRPolicy(sr.LSPObject.PlspID, sr.LSPObject.Name, segmentList, src, dst, color, preference, lspID, state)
 	if intent, ok := ss.takeSRPolicyIntent(sr.SrpObject.SrpID); ok {
-		p.Type = intent.polType
-		p.Metric = intent.metric
+		p.CandidatePath = intent.candidatePath
 	}
 
 	ss.srPolicies = append(ss.srPolicies, p)
@@ -2289,7 +2297,7 @@ func (ss *Session) SearchPlspID(color uint32, endpoint netip.Addr) (uint32, bool
 	defer ss.srPoliciesMu.RUnlock()
 
 	for _, v := range ss.srPolicies {
-		if v.Color == color && v.DstAddr == endpoint {
+		if v.Color == color && v.Endpoint == endpoint {
 			return v.PlspID, true
 		}
 	}

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -1702,21 +1702,17 @@ func (ss *Session) computePathFromTED(sr *pcep.StateReport) ([]table.Segment, er
 
 	metricType := ss.selectMetricType(sr)
 
+	plane, err := ss.planeFromReport(sr)
+	if err != nil {
+		return nil, fmt.Errorf("resolve underlay plane: %w", err)
+	}
+
 	ss.logger.Debug("Computed CSPF parameters",
 		logger.String("srcRouterID", srcRouterID),
 		logger.String("dstRouterID", dstRouterID),
-		logger.String("metricType", metricType.String()))
-
-	// The API does not yet accept an explicit underlay plane for path computation.
-	srcNode, ok := tedNode(ss.ted, srcRouterID)
-	if !ok {
-		return nil, fmt.Errorf("no node with router ID %s", srcRouterID)
-	}
-
-	plane, err := srcNode.DefaultPlane()
-	if err != nil {
-		return nil, fmt.Errorf("get default plane: %w", err)
-	}
+		logger.String("metricType", metricType.String()),
+		logger.String("family", plane.Family.String()),
+		logger.String("dataPlane", plane.DataPlane.String()))
 
 	segmentList, err := cspf.CSPF(srcRouterID, dstRouterID, metricType, cspf.PathScope{Plane: plane}, ss.ted)
 	if err != nil {
@@ -1724,6 +1720,38 @@ func (ss *Session) computePathFromTED(sr *pcep.StateReport) ([]table.Segment, er
 	}
 
 	return segmentList, nil
+}
+
+func (ss *Session) planeFromReport(sr *pcep.StateReport) (table.Plane, error) {
+	family := table.FamilyOfAddr(sr.LSPObject.SrcAddr)
+	if family == table.AFUnspecified || family != table.FamilyOfAddr(sr.LSPObject.DstAddr) {
+		return table.Plane{}, errors.New("LSP source and destination addresses must be valid and share an address family")
+	}
+
+	dataPlane, err := ss.dataPlaneFromPeerCapabilities(family)
+	if err != nil {
+		return table.Plane{}, err
+	}
+
+	return table.Plane{Family: family, DataPlane: dataPlane}, nil
+}
+
+func (ss *Session) dataPlaneFromPeerCapabilities(af table.AddressFamily) (table.DataPlane, error) {
+	caps := ss.ReceivedCapabilities()
+
+	srv6 := af == table.AFIPv6 && peerSupportsPST(caps, pcep.PathSetupTypeSRv6TE)
+	srmpls := peerSupportsPST(caps, pcep.PathSetupTypeSRTE)
+
+	switch {
+	case srv6 && !srmpls:
+		return table.DPSRv6, nil
+	case srmpls && !srv6:
+		return table.DPSRMPLS, nil
+	case srv6 && srmpls:
+		return table.DPUnspecified, errors.New("PCC advertises both SR-MPLS and SRv6 path setup types; the data plane is ambiguous")
+	default:
+		return table.DPUnspecified, errors.New("PCC does not advertise a Segment Routing path setup type")
+	}
 }
 
 func (ss *Session) extractSrcDstRouterIDs(sr *pcep.StateReport) (srcRouterID, dstRouterID string, err error) {
@@ -1741,14 +1769,15 @@ func (ss *Session) extractSrcDstRouterIDs(sr *pcep.StateReport) (srcRouterID, ds
 		return "", "", errors.New("could not extract valid source and destination addresses")
 	}
 
+	routerIDIndex := ss.ted.RouterIDIndex()
 	addrIndex := ss.ted.AddressRouterIDIndex()
 
-	srcRouterID, err = ss.findRouterIDFromAddress(addrIndex, srcAddr)
+	srcRouterID, err = ss.findRouterIDFromAddress(routerIDIndex, addrIndex, srcAddr)
 	if err != nil {
 		return "", "", fmt.Errorf("cannot find source router ID for %s: %w", srcAddr, err)
 	}
 
-	dstRouterID, err = ss.findRouterIDFromAddress(addrIndex, dstAddr)
+	dstRouterID, err = ss.findRouterIDFromAddress(routerIDIndex, addrIndex, dstAddr)
 	if err != nil {
 		return "", "", fmt.Errorf("cannot find destination router ID for %s: %w", dstAddr, err)
 	}
@@ -1756,12 +1785,14 @@ func (ss *Session) extractSrcDstRouterIDs(sr *pcep.StateReport) (srcRouterID, ds
 	return srcRouterID, dstRouterID, nil
 }
 
-func (ss *Session) findRouterIDFromAddress(addrIndex map[netip.Addr]string, addr netip.Addr) (string, error) {
-	if node, ok := tedNode(ss.ted, addr.String()); ok {
-		return node.RouterID, nil
+// RouterIDIndex is authoritative; AddressRouterIDIndex is a fallback for
+// non-loopback addresses and uses "" for ambiguous advertisements.
+func (ss *Session) findRouterIDFromAddress(routerIDIndex, addrIndex map[netip.Addr]string, addr netip.Addr) (string, error) {
+	if routerID, ok := routerIDIndex[addr]; ok {
+		return routerID, nil
 	}
 
-	if routerID, ok := addrIndex[addr]; ok {
+	if routerID, ok := addrIndex[addr]; ok && routerID != "" {
 		return routerID, nil
 	}
 

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -218,14 +218,14 @@ func TestSRPolicyIntent_AttachedOnCreationBySRPID(t *testing.T) {
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 	sr := newTestStateReport(t, 1, 7)
 
-	ss.rememberSRPolicyIntent(7, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(7, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
 
 	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
 	require.True(t, found, "SR Policy reported by the PCC was not registered")
-	assert.Equal(t, table.PolicyTypeDynamic, policy.Type)
-	assert.Equal(t, table.TEMetric, policy.Metric)
+	require.NotNil(t, policy.CandidatePath.Dynamic)
+	assert.Equal(t, table.TEMetric, policy.CandidatePath.Dynamic.Metric)
 }
 
 func TestSRPolicyIntent_AttachedOnUpdateBySRPID(t *testing.T) {
@@ -233,26 +233,25 @@ func TestSRPolicyIntent_AttachedOnUpdateBySRPID(t *testing.T) {
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Explicit: &table.ExplicitPath{}})
 
 	sr := newTestStateReport(t, 1, 1)
 	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
 
 	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
 	require.True(t, found, "SR Policy reported by the PCC was not registered")
-	require.Equal(t, table.PolicyTypeExplicit, policy.Type, "initial policy intent")
-	require.Equal(t, table.UnspecifiedMetric, policy.Metric, "initial policy intent")
+	require.NotNil(t, policy.CandidatePath.Explicit, "initial policy intent")
 
 	// A PCRpt for the same PLSP-ID takes the update path and must pick up the new intent.
-	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(2, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	sr2 := newTestStateReport(t, 1, 2)
 	require.NoError(t, ss.handleStateReport(sr2, pcep.NewPCRptMessage()))
 
 	policy, found = ss.SearchSRPolicy(sr2.LSPObject.PlspID)
 	require.True(t, found, "SR Policy reported by the PCC was not registered")
-	assert.Equal(t, table.PolicyTypeDynamic, policy.Type, "policy type after update")
-	assert.Equal(t, table.TEMetric, policy.Metric, "policy metric after update")
+	require.NotNil(t, policy.CandidatePath.Dynamic, "policy type after update")
+	assert.Equal(t, table.TEMetric, policy.CandidatePath.Dynamic.Metric, "policy metric after update")
 }
 
 func TestSRPolicyIntent_UnknownWhenNeverRemembered(t *testing.T) {
@@ -265,8 +264,8 @@ func TestSRPolicyIntent_UnknownWhenNeverRemembered(t *testing.T) {
 
 	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
 	require.True(t, found, "SR Policy reported by the PCC was not registered")
-	assert.Equal(t, table.PolicyType(""), policy.Type, "policy type should be unset")
-	assert.Equal(t, table.UnspecifiedMetric, policy.Metric)
+	assert.Nil(t, policy.CandidatePath.Dynamic, "policy type should be unset")
+	assert.Nil(t, policy.CandidatePath.Explicit, "policy type should be unset")
 }
 
 func TestSRPolicyIntent_IndependentPerSRPID(t *testing.T) {
@@ -274,16 +273,16 @@ func TestSRPolicyIntent_IndependentPerSRPID(t *testing.T) {
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeExplicit, table.UnspecifiedMetric)
-	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Explicit: &table.ExplicitPath{}})
+	ss.rememberSRPolicyIntent(2, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	// SRP-ID 2's PCRpt arrives first and must only consume intent 2.
 	srB := newTestStateReport(t, 20, 2)
 	require.NoError(t, ss.handleStateReport(srB, pcep.NewPCRptMessage()))
 	policyB, found := ss.SearchSRPolicy(srB.LSPObject.PlspID)
 	require.True(t, found, "SR Policy for SRP-ID 2 was not registered")
-	assert.Equal(t, table.PolicyTypeDynamic, policyB.Type, "policy for SRP-ID 2")
-	assert.Equal(t, table.TEMetric, policyB.Metric, "policy for SRP-ID 2")
+	require.NotNil(t, policyB.CandidatePath.Dynamic, "policy for SRP-ID 2")
+	assert.Equal(t, table.TEMetric, policyB.CandidatePath.Dynamic.Metric, "policy for SRP-ID 2")
 
 	ss.srPolicyIntentsMu.Lock()
 	_, ok := ss.srPolicyIntents[1]
@@ -295,22 +294,21 @@ func TestSRPolicyIntent_IndependentPerSRPID(t *testing.T) {
 	require.NoError(t, ss.handleStateReport(srA, pcep.NewPCRptMessage()))
 	policyA, found := ss.SearchSRPolicy(srA.LSPObject.PlspID)
 	require.True(t, found, "SR Policy for SRP-ID 1 was not registered")
-	assert.Equal(t, table.PolicyTypeExplicit, policyA.Type, "policy for SRP-ID 1")
-	assert.Equal(t, table.UnspecifiedMetric, policyA.Metric, "policy for SRP-ID 1")
+	assert.NotNil(t, policyA.CandidatePath.Explicit, "policy for SRP-ID 1")
 }
 
 func TestSRPolicyIntent_UnsolicitedPCRptDoesNotConsume(t *testing.T) {
 	t.Parallel()
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	sr := newTestStateReport(t, 1, 0)
 	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
 
 	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
 	require.True(t, found, "SR Policy reported by the PCC was not registered")
-	assert.Equal(t, table.PolicyType(""), policy.Type, "unsolicited PCRpt must not consume an intent")
+	assert.Nil(t, policy.CandidatePath.Dynamic, "unsolicited PCRpt must not consume an intent")
 
 	_, ok := ss.takeSRPolicyIntent(1)
 	assert.True(t, ok, "intent for SRP-ID 1 must remain after an unrelated unsolicited PCRpt")
@@ -325,7 +323,7 @@ func TestSRPolicyIntent_ClearedOnRFlagDelete(t *testing.T) {
 	sr := newTestStateReport(t, 1, 0)
 	require.NoError(t, ss.handleStateReport(sr, pcep.NewPCRptMessage()))
 
-	ss.rememberSRPolicyIntent(5, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(5, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	del := newTestStateReport(t, 1, 5)
 	del.LSPObject.RFlag = true
@@ -342,8 +340,8 @@ func TestHandlePCErr_ForgetsReportedSRPIDIntents(t *testing.T) {
 	t.Parallel()
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
-	ss.rememberSRPolicyIntent(2, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
+	ss.rememberSRPolicyIntent(2, table.CandidatePath{Explicit: &table.ExplicitPath{}})
 
 	pcerrMessage := pcep.NewPCErrMessage(1, 1, nil)
 	pcerrMessage.SRPs = []*pcep.SrpObject{{SrpID: 1}}
@@ -380,15 +378,13 @@ func TestSendSRPolicyRequest_ForgetsIntentOnSendFailure(t *testing.T) {
 	req := &pb.CreateSRPolicyRequest{
 		SrPolicy: &pb.SRPolicy{
 			PeerAddr:   ss.peerAddr.AsSlice(),
-			DstAddr:    dstAddr.AsSlice(),
+			Endpoint:   dstAddr.AsSlice(),
 			Color:      100,
 			PolicyName: testSRPolicyName,
-			Type:       pb.SRPolicyType_SR_POLICY_TYPE_EXPLICIT,
 		},
-		DisablePathCompute: true,
 	}
 
-	err := sendSRPolicyRequest(apiServer, req, resolvedPath{SrcAddr: netip.MustParseAddr("10.255.0.1"), DstAddr: dstAddr, Metric: table.UnspecifiedMetric}, true)
+	err := sendSRPolicyRequest(apiServer, req, resolvedPath{Headend: netip.MustParseAddr("10.255.0.1"), Endpoint: dstAddr})
 	require.Error(t, err, "expected sendSRPolicyRequest to fail once the connection is closed")
 
 	_, ok := ss.takeSRPolicyIntent(wantSRPID)
@@ -405,7 +401,7 @@ func TestCloseSession_ClearsSRPolicyIntents(t *testing.T) {
 	})
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	s := &Server{sessionList: []*Session{ss}, logger: logger.NewNop()}
 	s.closeSession(ss)
@@ -451,12 +447,11 @@ func TestConcurrentSRPolicyRequestsAllocateUniqueSRPIDs(t *testing.T) {
 	for i := range goroutines {
 		wg.Go(func() {
 			srPolicy := table.SRPolicy{
-				Name:    "concurrent-test",
-				SrcAddr: netip.MustParseAddr("10.255.0.1"),
-				DstAddr: netip.MustParseAddr("10.255.0.2"),
-				Color:   uint32(i),
-				Type:    table.PolicyTypeDynamic,
-				Metric:  table.TEMetric,
+				Name:          "concurrent-test",
+				Headend:       netip.MustParseAddr("10.255.0.1"),
+				Endpoint:      netip.MustParseAddr("10.255.0.2"),
+				Color:         uint32(i),
+				CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
 			}
 
 			var err error
@@ -491,7 +486,7 @@ func TestAllocateSRPID_SkipsReservedValues(t *testing.T) {
 	ss.srpIDHead = math.MaxUint32 - 1
 
 	for i, want := range []uint32{math.MaxUint32 - 1, 1, 2} {
-		got, err := ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+		got, err := ss.allocateSRPID(table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 		require.NoErrorf(t, err, "allocation %d", i)
 		require.NotContainsf(t, []uint32{0, math.MaxUint32}, got, "allocation %d: got reserved SRP-ID", i)
 		assert.Equalf(t, want, got, "allocation %d", i)
@@ -564,7 +559,7 @@ func TestSweepExpiredSRPolicyIntents_RemovesExpired(t *testing.T) {
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 	ss.srPolicyIntentsMu.Lock()
 	ss.srPolicyIntents = map[uint32]srPolicyIntent{
-		1: {polType: table.PolicyTypeDynamic, metric: table.TEMetric, expiresAt: time.Now().Add(-time.Second)},
+		1: {candidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}}, expiresAt: time.Now().Add(-time.Second)},
 	}
 	ss.srPolicyIntentsMu.Unlock()
 
@@ -580,7 +575,7 @@ func TestSweepExpiredSRPolicyIntents_KeepsUnexpired(t *testing.T) {
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 	ss.srPolicyIntentsMu.Lock()
 	ss.srPolicyIntents = map[uint32]srPolicyIntent{
-		1: {polType: table.PolicyTypeDynamic, metric: table.TEMetric, expiresAt: time.Now().Add(time.Hour)},
+		1: {candidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}}, expiresAt: time.Now().Add(time.Hour)},
 	}
 	ss.srPolicyIntentsMu.Unlock()
 
@@ -594,8 +589,8 @@ func TestSweepExpiredSRPolicyIntents_KeepsUnrelatedIntent(t *testing.T) {
 	t.Parallel()
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
-	ss.rememberSRPolicyIntent(2, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
+	ss.rememberSRPolicyIntent(2, table.CandidatePath{Explicit: &table.ExplicitPath{}})
 
 	_, ok := ss.takeSRPolicyIntent(1)
 	require.True(t, ok, "expected intent 1 to be present before consuming it")
@@ -616,7 +611,7 @@ func TestIntentSweep_RunsInBackgroundAndStopsCleanly(t *testing.T) {
 	ss.startIntentSweep()
 	defer ss.stopIntentSweep()
 
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	require.Eventually(t, func() bool {
 		return !ss.srPolicyIntentExists(1)
@@ -627,7 +622,7 @@ func TestRememberSRPolicyIntent_IgnoresReservedSRPID(t *testing.T) {
 	t.Parallel()
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
-	ss.rememberSRPolicyIntent(0, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(0, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 	assert.False(t, ss.srPolicyIntentExists(0))
 }
 
@@ -684,7 +679,7 @@ func TestIntentSweep_ConcurrentWithIntentConsumption(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := uint32(1); i <= 20; i++ {
 		wg.Go(func() {
-			ss.rememberSRPolicyIntent(i, table.PolicyTypeDynamic, table.TEMetric)
+			ss.rememberSRPolicyIntent(i, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 			time.Sleep(time.Millisecond)
 			ss.takeSRPolicyIntent(i)
 		})
@@ -717,13 +712,13 @@ func TestAllocateSRPID_SkipsInUseIDsOnWraparound(t *testing.T) {
 	ss.srpIDHead = math.MaxUint32 - 1
 
 	// Pre-occupy SRP-ID 1 so the wraparound scan must skip over it.
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Explicit: &table.ExplicitPath{}})
 
-	got, err := ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+	got, err := ss.allocateSRPID(table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 	require.NoError(t, err, "allocation 1")
 	require.Equal(t, uint32(math.MaxUint32-1), got, "allocation 1")
 
-	got, err = ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+	got, err = ss.allocateSRPID(table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 	require.NoError(t, err, "allocation 2")
 	assert.Equal(t, uint32(2), got, "allocation 2: SRP-ID 1 is still in use and must be skipped")
 
@@ -736,10 +731,10 @@ func TestAllocateSRPID_ErrorsWhenExhausted(t *testing.T) {
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 	ss.srpIDMax = 3 // valid range is [1, 2]; 0 and 3 are reserved.
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
-	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
+	ss.rememberSRPolicyIntent(2, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
-	_, err := ss.allocateSRPID(table.PolicyTypeDynamic, table.TEMetric)
+	_, err := ss.allocateSRPID(table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 	assert.Error(t, err, "expected an error when every non-reserved SRP-ID is in use")
 }
 
@@ -748,15 +743,14 @@ func TestSendPCInitiate_ErrorsWhenSRPIDExhausted(t *testing.T) {
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 	ss.srpIDMax = 3
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
-	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
+	ss.rememberSRPolicyIntent(2, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	srPolicy := table.SRPolicy{
-		Name:    "srp-id-exhausted",
-		SrcAddr: netip.MustParseAddr("10.255.0.1"),
-		DstAddr: netip.MustParseAddr("10.255.0.2"),
-		Type:    table.PolicyTypeDynamic,
-		Metric:  table.TEMetric,
+		Name:          "srp-id-exhausted",
+		Headend:       netip.MustParseAddr("10.255.0.1"),
+		Endpoint:      netip.MustParseAddr("10.255.0.2"),
+		CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
 	}
 
 	assert.Error(t, ss.SendPCInitiate(srPolicy, false))
@@ -767,15 +761,14 @@ func TestSendPCUpdate_ErrorsWhenSRPIDExhausted(t *testing.T) {
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 	ss.srpIDMax = 3
-	ss.rememberSRPolicyIntent(1, table.PolicyTypeDynamic, table.TEMetric)
-	ss.rememberSRPolicyIntent(2, table.PolicyTypeDynamic, table.TEMetric)
+	ss.rememberSRPolicyIntent(1, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
+	ss.rememberSRPolicyIntent(2, table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}})
 
 	srPolicy := table.SRPolicy{
-		Name:    "srp-id-exhausted",
-		SrcAddr: netip.MustParseAddr("10.255.0.1"),
-		DstAddr: netip.MustParseAddr("10.255.0.2"),
-		Type:    table.PolicyTypeDynamic,
-		Metric:  table.TEMetric,
+		Name:          "srp-id-exhausted",
+		Headend:       netip.MustParseAddr("10.255.0.1"),
+		Endpoint:      netip.MustParseAddr("10.255.0.2"),
+		CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
 	}
 
 	assert.Error(t, ss.SendPCUpdate(srPolicy))
@@ -806,11 +799,10 @@ var concurrentSendCases = []concurrentSendCase{
 		name: "SendPCUpdate",
 		send: func(ss *Session, _ int) error {
 			return ss.SendPCUpdate(table.SRPolicy{
-				Name:    "concurrent-send-test",
-				SrcAddr: netip.MustParseAddr("10.255.0.1"),
-				DstAddr: netip.MustParseAddr("10.255.0.2"),
-				Type:    table.PolicyTypeDynamic,
-				Metric:  table.TEMetric,
+				Name:          "concurrent-send-test",
+				Headend:       netip.MustParseAddr("10.255.0.1"),
+				Endpoint:      netip.MustParseAddr("10.255.0.2"),
+				CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
 			})
 		},
 	},
@@ -818,12 +810,11 @@ var concurrentSendCases = []concurrentSendCase{
 		name: "RequestSRPolicyCreated",
 		send: func(ss *Session, i int) error {
 			return ss.RequestSRPolicyCreated(table.SRPolicy{
-				Name:    "concurrent-send-test",
-				SrcAddr: netip.MustParseAddr("10.255.0.1"),
-				DstAddr: netip.MustParseAddr("10.255.0.2"),
-				Color:   uint32(i),
-				Type:    table.PolicyTypeDynamic,
-				Metric:  table.TEMetric,
+				Name:          "concurrent-send-test",
+				Headend:       netip.MustParseAddr("10.255.0.1"),
+				Endpoint:      netip.MustParseAddr("10.255.0.2"),
+				Color:         uint32(i),
+				CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
 			})
 		},
 	},
@@ -3671,7 +3662,7 @@ func TestReceivePCEPMessage_ProcessesMessagesThenReturnsOnClose(t *testing.T) {
 	})
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
-	ss.rememberSRPolicyIntent(9, table.PolicyTypeExplicit, table.UnspecifiedMetric)
+	ss.rememberSRPolicyIntent(9, table.CandidatePath{Explicit: &table.ExplicitPath{}})
 
 	keepaliveMessage := pcep.NewKeepaliveMessage()
 	writeMessage(t, client, keepaliveMessage)
@@ -4872,7 +4863,7 @@ func TestUpdateOrCreatePolicy_SrcAddrFallsBackToAssociationSrc(t *testing.T) {
 
 	policy, found := ss.SearchSRPolicy(1)
 	require.True(t, found)
-	assert.Equal(t, netip.MustParseAddr("192.0.2.9"), policy.SrcAddr)
+	assert.Equal(t, netip.MustParseAddr("192.0.2.9"), policy.Headend)
 }
 
 func TestUpdateOrCreatePolicy_InvalidSrcAddr(t *testing.T) {
@@ -4899,7 +4890,7 @@ func TestUpdateOrCreatePolicy_DstAddrFallsBackToAssociationEndpoint(t *testing.T
 
 	policy, found := ss.SearchSRPolicy(1)
 	require.True(t, found)
-	assert.Equal(t, netip.MustParseAddr("192.0.2.20"), policy.DstAddr)
+	assert.Equal(t, netip.MustParseAddr("192.0.2.20"), policy.Endpoint)
 }
 
 func TestUpdateOrCreatePolicy_InvalidDstAddr(t *testing.T) {
@@ -4996,8 +4987,8 @@ func TestSendPCInitiate_InvalidSegmentTypeIsRejected(t *testing.T) {
 	wantSRPID := ss.srpIDHead
 	srPolicy := table.SRPolicy{
 		Name:        "bad-segment",
-		SrcAddr:     netip.MustParseAddr("10.255.0.1"),
-		DstAddr:     netip.MustParseAddr("10.255.0.2"),
+		Headend:     netip.MustParseAddr("10.255.0.1"),
+		Endpoint:    netip.MustParseAddr("10.255.0.2"),
 		SegmentList: []table.Segment{unknownSegment{}},
 	}
 
@@ -5184,21 +5175,19 @@ func TestSessionStats_SendCountersIncrementOnSuccess(t *testing.T) {
 	assert.Equal(t, uint64(1), ss.Stats().PCErrSent)
 
 	require.NoError(t, ss.SendPCUpdate(table.SRPolicy{
-		Name:    "stats-test",
-		SrcAddr: netip.MustParseAddr("10.255.0.1"),
-		DstAddr: netip.MustParseAddr("10.255.0.2"),
-		Type:    table.PolicyTypeDynamic,
-		Metric:  table.TEMetric,
+		Name:          "stats-test",
+		Headend:       netip.MustParseAddr("10.255.0.1"),
+		Endpoint:      netip.MustParseAddr("10.255.0.2"),
+		CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
 	}))
 	require.NoError(t, readPCEPMessage(client))
 	assert.Equal(t, uint64(1), ss.Stats().UpdSent)
 
 	require.NoError(t, ss.SendPCInitiate(table.SRPolicy{
-		Name:    "stats-test",
-		SrcAddr: netip.MustParseAddr("10.255.0.1"),
-		DstAddr: netip.MustParseAddr("10.255.0.2"),
-		Type:    table.PolicyTypeDynamic,
-		Metric:  table.TEMetric,
+		Name:          "stats-test",
+		Headend:       netip.MustParseAddr("10.255.0.1"),
+		Endpoint:      netip.MustParseAddr("10.255.0.2"),
+		CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
 	}, false))
 	require.NoError(t, readPCEPMessage(client))
 	assert.Equal(t, uint64(1), ss.Stats().PCInitiateSent)
@@ -5507,9 +5496,9 @@ func TestHandleStateReport_UnsupportedAssocTypeIsIgnoredForSRPolicySemantics(t *
 	policy, found := ss.SearchSRPolicy(sr.LSPObject.PlspID)
 	require.True(t, found)
 	assert.Equal(t, uint32(55), policy.Color)
-	assert.Equal(t, uint32(33), policy.Preference)
-	assert.Equal(t, netip.MustParseAddr("192.0.2.1"), policy.SrcAddr)
-	assert.Equal(t, netip.MustParseAddr("192.0.2.2"), policy.DstAddr)
+	assert.Equal(t, uint32(33), policy.CandidatePath.Preference)
+	assert.Equal(t, netip.MustParseAddr("192.0.2.1"), policy.Headend)
+	assert.Equal(t, netip.MustParseAddr("192.0.2.2"), policy.Endpoint)
 }
 
 func TestHandleStateReport_EveryUnsupportedAssocTypeIsReported(t *testing.T) {
@@ -5788,18 +5777,15 @@ func TestSendPCUpdateAndPCInitiate_RejectSegmentListDeeperThanPeerMSD(t *testing
 		[]pcep.CapabilityInterface{pcep.NewSRPCECapability(false, false, 1)})
 
 	srPolicy := table.SRPolicy{
-		Name:        "too-deep",
-		SrcAddr:     netip.MustParseAddr("10.255.0.1"),
-		DstAddr:     netip.MustParseAddr("10.255.0.2"),
-		Type:        table.PolicyTypeDynamic,
-		Metric:      table.TEMetric,
-		SegmentList: []table.Segment{table.NewSegmentSRMPLS(16001), table.NewSegmentSRMPLS(16002)},
+		Name:          "too-deep",
+		Headend:       netip.MustParseAddr("10.255.0.1"),
+		Endpoint:      netip.MustParseAddr("10.255.0.2"),
+		CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
+		SegmentList:   []table.Segment{table.NewSegmentSRMPLS(16001), table.NewSegmentSRMPLS(16002)},
 	}
 
 	require.ErrorContains(t, ss.SendPCUpdate(srPolicy), "maximum SID depth")
 	require.ErrorContains(t, ss.SendPCInitiate(srPolicy, false), "maximum SID depth")
-
-	// Delete is not subject to the SID depth limit.
 	require.NoError(t, ss.SendPCInitiate(srPolicy, true))
 	assert.Equal(t, uint64(0), ss.Stats().UpdSent)
 }
@@ -5817,19 +5803,36 @@ func TestSendPCUpdateAndPCInitiate_RejectUnadvertisedPathSetupType(t *testing.T)
 		}})
 
 	srPolicy := table.SRPolicy{
-		Name:        "srv6-to-sr-mpls-only-pcc",
-		SrcAddr:     netip.MustParseAddr("2001:db8::1"),
-		DstAddr:     netip.MustParseAddr("2001:db8::2"),
-		Type:        table.PolicyTypeDynamic,
-		Metric:      table.TEMetric,
-		SegmentList: []table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8::100")))},
+		Name:          "srv6-to-sr-mpls-only-pcc",
+		Headend:       netip.MustParseAddr("2001:db8::1"),
+		Endpoint:      netip.MustParseAddr("2001:db8::2"),
+		CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
+		SegmentList:   []table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8::100")))},
 	}
 
 	require.ErrorContains(t, ss.SendPCUpdate(srPolicy), "path setup type")
 	require.ErrorContains(t, ss.SendPCInitiate(srPolicy, false), "path setup type")
-
-	// Deletion uses the same PATH-SETUP-TYPE TLV and is rejected too.
 	require.ErrorContains(t, ss.SendPCInitiate(srPolicy, true), "path setup type")
 	assert.Equal(t, uint64(0), ss.Stats().UpdSent)
 	assert.Equal(t, uint64(0), ss.Stats().PCInitiateSent)
+}
+
+func TestSendPCInitiate_RejectsIPv6EndpointForJuniperLegacyPCC(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newTCPConnPair(t)
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), nil, 0)
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.JuniperLegacy, nil)
+
+	srPolicy := table.SRPolicy{
+		Name:          "juniper-legacy-ipv6-endpoint",
+		Headend:       netip.MustParseAddr("2001:db8::1"),
+		Endpoint:      netip.MustParseAddr("2001:db8::2"),
+		CandidatePath: table.CandidatePath{Dynamic: &table.DynamicPath{Metric: table.TEMetric}},
+	}
+
+	require.ErrorContains(t, ss.SendPCInitiate(srPolicy, false), "Juniper legacy")
+	require.NoError(t, ss.SendPCInitiate(srPolicy, true))
+	assert.Equal(t, uint64(1), ss.Stats().PCInitiateSent)
 }

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -1006,6 +1006,7 @@ func TestFindRouterIDFromAddress(t *testing.T) {
 	ted.Nodes["198.51.100.2"] = nil
 
 	ss := &Session{ted: ted}
+	routerIDIndex := ted.RouterIDIndex()
 	addrIndex := ted.AddressRouterIDIndex()
 
 	cases := []struct {
@@ -1017,7 +1018,7 @@ func TestFindRouterIDFromAddress(t *testing.T) {
 		{"ipv4 prefix", netip.MustParseAddr("192.0.2.10"), "router-v4", false},
 		{"ipv6 prefix", netip.MustParseAddr("2001:db8::1"), "router-v6", false},
 		{"non-host prefix network address", netip.MustParseAddr("192.0.2.0"), "router-subnet", false},
-		{"router id match", netip.MustParseAddr("198.51.100.1"), "198.51.100.1", false},
+		{"router id string coincidentally matching the address, but no prefix advertised", netip.MustParseAddr("198.51.100.1"), "", true},
 		{"nil node entry", netip.MustParseAddr("198.51.100.2"), "", true},
 		{"not found", netip.MustParseAddr("203.0.113.5"), "", true},
 	}
@@ -1025,7 +1026,7 @@ func TestFindRouterIDFromAddress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := ss.findRouterIDFromAddress(addrIndex, tc.addr)
+			got, err := ss.findRouterIDFromAddress(routerIDIndex, addrIndex, tc.addr)
 			if tc.wantErr {
 				require.Errorf(t, err, "expected error, got routerID %q", got)
 				return
@@ -1035,6 +1036,25 @@ func TestFindRouterIDFromAddress(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestFindRouterIDFromAddress_AmbiguousFallsBackToNotFound(t *testing.T) {
+	t.Parallel()
+
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+
+	for _, routerID := range []string{"router-a", "router-b"} {
+		node := table.NewLsNode(0, routerID)
+		prefix := table.NewLsPrefix(node)
+		prefix.Prefix = netip.MustParsePrefix("192.0.2.0/24")
+		node.Prefixes = append(node.Prefixes, prefix)
+		ted.Nodes[node.RouterID] = node
+	}
+
+	ss := &Session{ted: ted}
+
+	_, err := ss.findRouterIDFromAddress(ted.RouterIDIndex(), ted.AddressRouterIDIndex(), netip.MustParseAddr("192.0.2.0"))
+	assert.Error(t, err, "expected an ambiguous address to be treated as not found")
 }
 
 func TestExtractSrcDstRouterIDs(t *testing.T) {
@@ -1048,7 +1068,10 @@ func TestExtractSrcDstRouterIDs(t *testing.T) {
 	srcNode.Prefixes = append(srcNode.Prefixes, srcPrefix)
 	ted.Nodes[srcNode.RouterID] = srcNode
 
-	dstNode := table.NewLsNode(0, "10.255.0.2")
+	dstNode := table.NewLsNode(0, "dst-router")
+	dstPrefix := table.NewLsPrefix(dstNode)
+	dstPrefix.Prefix = netip.MustParsePrefix("10.255.0.2/32")
+	dstNode.Prefixes = append(dstNode.Prefixes, dstPrefix)
 	ted.Nodes[dstNode.RouterID] = dstNode
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), ted, 0)
@@ -1057,7 +1080,7 @@ func TestExtractSrcDstRouterIDs(t *testing.T) {
 	srcRouterID, dstRouterID, err := ss.extractSrcDstRouterIDs(sr)
 	require.NoError(t, err, "extractSrcDstRouterIDs failed")
 	assert.Equal(t, "src-router", srcRouterID)
-	assert.Equal(t, "10.255.0.2", dstRouterID)
+	assert.Equal(t, "dst-router", dstRouterID)
 }
 
 func TestExtractSrcDstRouterIDs_AddressNotFound(t *testing.T) {
@@ -4508,12 +4531,14 @@ func newLinkedSRv6Nodes(srcAddr, dstAddr netip.Addr, metric uint32) (src, dst *t
 func TestHandleSRPolicyWithPLSPID_CreateEroFromSegmentListErrorIsPropagated(t *testing.T) {
 	t.Parallel()
 
-	srcAddr := netip.MustParseAddr("10.1.0.1")
-	dstAddr := netip.MustParseAddr("10.1.0.2")
+	srcAddr := netip.MustParseAddr("2001:db8:e::1")
+	dstAddr := netip.MustParseAddr("2001:db8:e::2")
 	srcNode, dstNode := newLinkedSRv6Nodes(srcAddr, dstAddr, 10)
 	ted := &table.LsTED{Nodes: map[string]*table.LsNode{srcNode.RouterID: srcNode, dstNode.RouterID: dstNode}}
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), ted, 0)
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+		[]pcep.CapabilityInterface{pcep.NewSRv6PCECapability(false)})
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = srcAddr
@@ -4599,6 +4624,8 @@ func TestHandleSRPolicyWithPLSPID_SendPCUpdateFailureIsPropagated(t *testing.T) 
 	require.NoError(t, server.Close(), "failed to close server connection")
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), server, logger.NewNop(), ted, 0)
+	ss.commitPeerOpen(OpenParams{SessionID: 1, Keepalive: 30, DeadTimer: 120}, pcep.RFCCompliant,
+		[]pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
 
 	sr := newTestStateReport(t, 1, 0)
 	sr.LSPObject.SrcAddr = srcAddr
@@ -4645,6 +4672,113 @@ func TestSelectMetricType(t *testing.T) {
 			assert.Equal(t, tc.want, ss.selectMetricType(sr))
 		})
 	}
+}
+
+func TestDataPlaneFromPeerCapabilities(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		af      table.AddressFamily
+		caps    []pcep.CapabilityInterface
+		want    table.DataPlane
+		wantErr string
+	}{
+		{
+			name: "legacy SR-CAPABILITY implies SR-MPLS for IPv4",
+			af:   table.AFIPv4,
+			caps: []pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)},
+			want: table.DPSRMPLS,
+		},
+		{
+			name: "legacy SR-CAPABILITY implies SR-MPLS for IPv6 too (no PST-CAP TLV to say otherwise)",
+			af:   table.AFIPv6,
+			caps: []pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)},
+			want: table.DPSRMPLS,
+		},
+		{
+			name: "PST-CAP advertising only SRv6TE implies SRv6 for IPv6",
+			af:   table.AFIPv6,
+			caps: []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE}}},
+			want: table.DPSRv6,
+		},
+		{
+			name:    "SRv6TE support is irrelevant for an IPv4 LSP",
+			af:      table.AFIPv4,
+			caps:    []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRv6TE}}},
+			wantErr: "does not advertise",
+		},
+		{
+			name:    "PST-CAP advertising both SRTE and SRv6TE is ambiguous for IPv6",
+			af:      table.AFIPv6,
+			caps:    []pcep.CapabilityInterface{&pcep.PathSetupTypeCapability{PathSetupTypes: pcep.Psts{pcep.PathSetupTypeSRTE, pcep.PathSetupTypeSRv6TE}}},
+			wantErr: "ambiguous",
+		},
+		{
+			name:    "no capabilities at all",
+			af:      table.AFIPv4,
+			caps:    nil,
+			wantErr: "does not advertise",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
+			ss.commitPeerOpen(OpenParams{}, pcep.RFCCompliant, tc.caps)
+
+			got, err := ss.dataPlaneFromPeerCapabilities(tc.af)
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPlaneFromReport(t *testing.T) {
+	t.Parallel()
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
+	ss.commitPeerOpen(OpenParams{}, pcep.RFCCompliant, []pcep.CapabilityInterface{pcep.NewSRPCECapability(true, false, 0)})
+
+	t.Run("family comes from the LSP's own addresses", func(t *testing.T) {
+		t.Parallel()
+
+		sr := newTestStateReport(t, 1, 0)
+		sr.LSPObject.SrcAddr = netip.MustParseAddr("10.0.0.1")
+		sr.LSPObject.DstAddr = netip.MustParseAddr("10.0.0.2")
+
+		plane, err := ss.planeFromReport(sr)
+		require.NoError(t, err)
+		assert.Equal(t, table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS}, plane)
+	})
+
+	t.Run("mismatched src/dst families are rejected", func(t *testing.T) {
+		t.Parallel()
+
+		sr := newTestStateReport(t, 1, 0)
+		sr.LSPObject.SrcAddr = netip.MustParseAddr("10.0.0.1")
+		sr.LSPObject.DstAddr = netip.MustParseAddr("2001:db8::1")
+
+		_, err := ss.planeFromReport(sr)
+		assert.ErrorContains(t, err, "share an address family")
+	})
+
+	t.Run("invalid addresses are rejected", func(t *testing.T) {
+		t.Parallel()
+
+		sr := newTestStateReport(t, 1, 0)
+		sr.LSPObject.SrcAddr = netip.Addr{}
+		sr.LSPObject.DstAddr = netip.Addr{}
+
+		_, err := ss.planeFromReport(sr)
+		assert.Error(t, err)
+	})
 }
 
 func TestResolveColorPreference_CiscoLegacy(t *testing.T) {

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -190,7 +190,7 @@ func TestSRPolicies_SnapshotSRv6StructureIsIndependent(t *testing.T) {
 
 	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), nil, 0)
 
-	srv6Seg := table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1005::"))
+	srv6Seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8:1005::")))
 	srv6Seg.Structure = &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalArg: 80}
 	ss.srPolicies = append(ss.srPolicies, table.NewSRPolicy(1, "pe01-policy1", []table.Segment{srv6Seg}, netip.MustParseAddr("10.255.0.1"), netip.MustParseAddr("10.255.0.2"), 0, 0, 0, table.PolicyUp))
 
@@ -4786,7 +4786,7 @@ func TestUpdateOrCreatePolicy_StaleLSPIDIsIgnored(t *testing.T) {
 func TestCreateEroFromSegmentList_SRv6(t *testing.T) {
 	t.Parallel()
 
-	seg := table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::1"))
+	seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8:1::1")))
 
 	ero, err := createEroFromSegmentList([]table.Segment{seg})
 	require.NoError(t, err)
@@ -4812,7 +4812,7 @@ func TestCreateEroFromSegmentList_InvalidSegmentReturnsError(t *testing.T) {
 func TestCreateEroFromSegmentList_SRv6InvalidSegmentReturnsError(t *testing.T) {
 	t.Parallel()
 
-	seg := table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::1"))
+	seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8:1::1")))
 	seg.LocalAddr = netip.MustParseAddr("fe80::1") // link-local adjacency NAI is unsupported.
 	seg.RemoteAddr = netip.MustParseAddr("fe80::2")
 
@@ -4835,7 +4835,8 @@ func TestSendPCEPMessage_SerializeErrorIsPropagated(t *testing.T) {
 
 type unknownSegment struct{}
 
-func (unknownSegment) SidString() string { return "unknown" }
+func (unknownSegment) SidString() string       { return "unknown" }
+func (unknownSegment) Family() table.DataPlane { return table.DPUnspecified }
 
 func TestSendPCInitiate_InvalidSegmentTypeIsRejected(t *testing.T) {
 	t.Parallel()
@@ -5411,7 +5412,7 @@ func TestValidateSegmentListForPeer(t *testing.T) {
 		table.NewSegmentSRMPLS(16003),
 	}
 
-	srv6Segment := table.NewSegmentSRv6(netip.MustParseAddr("2001:db8::1"))
+	srv6Segment := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8::1")))
 	srv6 := []table.Segment{srv6Segment, srv6Segment, srv6Segment}
 
 	cases := map[string]struct {
@@ -5670,7 +5671,7 @@ func TestSendPCUpdateAndPCInitiate_RejectUnadvertisedPathSetupType(t *testing.T)
 		DstAddr:     netip.MustParseAddr("2001:db8::2"),
 		Type:        table.PolicyTypeDynamic,
 		Metric:      table.TEMetric,
-		SegmentList: []table.Segment{table.NewSegmentSRv6(netip.MustParseAddr("2001:db8::100"))},
+		SegmentList: []table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8::100")))},
 	}
 
 	require.ErrorContains(t, ss.SendPCUpdate(srPolicy), "path setup type")

--- a/pkg/server/session_internal_test.go
+++ b/pkg/server/session_internal_test.go
@@ -4442,8 +4442,23 @@ func TestComputePathFromTED_CSPFFailsWithoutNodeSID(t *testing.T) {
 	assert.Error(t, err, "CSPF must fail when the headend advertises no Prefix-SID or SRv6 SID")
 }
 
-// newLinkedSRMPLSNodes builds two SR-MPLS nodes connected by a link with the given TE metric.
-// Each node has a Prefix-SID bound to its address.
+func TestComputePathFromTED_SrcRouterIDNotInTED(t *testing.T) {
+	t.Parallel()
+
+	srcNode := table.NewLsNode(0, "src-alias")
+	dstNode := table.NewLsNode(0, "10.255.0.2")
+	ted := &table.LsTED{Nodes: map[string]*table.LsNode{
+		"10.255.0.1": srcNode, // keyed by address, not by srcNode.RouterID
+		"10.255.0.2": dstNode,
+	}}
+
+	ss := NewSession(testLocalOpen(1), netip.MustParseAddr("10.0.255.1"), nil, logger.NewNop(), ted, 0)
+	sr := newTestStateReport(t, 1, 0)
+
+	_, err := ss.computePathFromTED(sr)
+	assert.Error(t, err, "must fail when the resolved router ID no longer keys a node in the TED")
+}
+
 func newLinkedSRMPLSNodes(srcAddr, dstAddr netip.Addr, metric uint32) (src, dst *table.LsNode) {
 	src = table.NewLsNode(65000, "PE1")
 	srcPrefix := table.NewLsPrefix(src)
@@ -4462,6 +4477,7 @@ func newLinkedSRMPLSNodes(srcAddr, dstAddr netip.Addr, metric uint32) (src, dst 
 	dst.SrgbBegin, dst.SrgbEnd = 16000, 23999
 
 	link := table.NewLsLink(src, dst)
+	link.Local.IPv4, link.Remote.IPv4 = srcAddr, dstAddr
 	link.Metrics = []*table.Metric{table.NewMetric(table.TEMetric, metric)}
 	src.AddLink(link)
 
@@ -4482,6 +4498,7 @@ func newLinkedSRv6Nodes(srcAddr, dstAddr netip.Addr, metric uint32) (src, dst *t
 	dst.SRv6SIDs = []*table.LsSrv6SID{{Sids: []string{"fe80::2"}}}
 
 	link := table.NewLsLink(src, dst)
+	link.Local.IPv6, link.Remote.IPv6 = netip.MustParseAddr("2001:db8:f::1"), netip.MustParseAddr("2001:db8:f::2")
 	link.Metrics = []*table.Metric{table.NewMetric(table.TEMetric, metric)}
 	src.AddLink(link)
 

--- a/pkg/table/endpoint.go
+++ b/pkg/table/endpoint.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package table
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+)
+
+// EndpointSpec identifies how the policy endpoints are specified (RFC 9256 §2.1).
+// Address and router-ID forms are mutually exclusive.
+type EndpointSpec struct {
+	Headend          netip.Addr
+	Endpoint         netip.Addr
+	HeadendRouterID  string
+	EndpointRouterID string
+	Family           AddressFamily
+}
+
+// UsesRouterID reports whether s names its endpoints by router ID.
+func (s EndpointSpec) UsesRouterID() bool {
+	return s.HeadendRouterID != "" || s.EndpointRouterID != ""
+}
+
+// Resolve returns the policy endpoints as addresses.
+// Explicit address-family selections must be supported by both endpoints;
+// otherwise, the unique common loopback family is used.
+func (s EndpointSpec) Resolve(ted *LsTED, underlayFamily AddressFamily) (headend, endpoint netip.Addr, err error) {
+	usesAddr := s.Headend.IsValid() || s.Endpoint.IsValid()
+	usesRouterID := s.UsesRouterID()
+
+	switch {
+	case usesAddr && usesRouterID:
+		return netip.Addr{}, netip.Addr{}, errors.New("headend/endpoint and headendRouterID/endpointRouterID are mutually exclusive")
+	case usesAddr:
+		if s.Family.IsValid() {
+			return netip.Addr{}, netip.Addr{}, errors.New("endpointFamily is valid only with the headendRouterID/endpointRouterID form")
+		}
+
+		if !s.Headend.IsValid() || !s.Endpoint.IsValid() {
+			return netip.Addr{}, netip.Addr{}, errors.New("both headend and endpoint must be set")
+		}
+
+		return s.Headend, s.Endpoint, nil
+	case usesRouterID:
+		if s.HeadendRouterID == "" || s.EndpointRouterID == "" {
+			return netip.Addr{}, netip.Addr{}, errors.New("both headendRouterID and endpointRouterID must be set")
+		}
+
+		return s.resolveViaTED(ted, underlayFamily)
+	default:
+		return netip.Addr{}, netip.Addr{}, errors.New("either headend/endpoint or headendRouterID/endpointRouterID must be set")
+	}
+}
+
+func (s EndpointSpec) resolveViaTED(ted *LsTED, underlayFamily AddressFamily) (headend, endpoint netip.Addr, err error) {
+	if ted == nil {
+		return netip.Addr{}, netip.Addr{}, errors.New("ted is nil")
+	}
+
+	headendNode, ok := ted.Nodes[s.HeadendRouterID]
+	if !ok || headendNode == nil {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("no node with router ID %s", s.HeadendRouterID)
+	}
+
+	endpointNode, ok := ted.Nodes[s.EndpointRouterID]
+	if !ok || endpointNode == nil {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("no node with router ID %s", s.EndpointRouterID)
+	}
+
+	family, err := s.resolveFamily(headendNode, endpointNode, underlayFamily)
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, err
+	}
+
+	headend, err = headendNode.LoopbackAddr(family)
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("headend %s: %w", s.HeadendRouterID, err)
+	}
+
+	endpoint, err = endpointNode.LoopbackAddr(family)
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("endpoint %s: %w", s.EndpointRouterID, err)
+	}
+
+	return headend, endpoint, nil
+}
+
+func (s EndpointSpec) resolveFamily(headendNode, endpointNode *LsNode, underlayFamily AddressFamily) (AddressFamily, error) {
+	if s.Family.IsValid() {
+		return s.Family, nil
+	}
+
+	if underlayFamily.IsValid() {
+		if headendNode.HasLoopback(underlayFamily) && endpointNode.HasLoopback(underlayFamily) {
+			return underlayFamily, nil
+		}
+
+		return AFUnspecified, fmt.Errorf("underlay family %v has no loopback on headend %s and/or endpoint %s; specify endpointFamily", underlayFamily, s.HeadendRouterID, s.EndpointRouterID)
+	}
+
+	var candidates []AddressFamily
+
+	for _, af := range []AddressFamily{AFIPv4, AFIPv6} {
+		if headendNode.HasLoopback(af) && endpointNode.HasLoopback(af) {
+			candidates = append(candidates, af)
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		return AFUnspecified, fmt.Errorf("headend %s and endpoint %s share no common loopback address family; specify endpointFamily", s.HeadendRouterID, s.EndpointRouterID)
+	case 1:
+		return candidates[0], nil
+	default:
+		return AFUnspecified, fmt.Errorf("headend %s and endpoint %s share multiple loopback address families %v; specify endpointFamily", s.HeadendRouterID, s.EndpointRouterID, candidates)
+	}
+}

--- a/pkg/table/endpoint.go
+++ b/pkg/table/endpoint.go
@@ -27,9 +27,7 @@ func (s EndpointSpec) UsesRouterID() bool {
 }
 
 // Resolve returns the policy endpoints as addresses.
-// Explicit address-family selections must be supported by both endpoints;
-// otherwise, the unique common loopback family is used.
-func (s EndpointSpec) Resolve(ted *LsTED, underlayFamily AddressFamily) (headend, endpoint netip.Addr, err error) {
+func (s EndpointSpec) Resolve(ted *LsTED) (headend, endpoint netip.Addr, err error) {
 	usesAddr := s.Headend.IsValid() || s.Endpoint.IsValid()
 	usesRouterID := s.UsesRouterID()
 
@@ -51,13 +49,13 @@ func (s EndpointSpec) Resolve(ted *LsTED, underlayFamily AddressFamily) (headend
 			return netip.Addr{}, netip.Addr{}, errors.New("both headendRouterID and endpointRouterID must be set")
 		}
 
-		return s.resolveViaTED(ted, underlayFamily)
+		return s.resolveViaTED(ted)
 	default:
 		return netip.Addr{}, netip.Addr{}, errors.New("either headend/endpoint or headendRouterID/endpointRouterID must be set")
 	}
 }
 
-func (s EndpointSpec) resolveViaTED(ted *LsTED, underlayFamily AddressFamily) (headend, endpoint netip.Addr, err error) {
+func (s EndpointSpec) resolveViaTED(ted *LsTED) (headend, endpoint netip.Addr, err error) {
 	if ted == nil {
 		return netip.Addr{}, netip.Addr{}, errors.New("ted is nil")
 	}
@@ -72,7 +70,7 @@ func (s EndpointSpec) resolveViaTED(ted *LsTED, underlayFamily AddressFamily) (h
 		return netip.Addr{}, netip.Addr{}, fmt.Errorf("no node with router ID %s", s.EndpointRouterID)
 	}
 
-	family, err := s.resolveFamily(headendNode, endpointNode, underlayFamily)
+	family, err := s.resolveFamily(headendNode, endpointNode)
 	if err != nil {
 		return netip.Addr{}, netip.Addr{}, err
 	}
@@ -90,17 +88,9 @@ func (s EndpointSpec) resolveViaTED(ted *LsTED, underlayFamily AddressFamily) (h
 	return headend, endpoint, nil
 }
 
-func (s EndpointSpec) resolveFamily(headendNode, endpointNode *LsNode, underlayFamily AddressFamily) (AddressFamily, error) {
+func (s EndpointSpec) resolveFamily(headendNode, endpointNode *LsNode) (AddressFamily, error) {
 	if s.Family.IsValid() {
 		return s.Family, nil
-	}
-
-	if underlayFamily.IsValid() {
-		if headendNode.HasLoopback(underlayFamily) && endpointNode.HasLoopback(underlayFamily) {
-			return underlayFamily, nil
-		}
-
-		return AFUnspecified, fmt.Errorf("underlay family %v has no loopback on headend %s and/or endpoint %s; specify endpointFamily", underlayFamily, s.HeadendRouterID, s.EndpointRouterID)
 	}
 
 	var candidates []AddressFamily

--- a/pkg/table/endpoint_test.go
+++ b/pkg/table/endpoint_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package table_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nttcom/pola/pkg/table"
+)
+
+func lsNodeWithLoopbacks(routerID string, addrs ...string) *table.LsNode {
+	n := &table.LsNode{RouterID: routerID}
+
+	for _, a := range addrs {
+		bits := 32
+		if netip.MustParseAddr(a).Is6() {
+			bits = 128
+		}
+
+		n.Prefixes = append(n.Prefixes, &table.LsPrefix{Prefix: netip.PrefixFrom(netip.MustParseAddr(a), bits)})
+	}
+
+	return n
+}
+
+func TestEndpointSpecResolve(t *testing.T) {
+	t.Parallel()
+
+	addrV4A := netip.MustParseAddr("10.0.0.1")
+	addrV4B := netip.MustParseAddr("10.0.0.2")
+
+	tests := []struct {
+		name           string
+		spec           table.EndpointSpec
+		ted            *table.LsTED
+		underlayFamily table.AddressFamily
+		wantHeadend    netip.Addr
+		wantEndpoint   netip.Addr
+		wantErr        bool
+	}{
+		{
+			name:         "address form passes through without touching the TED",
+			spec:         table.EndpointSpec{Headend: addrV4A, Endpoint: addrV4B},
+			ted:          nil,
+			wantHeadend:  addrV4A,
+			wantEndpoint: addrV4B,
+		},
+		{
+			name: "router ID form resolves via the underlay family (IPv4)",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1"),
+				lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2"),
+			),
+			underlayFamily: table.AFIPv4,
+			wantHeadend:    netip.MustParseAddr("10.0.0.1"),
+			wantEndpoint:   netip.MustParseAddr("10.0.0.2"),
+		},
+		{
+			name: "router ID form resolves via the underlay family (IPv6)",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, testSRv6SID1),
+				lsNodeWithLoopbacks(testRouterIDB, testSRv6SID2),
+			),
+			underlayFamily: table.AFIPv6,
+			wantHeadend:    netip.MustParseAddr(testSRv6SID1),
+			wantEndpoint:   netip.MustParseAddr(testSRv6SID2),
+		},
+		{
+			name: "explicit endpointFamily overrides the underlay family (cross-AF, not rejected)",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB, Family: table.AFIPv4},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1", testSRv6SID1),
+				lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2", testSRv6SID2),
+			),
+			underlayFamily: table.AFIPv6,
+			wantHeadend:    netip.MustParseAddr("10.0.0.1"),
+			wantEndpoint:   netip.MustParseAddr("10.0.0.2"),
+		},
+		{
+			name: "underlay family without a shared loopback is an error, not a silent fallback",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1"),
+				lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2"),
+			),
+			underlayFamily: table.AFIPv6,
+			wantErr:        true,
+		},
+		{
+			name: "dual-stack nodes with no underlay family and no explicit family is ambiguous",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1", testSRv6SID1),
+				lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2", testSRv6SID2),
+			),
+			wantErr: true,
+		},
+		{
+			name: "no shared address family is an error",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1"),
+				lsNodeWithLoopbacks(testRouterIDB, testSRv6SID2),
+			),
+			wantErr: true,
+		},
+		{
+			name:    "address form combined with endpointFamily is rejected",
+			spec:    table.EndpointSpec{Headend: addrV4A, Endpoint: addrV4B, Family: table.AFIPv4},
+			ted:     nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			headend, endpoint, err := tt.spec.Resolve(tt.ted, tt.underlayFamily)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHeadend, headend)
+			assert.Equal(t, tt.wantEndpoint, endpoint)
+		})
+	}
+}

--- a/pkg/table/endpoint_test.go
+++ b/pkg/table/endpoint_test.go
@@ -37,13 +37,12 @@ func TestEndpointSpecResolve(t *testing.T) {
 	addrV4B := netip.MustParseAddr("10.0.0.2")
 
 	tests := []struct {
-		name           string
-		spec           table.EndpointSpec
-		ted            *table.LsTED
-		underlayFamily table.AddressFamily
-		wantHeadend    netip.Addr
-		wantEndpoint   netip.Addr
-		wantErr        bool
+		name         string
+		spec         table.EndpointSpec
+		ted          *table.LsTED
+		wantHeadend  netip.Addr
+		wantEndpoint netip.Addr
+		wantErr      bool
 	}{
 		{
 			name:         "address form passes through without touching the TED",
@@ -53,50 +52,47 @@ func TestEndpointSpecResolve(t *testing.T) {
 			wantEndpoint: addrV4B,
 		},
 		{
-			name: "router ID form resolves via the underlay family (IPv4)",
+			name: "router ID form resolves via the unique common loopback family (IPv4)",
 			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
 			ted: newTestTED(
 				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1"),
 				lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2"),
 			),
-			underlayFamily: table.AFIPv4,
-			wantHeadend:    netip.MustParseAddr("10.0.0.1"),
-			wantEndpoint:   netip.MustParseAddr("10.0.0.2"),
+			wantHeadend:  netip.MustParseAddr("10.0.0.1"),
+			wantEndpoint: netip.MustParseAddr("10.0.0.2"),
 		},
 		{
-			name: "router ID form resolves via the underlay family (IPv6)",
+			name: "router ID form resolves via the unique common loopback family (IPv6)",
 			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
 			ted: newTestTED(
 				lsNodeWithLoopbacks(testRouterIDA, testSRv6SID1),
 				lsNodeWithLoopbacks(testRouterIDB, testSRv6SID2),
 			),
-			underlayFamily: table.AFIPv6,
-			wantHeadend:    netip.MustParseAddr(testSRv6SID1),
-			wantEndpoint:   netip.MustParseAddr(testSRv6SID2),
+			wantHeadend:  netip.MustParseAddr(testSRv6SID1),
+			wantEndpoint: netip.MustParseAddr(testSRv6SID2),
 		},
 		{
-			name: "explicit endpointFamily overrides the underlay family (cross-AF, not rejected)",
+			name: "explicit endpointFamily picks among multiple shared loopback families",
 			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB, Family: table.AFIPv4},
 			ted: newTestTED(
 				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1", testSRv6SID1),
 				lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2", testSRv6SID2),
 			),
-			underlayFamily: table.AFIPv6,
-			wantHeadend:    netip.MustParseAddr("10.0.0.1"),
-			wantEndpoint:   netip.MustParseAddr("10.0.0.2"),
+			wantHeadend:  netip.MustParseAddr("10.0.0.1"),
+			wantEndpoint: netip.MustParseAddr("10.0.0.2"),
 		},
 		{
-			name: "underlay family without a shared loopback is an error, not a silent fallback",
+			name: "endpoint family resolution is independent of the underlay plane",
 			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
 			ted: newTestTED(
 				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1"),
 				lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2"),
 			),
-			underlayFamily: table.AFIPv6,
-			wantErr:        true,
+			wantHeadend:  netip.MustParseAddr("10.0.0.1"),
+			wantEndpoint: netip.MustParseAddr("10.0.0.2"),
 		},
 		{
-			name: "dual-stack nodes with no underlay family and no explicit family is ambiguous",
+			name: "dual-stack nodes with no explicit family is ambiguous",
 			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
 			ted: newTestTED(
 				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1", testSRv6SID1),
@@ -119,13 +115,75 @@ func TestEndpointSpecResolve(t *testing.T) {
 			ted:     nil,
 			wantErr: true,
 		},
+		{
+			name:    "mixing address and router ID forms is rejected",
+			spec:    table.EndpointSpec{Headend: addrV4A, HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "address form with only headend set is rejected",
+			spec:    table.EndpointSpec{Headend: addrV4A},
+			ted:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "router ID form with only headendRouterID set is rejected",
+			spec:    table.EndpointSpec{HeadendRouterID: testRouterIDA},
+			ted:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "neither form set is rejected",
+			spec:    table.EndpointSpec{},
+			ted:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "router ID form with a nil TED is rejected",
+			spec:    table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "unknown headend router ID is rejected",
+			spec:    table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted:     newTestTED(lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2")),
+			wantErr: true,
+		},
+		{
+			name: "unknown endpoint router ID is rejected",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1"),
+			),
+			wantErr: true,
+		},
+		{
+			name: "explicit endpointFamily unavailable on the headend is rejected",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB, Family: table.AFIPv6},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, "10.0.0.1"),
+				lsNodeWithLoopbacks(testRouterIDB, testSRv6SID2),
+			),
+			wantErr: true,
+		},
+		{
+			name: "explicit endpointFamily unavailable on the endpoint is rejected",
+			spec: table.EndpointSpec{HeadendRouterID: testRouterIDA, EndpointRouterID: testRouterIDB, Family: table.AFIPv6},
+			ted: newTestTED(
+				lsNodeWithLoopbacks(testRouterIDA, testSRv6SID1),
+				lsNodeWithLoopbacks(testRouterIDB, "10.0.0.2"),
+			),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			headend, endpoint, err := tt.spec.Resolve(tt.ted, tt.underlayFamily)
+			headend, endpoint, err := tt.spec.Resolve(tt.ted)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/table/plane.go
+++ b/pkg/table/plane.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package table
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+)
+
+// AddressFamily identifies an IP address family.
+// AFUnspecified is never valid where a concrete family is required.
+type AddressFamily uint8
+
+const (
+	// AFUnspecified means no address family was specified.
+	AFUnspecified AddressFamily = iota
+	// AFIPv4 means IPv4.
+	AFIPv4
+	// AFIPv6 means IPv6.
+	AFIPv6
+)
+
+// IsValid reports whether af is a concrete address family.
+func (af AddressFamily) IsValid() bool {
+	switch af {
+	case AFIPv4, AFIPv6:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the lowercase name of af.
+func (af AddressFamily) String() string {
+	switch af {
+	case AFIPv4:
+		return "ipv4"
+	case AFIPv6:
+		return "ipv6"
+	default:
+		return "unspecified"
+	}
+}
+
+// AddressFamilySet is a bitset of AddressFamily values.
+// Bit 0 is IPv4; bit 1 is IPv6.
+type AddressFamilySet uint8
+
+const (
+	// AddressFamilySetIPv4 is the IPv4 bit.
+	AddressFamilySetIPv4 AddressFamilySet = 1 << iota
+	// AddressFamilySetIPv6 is the IPv6 bit.
+	AddressFamilySetIPv6
+)
+
+// Has reports whether af is a member of s.
+func (s AddressFamilySet) Has(af AddressFamily) bool {
+	switch af {
+	case AFIPv4:
+		return s&AddressFamilySetIPv4 != 0
+	case AFIPv6:
+		return s&AddressFamilySetIPv6 != 0
+	default:
+		return false
+	}
+}
+
+// DataPlane identifies a forwarding plane.
+// DPUnspecified must be resolved explicitly where a concrete plane is required.
+type DataPlane uint8
+
+const (
+	// DPUnspecified means no data plane was specified.
+	DPUnspecified DataPlane = iota
+	// DPSRMPLS means SR-MPLS.
+	DPSRMPLS
+	// DPSRv6 means SRv6.
+	DPSRv6
+)
+
+// String returns the lowercase name of dp.
+func (dp DataPlane) String() string {
+	switch dp {
+	case DPSRMPLS:
+		return "sr-mpls"
+	case DPSRv6:
+		return "srv6"
+	default:
+		return "unspecified"
+	}
+}
+
+// Plane pairs an address family with a data plane.
+// It is the unit of scope used by the TED, CSPF, and SR abstractions.
+type Plane struct {
+	Family    AddressFamily
+	DataPlane DataPlane
+}
+
+// Validate reports an error for an unspecified or unsupported plane combination.
+// SRv6 requires IPv6.
+func (p Plane) Validate() error {
+	if !p.Family.IsValid() {
+		return errors.New("address family must be specified")
+	}
+
+	switch p.DataPlane {
+	case DPSRMPLS:
+		return nil
+	case DPSRv6:
+		if p.Family != AFIPv6 {
+			return fmt.Errorf("SRv6 requires IPv6, got %s", p.Family)
+		}
+
+		return nil
+	default:
+		return errors.New("data plane must be specified")
+	}
+}
+
+// FamilyOfAddr returns the address family of addr.
+// IPv4-mapped IPv6 addresses are normalized to AFIPv4.
+func FamilyOfAddr(addr netip.Addr) AddressFamily {
+	if !addr.IsValid() {
+		return AFUnspecified
+	}
+
+	addr = addr.Unmap()
+
+	switch {
+	case addr.Is4():
+		return AFIPv4
+	case addr.Is6():
+		return AFIPv6
+	default:
+		return AFUnspecified
+	}
+}

--- a/pkg/table/plane_internal_test.go
+++ b/pkg/table/plane_internal_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 NTT Communications Corporation
+//
+// This software is released under the MIT License.
+// see https://github.com/nttcom/pola/blob/main/LICENSE
+
+package table
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddressFamily_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		af   AddressFamily
+		want string
+	}{
+		{"IPv4", AFIPv4, "ipv4"},
+		{"IPv6", AFIPv6, "ipv6"},
+		{"unspecified", AFUnspecified, "unspecified"},
+		{"unknown value", AddressFamily(99), "unspecified"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.af.String())
+		})
+	}
+}
+
+func TestAddressFamilySet_Has(t *testing.T) {
+	t.Parallel()
+
+	s := AddressFamilySetIPv4 | AddressFamilySetIPv6
+
+	tests := []struct {
+		name string
+		s    AddressFamilySet
+		af   AddressFamily
+		want bool
+	}{
+		{"set with IPv4 bit has IPv4", s, AFIPv4, true},
+		{"set with IPv6 bit has IPv6", s, AFIPv6, true},
+		{"empty set does not have IPv4", AddressFamilySet(0), AFIPv4, false},
+		{"empty set does not have IPv6", AddressFamilySet(0), AFIPv6, false},
+		{"unspecified family is never a member", s, AFUnspecified, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.s.Has(tt.af))
+		})
+	}
+}
+
+func TestDataPlane_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		dp   DataPlane
+		want string
+	}{
+		{"SR-MPLS", DPSRMPLS, "sr-mpls"},
+		{"SRv6", DPSRv6, "srv6"},
+		{"unspecified", DPUnspecified, "unspecified"},
+		{"unknown value", DataPlane(99), "unspecified"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.dp.String())
+		})
+	}
+}
+
+func TestPlane_Validate(t *testing.T) {
+	t.Parallel()
+
+	families := []AddressFamily{AFUnspecified, AFIPv4, AFIPv6}
+	dataPlanes := []DataPlane{DPUnspecified, DPSRMPLS, DPSRv6}
+
+	for _, af := range families {
+		for _, dp := range dataPlanes {
+			p := Plane{Family: af, DataPlane: dp}
+			wantErr := af == AFUnspecified || dp == DPUnspecified || (af == AFIPv4 && dp == DPSRv6)
+
+			err := p.Validate()
+			if wantErr {
+				assert.Errorf(t, err, "Plane{%v, %v} should be invalid", af, dp)
+			} else {
+				assert.NoErrorf(t, err, "Plane{%v, %v} should be valid", af, dp)
+			}
+		}
+	}
+}
+
+func TestFamilyOfAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr string
+		want AddressFamily
+	}{
+		{"plain IPv4", "192.0.2.1", AFIPv4},
+		{"IPv4-mapped IPv6", "::ffff:192.0.2.1", AFIPv4},
+		{"ordinary IPv6", "2001:db8::1", AFIPv6},
+		{"link-local IPv6", "fe80::1", AFIPv6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, FamilyOfAddr(netip.MustParseAddr(tt.addr)))
+		})
+	}
+
+	t.Run("invalid address is unspecified", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, AFUnspecified, FamilyOfAddr(netip.Addr{}))
+	})
+}

--- a/pkg/table/sid_validate.go
+++ b/pkg/table/sid_validate.go
@@ -148,33 +148,37 @@ func (idx *SIDIndex) addLinkSIDs(node *LsNode) {
 	}
 }
 
-// addAdjSID registers a link's SR-MPLS adjacency SID and its next hop.
+// addAdjSID registers a link's SR-MPLS adjacency SIDs and their next hop.
 func (idx *SIDIndex) addAdjSID(node *LsNode, l *LsLink) {
-	if l.AdjSid == 0 {
-		return
-	}
+	for _, adjSID := range l.AdjSids {
+		if adjSID.Sid == 0 {
+			continue
+		}
 
-	idx.mplsSIDs[l.AdjSid] = struct{}{}
-	if l.RemoteNode != nil {
-		idx.mplsAdjSIDNextHop[adjKeyMPLS{node.RouterID, l.AdjSid}] = l.RemoteNode.RouterID
+		idx.mplsSIDs[adjSID.Sid] = struct{}{}
+		if l.Remote.Node != nil {
+			idx.mplsAdjSIDNextHop[adjKeyMPLS{node.RouterID, adjSID.Sid}] = l.Remote.Node.RouterID
+		}
 	}
 }
 
 // addEndXSID registers a link's SRv6 End.X SIDs and their next hop.
 func (idx *SIDIndex) addEndXSID(node *LsNode, l *LsLink) {
-	if l.Srv6EndXSID == nil {
-		return
-	}
+	for _, endXSID := range l.Srv6EndXSIDs {
+		if endXSID == nil {
+			continue
+		}
 
-	addrs := parseSRv6Addrs(l.Srv6EndXSID.Sids)
-	idx.addSRv6(node.RouterID, addrs, l.Srv6EndXSID.Srv6SIDStructure)
+		addrs := parseSRv6Addrs(endXSID.Sids)
+		idx.addSRv6(node.RouterID, addrs, endXSID.Srv6SIDStructure)
 
-	if l.RemoteNode == nil {
-		return
-	}
+		if l.Remote.Node == nil {
+			continue
+		}
 
-	for _, addr := range addrs {
-		idx.srv6AdjSIDNextHop[adjKeySRv6{node.RouterID, addr}] = l.RemoteNode.RouterID
+		for _, addr := range addrs {
+			idx.srv6AdjSIDNextHop[adjKeySRv6{node.RouterID, addr}] = l.Remote.Node.RouterID
+		}
 	}
 }
 
@@ -197,7 +201,7 @@ func parseSRv6Addrs(sids []string) []netip.Addr {
 	addrs := make([]netip.Addr, 0, len(sids))
 
 	for _, sid := range sids {
-		if addr, err := netip.ParseAddr(sid); err == nil && addr.Is6() {
+		if addr, err := netip.ParseAddr(sid); err == nil && addr.Is6() && !addr.Is4In6() {
 			addrs = append(addrs, addr)
 		}
 	}
@@ -273,7 +277,7 @@ func (idx *SIDIndex) Has(seg Segment) bool {
 }
 
 func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
-	if _, ok := idx.srv6SIDs[s.Sid]; ok {
+	if _, ok := idx.srv6SIDs[s.Sid.Addr()]; ok {
 		return true
 	}
 
@@ -286,7 +290,7 @@ func (idx *SIDIndex) hasSRv6(s SegmentSRv6) bool {
 		declaredLocBits = int(s.Structure.LocalBlock) + int(s.Structure.LocalNode)
 	}
 
-	_, found := idx.lookupSRv6Locator(s.Sid, declaredLocBits)
+	_, found := idx.lookupSRv6Locator(s.Sid.Addr(), declaredLocBits)
 
 	return found
 }
@@ -367,7 +371,7 @@ func (idx *SIDIndex) nextHopMPLS(owner string, s SegmentSRMPLS) (string, error) 
 }
 
 func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
-	if next, ok := idx.srv6NodeSIDOwner[s.Sid]; ok {
+	if next, ok := idx.srv6NodeSIDOwner[s.Sid.Addr()]; ok {
 		return next, nil
 	}
 
@@ -379,7 +383,7 @@ func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
 		return "", fmt.Errorf("SID %s not found in TED", s.SidString())
 	}
 
-	if next, ok := idx.srv6AdjSIDNextHop[adjKeySRv6{owner, s.Sid}]; ok {
+	if next, ok := idx.srv6AdjSIDNextHop[adjKeySRv6{owner, s.Sid.Addr()}]; ok {
 		return next, nil
 	}
 
@@ -390,7 +394,7 @@ func (idx *SIDIndex) nextHopSRv6(owner string, s SegmentSRv6) (string, error) {
 		}
 	}
 
-	if _, ok := idx.srv6SIDs[s.Sid]; ok {
+	if _, ok := idx.srv6SIDs[s.Sid.Addr()]; ok {
 		return "", fmt.Errorf("%s does not have adjacency SID %s", owner, s.SidString())
 	}
 
@@ -466,7 +470,7 @@ func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bo
 		declaredLocBits = int(s.Structure.LocalBlock) + int(s.Structure.LocalNode)
 	}
 
-	locInfo, found := idx.lookupSRv6Locator(s.Sid, declaredLocBits)
+	locInfo, found := idx.lookupSRv6Locator(s.Sid.Addr(), declaredLocBits)
 	if !found {
 		return ownerUnknown, false
 	}
@@ -490,7 +494,7 @@ func (idx *SIDIndex) usidContainerOwner(s SegmentSRv6) (owner string, matched bo
 		return locInfo.owner, true
 	}
 
-	segments := uSIDMicroSegmentPrefixes(s.Sid, structure)
+	segments := uSIDMicroSegmentPrefixes(s.Sid.Addr(), structure)
 	if len(segments) == 0 {
 		return ownerUnknown, true
 	}

--- a/pkg/table/sid_validate_internal_test.go
+++ b/pkg/table/sid_validate_internal_test.go
@@ -30,7 +30,10 @@ func TestSIDIndexNextHop_OwnerUnknownBranches(t *testing.T) {
 	node := &LsNode{
 		RouterID: sidValidateInternalTestRouterID1,
 		Links: []*LsLink{
-			{AdjSid: 24001, Srv6EndXSID: &Srv6EndXSID{Sids: []string{"2001:db8::a"}}},
+			{
+				AdjSids:      []AdjSID{{Sid: 24001}},
+				Srv6EndXSIDs: []*Srv6EndXSID{{Sids: []string{"2001:db8::a"}}},
+			},
 		},
 		SRv6SIDs: []*LsSrv6SID{
 			{Sids: []string{"2001:db8::1"}},
@@ -57,7 +60,7 @@ func TestSIDIndexNextHop_OwnerUnknownBranches(t *testing.T) {
 	t.Run("owner unknown with known SRv6 adjacency SID", func(t *testing.T) {
 		t.Parallel()
 
-		next, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(netip.MustParseAddr("2001:db8::a")))
+		next, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(SRv6SID(netip.MustParseAddr("2001:db8::a"))))
 		require.NoError(t, err)
 		assert.Equal(t, ownerUnknown, next)
 	})
@@ -65,10 +68,29 @@ func TestSIDIndexNextHop_OwnerUnknownBranches(t *testing.T) {
 	t.Run("owner unknown with unknown SRv6 SID", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(netip.MustParseAddr("2001:db8::99")))
+		_, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(SRv6SID(netip.MustParseAddr("2001:db8::99"))))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in TED")
 	})
+}
+
+func TestAddLinkSIDs_SkipsZeroAdjSIDAndNilEndXSID(t *testing.T) {
+	t.Parallel()
+
+	node := &LsNode{
+		RouterID: sidValidateInternalTestRouterID1,
+		Links: []*LsLink{
+			{
+				AdjSids:      []AdjSID{{Sid: 0}, {Sid: 24001}},
+				Srv6EndXSIDs: []*Srv6EndXSID{nil, {Sids: []string{"2001:db8::a"}}},
+			},
+		},
+	}
+	idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
+
+	assert.False(t, idx.Has(NewSegmentSRMPLS(0)), "a zero Adj-SID must not be registered")
+	assert.True(t, idx.Has(NewSegmentSRMPLS(24001)))
+	assert.True(t, idx.Has(NewSegmentSRv6(SRv6SID(netip.MustParseAddr("2001:db8::a")))))
 }
 
 func TestSIDIndexNextHop_ConflictingExactOwnerIsDeterministic(t *testing.T) {
@@ -83,7 +105,7 @@ func TestSIDIndexNextHop_ConflictingExactOwnerIsDeterministic(t *testing.T) {
 		for range 20 {
 			idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
 
-			next, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(netip.MustParseAddr("2001:db8::1")))
+			next, err := idx.NextHop(ownerUnknown, NewSegmentSRv6(SRv6SID(netip.MustParseAddr("2001:db8::1"))))
 			require.NoError(t, err)
 			assert.Equal(t, ownerUnknown, next, "conflicting owners must never resolve to whichever node was visited last")
 		}
@@ -360,7 +382,7 @@ func TestAddSRv6_StructurePresence(t *testing.T) {
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
 
 		assert.Empty(t, idx.srv6Locators, "no structure was advertised, so no locator can be derived")
-		assert.True(t, idx.Has(NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))))
+		assert.True(t, idx.Has(NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fc00:1::1")))))
 	})
 
 	t.Run("LocalNode zero with LocalBlock set registers a locator, not skipped as if absent", func(t *testing.T) {
@@ -384,7 +406,7 @@ func TestAddSRv6_StructurePresence(t *testing.T) {
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
 
-		assert.True(t, idx.Has(NewSegmentSRv6(netip.MustParseAddr("fc00::1"))), "expected the exact SID to still be registered")
+		assert.True(t, idx.Has(NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fc00::1")))), "expected the exact SID to still be registered")
 		assert.Empty(t, idx.srv6Locators, "a zero-width locator carries no usable per-node prefix, present or not")
 	})
 
@@ -396,8 +418,8 @@ func TestAddSRv6_StructurePresence(t *testing.T) {
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeAbsent, nodePresentZero))
 
 		assert.Empty(t, idx.srv6Locators)
-		assert.True(t, idx.Has(NewSegmentSRv6(netip.MustParseAddr("fc00::1"))))
-		assert.True(t, idx.Has(NewSegmentSRv6(netip.MustParseAddr("fc00::2"))))
+		assert.True(t, idx.Has(NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fc00::1")))))
+		assert.True(t, idx.Has(NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fc00::2")))))
 	})
 }
 
@@ -418,7 +440,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY, nodeZ))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
@@ -438,7 +460,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100:0200::")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
@@ -456,7 +478,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100::")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
@@ -476,7 +498,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeZ))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100:0200:0300::")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
@@ -493,7 +515,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fd00:bb00:0100:0200:0300::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fd00:bb00:0100:0200:0300::")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
@@ -510,7 +532,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
 
 		// The first micro-segment is all zero, marking the container end (RFC 9800 §5).
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0000::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0000::")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
@@ -530,7 +552,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100::")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
@@ -548,7 +570,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100::")))
 		seg.USid = true
 
 		owner, matched := idx.usidContainerOwner(seg)
@@ -565,7 +587,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(node))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100::")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 0, LocalArg: 0}
 
@@ -585,7 +607,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeA, nodeB))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100:0200::")))
 		seg.USid = true
 
 		owner, matched := idx.usidContainerOwner(seg)
@@ -604,7 +626,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeBroad, nodeSpecific))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("1234:5678::"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("1234:5678::")))
 		seg.USid = true
 
 		owner, matched := idx.usidContainerOwner(seg)
@@ -620,7 +642,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fc00:1::1")))
 		seg.USid = true
 
 		owner, matched := idx.usidContainerOwner(seg)
@@ -639,7 +661,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX, nodeY))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fc00:1::1")))
 		seg.USid = true
 
 		owner, matched := idx.usidContainerOwner(seg)
@@ -655,7 +677,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		}}}
 		idx := NewSIDIndex(newSIDValidateInternalTestTED(nodeX))
 
-		seg := NewSegmentSRv6(netip.MustParseAddr("fc00:1::1"))
+		seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fc00:1::1")))
 		seg.USid = true
 		seg.Structure = &SIDStructure{LocalBlock: 32, LocalNode: 0, LocalFunc: 16, LocalArg: 0}
 
@@ -681,7 +703,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Run("address outside the nested locator falls back to the flat umbrella owner", func(t *testing.T) {
 			t.Parallel()
 
-			seg := NewSegmentSRv6(netip.MustParseAddr("fcbb::1"))
+			seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb::1")))
 			seg.USid = true
 
 			owner, matched := idx.usidContainerOwner(seg)
@@ -692,7 +714,7 @@ func TestUSIDContainerOwner(t *testing.T) {
 		t.Run("address within the nested locator still decomposes through the uSID chain", func(t *testing.T) {
 			t.Parallel()
 
-			seg := NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:0100:0200::"))
+			seg := NewSegmentSRv6(SRv6SID(netip.MustParseAddr("fcbb:bb00:0100:0200::")))
 			seg.USid = true
 
 			owner, matched := idx.usidContainerOwner(seg)

--- a/pkg/table/sid_validate_test.go
+++ b/pkg/table/sid_validate_test.go
@@ -46,7 +46,7 @@ func TestSIDIndexHas_SRMPLS(t *testing.T) {
 			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 3, HasSidIndex: true},
 		},
 		Links: []*table.LsLink{
-			{AdjSid: 24001},
+			{AdjSids: []table.AdjSID{{Sid: 24001}}},
 		},
 	}
 	ted := newTestTED(node)
@@ -221,10 +221,10 @@ func TestSIDIndexHas_SRv6Exact(t *testing.T) {
 		},
 		Links: []*table.LsLink{
 			{
-				Srv6EndXSID: &table.Srv6EndXSID{
+				Srv6EndXSIDs: []*table.Srv6EndXSID{{
 					Sids:             []string{"2001:db8:1::1"},
 					Srv6SIDStructure: &table.SIDStructure{},
-				},
+				}},
 			},
 		},
 	}
@@ -235,9 +235,9 @@ func TestSIDIndexHas_SRv6Exact(t *testing.T) {
 		seg  table.Segment
 		want bool
 	}{
-		{"End SID exact match", table.NewSegmentSRv6(netip.MustParseAddr(testSRv6ExactSID)), true},
-		{"End.X SID exact match", table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::1")), true},
-		{"unknown SID", table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::99")), false},
+		{"End SID exact match", table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6ExactSID))), true},
+		{"End.X SID exact match", table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8:1::1"))), true},
+		{"unknown SID", table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8:1::99"))), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -269,7 +269,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 	t.Run("structure present, container within locator", func(t *testing.T) {
 		t.Parallel()
 
-		seg := table.NewSegmentSRv6(container)
+		seg := table.NewSegmentSRv6(table.SRv6SID(container))
 		seg.USid = true
 		seg.Structure = &table.SIDStructure{LocalBlock: 32, LocalNode: 16}
 		assert.True(t, table.NewSIDIndex(ted).Has(seg), "expected uSID container to be accepted via locator containment")
@@ -278,7 +278,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 	t.Run("no structure, falls back to containment", func(t *testing.T) {
 		t.Parallel()
 
-		seg := table.NewSegmentSRv6(container)
+		seg := table.NewSegmentSRv6(table.SRv6SID(container))
 		seg.USid = true
 		assert.True(t, table.NewSIDIndex(ted).Has(seg), "expected uSID container without structure to be accepted via containment fallback")
 	})
@@ -286,7 +286,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 	t.Run("declared locator shorter than TED advertised", func(t *testing.T) {
 		t.Parallel()
 
-		seg := table.NewSegmentSRv6(container)
+		seg := table.NewSegmentSRv6(table.SRv6SID(container))
 		seg.USid = true
 		// Declares a /32 locator (block=24,node=8), which contradicts the /48
 		// the TED actually advertises.
@@ -297,7 +297,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 	t.Run("declared zero-width locator does not match an unrelated enclosing TED locator", func(t *testing.T) {
 		t.Parallel()
 
-		seg := table.NewSegmentSRv6(container)
+		seg := table.NewSegmentSRv6(table.SRv6SID(container))
 		seg.USid = true
 		seg.Structure = &table.SIDStructure{LocalFunc: 48}
 		assert.False(t, table.NewSIDIndex(ted).Has(seg), "expected declared zero-width locator not to match an unrelated enclosing TED locator")
@@ -306,7 +306,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 	t.Run("outside any known locator", func(t *testing.T) {
 		t.Parallel()
 
-		seg := table.NewSegmentSRv6(netip.MustParseAddr("fcbb:bb00:ffff::"))
+		seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fcbb:bb00:ffff::")))
 		seg.USid = true
 		assert.False(t, table.NewSIDIndex(ted).Has(seg), "expected mismatch for a SID outside any known locator")
 	})
@@ -314,7 +314,7 @@ func TestSIDIndexHas_USID(t *testing.T) {
 	t.Run("non-uSID segment does not fall back to locator containment", func(t *testing.T) {
 		t.Parallel()
 
-		seg := table.NewSegmentSRv6(container)
+		seg := table.NewSegmentSRv6(table.SRv6SID(container))
 		assert.False(t, table.NewSIDIndex(ted).Has(seg), "expected non-uSID segment to require an exact SID match")
 	})
 }
@@ -339,7 +339,7 @@ func TestSIDIndexAddLinkSIDs_SkipsNilLink(t *testing.T) {
 
 	node := &table.LsNode{
 		RouterID: testRouterID1,
-		Links:    []*table.LsLink{nil, {AdjSid: 24001}},
+		Links:    []*table.LsLink{nil, {AdjSids: []table.AdjSID{{Sid: 24001}}}},
 	}
 	idx := table.NewSIDIndex(newTestTED(node))
 	assert.True(t, idx.Has(table.NewSegmentSRMPLS(24001)), "expected the adj SID after the nil link to still be registered")
@@ -363,7 +363,7 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{"10.0.0.1"}}},
 		}
 		idx := table.NewSIDIndex(newTestTED(node))
-		assert.False(t, idx.Has(table.NewSegmentSRv6(netip.MustParseAddr("10.0.0.1"))), "expected an IPv4 address advertised as an SRv6 SID to be ignored")
+		assert.False(t, idx.Has(table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("10.0.0.1")))), "expected an IPv4 address advertised as an SRv6 SID to be ignored")
 	})
 
 	t.Run("unparsable SID is not registered", func(t *testing.T) {
@@ -374,7 +374,7 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{testInvalidAddr}}},
 		}
 		idx := table.NewSIDIndex(newTestTED(node))
-		assert.False(t, idx.Has(table.NewSegmentSRv6(netip.MustParseAddr(testSRv6SID1))))
+		assert.False(t, idx.Has(table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1)))))
 	})
 
 	t.Run("zero locator length still registers the exact SID but skips the locator", func(t *testing.T) {
@@ -386,9 +386,9 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{sid.String()}, SIDStructure: &table.SIDStructure{}}},
 		}
 		idx := table.NewSIDIndex(newTestTED(node))
-		assert.True(t, idx.Has(table.NewSegmentSRv6(sid)), "expected exact match regardless of locator length")
+		assert.True(t, idx.Has(table.NewSegmentSRv6(table.SRv6SID(sid))), "expected exact match regardless of locator length")
 
-		other := table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::1234"))
+		other := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00:0:1::1234")))
 		other.USid = true
 		assert.False(t, idx.Has(other), "expected no locator fallback registered when LocalBlock+LocalNode is 0")
 	})
@@ -402,9 +402,9 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{sid.String()}, SIDStructure: &table.SIDStructure{LocalBlock: 200, LocalNode: 200}}},
 		}
 		idx := table.NewSIDIndex(newTestTED(node))
-		assert.True(t, idx.Has(table.NewSegmentSRv6(sid)), "expected exact match regardless of locator length")
+		assert.True(t, idx.Has(table.NewSegmentSRv6(table.SRv6SID(sid))), "expected exact match regardless of locator length")
 
-		other := table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::1234"))
+		other := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00:0:1::1234")))
 		other.USid = true
 		assert.False(t, idx.Has(other), "expected no locator fallback registered when LocalBlock+LocalNode exceeds 128 bits")
 	})
@@ -426,9 +426,9 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 			}},
 		}
 		idx := table.NewSIDIndex(newTestTED(node))
-		assert.True(t, idx.Has(table.NewSegmentSRv6(sid)), "expected exact match regardless of total width")
+		assert.True(t, idx.Has(table.NewSegmentSRv6(table.SRv6SID(sid))), "expected exact match regardless of total width")
 
-		other := table.NewSegmentSRv6(netip.MustParseAddr("fc00:0:1::1234"))
+		other := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00:0:1::1234")))
 		other.USid = true
 		assert.False(t, idx.Has(other), "expected no locator fallback registered when LocalBlock+LocalNode+LocalFunc+LocalArg exceeds 128 bits")
 	})
@@ -442,7 +442,7 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 		}
 		idx := table.NewSIDIndex(newTestTED(node))
 
-		seg := table.NewSegmentSRv6(netip.MustParseAddr("10.0.0.1"))
+		seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("10.0.0.1")))
 		assert.False(t, idx.Has(seg))
 		_, err := idx.NextHop(testRouterID1, seg)
 		assert.Error(t, err, "expected NextHop to agree with Has() for a non-IPv6 advertised SID")
@@ -454,13 +454,13 @@ func TestSIDIndexAddSRv6_EdgeCases(t *testing.T) {
 		nodeA := &table.LsNode{RouterID: testRouterIDA}
 		nodeB := &table.LsNode{RouterID: testRouterIDB}
 		nodeA.Links = []*table.LsLink{{
-			LocalNode:   nodeA,
-			RemoteNode:  nodeB,
-			Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"10.0.0.1"}},
+			Local:        table.LinkEndpoint{Node: nodeA},
+			Remote:       table.LinkEndpoint{Node: nodeB},
+			Srv6EndXSIDs: []*table.Srv6EndXSID{{Sids: []string{"10.0.0.1"}}},
 		}}
 		idx := table.NewSIDIndex(newTestTED(nodeA, nodeB))
 
-		seg := table.NewSegmentSRv6(netip.MustParseAddr("10.0.0.1"))
+		seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("10.0.0.1")))
 		assert.False(t, idx.Has(seg))
 		_, err := idx.NextHop(testRouterIDA, seg)
 		assert.Error(t, err, "expected NextHop to agree with Has() for a non-IPv6 advertised End.X SID")
@@ -483,7 +483,7 @@ func TestSIDIndexHas_EmptyTED(t *testing.T) {
 
 			idx := table.NewSIDIndex(tt.ted)
 			assert.False(t, idx.Has(table.NewSegmentSRMPLS(16003)), "expected no match against an empty TED")
-			assert.False(t, idx.Has(table.NewSegmentSRv6(netip.MustParseAddr(testSRv6ExactSID))), "expected no match against an empty TED")
+			assert.False(t, idx.Has(table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6ExactSID)))), "expected no match against an empty TED")
 		})
 	}
 }
@@ -503,7 +503,7 @@ func TestMissingSegments(t *testing.T) {
 	segmentList := []table.Segment{
 		table.NewSegmentSRMPLS(16003),
 		table.NewSegmentSRMPLS(16099),
-		table.NewSegmentSRv6(netip.MustParseAddr("2001:db8:1::99")),
+		table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("2001:db8:1::99"))),
 	}
 
 	want := []table.MissingSegment{
@@ -515,8 +515,8 @@ func TestMissingSegments(t *testing.T) {
 
 type fakeUnknownSegment struct{}
 
-func (fakeUnknownSegment) SidString() string              { return "unknown" }
-func (fakeUnknownSegment) GetFamily() table.SegmentFamily { return table.SegmentUnknown }
+func (fakeUnknownSegment) SidString() string       { return "unknown" }
+func (fakeUnknownSegment) Family() table.DataPlane { return table.DPUnspecified }
 
 func TestHasUnknownSegmentType(t *testing.T) {
 	t.Parallel()
@@ -533,7 +533,7 @@ func TestHasUnknownSegmentType(t *testing.T) {
 		},
 		{
 			name: "all known, SRv6",
-			segs: []table.Segment{table.NewSegmentSRv6(netip.MustParseAddr(testSRv6SID1))},
+			segs: []table.Segment{table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1)))},
 			want: false,
 		},
 		{
@@ -591,7 +591,7 @@ func TestOutOfRangeSRMPLSLabels(t *testing.T) {
 		},
 		{
 			name: "SRv6 and nil segments are ignored",
-			segs: []table.Segment{nil, table.NewSegmentSRv6(netip.MustParseAddr(testSRv6SID1))},
+			segs: []table.Segment{nil, table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1)))},
 		},
 		{
 			name: "empty list",
@@ -617,8 +617,8 @@ func TestHasMixedSegmentTypes(t *testing.T) {
 		{
 			name: "all SRv6",
 			segs: []table.Segment{
-				table.NewSegmentSRv6(netip.MustParseAddr(testSRv6SID1)),
-				table.NewSegmentSRv6(netip.MustParseAddr(testSRv6SID2)),
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1))),
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID2))),
 			},
 			want: false,
 		},
@@ -630,7 +630,7 @@ func TestHasMixedSegmentTypes(t *testing.T) {
 		{
 			name: "mixed SRv6 then SR-MPLS",
 			segs: []table.Segment{
-				table.NewSegmentSRv6(netip.MustParseAddr(testSRv6SID1)),
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1))),
 				table.NewSegmentSRMPLS(16001),
 			},
 			want: true,
@@ -639,14 +639,14 @@ func TestHasMixedSegmentTypes(t *testing.T) {
 			name: "mixed SR-MPLS then SRv6",
 			segs: []table.Segment{
 				table.NewSegmentSRMPLS(16001),
-				table.NewSegmentSRv6(netip.MustParseAddr(testSRv6SID1)),
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1))),
 			},
 			want: true,
 		},
 		{
 			name: "SRv6 with unknown family",
 			segs: []table.Segment{
-				table.NewSegmentSRv6(netip.MustParseAddr(testSRv6SID1)),
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6SID1))),
 				fakeUnknownSegment{},
 			},
 			want: false,
@@ -700,8 +700,14 @@ func TestValidateExplicitPath(t *testing.T) {
 		SrgbBegin: 16000,
 		Prefixes:  []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.12/32"), SidIndex: 3, HasSidIndex: true}},
 	}
-	nodeA.Links = []*table.LsLink{{LocalNode: nodeA, RemoteNode: nodeB, AdjSid: 24001}}
-	nodeB.Links = []*table.LsLink{{LocalNode: nodeB, RemoteNode: nodeC, AdjSid: 24002}}
+	nodeA.Links = []*table.LsLink{{
+		Local: table.LinkEndpoint{Node: nodeA}, Remote: table.LinkEndpoint{Node: nodeB},
+		AdjSids: []table.AdjSID{{Sid: 24001}},
+	}}
+	nodeB.Links = []*table.LsLink{{
+		Local: table.LinkEndpoint{Node: nodeB}, Remote: table.LinkEndpoint{Node: nodeC},
+		AdjSids: []table.AdjSID{{Sid: 24002}},
+	}}
 
 	ted := newTestTED(nodeA, nodeB, nodeC)
 
@@ -789,8 +795,8 @@ func TestValidateExplicitPathSRv6(t *testing.T) {
 		RouterID: testRouterIDC,
 		SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{"fc00::c:1"}}},
 	}
-	nodeA.Links = []*table.LsLink{{LocalNode: nodeA, RemoteNode: nodeB, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"fc00::a:b"}}}}
-	nodeB.Links = []*table.LsLink{{LocalNode: nodeB, RemoteNode: nodeC, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"fc00::b:c"}}}}
+	nodeA.Links = []*table.LsLink{{Local: table.LinkEndpoint{Node: nodeA}, Remote: table.LinkEndpoint{Node: nodeB}, Srv6EndXSIDs: []*table.Srv6EndXSID{{Sids: []string{"fc00::a:b"}}}}}
+	nodeB.Links = []*table.LsLink{{Local: table.LinkEndpoint{Node: nodeB}, Remote: table.LinkEndpoint{Node: nodeC}, Srv6EndXSIDs: []*table.Srv6EndXSID{{Sids: []string{"fc00::b:c"}}}}}
 
 	ted := newTestTED(nodeA, nodeB, nodeC)
 
@@ -804,8 +810,8 @@ func TestValidateExplicitPathSRv6(t *testing.T) {
 			name: "valid: A to B via End SID, B to C via End.X on B",
 			src:  testRouterIDA,
 			segs: []table.Segment{
-				table.NewSegmentSRv6(netip.MustParseAddr("fc00::b:1")), // End SID of B
-				table.NewSegmentSRv6(netip.MustParseAddr("fc00::b:c")), // End.X on B -> C
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00::b:1"))), // End SID of B
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00::b:c"))), // End.X on B -> C
 			},
 			wantErr: "",
 		},
@@ -813,7 +819,7 @@ func TestValidateExplicitPathSRv6(t *testing.T) {
 			name: "End.X on wrong owner: B End.X used while owner is A",
 			src:  testRouterIDA,
 			segs: []table.Segment{
-				table.NewSegmentSRv6(netip.MustParseAddr("fc00::b:c")), // belongs to B, not A
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00::b:c"))), // belongs to B, not A
 			},
 			wantErr: "does not have adjacency SID",
 		},
@@ -821,7 +827,7 @@ func TestValidateExplicitPathSRv6(t *testing.T) {
 			name: "SRv6 SID not in TED",
 			src:  testRouterIDA,
 			segs: []table.Segment{
-				table.NewSegmentSRv6(netip.MustParseAddr("fd00::dead:beef")),
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fd00::dead:beef"))),
 			},
 			wantErr: "not found in TED",
 		},
@@ -829,7 +835,7 @@ func TestValidateExplicitPathSRv6(t *testing.T) {
 			name: "single End SID valid",
 			src:  testRouterIDA,
 			segs: []table.Segment{
-				table.NewSegmentSRv6(netip.MustParseAddr("fc00::a:1")), // End SID of A
+				table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fc00::a:1"))), // End SID of A
 			},
 			wantErr: "",
 		},
@@ -865,14 +871,14 @@ func usidLocatorNode(routerID, sid string, remote *table.LsNode, endXSid string)
 		}},
 	}
 	if remote != nil {
-		node.Links = []*table.LsLink{{RemoteNode: remote, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{endXSid}}}}
+		node.Links = []*table.LsLink{{Remote: table.LinkEndpoint{Node: remote}, Srv6EndXSIDs: []*table.Srv6EndXSID{{Sids: []string{endXSid}}}}}
 	}
 
 	return node
 }
 
 func usidContainerSeg(addr string, structure *table.SIDStructure) table.Segment {
-	seg := table.NewSegmentSRv6(netip.MustParseAddr(addr))
+	seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(addr)))
 	seg.USid = true
 	seg.Structure = structure
 
@@ -897,7 +903,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
 			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
-			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
+			table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(endXToW1))),
 		})
 		require.NoError(t, err)
 	})
@@ -911,7 +917,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
 			usidContainerSeg("fcbb:bb00:0100::", &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
-			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
+			table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(endXToW1))),
 		})
 		require.NoError(t, err)
 	})
@@ -927,7 +933,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
 			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
-			table.NewSegmentSRv6(netip.MustParseAddr(endXToW3)),
+			table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(endXToW3))),
 		})
 		require.NoError(t, err)
 	})
@@ -943,7 +949,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
 			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
-			table.NewSegmentSRv6(netip.MustParseAddr(endXToW1)),
+			table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(endXToW1))),
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not have adjacency SID")
@@ -960,7 +966,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
 			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
-			table.NewSegmentSRv6(netip.MustParseAddr(endXToW3)),
+			table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(endXToW3))),
 		})
 		require.NoError(t, err)
 	})
@@ -974,7 +980,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
 			usidContainerSeg(container, &table.SIDStructure{LocalBlock: 32, LocalNode: 16}),
-			table.NewSegmentSRv6(netip.MustParseAddr("fd00::dead:beef")),
+			table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr("fd00::dead:beef"))),
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in TED")
@@ -1013,7 +1019,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 		ted := newTestTED(nodeX)
 
 		err := table.ValidateExplicitPath(ted, "X", []table.Segment{
-			table.NewSegmentSRv6(netip.MustParseAddr(container)),
+			table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(container))),
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in TED")
@@ -1030,7 +1036,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 			RouterID: testRouterIDB,
 			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{"fc00::b:1"}}},
 		}
-		nodeA.Links = []*table.LsLink{{LocalNode: nodeA, RemoteNode: nodeB, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"fc00::a:b"}}}}
+		nodeA.Links = []*table.LsLink{{Local: table.LinkEndpoint{Node: nodeA}, Remote: table.LinkEndpoint{Node: nodeB}, Srv6EndXSIDs: []*table.Srv6EndXSID{{Sids: []string{"fc00::a:b"}}}}}
 		ted := newTestTED(nodeA, nodeB)
 
 		err := table.ValidateExplicitPath(ted, testRouterIDB, []table.Segment{
@@ -1068,7 +1074,7 @@ func TestValidateExplicitPathUSID(t *testing.T) {
 			RouterID: testRouterIDB,
 			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{"fc00::b:1"}}},
 		}
-		nodeA.Links = []*table.LsLink{{LocalNode: nodeA, RemoteNode: nodeB, Srv6EndXSID: &table.Srv6EndXSID{Sids: []string{"fc00::a:b"}}}}
+		nodeA.Links = []*table.LsLink{{Local: table.LinkEndpoint{Node: nodeA}, Remote: table.LinkEndpoint{Node: nodeB}, Srv6EndXSIDs: []*table.Srv6EndXSID{{Sids: []string{"fc00::a:b"}}}}}
 		ted := newTestTED(nodeA, nodeB)
 
 		// A /32 locator has no node bits and resolves directly to its owner.

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -53,6 +53,9 @@ type SRPolicy struct {
 	// Type and Metric are only known for policies created by Pola.
 	Type   PolicyType `json:"type,omitempty"`
 	Metric MetricType `json:"metric,omitempty"`
+	// Plane is the underlay plane used for dynamic path computation.
+	// Zero for explicit paths, which have no underlay plane.
+	Plane Plane `json:"plane,omitzero"`
 }
 
 // NewSRPolicy creates a new SR Policy with the given attributes.

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -26,36 +26,52 @@ const (
 	PolicyUnknown = PolicyState("unknown")
 )
 
-// PolicyType is the SR Policy candidate path type defined in RFC 9256 §2.4.2.
-// The zero value means the type is unknown.
-type PolicyType string
+// DefaultPreference is the default SR Policy candidate path preference (RFC 9256 §2.7).
+const DefaultPreference uint32 = 100
 
-const (
-	// PolicyTypeExplicit indicates an explicit path SR Policy candidate path.
-	PolicyTypeExplicit = PolicyType("explicit")
-	// PolicyTypeDynamic indicates a dynamic SR Policy candidate path.
-	PolicyTypeDynamic = PolicyType("dynamic")
-)
+// DynamicPath is a candidate path with an optimization objective
+// for a specific underlay plane (RFC 9256 §2.2).
+type DynamicPath struct {
+	Metric MetricType `json:"metric"`
+	// Plane is the underlay scope used for TED path computation.
+	Plane Plane `json:"plane,omitzero"`
+}
+
+// ExplicitPath is a candidate path fully specified as a segment list (RFC 9256 §2.2).
+type ExplicitPath struct {
+	SegmentList []Segment `json:"segmentList"`
+}
+
+// CandidatePath is either Dynamic or Explicit (RFC 9256 §2.2).
+// The zero value represents an unknown candidate path type.
+type CandidatePath struct {
+	// Preference selects the active candidate path (RFC 9256 §2.7).
+	Preference uint32        `json:"preference"`
+	Dynamic    *DynamicPath  `json:"dynamic,omitempty"`
+	Explicit   *ExplicitPath `json:"explicit,omitempty"`
+}
 
 // SRPolicy represents an SR Policy with its path and attributes.
 type SRPolicy struct {
-	PlspID      uint32      `json:"plspId,omitempty"`
-	Name        string      `json:"policyName"`
-	SegmentList []Segment   `json:"segmentList"`
-	SrcAddr     netip.Addr  `json:"srcAddr"`
-	DstAddr     netip.Addr  `json:"dstAddr"`
-	SrcRouterID string      `json:"srcRouterId,omitempty"`
-	DstRouterID string      `json:"dstRouterId,omitempty"`
-	Color       uint32      `json:"color"`
-	Preference  uint32      `json:"preference"`
-	LSPID       uint16      `json:"lspId,omitempty"`
-	State       PolicyState `json:"state,omitempty"`
-	// Type and Metric are only known for policies created by Pola.
-	Type   PolicyType `json:"type,omitempty"`
-	Metric MetricType `json:"metric,omitempty"`
-	// Plane is the underlay plane used for dynamic path computation.
-	// Zero for explicit paths, which have no underlay plane.
-	Plane Plane `json:"plane,omitzero"`
+	// Headend and Endpoint identify the policy (RFC 9256 §2.1).
+	Headend  netip.Addr `json:"headend"`
+	Endpoint netip.Addr `json:"endpoint"`
+	Color    uint32     `json:"color"`
+	Name     string     `json:"policyName"`
+
+	// Router IDs are populated for display when resolvable from the TED.
+	HeadendRouterID  string `json:"headendRouterId,omitempty"`
+	EndpointRouterID string `json:"endpointRouterId,omitempty"`
+
+	// SegmentList is the currently signaled segment list.
+	SegmentList []Segment `json:"segmentList"`
+
+	CandidatePath CandidatePath `json:"candidatePath"`
+
+	// PlspID, LSPID, and State are PCEP-assigned state, not policy identity.
+	PlspID uint32      `json:"plspId,omitempty"`
+	LSPID  uint16      `json:"lspId,omitempty"`
+	State  PolicyState `json:"state,omitempty"`
 }
 
 // NewSRPolicy creates a new SR Policy with the given attributes.
@@ -63,23 +79,23 @@ func NewSRPolicy(
 	plspID uint32,
 	name string,
 	segmentList []Segment,
-	srcAddr netip.Addr,
-	dstAddr netip.Addr,
+	headend netip.Addr,
+	endpoint netip.Addr,
 	color uint32,
 	preference uint32,
 	lspID uint16,
 	state PolicyState,
 ) *SRPolicy {
 	p := &SRPolicy{
-		PlspID:      plspID,
-		Name:        name,
-		SegmentList: segmentList,
-		SrcAddr:     srcAddr,
-		DstAddr:     dstAddr,
-		Color:       color,
-		Preference:  preference,
-		LSPID:       lspID,
-		State:       state,
+		PlspID:        plspID,
+		Name:          name,
+		SegmentList:   segmentList,
+		Headend:       headend,
+		Endpoint:      endpoint,
+		Color:         color,
+		CandidatePath: CandidatePath{Preference: preference},
+		LSPID:         lspID,
+		State:         state,
 	}
 
 	return p
@@ -109,7 +125,7 @@ func (p *SRPolicy) Update(df PolicyDiff) {
 	}
 
 	if df.Preference != nil {
-		p.Preference = *df.Preference
+		p.CandidatePath.Preference = *df.Preference
 	}
 
 	if df.SegmentList != nil {

--- a/pkg/table/sr_policy.go
+++ b/pkg/table/sr_policy.go
@@ -120,6 +120,8 @@ const SRv6SIDBitLength = 128
 // Segment is an interface for SR Policy segments (SRv6 or SR-MPLS).
 type Segment interface {
 	SidString() string
+	// Family reports the data plane this segment belongs to.
+	Family() DataPlane
 }
 
 func segmentFamily(segment Segment) SegmentFamily {
@@ -133,11 +135,42 @@ func segmentFamily(segment Segment) SegmentFamily {
 	}
 }
 
+// SRv6SID is distinct from netip.Addr to prevent accidental mixing of
+// full-SIDs, locators, and ordinary IPv6 addresses.
+type SRv6SID netip.Addr
+
+// Addr returns sid as a netip.Addr.
+func (sid SRv6SID) Addr() netip.Addr { return netip.Addr(sid) }
+
+// String returns the string representation of sid.
+func (sid SRv6SID) String() string { return netip.Addr(sid).String() }
+
+// IsValid reports whether sid holds a valid address.
+func (sid SRv6SID) IsValid() bool { return netip.Addr(sid).IsValid() }
+
+// ParseSRv6SID parses s as an SRv6 SID and rejects IPv4-mapped IPv6 addresses.
+func ParseSRv6SID(s string) (SRv6SID, error) {
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return SRv6SID{}, fmt.Errorf("invalid SRv6 SID %q: %w", s, err)
+	}
+
+	if !addr.Is6() || addr.Is4In6() {
+		return SRv6SID{}, fmt.Errorf("SRv6 SID %q is not a valid IPv6 address", s)
+	}
+
+	return SRv6SID(addr), nil
+}
+
 // NewSegment creates a Segment from a SID string, which can be either an IPv6 address (SRv6) or a number (SR-MPLS).
 func NewSegment(sid string) (Segment, error) {
-	addr, err := netip.ParseAddr(sid)
-	if err == nil && addr.Is6() {
-		return NewSegmentSRv6(addr), nil
+	if addr, err := netip.ParseAddr(sid); err == nil && addr.Is6() {
+		srv6SID, err := ParseSRv6SID(sid)
+		if err != nil {
+			return nil, err
+		}
+
+		return NewSegmentSRv6(srv6SID), nil
 	}
 
 	i, err := strconv.ParseUint(sid, 10, 32)
@@ -200,11 +233,18 @@ const FirstSIDIndex = 0
 
 // SegmentSRv6 represents an SRv6 segment.
 type SegmentSRv6 struct {
-	Sid        netip.Addr    `json:"sid"`
+	Sid        SRv6SID       `json:"sid"`
 	LocalAddr  netip.Addr    `json:"localAddr,omitzero"`
 	RemoteAddr netip.Addr    `json:"remoteAddr,omitzero"`
 	Structure  *SIDStructure `json:"sidStructure,omitempty"`
 	USid       bool          `json:"uSid,omitempty"`
+	// Behavior is the TED-advertised endpoint behavior (RFC 9603 §4.3.1).
+	// Zero means unknown; BehaviorOrDerived derives it from other fields.
+	Behavior uint16 `json:"behavior,omitempty"`
+	// LocalIfaceID/RemoteIfaceID identify the interface for link-local RemoteAddr
+	// in NAI type 6 encoding (RFC 8664/9603 §4.3.1). nil means not advertised.
+	LocalIfaceID  *uint32 `json:"localIfaceId,omitempty"`
+	RemoteIfaceID *uint32 `json:"remoteIfaceId,omitempty"`
 }
 
 // SidString returns the SRv6 SID as a string.
@@ -212,8 +252,16 @@ func (seg SegmentSRv6) SidString() string {
 	return seg.Sid.String()
 }
 
-// Behavior returns the endpoint behavior of the SRv6 segment based on its attributes.
-func (seg SegmentSRv6) Behavior() uint16 {
+// Family reports the data plane this segment belongs to.
+func (seg SegmentSRv6) Family() DataPlane { return DPSRv6 }
+
+// BehaviorOrDerived returns the TED-advertised endpoint behavior, or derives
+// it from the segment's other attributes when the behavior is unknown.
+func (seg SegmentSRv6) BehaviorOrDerived() uint16 {
+	if seg.Behavior != 0 {
+		return seg.Behavior
+	}
+
 	if !seg.LocalAddr.IsValid() {
 		return BehaviorOpaque
 	}
@@ -234,14 +282,14 @@ func (seg SegmentSRv6) Behavior() uint16 {
 }
 
 // NewSegmentSRv6 creates a new SRv6 segment with the given SID.
-func NewSegmentSRv6(sid netip.Addr) SegmentSRv6 {
+func NewSegmentSRv6(sid SRv6SID) SegmentSRv6 {
 	return SegmentSRv6{
 		Sid: sid,
 	}
 }
 
 // NewSegmentSRv6WithNodeInfo creates a new SRv6 segment with the given SID and enriches it with node information from the TED.
-func NewSegmentSRv6WithNodeInfo(sid netip.Addr, n *LsNode) (SegmentSRv6, error) {
+func NewSegmentSRv6WithNodeInfo(sid SRv6SID, n *LsNode) (SegmentSRv6, error) {
 	seg := SegmentSRv6{
 		Sid: sid,
 	}
@@ -261,6 +309,7 @@ func NewSegmentSRv6WithNodeInfo(sid netip.Addr, n *LsNode) (SegmentSRv6, error) 
 		seg.LocalAddr = addr
 
 		seg.Structure = srv6SID.SIDStructure.Clone()
+		seg.Behavior = srv6SID.EndpointBehavior.Behavior
 
 		if IsUSidBehavior(srv6SID.EndpointBehavior.Behavior) {
 			seg.USid = true
@@ -289,12 +338,19 @@ type SegmentSRMPLS struct {
 	// Optional NAI for SR-ERO encoding (RFC 8664 §4.3.1).
 	LocalAddr  netip.Addr `json:"localAddr,omitzero"`
 	RemoteAddr netip.Addr `json:"remoteAddr,omitzero"`
+	// LocalIfaceID/RemoteIfaceID identify the interface for link-local RemoteAddr
+	// in NAI type 6 encoding. nil means not advertised.
+	LocalIfaceID  *uint32 `json:"localIfaceId,omitempty"`
+	RemoteIfaceID *uint32 `json:"remoteIfaceId,omitempty"`
 }
 
 // SidString returns the SR-MPLS SID as a string.
 func (seg SegmentSRMPLS) SidString() string {
 	return strconv.FormatUint(uint64(seg.Sid), 10)
 }
+
+// Family reports the data plane this segment belongs to.
+func (seg SegmentSRMPLS) Family() DataPlane { return DPSRMPLS }
 
 // HasMPLSStackEntryAttrs reports whether the SR-MPLS segment has any MPLS stack entry attributes set.
 func (seg SegmentSRMPLS) HasMPLSStackEntryAttrs() bool {

--- a/pkg/table/sr_policy_test.go
+++ b/pkg/table/sr_policy_test.go
@@ -185,15 +185,15 @@ func TestNewSRPolicy(t *testing.T) {
 	p := table.NewSRPolicy(1, "policy1", segList, srcAddr, dstAddr, 100, 200, 1, table.PolicyUp)
 
 	want := &table.SRPolicy{
-		PlspID:      1,
-		Name:        "policy1",
-		SegmentList: segList,
-		SrcAddr:     srcAddr,
-		DstAddr:     dstAddr,
-		Color:       100,
-		Preference:  200,
-		LSPID:       1,
-		State:       table.PolicyUp,
+		PlspID:        1,
+		Name:          "policy1",
+		SegmentList:   segList,
+		Headend:       srcAddr,
+		Endpoint:      dstAddr,
+		Color:         100,
+		CandidatePath: table.CandidatePath{Preference: 200},
+		LSPID:         1,
+		State:         table.PolicyUp,
 	}
 	assert.Equal(t, want, p)
 }
@@ -214,19 +214,19 @@ func TestSRPolicyUpdate(t *testing.T) {
 		{
 			name: "state and LSPID always applied, optional fields left unset when nil",
 			diff: table.PolicyDiff{State: table.PolicyDown, LSPID: 5},
-			want: table.SRPolicy{Name: "original", Color: 100, Preference: 200, LSPID: 5, State: table.PolicyDown, SegmentList: []table.Segment{table.NewSegmentSRMPLS(16001)}},
+			want: table.SRPolicy{Name: "original", Color: 100, CandidatePath: table.CandidatePath{Preference: 200}, LSPID: 5, State: table.PolicyDown, SegmentList: []table.Segment{table.NewSegmentSRMPLS(16001)}},
 		},
 		{
 			name: "optional fields applied when set",
 			diff: table.PolicyDiff{Name: &name, Color: &color, Preference: &preference, SegmentList: newSegList, State: table.PolicyUp, LSPID: 6},
-			want: table.SRPolicy{Name: name, Color: color, Preference: preference, LSPID: 6, State: table.PolicyUp, SegmentList: newSegList},
+			want: table.SRPolicy{Name: name, Color: color, CandidatePath: table.CandidatePath{Preference: preference}, LSPID: 6, State: table.PolicyUp, SegmentList: newSegList},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			p := &table.SRPolicy{Name: "original", Color: 100, Preference: 200, SegmentList: []table.Segment{table.NewSegmentSRMPLS(16001)}}
+			p := &table.SRPolicy{Name: "original", Color: 100, CandidatePath: table.CandidatePath{Preference: 200}, SegmentList: []table.Segment{table.NewSegmentSRMPLS(16001)}}
 			p.Update(tt.diff)
 			assert.Equal(t, tt.want, *p)
 		})

--- a/pkg/table/sr_policy_test.go
+++ b/pkg/table/sr_policy_test.go
@@ -32,7 +32,7 @@ func newTestSegmentSRMPLS(sid uint32, local, remote string) table.SegmentSRMPLS 
 }
 
 func newTestSegmentSRv6(local, remote string) table.SegmentSRv6 {
-	seg := table.NewSegmentSRv6(netip.MustParseAddr(testSRv6Addr))
+	seg := table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6Addr)))
 	if local != "" {
 		seg.LocalAddr = netip.MustParseAddr(local)
 	}
@@ -153,7 +153,8 @@ func TestSegmentsEqual(t *testing.T) {
 
 type fakeUnknownSidSegment struct{}
 
-func (fakeUnknownSidSegment) SidString() string { return "unknown" }
+func (fakeUnknownSidSegment) SidString() string       { return "unknown" }
+func (fakeUnknownSidSegment) Family() table.DataPlane { return table.DPUnspecified }
 
 func TestSegmentsEqual_UnknownType(t *testing.T) {
 	t.Parallel()
@@ -241,7 +242,7 @@ func TestNewSegment(t *testing.T) {
 		want    table.Segment
 		wantErr bool
 	}{
-		{"SRv6 address", testSRv6Addr, table.NewSegmentSRv6(netip.MustParseAddr(testSRv6Addr)), false},
+		{"SRv6 address", testSRv6Addr, table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6Addr))), false},
 		{"SR-MPLS label", "16001", table.NewSegmentSRMPLS(16001), false},
 		{"IPv4 address is not a valid SID", "10.0.0.1", nil, true},
 		{"non-numeric, non-IP string", "not-a-sid", nil, true},
@@ -260,6 +261,62 @@ func TestNewSegment(t *testing.T) {
 			assert.Equal(t, tt.want, seg)
 		})
 	}
+}
+
+func TestParseSRv6SID_And_NewSegment_RejectsFourInSix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		sid     string
+		wantErr bool
+	}{
+		{"IPv4-mapped IPv6 address is rejected", "::ffff:192.0.2.1", true},
+		{"ordinary SRv6 SID is accepted", "2001:db8::1", false},
+		{"link-local IPv6 address is accepted", "fe80::1", false},
+		{"SR-MPLS label is not an SRv6 SID", "16000", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := table.ParseSRv6SID(tt.sid)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("NewSegment rejects an IPv4-mapped IPv6 SID", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := table.NewSegment("::ffff:192.0.2.1")
+		assert.Error(t, err)
+	})
+
+	t.Run("NewSegment accepts an SR-MPLS label", func(t *testing.T) {
+		t.Parallel()
+
+		seg, err := table.NewSegment("16000")
+		require.NoError(t, err)
+		assert.Equal(t, table.NewSegmentSRMPLS(16000), seg)
+	})
+}
+
+func TestSRv6SID_IsValid(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, table.SRv6SID(netip.MustParseAddr(testSRv6Addr)).IsValid())
+	assert.False(t, table.SRv6SID{}.IsValid())
+}
+
+func TestSegment_Family(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, table.DPSRv6, table.NewSegmentSRv6(table.SRv6SID(netip.MustParseAddr(testSRv6Addr))).Family())
+	assert.Equal(t, table.DPSRMPLS, table.NewSegmentSRMPLS(16000).Family())
 }
 
 func TestBehaviorToString(t *testing.T) {
@@ -363,9 +420,17 @@ func TestSegmentSRv6_Behavior(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, tt.seg.Behavior())
+			assert.Equal(t, tt.want, tt.seg.BehaviorOrDerived())
 		})
 	}
+}
+
+func TestSegmentSRv6_BehaviorOrDerived_PrefersTEDValue(t *testing.T) {
+	t.Parallel()
+
+	seg := newTestSegmentSRv6("2001:db8::1", "")
+	seg.Behavior = table.BehaviorENDX
+	assert.Equal(t, table.BehaviorENDX, seg.BehaviorOrDerived())
 }
 
 func TestIsUSidBehavior(t *testing.T) {
@@ -443,8 +508,9 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 				},
 			},
 			want: table.SegmentSRv6{
-				Sid:       netip.MustParseAddr("2001:db8::1"),
+				Sid:       table.SRv6SID(netip.MustParseAddr("2001:db8::1")),
 				LocalAddr: netip.MustParseAddr(testSRv6Addr),
+				Behavior:  table.BehaviorEND,
 				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16, LocalFunc: 16},
 				USid:      false,
 			},
@@ -461,8 +527,9 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 				},
 			},
 			want: table.SegmentSRv6{
-				Sid:       netip.MustParseAddr("2001:db8::1"),
+				Sid:       table.SRv6SID(netip.MustParseAddr("2001:db8::1")),
 				LocalAddr: netip.MustParseAddr("fcbb:bb00:0100::"),
+				Behavior:  table.BehaviorUN,
 				Structure: &table.SIDStructure{LocalBlock: 32, LocalNode: 16},
 				USid:      true,
 			},
@@ -476,8 +543,9 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 				},
 			},
 			want: table.SegmentSRv6{
-				Sid:       netip.MustParseAddr("2001:db8::1"),
+				Sid:       table.SRv6SID(netip.MustParseAddr("2001:db8::1")),
 				LocalAddr: netip.MustParseAddr(testSRv6Addr),
+				Behavior:  table.BehaviorEND,
 			},
 		},
 		{
@@ -489,8 +557,9 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 				},
 			},
 			want: table.SegmentSRv6{
-				Sid:       netip.MustParseAddr("2001:db8::1"),
+				Sid:       table.SRv6SID(netip.MustParseAddr("2001:db8::1")),
 				LocalAddr: netip.MustParseAddr(testSRv6Addr),
+				Behavior:  table.BehaviorEND,
 			},
 		},
 		{
@@ -510,7 +579,7 @@ func TestNewSegmentSRv6WithNodeInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := table.NewSegmentSRv6WithNodeInfo(netip.MustParseAddr("2001:db8::1"), tt.node)
+			got, err := table.NewSegmentSRv6WithNodeInfo(table.SRv6SID(netip.MustParseAddr("2001:db8::1")), tt.node)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -530,6 +531,7 @@ type LinkKey struct {
 	RemoteRouterID string
 	local          endpointKey
 	remote         endpointKey
+	multiTopoIDs   string
 }
 
 // LsLink represents a link in the BGP-LS TED.
@@ -538,6 +540,7 @@ type LsLink struct {
 	Metrics       []*Metric
 	AdjSids       []AdjSID
 	Srv6EndXSIDs  []*Srv6EndXSID
+	MultiTopoIDs  map[uint16]struct{}
 }
 
 // NewLsLink creates a new BGP-LS link between two nodes.
@@ -563,6 +566,54 @@ func (l *LsLink) Families() AddressFamilySet {
 	return s
 }
 
+// mtIDFamily returns the address family for an IS-IS Multi-Topology ID.
+func mtIDFamily(id uint16) AddressFamily {
+	switch id {
+	case 0: // Standard topology: IPv4 unicast (and IPv6 when topology 2 is absent).
+		return AFIPv4
+	case 2: // IPv6 routing topology.
+		return AFIPv6
+	default:
+		return AFUnspecified
+	}
+}
+
+// UsableForFamily reports whether l is usable for CSPF in address family af.
+// Links with a Multi-Topology ID are usable only for the family it identifies.
+func (l *LsLink) UsableForFamily(af AddressFamily) bool {
+	if len(l.MultiTopoIDs) == 0 {
+		return l.Families().Has(af)
+	}
+
+	for id := range l.MultiTopoIDs {
+		if mtIDFamily(id) == af {
+			return true
+		}
+	}
+
+	return false
+}
+
+func multiTopoIDsKey(ids map[uint16]struct{}) string {
+	if len(ids) == 0 {
+		return ""
+	}
+
+	sorted := make([]int, 0, len(ids))
+	for id := range ids {
+		sorted = append(sorted, int(id))
+	}
+
+	sort.Ints(sorted)
+
+	parts := make([]string, len(sorted))
+	for i, id := range sorted {
+		parts[i] = strconv.Itoa(id)
+	}
+
+	return strings.Join(parts, ",")
+}
+
 // Key returns l's link identity for TED update dedup/merge.
 func (l *LsLink) Key() LinkKey {
 	return LinkKey{
@@ -570,6 +621,7 @@ func (l *LsLink) Key() LinkKey {
 		RemoteRouterID: nodeRouterID(l.Remote.Node),
 		local:          newEndpointKey(l.Local),
 		remote:         newEndpointKey(l.Remote),
+		multiTopoIDs:   multiTopoIDsKey(l.MultiTopoIDs),
 	}
 }
 

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -227,7 +227,11 @@ func printLink(ew *errWriter, link *LsLink) {
 		}
 
 		ew.println("      SRv6 End.X SID:")
-		ew.printf("        EndpointBehavior: %s\n", BehaviorToString(endXSID.EndpointBehavior))
+		ew.printf("        EndpointBehavior: %s, Flags: %d, Algorithm: %d, Weight: %d\n",
+			BehaviorToString(endXSID.EndpointBehavior.Behavior),
+			endXSID.EndpointBehavior.Flags,
+			endXSID.EndpointBehavior.Algorithm,
+			endXSID.Weight)
 		ew.printf("        SIDs: %v\n", endXSID.Sids)
 		printSIDStructure(ew, "        ", endXSID.Srv6SIDStructure)
 	}
@@ -748,6 +752,10 @@ func ParseSIDStructure(s string) (*SIDStructure, error) {
 }
 
 // EndpointBehavior represents the endpoint behavior attributes of an SRv6 SID.
+//
+// RFC 9514 defines the same Endpoint Behavior, Flags, and Algorithm fields for
+// the SRv6 End.X SID and Endpoint Behavior TLVs. Flags are preserved as a raw
+// octet because their semantics depend on the advertising protocol and TLV.
 type EndpointBehavior struct {
 	Behavior  uint16
 	Flags     uint8
@@ -893,9 +901,10 @@ func (m MetricType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.DisplayString())
 }
 
-// Srv6EndXSID represents an SRv6 End.X SID in the BGP-LS TED.
+// Srv6EndXSID represents an SRv6 End.X SID in the BGP-LS TED (RFC 9514 §4.1).
 type Srv6EndXSID struct {
-	EndpointBehavior uint16
+	EndpointBehavior EndpointBehavior
+	Weight           uint8
 	Sids             []string
 	Srv6SIDStructure *SIDStructure // nil when the SID Structure TLV was not advertised
 }

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -429,6 +429,12 @@ func (n *LsNode) LoopbackAddr(af AddressFamily) (netip.Addr, error) {
 	return netip.Addr{}, fmt.Errorf("node doesn't have a %s loopback address", af)
 }
 
+// HasLoopback reports whether the node has a loopback address in af.
+func (n *LsNode) HasLoopback(af AddressFamily) bool {
+	_, err := n.LoopbackAddr(af)
+	return err == nil
+}
+
 // UpdateTED updates the TED with this node's information.
 func (n *LsNode) UpdateTED(ted *LsTED, cfgASN uint32) {
 	nodes := ted.Nodes

--- a/pkg/table/ted.go
+++ b/pkg/table/ted.go
@@ -49,7 +49,7 @@ func (ted *LsTED) RouterIDIndex() map[netip.Addr]string {
 	return index
 }
 
-// AddressRouterIDIndex builds an index from prefix addresses to router IDs.
+// AddressRouterIDIndex marks addresses advertised by multiple routers as ambiguous.
 func (ted *LsTED) AddressRouterIDIndex() map[netip.Addr]string {
 	if ted == nil {
 		return nil
@@ -63,7 +63,7 @@ func (ted *LsTED) AddressRouterIDIndex() map[netip.Addr]string {
 		}
 
 		for _, prefix := range node.Prefixes {
-			index[prefix.Prefix.Addr()] = routerID
+			mergeSIDOwner(index, prefix.Prefix.Addr(), routerID)
 		}
 	}
 
@@ -184,19 +184,23 @@ func printLink(ew *errWriter, link *LsLink) {
 	localIP := displayNone
 	remoteIP := displayNone
 
-	if link.LocalIP.IsValid() {
-		localIP = link.LocalIP.String()
+	if link.Local.IPv4.IsValid() {
+		localIP = link.Local.IPv4.String()
+	} else if link.Local.IPv6.IsValid() {
+		localIP = link.Local.IPv6.String()
 	}
 
-	if link.RemoteIP.IsValid() {
-		remoteIP = link.RemoteIP.String()
+	if link.Remote.IPv4.IsValid() {
+		remoteIP = link.Remote.IPv4.String()
+	} else if link.Remote.IPv6.IsValid() {
+		remoteIP = link.Remote.IPv6.String()
 	}
 
 	ew.printf("    Local: %s Remote: %s\n", localIP, remoteIP)
 
 	remoteNodeID := displayNone
-	if link.RemoteNode != nil {
-		remoteNodeID = link.RemoteNode.RouterID
+	if link.Remote.Node != nil {
+		remoteNodeID = link.Remote.Node.RouterID
 	}
 
 	ew.printf("      RemoteNode: %s\n", remoteNodeID)
@@ -213,13 +217,19 @@ func printLink(ew *errWriter, link *LsLink) {
 		}
 	}
 
-	ew.printf("      Adj-SID: %d\n", link.AdjSid)
+	for _, adjSID := range link.AdjSids {
+		ew.printf("      Adj-SID: %d\n", adjSID.Sid)
+	}
 
-	if link.Srv6EndXSID != nil {
+	for _, endXSID := range link.Srv6EndXSIDs {
+		if endXSID == nil {
+			continue
+		}
+
 		ew.println("      SRv6 End.X SID:")
-		ew.printf("        EndpointBehavior: %s\n", BehaviorToString(link.Srv6EndXSID.EndpointBehavior))
-		ew.printf("        SIDs: %v\n", link.Srv6EndXSID.Sids)
-		printSIDStructure(ew, "        ", link.Srv6EndXSID.Srv6SIDStructure)
+		ew.printf("        EndpointBehavior: %s\n", BehaviorToString(endXSID.EndpointBehavior))
+		ew.printf("        SIDs: %v\n", endXSID.Sids)
+		printSIDStructure(ew, "        ", endXSID.Srv6SIDStructure)
 	}
 }
 
@@ -274,12 +284,12 @@ type TEDElem interface {
 
 // LsNode represents a node in the BGP-LS TED.
 type LsNode struct {
-	ASN        uint32 // primary key, in MP_REACH_NLRI Attr
-	RouterID   string // primary key, in MP_REACH_NLRI Attr
-	IsisAreaID string // in BGP-LS Attr
-	Hostname   string // in BGP-LS Attr
-	SrgbBegin  uint32 // in BGP-LS Attr
-	SrgbEnd    uint32 // in BGP-LS Attr
+	ASN        uint32
+	RouterID   string
+	IsisAreaID string
+	Hostname   string
+	SrgbBegin  uint32
+	SrgbEnd    uint32
 	Links      []*LsLink
 	Prefixes   []*LsPrefix
 	SRv6SIDs   []*LsSrv6SID
@@ -293,57 +303,130 @@ func NewLsNode(asn uint32, nodeID string) *LsNode {
 	}
 }
 
-// NodeSegment returns a Segment for this node (either SR-MPLS or SRv6).
-func (n *LsNode) NodeSegment() (Segment, error) {
-	// for SR-MPLS Segment
-	for _, prefix := range n.Prefixes {
-		if prefix.HasPrefixSID() {
-			if n.SrgbBegin == 0 {
-				return nil, fmt.Errorf("cannot resolve prefix-SID index %d without an SRGB", prefix.SidIndex)
-			}
-
-			label, ok := srgbLabel(n, prefix.SidIndex)
-			if !ok {
-				return nil, fmt.Errorf("prefix-SID index %d is out of range for SRGB [%d, %d)", prefix.SidIndex, n.SrgbBegin, n.SrgbEnd)
-			}
-
-			return NewSegmentSRMPLS(label), nil
-		}
+// NodeSegment returns a Segment for the given Plane.
+// The Plane must be fully specified; no implicit defaults are used.
+func (n *LsNode) NodeSegment(plane Plane) (Segment, error) {
+	if err := plane.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid plane: %w", err)
 	}
-	// for SRv6 Segment
-	for _, srv6SID := range n.SRv6SIDs {
-		if len(srv6SID.Sids) > FirstSIDIndex {
-			addr, err := netip.ParseAddr(srv6SID.Sids[FirstSIDIndex])
-			if err != nil {
-				return nil, fmt.Errorf("SRv6 SID %q is invalid: %w", srv6SID.Sids[FirstSIDIndex], err)
-			}
 
-			if !addr.Is6() || addr.Is4In6() {
-				return nil, fmt.Errorf("SRv6 SID %q is not a valid IPv6 address", srv6SID.Sids[FirstSIDIndex])
-			}
+	switch plane.DataPlane {
+	case DPSRMPLS:
+		return n.nodeSegmentSRMPLS(plane.Family)
+	case DPSRv6:
+		return n.nodeSegmentSRv6()
+	default:
+		return nil, errors.New("data plane must be specified")
+	}
+}
 
-			return NewSegmentSRv6WithNodeInfo(addr, n)
+func (n *LsNode) nodeSegmentSRMPLS(af AddressFamily) (Segment, error) {
+	for _, prefix := range n.Prefixes {
+		if !prefix.HasPrefixSID() || FamilyOfAddr(prefix.Prefix.Addr()) != af {
+			continue
 		}
+
+		if n.SrgbBegin == 0 {
+			return nil, fmt.Errorf("cannot resolve prefix-SID index %d without an SRGB", prefix.SidIndex)
+		}
+
+		label, ok := srgbLabel(n, prefix.SidIndex)
+		if !ok {
+			return nil, fmt.Errorf("prefix-SID index %d is out of range for SRGB [%d, %d)", prefix.SidIndex, n.SrgbBegin, n.SrgbEnd)
+		}
+
+		return NewSegmentSRMPLS(label), nil
+	}
+
+	return nil, fmt.Errorf("node doesn't have a %s Prefix-SID", af)
+}
+
+func (n *LsNode) nodeSegmentSRv6() (Segment, error) {
+	for _, srv6SID := range n.SRv6SIDs {
+		if len(srv6SID.Sids) <= FirstSIDIndex {
+			continue
+		}
+
+		sid, err := ParseSRv6SID(srv6SID.Sids[FirstSIDIndex])
+		if err != nil {
+			return nil, fmt.Errorf("SRv6 SID %q is invalid: %w", srv6SID.Sids[FirstSIDIndex], err)
+		}
+
+		return NewSegmentSRv6WithNodeInfo(sid, n)
 	}
 
 	return nil, errors.New("node doesn't have a Node SID")
 }
 
-// LoopbackAddr returns the loopback address of the node.
-func (n *LsNode) LoopbackAddr() (netip.Addr, error) {
-	for _, prefix := range n.Prefixes {
-		if prefix.Prefix.Addr().Is4() {
-			if prefix.Prefix.Bits() == 32 {
-				return prefix.Prefix.Addr(), nil
-			}
-		} else if prefix.Prefix.Addr().Is6() {
-			if prefix.Prefix.Bits() == 128 {
-				return prefix.Prefix.Addr(), nil
-			}
+// candidatePlanes lists the valid (family, data plane) combinations.
+// The order is not significant; DefaultPlane requires exactly one to be viable.
+var candidatePlanes = []Plane{
+	{Family: AFIPv4, DataPlane: DPSRMPLS},
+	{Family: AFIPv6, DataPlane: DPSRMPLS},
+	{Family: AFIPv6, DataPlane: DPSRv6},
+}
+
+// DefaultPlane returns the node's unique viable Plane.
+// An explicit plane is required when the node supports multiple planes.
+func (n *LsNode) DefaultPlane() (Plane, error) {
+	var candidates []Plane
+
+	for _, p := range candidatePlanes {
+		if _, err := n.NodeSegment(p); err == nil {
+			candidates = append(candidates, p)
 		}
 	}
 
-	return netip.Addr{}, errors.New("node doesn't have a loopback address")
+	switch len(candidates) {
+	case 0:
+		return Plane{}, errors.New("node doesn't have a Node SID")
+	case 1:
+		return candidates[0], nil
+	default:
+		return Plane{}, fmt.Errorf("node advertises multiple planes %v; an explicit plane is required", candidates)
+	}
+}
+
+// DefaultLoopbackFamily returns the node's unique viable address family.
+// An explicit family is required when the node has loopbacks in multiple families.
+func (n *LsNode) DefaultLoopbackFamily() (AddressFamily, error) {
+	var candidates []AddressFamily
+
+	for _, af := range []AddressFamily{AFIPv4, AFIPv6} {
+		if _, err := n.LoopbackAddr(af); err == nil {
+			candidates = append(candidates, af)
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		return AFUnspecified, errors.New("node doesn't have a loopback address")
+	case 1:
+		return candidates[0], nil
+	default:
+		return AFUnspecified, fmt.Errorf("node has loopback addresses in multiple families %v; an explicit family is required", candidates)
+	}
+}
+
+// LoopbackAddr returns the node's loopback address in the given address family.
+// An explicit family is required; there is no implicit default.
+func (n *LsNode) LoopbackAddr(af AddressFamily) (netip.Addr, error) {
+	if !af.IsValid() {
+		return netip.Addr{}, errors.New("address family must be specified")
+	}
+
+	for _, prefix := range n.Prefixes {
+		addr := prefix.Prefix.Addr()
+		if prefix.Prefix.Bits() != addr.BitLen() {
+			continue
+		}
+
+		if FamilyOfAddr(addr) == af {
+			return addr, nil
+		}
+	}
+
+	return netip.Addr{}, fmt.Errorf("node doesn't have a %s loopback address", af)
 }
 
 // UpdateTED updates the TED with this node's information.
@@ -364,28 +447,142 @@ func (n *LsNode) UpdateTED(ted *LsTED, cfgASN uint32) {
 	}
 }
 
-// AddLink adds a link to this node.
+// AddLink replaces an existing link with the same Key() instead of
+// creating a duplicate.
 func (n *LsNode) AddLink(link *LsLink) {
+	key := link.Key()
+
+	for i, existing := range n.Links {
+		if existing != nil && existing.Key() == key {
+			n.Links[i] = link
+			return
+		}
+	}
+
 	n.Links = append(n.Links, link)
+}
+
+// LinkEndpoint contains the node, addresses, and interface ID for one side of an LsLink.
+// InterfaceID scopes a link-local IPv6 address; nil means not advertised and differs from 0.
+type LinkEndpoint struct {
+	Node        *LsNode
+	InterfaceID *uint32
+	IPv4        netip.Addr
+	IPv6        netip.Addr
+}
+
+// Addr returns the endpoint's address in the given family, or the zero address if none was advertised.
+func (e LinkEndpoint) Addr(af AddressFamily) netip.Addr {
+	switch af {
+	case AFIPv4:
+		return e.IPv4
+	case AFIPv6:
+		return e.IPv6
+	default:
+		return netip.Addr{}
+	}
+}
+
+// AdjSID is a link Adjacency-SID tagged with its address family.
+// Family is AFUnspecified when GoBGP cannot distinguish IPv4 and IPv6 Adj-SIDs.
+type AdjSID struct {
+	Family AddressFamily
+	Sid    uint32
+}
+
+// endpointKey defines the endpoint identity used by LinkKey.
+// Interface ID takes precedence; otherwise the address is used.
+// An endpoint with neither has no identity of its own.
+type endpointKey struct {
+	hasIfaceID bool
+	ifaceID    uint32
+	addr       netip.Addr
+}
+
+func newEndpointKey(e LinkEndpoint) endpointKey {
+	if e.InterfaceID != nil {
+		return endpointKey{hasIfaceID: true, ifaceID: *e.InterfaceID}
+	}
+
+	switch {
+	case e.IPv4.IsValid():
+		return endpointKey{addr: e.IPv4}
+	case e.IPv6.IsValid():
+		return endpointKey{addr: e.IPv6}
+	default:
+		return endpointKey{}
+	}
+}
+
+// LinkKey identifies an LsLink across TED updates and re-advertisements.
+type LinkKey struct {
+	LocalRouterID  string
+	RemoteRouterID string
+	local          endpointKey
+	remote         endpointKey
 }
 
 // LsLink represents a link in the BGP-LS TED.
 type LsLink struct {
-	LocalNode   *LsNode      // Primary key, in MP_REACH_NLRI Attr
-	RemoteNode  *LsNode      // Primary key, in MP_REACH_NLRI Attr
-	LocalIP     netip.Addr   // In MP_REACH_NLRI Attr
-	RemoteIP    netip.Addr   // In MP_REACH_NLRI Attr
-	Metrics     []*Metric    // In BGP-LS Attr
-	AdjSid      uint32       // In BGP-LS Attr
-	Srv6EndXSID *Srv6EndXSID // In BGP-LS Attr
+	Local, Remote LinkEndpoint
+	Metrics       []*Metric
+	AdjSids       []AdjSID
+	Srv6EndXSIDs  []*Srv6EndXSID
 }
 
 // NewLsLink creates a new BGP-LS link between two nodes.
 func NewLsLink(localNode, remoteNode *LsNode) *LsLink {
 	return &LsLink{
-		LocalNode:  localNode,
-		RemoteNode: remoteNode,
+		Local:  LinkEndpoint{Node: localNode},
+		Remote: LinkEndpoint{Node: remoteNode},
 	}
+}
+
+// Families reports the address families for which both endpoints have an address.
+func (l *LsLink) Families() AddressFamilySet {
+	var s AddressFamilySet
+
+	if l.Local.IPv4.IsValid() && l.Remote.IPv4.IsValid() {
+		s |= AddressFamilySetIPv4
+	}
+
+	if l.Local.IPv6.IsValid() && l.Remote.IPv6.IsValid() {
+		s |= AddressFamilySetIPv6
+	}
+
+	return s
+}
+
+// Key returns l's link identity for TED update dedup/merge.
+func (l *LsLink) Key() LinkKey {
+	return LinkKey{
+		LocalRouterID:  nodeRouterID(l.Local.Node),
+		RemoteRouterID: nodeRouterID(l.Remote.Node),
+		local:          newEndpointKey(l.Local),
+		remote:         newEndpointKey(l.Remote),
+	}
+}
+
+func nodeRouterID(n *LsNode) string {
+	if n == nil {
+		return ""
+	}
+
+	return n.RouterID
+}
+
+// Validate reports an error if a link-local IPv6 address lacks the
+// interface ID required to scope it in NAI type 6 (RFC 8664/9603).
+func (l *LsLink) Validate() error {
+	if l.Local.IPv6.IsValid() && l.Local.IPv6.IsLinkLocalUnicast() && l.Local.InterfaceID == nil {
+		return errors.New("local link-local IPv6 address requires an interface ID")
+	}
+
+	if l.Remote.IPv6.IsValid() && l.Remote.IPv6.IsLinkLocalUnicast() && l.Remote.InterfaceID == nil {
+		return errors.New("remote link-local IPv6 address requires an interface ID")
+	}
+
+	return nil
 }
 
 // Metric returns the metric value of the given type for this link.
@@ -408,28 +605,28 @@ func (l *LsLink) Metric(metricType MetricType) (uint32, error) {
 func (l *LsLink) UpdateTED(ted *LsTED, cfgASN uint32) {
 	nodes := ted.Nodes
 
-	if l.LocalNode.ASN != cfgASN || l.RemoteNode.ASN != cfgASN {
+	if l.Local.Node.ASN != cfgASN || l.Remote.Node.ASN != cfgASN {
 		return
 	}
 
-	if _, ok := nodes[l.LocalNode.RouterID]; !ok {
-		nodes[l.LocalNode.RouterID] = NewLsNode(l.LocalNode.ASN, l.LocalNode.RouterID)
+	if _, ok := nodes[l.Local.Node.RouterID]; !ok {
+		nodes[l.Local.Node.RouterID] = NewLsNode(l.Local.Node.ASN, l.Local.Node.RouterID)
 	}
 
-	if _, ok := nodes[l.RemoteNode.RouterID]; !ok {
-		nodes[l.RemoteNode.RouterID] = NewLsNode(l.RemoteNode.ASN, l.RemoteNode.RouterID)
+	if _, ok := nodes[l.Remote.Node.RouterID]; !ok {
+		nodes[l.Remote.Node.RouterID] = NewLsNode(l.Remote.Node.ASN, l.Remote.Node.RouterID)
 	}
 
-	l.LocalNode, l.RemoteNode = nodes[l.LocalNode.RouterID], nodes[l.RemoteNode.RouterID]
+	l.Local.Node, l.Remote.Node = nodes[l.Local.Node.RouterID], nodes[l.Remote.Node.RouterID]
 
-	l.LocalNode.AddLink(l)
+	l.Local.Node.AddLink(l)
 }
 
 // LsPrefix represents a prefix in the BGP-LS TED.
 type LsPrefix struct {
-	LocalNode *LsNode      // primary key, in MP_REACH_NLRI Attr
-	Prefix    netip.Prefix // in MP_REACH_NLRI Attr
-	SidIndex  uint32       // in BGP-LS Attr (only for Lo Address Prefix)
+	LocalNode *LsNode
+	Prefix    netip.Prefix
+	SidIndex  uint32
 	// HasSidIndex reports whether a Prefix-SID TLV is present.
 	HasSidIndex bool
 }
@@ -460,7 +657,7 @@ func (lp *LsPrefix) UpdateTED(ted *LsTED, cfgASN uint32) {
 
 	localNode := nodes[lp.LocalNode.RouterID]
 	for _, pref := range localNode.Prefixes {
-		if pref.Prefix.String() == lp.Prefix.String() {
+		if pref.Prefix == lp.Prefix {
 			return
 		}
 	}
@@ -468,11 +665,10 @@ func (lp *LsPrefix) UpdateTED(ted *LsTED, cfgASN uint32) {
 	localNode.Prefixes = append(localNode.Prefixes, lp)
 }
 
-// SIDStructure is the LocalBlock, LocalNode, LocalFunc, LocalArg length split
-// of an SRv6 SID (RFC 9603 §4.1).
+// SIDStructure is the length split of an SRv6 SID (RFC 9603 §4.1).
 //
-// A nil value indicates that no structure was advertised or declared;
-// an all-zero value is a valid, explicitly declared structure.
+// A nil value means no structure was advertised or declared; an all-zero
+// value is a valid, explicitly declared structure.
 type SIDStructure struct {
 	LocalBlock uint8 `json:"localBlock"`
 	LocalNode  uint8 `json:"localNode"`
@@ -585,9 +781,33 @@ func (s *LsSrv6SID) UpdateTED(ted *LsTED, cfgASN uint32) {
 	s.LocalNode.AddSrv6SID(s)
 }
 
-// AddSrv6SID adds an SRv6 SID to this node.
+// AddSrv6SID replaces a re-advertisement of the same SID.
+// Entries without a SID have no dedup key and are always appended.
 func (n *LsNode) AddSrv6SID(s *LsSrv6SID) {
+	key, ok := srv6SIDKey(s)
+	if !ok {
+		n.SRv6SIDs = append(n.SRv6SIDs, s)
+		return
+	}
+
+	for i, existing := range n.SRv6SIDs {
+		if existingKey, ok := srv6SIDKey(existing); ok && existingKey == key {
+			n.SRv6SIDs[i] = s
+			return
+		}
+	}
+
 	n.SRv6SIDs = append(n.SRv6SIDs, s)
+}
+
+// srv6SIDKey identifies an LsSrv6SID by its first SID value.
+// It returns no key when the SID list is empty.
+func srv6SIDKey(s *LsSrv6SID) (key string, ok bool) {
+	if s == nil || len(s.Sids) <= FirstSIDIndex {
+		return "", false
+	}
+
+	return s.Sids[FirstSIDIndex], true
 }
 
 // Metric represents a link metric with its type and value.

--- a/pkg/table/ted_internal_test.go
+++ b/pkg/table/ted_internal_test.go
@@ -97,7 +97,8 @@ func TestPrintLink(t *testing.T) {
 
 		link := &LsLink{
 			Srv6EndXSIDs: []*Srv6EndXSID{{
-				EndpointBehavior: 5,
+				EndpointBehavior: EndpointBehavior{Behavior: 5, Flags: 0xC0, Algorithm: 128},
+				Weight:           7,
 				Sids:             []string{tedInternalTestSRv6SID1},
 				Srv6SIDStructure: &SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
 			}},
@@ -107,7 +108,8 @@ func TestPrintLink(t *testing.T) {
 		printLink(&errWriter{w: &buf}, link)
 
 		assert.Contains(t, buf.String(), "SRv6 End.X SID:")
-		assert.Contains(t, buf.String(), "EndpointBehavior: "+BehaviorToString(5))
+		assert.Contains(t, buf.String(),
+			"EndpointBehavior: "+BehaviorToString(5)+", Flags: 192, Algorithm: 128, Weight: 7")
 		assert.Contains(t, buf.String(), fmt.Sprintf("SIDs: [%s]", tedInternalTestSRv6SID1))
 		assert.Contains(t, buf.String(), "Block: 1, Node: 2, Func: 3, Arg: 4")
 	})

--- a/pkg/table/ted_internal_test.go
+++ b/pkg/table/ted_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const tedInternalTestSRv6SID1 = "2001:db8::1"
@@ -33,9 +34,8 @@ func TestPrintLink(t *testing.T) {
 		t.Parallel()
 
 		link := &LsLink{
-			LocalIP:    netip.MustParseAddr("192.0.2.1"),
-			RemoteIP:   netip.MustParseAddr("192.0.2.2"),
-			RemoteNode: &LsNode{RouterID: "R2"},
+			Local:  LinkEndpoint{IPv4: netip.MustParseAddr("192.0.2.1")},
+			Remote: LinkEndpoint{IPv4: netip.MustParseAddr("192.0.2.2"), Node: &LsNode{RouterID: "R2"}},
 		}
 
 		var buf bytes.Buffer
@@ -43,6 +43,42 @@ func TestPrintLink(t *testing.T) {
 
 		assert.Contains(t, buf.String(), "Local: 192.0.2.1 Remote: 192.0.2.2")
 		assert.Contains(t, buf.String(), "RemoteNode: R2")
+	})
+
+	t.Run("IPv6-only endpoints are printed", func(t *testing.T) {
+		t.Parallel()
+
+		link := &LsLink{
+			Local:  LinkEndpoint{IPv6: netip.MustParseAddr("2001:db8::1")},
+			Remote: LinkEndpoint{IPv6: netip.MustParseAddr("2001:db8::2")},
+		}
+
+		var buf bytes.Buffer
+		printLink(&errWriter{w: &buf}, link)
+
+		assert.Contains(t, buf.String(), "Local: 2001:db8::1 Remote: 2001:db8::2")
+	})
+
+	t.Run("Adj-SID is printed", func(t *testing.T) {
+		t.Parallel()
+
+		link := &LsLink{AdjSids: []AdjSID{{Sid: 24001}}}
+
+		var buf bytes.Buffer
+		printLink(&errWriter{w: &buf}, link)
+
+		assert.Contains(t, buf.String(), "Adj-SID: 24001")
+	})
+
+	t.Run("a nil SRv6 End.X SID entry is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		link := &LsLink{Srv6EndXSIDs: []*Srv6EndXSID{nil, {Sids: []string{tedInternalTestSRv6SID1}}}}
+
+		var buf bytes.Buffer
+		printLink(&errWriter{w: &buf}, link)
+
+		assert.Contains(t, buf.String(), fmt.Sprintf("SIDs: [%s]", tedInternalTestSRv6SID1))
 	})
 
 	t.Run("metrics are printed", func(t *testing.T) {
@@ -60,11 +96,11 @@ func TestPrintLink(t *testing.T) {
 		t.Parallel()
 
 		link := &LsLink{
-			Srv6EndXSID: &Srv6EndXSID{
+			Srv6EndXSIDs: []*Srv6EndXSID{{
 				EndpointBehavior: 5,
 				Sids:             []string{tedInternalTestSRv6SID1},
 				Srv6SIDStructure: &SIDStructure{LocalBlock: 1, LocalNode: 2, LocalFunc: 3, LocalArg: 4},
-			},
+			}},
 		}
 
 		var buf bytes.Buffer
@@ -83,7 +119,7 @@ func TestPrintNodeLinks(t *testing.T) {
 	t.Run("node with links", func(t *testing.T) {
 		t.Parallel()
 
-		node := &LsNode{Links: []*LsLink{nil, {RemoteNode: &LsNode{RouterID: "R2"}}}}
+		node := &LsNode{Links: []*LsLink{nil, {Remote: LinkEndpoint{Node: &LsNode{RouterID: "R2"}}}}}
 
 		var buf bytes.Buffer
 		printNodeLinks(&errWriter{w: &buf}, node)
@@ -203,7 +239,7 @@ func TestPrintNodes(t *testing.T) {
 		RouterID: "R1",
 		Hostname: "router1",
 		Links: []*LsLink{
-			{RemoteNode: &LsNode{RouterID: "R2"}},
+			{Remote: LinkEndpoint{Node: &LsNode{RouterID: "R2"}}},
 		},
 	}
 	nodes := map[string]*LsNode{"R1": node}
@@ -222,4 +258,155 @@ func TestPrintNodes_WithNilNode(t *testing.T) {
 	var buf bytes.Buffer
 	printNodes(&errWriter{w: &buf}, nodes)
 	assert.Empty(t, buf.String())
+}
+
+func TestLsLink_Families(t *testing.T) {
+	t.Parallel()
+
+	v4 := netip.MustParseAddr("192.0.2.1")
+	v6 := netip.MustParseAddr("2001:db8::1")
+
+	tests := []struct {
+		name string
+		link *LsLink
+		want AddressFamilySet
+	}{
+		{
+			name: "v4-only",
+			link: &LsLink{Local: LinkEndpoint{IPv4: v4}, Remote: LinkEndpoint{IPv4: v4}},
+			want: AddressFamilySetIPv4,
+		},
+		{
+			name: "v6-only",
+			link: &LsLink{Local: LinkEndpoint{IPv6: v6}, Remote: LinkEndpoint{IPv6: v6}},
+			want: AddressFamilySetIPv6,
+		},
+		{
+			name: "dual-stack",
+			link: &LsLink{
+				Local:  LinkEndpoint{IPv4: v4, IPv6: v6},
+				Remote: LinkEndpoint{IPv4: v4, IPv6: v6},
+			},
+			want: AddressFamilySetIPv4 | AddressFamilySetIPv6,
+		},
+		{
+			name: "one side missing the address excludes that family",
+			link: &LsLink{
+				Local:  LinkEndpoint{IPv4: v4, IPv6: v6},
+				Remote: LinkEndpoint{IPv4: v4},
+			},
+			want: AddressFamilySetIPv4,
+		},
+		{
+			name: "neither side has an address",
+			link: &LsLink{},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.link.Families())
+		})
+	}
+}
+
+func TestLsLink_KeyAndUpdateTED(t *testing.T) {
+	t.Parallel()
+
+	t.Run("re-advertising the same (nodes, interface IDs) merges into one link", func(t *testing.T) {
+		t.Parallel()
+
+		ted := &LsTED{Nodes: map[string]*LsNode{}}
+		ifaceID := uint32(5)
+
+		link1 := &LsLink{
+			Local:   LinkEndpoint{Node: NewLsNode(1, "A"), InterfaceID: &ifaceID},
+			Remote:  LinkEndpoint{Node: NewLsNode(1, "B")},
+			Metrics: []*Metric{NewMetric(IGPMetric, 10)},
+		}
+		link1.UpdateTED(ted, 1)
+
+		link2 := &LsLink{
+			Local:   LinkEndpoint{Node: NewLsNode(1, "A"), InterfaceID: &ifaceID},
+			Remote:  LinkEndpoint{Node: NewLsNode(1, "B")},
+			Metrics: []*Metric{NewMetric(IGPMetric, 20)},
+		}
+		link2.UpdateTED(ted, 1)
+
+		require.Len(t, ted.Nodes["A"].Links, 1)
+		metric, err := ted.Nodes["A"].Links[0].Metric(IGPMetric)
+		require.NoError(t, err)
+		assert.Equal(t, uint32(20), metric, "the later advertisement should replace the earlier one")
+	})
+
+	t.Run("a different interface ID produces a distinct parallel link", func(t *testing.T) {
+		t.Parallel()
+
+		ted := &LsTED{Nodes: map[string]*LsNode{}}
+		ifaceID1, ifaceID2 := uint32(5), uint32(6)
+
+		link1 := &LsLink{
+			Local:  LinkEndpoint{Node: NewLsNode(1, "A"), InterfaceID: &ifaceID1},
+			Remote: LinkEndpoint{Node: NewLsNode(1, "B")},
+		}
+		link1.UpdateTED(ted, 1)
+
+		link2 := &LsLink{
+			Local:  LinkEndpoint{Node: NewLsNode(1, "A"), InterfaceID: &ifaceID2},
+			Remote: LinkEndpoint{Node: NewLsNode(1, "B")},
+		}
+		link2.UpdateTED(ted, 1)
+
+		assert.Len(t, ted.Nodes["A"].Links, 2)
+	})
+}
+
+func TestLsLink_Validate(t *testing.T) {
+	t.Parallel()
+
+	linkLocal := netip.MustParseAddr("fe80::1")
+	global := netip.MustParseAddr("2001:db8::1")
+	ifaceID := uint32(3)
+
+	tests := []struct {
+		name    string
+		link    *LsLink
+		wantErr bool
+	}{
+		{
+			name:    "local link-local IPv6 without an interface ID is rejected",
+			link:    &LsLink{Local: LinkEndpoint{IPv6: linkLocal}},
+			wantErr: true,
+		},
+		{
+			name:    "local link-local IPv6 with an interface ID is accepted",
+			link:    &LsLink{Local: LinkEndpoint{IPv6: linkLocal, InterfaceID: &ifaceID}},
+			wantErr: false,
+		},
+		{
+			name:    "remote link-local IPv6 without an interface ID is rejected",
+			link:    &LsLink{Remote: LinkEndpoint{IPv6: linkLocal}},
+			wantErr: true,
+		},
+		{
+			name:    "a global IPv6 address needs no interface ID",
+			link:    &LsLink{Local: LinkEndpoint{IPv6: global}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.link.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/table/ted_internal_test.go
+++ b/pkg/table/ted_internal_test.go
@@ -363,6 +363,108 @@ func TestLsLink_KeyAndUpdateTED(t *testing.T) {
 
 		assert.Len(t, ted.Nodes["A"].Links, 2)
 	})
+
+	t.Run("same interface ID but different Multi-Topology IDs produce distinct parallel links", func(t *testing.T) {
+		t.Parallel()
+
+		ted := &LsTED{Nodes: map[string]*LsNode{}}
+		ifaceID := uint32(5)
+		v4 := netip.MustParseAddr("192.0.2.1")
+		v6 := netip.MustParseAddr("2001:db8::1")
+
+		ipv4Topo := &LsLink{
+			Local:        LinkEndpoint{Node: NewLsNode(1, "A"), InterfaceID: &ifaceID, IPv4: v4, IPv6: v6},
+			Remote:       LinkEndpoint{Node: NewLsNode(1, "B"), IPv4: v4, IPv6: v6},
+			Metrics:      []*Metric{NewMetric(IGPMetric, 10)},
+			MultiTopoIDs: map[uint16]struct{}{0: {}},
+		}
+		ipv4Topo.UpdateTED(ted, 1)
+
+		ipv6Topo := &LsLink{
+			Local:        LinkEndpoint{Node: NewLsNode(1, "A"), InterfaceID: &ifaceID, IPv4: v4, IPv6: v6},
+			Remote:       LinkEndpoint{Node: NewLsNode(1, "B"), IPv4: v4, IPv6: v6},
+			Metrics:      []*Metric{NewMetric(IGPMetric, 100)},
+			MultiTopoIDs: map[uint16]struct{}{2: {}},
+		}
+		ipv6Topo.UpdateTED(ted, 1)
+
+		require.Len(t, ted.Nodes["A"].Links, 2)
+
+		var v4Metric, v6Metric uint32
+		for _, link := range ted.Nodes["A"].Links {
+			metric, err := link.Metric(IGPMetric)
+			require.NoError(t, err)
+
+			switch {
+			case link.UsableForFamily(AFIPv4):
+				v4Metric = metric
+			case link.UsableForFamily(AFIPv6):
+				v6Metric = metric
+			}
+		}
+
+		assert.Equal(t, uint32(10), v4Metric, "the IPv4-topology metric must survive independently of the IPv6-topology one")
+		assert.Equal(t, uint32(100), v6Metric, "the IPv6-topology metric must survive independently of the IPv4-topology one")
+	})
+}
+
+func TestLsLink_UsableForFamily(t *testing.T) {
+	t.Parallel()
+
+	v4 := netip.MustParseAddr("192.0.2.1")
+	v6 := netip.MustParseAddr("2001:db8::1")
+
+	tests := []struct {
+		name     string
+		link     *LsLink
+		wantIPv4 bool
+		wantIPv6 bool
+	}{
+		{
+			name:     "no Multi-Topology ID: usable per address presence",
+			link:     &LsLink{Local: LinkEndpoint{IPv4: v4, IPv6: v6}, Remote: LinkEndpoint{IPv4: v4, IPv6: v6}},
+			wantIPv4: true,
+			wantIPv6: true,
+		},
+		{
+			name: "Multi-Topology ID 0 (standard): IPv4 only, despite dual-stack addressing",
+			link: &LsLink{
+				Local:        LinkEndpoint{IPv4: v4, IPv6: v6},
+				Remote:       LinkEndpoint{IPv4: v4, IPv6: v6},
+				MultiTopoIDs: map[uint16]struct{}{0: {}},
+			},
+			wantIPv4: true,
+			wantIPv6: false,
+		},
+		{
+			name: "Multi-Topology ID 2 (IPv6 routing topology): IPv6 only, despite dual-stack addressing",
+			link: &LsLink{
+				Local:        LinkEndpoint{IPv4: v4, IPv6: v6},
+				Remote:       LinkEndpoint{IPv4: v4, IPv6: v6},
+				MultiTopoIDs: map[uint16]struct{}{2: {}},
+			},
+			wantIPv4: false,
+			wantIPv6: true,
+		},
+		{
+			name: "Multi-Topology ID unrecognized (not standard or IPv6 topology): unusable for any family",
+			link: &LsLink{
+				Local:        LinkEndpoint{IPv4: v4, IPv6: v6},
+				Remote:       LinkEndpoint{IPv4: v4, IPv6: v6},
+				MultiTopoIDs: map[uint16]struct{}{1: {}},
+			},
+			wantIPv4: false,
+			wantIPv6: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.wantIPv4, tt.link.UsableForFamily(AFIPv4))
+			assert.Equal(t, tt.wantIPv6, tt.link.UsableForFamily(AFIPv6))
+		})
+	}
 }
 
 func TestLsLink_Validate(t *testing.T) {

--- a/pkg/table/ted_test.go
+++ b/pkg/table/ted_test.go
@@ -16,13 +16,20 @@ import (
 	"github.com/nttcom/pola/pkg/table"
 )
 
+var (
+	planeIPv4SRMPLS = table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRMPLS}
+	planeIPv6SRMPLS = table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRMPLS}
+	planeIPv6SRv6   = table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRv6}
+)
+
 func TestLsNodeNodeSegment(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		node *table.LsNode
-		want string
+		name  string
+		node  *table.LsNode
+		plane table.Plane
+		want  string
 	}{
 		{
 			name: "PrefixSIDIndexZero",
@@ -33,20 +40,23 @@ func TestLsNodeNodeSegment(t *testing.T) {
 					{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 0, HasSidIndex: true},
 				},
 			},
-			want: "16000",
+			plane: planeIPv4SRMPLS,
+			want:  "16000",
 		},
 		{
-			name: "SRv6 Node SID is used when no Prefix-SID is present",
+			name: "SRv6 Node SID is used for the SRv6 plane even when a Prefix-SID is present",
 			node: &table.LsNode{
-				RouterID: testRouterID1,
+				RouterID:  testRouterID1,
+				SrgbBegin: 16000,
 				Prefixes: []*table.LsPrefix{
-					{Prefix: netip.MustParsePrefix("10.0.0.1/32")},
+					{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 0, HasSidIndex: true},
 				},
 				SRv6SIDs: []*table.LsSrv6SID{
 					{Sids: []string{testSRv6SID1}},
 				},
 			},
-			want: testSRv6SID1,
+			plane: planeIPv6SRv6,
+			want:  testSRv6SID1,
 		},
 		{
 			name: "SRv6 SID entries with no Sids are skipped",
@@ -57,26 +67,70 @@ func TestLsNodeNodeSegment(t *testing.T) {
 					{Sids: []string{testSRv6SID2}},
 				},
 			},
-			want: testSRv6SID2,
+			plane: planeIPv6SRv6,
+			want:  testSRv6SID2,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			seg, err := tt.node.NodeSegment()
+			seg, err := tt.node.NodeSegment(tt.plane)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, seg.SidString())
 		})
 	}
 }
 
+func TestLsNodeNodeSegment_DualStackIsPlaneDeterministic(t *testing.T) {
+	t.Parallel()
+
+	node := &table.LsNode{
+		RouterID:  testRouterID1,
+		SrgbBegin: 16000,
+		Prefixes: []*table.LsPrefix{
+			{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 10, HasSidIndex: true},
+			{Prefix: netip.MustParsePrefix("2001:db8::1/128"), SidIndex: 20, HasSidIndex: true},
+		},
+		SRv6SIDs: []*table.LsSrv6SID{
+			{Sids: []string{testSRv6SID1}},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		plane table.Plane
+		want  string
+	}{
+		{"IPv4 SR-MPLS uses the IPv4 Prefix-SID", planeIPv4SRMPLS, "16010"},
+		{"IPv6 SR-MPLS uses the IPv6 Prefix-SID", planeIPv6SRMPLS, "16020"},
+		{"IPv6 SRv6 uses the SRv6 SID", planeIPv6SRv6, testSRv6SID1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			seg, err := node.NodeSegment(tt.plane)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, seg.SidString())
+		})
+	}
+
+	t.Run("an unspecified plane is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := node.NodeSegment(table.Plane{})
+		assert.Error(t, err)
+	})
+}
+
 func TestLsNodeNodeSegment_Errors(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		node *table.LsNode
+		name  string
+		node  *table.LsNode
+		plane table.Plane
 	}{
 		{
 			name: "NoPrefixSID",
@@ -87,6 +141,7 @@ func TestLsNodeNodeSegment_Errors(t *testing.T) {
 					{Prefix: netip.MustParsePrefix("10.0.0.1/32")},
 				},
 			},
+			plane: planeIPv4SRMPLS,
 		},
 		{
 			name: "SRv6 SID cannot be parsed as an address",
@@ -96,6 +151,7 @@ func TestLsNodeNodeSegment_Errors(t *testing.T) {
 					{Sids: []string{testInvalidAddr}},
 				},
 			},
+			plane: planeIPv6SRv6,
 		},
 		{
 			name: "SRv6 SID is an IPv4 address",
@@ -105,6 +161,7 @@ func TestLsNodeNodeSegment_Errors(t *testing.T) {
 					{Sids: []string{"192.0.2.1"}},
 				},
 			},
+			plane: planeIPv6SRv6,
 		},
 		{
 			name: "SRv6 SID is an IPv4-mapped IPv6 address",
@@ -114,24 +171,37 @@ func TestLsNodeNodeSegment_Errors(t *testing.T) {
 					{Sids: []string{"::ffff:192.0.2.1"}},
 				},
 			},
+			plane: planeIPv6SRv6,
 		},
 		{
 			name: "Prefix-SID index without an SRGB",
 			node: &table.LsNode{
 				RouterID: testRouterID1,
-				Prefixes: []*table.LsPrefix{{SidIndex: 10, HasSidIndex: true}},
+				Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 10, HasSidIndex: true}},
 			},
+			plane: planeIPv4SRMPLS,
 		},
 		{
-			name: "no Prefix-SID and no SRv6 SIDs",
-			node: &table.LsNode{RouterID: testRouterID1},
+			name:  "no Prefix-SID and no SRv6 SIDs",
+			node:  &table.LsNode{RouterID: testRouterID1},
+			plane: planeIPv4SRMPLS,
+		},
+		{
+			name:  "unspecified plane",
+			node:  &table.LsNode{RouterID: testRouterID1},
+			plane: table.Plane{},
+		},
+		{
+			name:  "SRv6 over IPv4 is never valid",
+			node:  &table.LsNode{RouterID: testRouterID1},
+			plane: table.Plane{Family: table.AFIPv4, DataPlane: table.DPSRv6},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := tt.node.NodeSegment()
+			_, err := tt.node.NodeSegment(tt.plane)
 			assert.Error(t, err, "expected an error for a node without a Node SID")
 		})
 	}
@@ -149,7 +219,7 @@ func TestNodeSegment_PrefixSIDOutsideSRGB(t *testing.T) {
 			node: &table.LsNode{
 				RouterID:  testRouterID1,
 				SrgbBegin: 0xFFFFF,
-				Prefixes:  []*table.LsPrefix{{SidIndex: 10, HasSidIndex: true}},
+				Prefixes:  []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 10, HasSidIndex: true}},
 			},
 		},
 		{
@@ -158,7 +228,7 @@ func TestNodeSegment_PrefixSIDOutsideSRGB(t *testing.T) {
 				RouterID:  testRouterID1,
 				SrgbBegin: 16000,
 				SrgbEnd:   16010,
-				Prefixes:  []*table.LsPrefix{{SidIndex: 100, HasSidIndex: true}},
+				Prefixes:  []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 100, HasSidIndex: true}},
 			},
 		},
 	}
@@ -166,7 +236,7 @@ func TestNodeSegment_PrefixSIDOutsideSRGB(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := tt.node.NodeSegment()
+			_, err := tt.node.NodeSegment(planeIPv4SRMPLS)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "out of range for SRGB")
 		})
@@ -179,32 +249,44 @@ func TestLsNodeLoopbackAddr(t *testing.T) {
 	tests := []struct {
 		name    string
 		node    *table.LsNode
+		af      table.AddressFamily
 		want    netip.Addr
 		wantErr bool
 	}{
 		{
 			name: "IPv4 /32 is a loopback address",
 			node: &table.LsNode{Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}}},
+			af:   table.AFIPv4,
 			want: netip.MustParseAddr("10.0.0.1"),
 		},
 		{
 			name:    "IPv4 non-/32 is not a loopback address",
 			node:    &table.LsNode{Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.0/24")}}},
+			af:      table.AFIPv4,
 			wantErr: true,
 		},
 		{
 			name: "IPv6 /128 is a loopback address",
 			node: &table.LsNode{Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("2001:db8::1/128")}}},
+			af:   table.AFIPv6,
 			want: netip.MustParseAddr(testSRv6SID1),
 		},
 		{
 			name:    "IPv6 non-/128 is not a loopback address",
 			node:    &table.LsNode{Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("2001:db8::/64")}}},
+			af:      table.AFIPv6,
 			wantErr: true,
 		},
 		{
 			name:    "no prefixes",
 			node:    &table.LsNode{},
+			af:      table.AFIPv4,
+			wantErr: true,
+		},
+		{
+			name:    "an unspecified address family is rejected",
+			node:    &table.LsNode{Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}}},
+			af:      table.AFUnspecified,
 			wantErr: true,
 		},
 	}
@@ -212,7 +294,7 @@ func TestLsNodeLoopbackAddr(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := tt.node.LoopbackAddr()
+			got, err := tt.node.LoopbackAddr(tt.af)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -221,6 +303,26 @@ func TestLsNodeLoopbackAddr(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func TestLsNodeLoopbackAddr_DualStackOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	v4 := &table.LsPrefix{Prefix: netip.MustParsePrefix("10.0.0.1/32")}
+	v6 := &table.LsPrefix{Prefix: netip.MustParsePrefix("2001:db8::1/128")}
+
+	forward := &table.LsNode{Prefixes: []*table.LsPrefix{v4, v6}}
+	reversed := &table.LsNode{Prefixes: []*table.LsPrefix{v6, v4}}
+
+	for _, af := range []table.AddressFamily{table.AFIPv4, table.AFIPv6} {
+		gotForward, err := forward.LoopbackAddr(af)
+		require.NoError(t, err)
+
+		gotReversed, err := reversed.LoopbackAddr(af)
+		require.NoError(t, err)
+
+		assert.Equal(t, gotForward, gotReversed)
 	}
 }
 
@@ -277,12 +379,123 @@ func TestLsNodeAddLink(t *testing.T) {
 	assert.Equal(t, []*table.LsLink{link}, node.Links)
 }
 
+func TestLsNodeDefaultPlane(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no viable plane", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&table.LsNode{RouterID: testRouterID1}).DefaultPlane()
+		assert.EqualError(t, err, "node doesn't have a Node SID")
+	})
+
+	t.Run("exactly one viable plane", func(t *testing.T) {
+		t.Parallel()
+
+		node := &table.LsNode{RouterID: testRouterID1, SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{testSRv6SID1}}}}
+
+		plane, err := node.DefaultPlane()
+		require.NoError(t, err)
+		assert.Equal(t, table.Plane{Family: table.AFIPv6, DataPlane: table.DPSRv6}, plane)
+	})
+
+	t.Run("multiple viable planes require an explicit choice", func(t *testing.T) {
+		t.Parallel()
+
+		node := &table.LsNode{
+			RouterID:  testRouterID1,
+			SrgbBegin: 16000,
+			Prefixes: []*table.LsPrefix{
+				{Prefix: netip.MustParsePrefix("10.0.0.1/32"), SidIndex: 0, HasSidIndex: true},
+			},
+			SRv6SIDs: []*table.LsSrv6SID{{Sids: []string{testSRv6SID1}}},
+		}
+
+		_, err := node.DefaultPlane()
+		assert.ErrorContains(t, err, "an explicit plane is required")
+	})
+}
+
+func TestLsNodeDefaultLoopbackFamily(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no loopback address", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&table.LsNode{RouterID: testRouterID1}).DefaultLoopbackFamily()
+		assert.EqualError(t, err, "node doesn't have a loopback address")
+	})
+
+	t.Run("exactly one address family", func(t *testing.T) {
+		t.Parallel()
+
+		node := &table.LsNode{
+			RouterID: testRouterID1,
+			Prefixes: []*table.LsPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}},
+		}
+
+		af, err := node.DefaultLoopbackFamily()
+		require.NoError(t, err)
+		assert.Equal(t, table.AFIPv4, af)
+	})
+
+	t.Run("multiple address families require an explicit choice", func(t *testing.T) {
+		t.Parallel()
+
+		node := &table.LsNode{
+			RouterID: testRouterID1,
+			Prefixes: []*table.LsPrefix{
+				{Prefix: netip.MustParsePrefix("10.0.0.1/32")},
+				{Prefix: netip.MustParsePrefix("2001:db8::1/128")},
+			},
+		}
+
+		_, err := node.DefaultLoopbackFamily()
+		assert.ErrorContains(t, err, "an explicit family is required")
+	})
+}
+
+func TestLinkEndpointAddr(t *testing.T) {
+	t.Parallel()
+
+	e := table.LinkEndpoint{
+		IPv4: netip.MustParseAddr("192.0.2.1"),
+		IPv6: netip.MustParseAddr("2001:db8::1"),
+	}
+
+	assert.Equal(t, e.IPv4, e.Addr(table.AFIPv4))
+	assert.Equal(t, e.IPv6, e.Addr(table.AFIPv6))
+	assert.False(t, e.Addr(table.AFUnspecified).IsValid())
+}
+
+func TestLsLinkKey_DistinguishesByAddressFamily(t *testing.T) {
+	t.Parallel()
+
+	ipv4Link := &table.LsLink{
+		Local:  table.LinkEndpoint{IPv4: netip.MustParseAddr("192.0.2.1")},
+		Remote: table.LinkEndpoint{IPv4: netip.MustParseAddr("192.0.2.2")},
+	}
+	ipv6Link := &table.LsLink{
+		Local:  table.LinkEndpoint{IPv6: netip.MustParseAddr("2001:db8::1")},
+		Remote: table.LinkEndpoint{IPv6: netip.MustParseAddr("2001:db8::2")},
+	}
+	noAddrLink := &table.LsLink{}
+
+	assert.NotEqual(t, ipv4Link.Key(), ipv6Link.Key())
+	assert.NotEqual(t, ipv4Link.Key(), noAddrLink.Key())
+	assert.Equal(t, noAddrLink.Key(), (&table.LsLink{}).Key())
+}
+
 func TestNewLsLink(t *testing.T) {
 	t.Parallel()
 
 	local := &table.LsNode{RouterID: "R1"}
 	remote := &table.LsNode{RouterID: "R2"}
-	assert.Equal(t, &table.LsLink{LocalNode: local, RemoteNode: remote}, table.NewLsLink(local, remote))
+	want := &table.LsLink{
+		Local:  table.LinkEndpoint{Node: local},
+		Remote: table.LinkEndpoint{Node: remote},
+	}
+	assert.Equal(t, want, table.NewLsLink(local, remote))
 }
 
 func TestLsLinkMetric(t *testing.T) {
@@ -340,8 +553,8 @@ func TestLsLinkUpdateTED_CreatesNodesAndAddsLink(t *testing.T) {
 
 	require.Contains(t, ted.Nodes, "R1")
 	require.Contains(t, ted.Nodes, "R2")
-	assert.Same(t, ted.Nodes["R1"], link.LocalNode)
-	assert.Same(t, ted.Nodes["R2"], link.RemoteNode)
+	assert.Same(t, ted.Nodes["R1"], link.Local.Node)
+	assert.Same(t, ted.Nodes["R2"], link.Remote.Node)
 	assert.Equal(t, []*table.LsLink{link}, ted.Nodes["R1"].Links)
 }
 
@@ -357,8 +570,8 @@ func TestLsLinkUpdateTED_ReusesExistingNodes(t *testing.T) {
 	link := table.NewLsLink(&table.LsNode{ASN: 1, RouterID: "R1"}, &table.LsNode{ASN: 1, RouterID: "R2"})
 	link.UpdateTED(ted, 1)
 
-	assert.Same(t, existingLocal, link.LocalNode, "expected the link to reference the existing node object")
-	assert.Same(t, existingRemote, link.RemoteNode)
+	assert.Same(t, existingLocal, link.Local.Node, "expected the link to reference the existing node object")
+	assert.Same(t, existingRemote, link.Remote.Node)
 	assert.Equal(t, []*table.LsLink{preexistingLink, link}, existingLocal.Links, "expected the link to be appended to existing links")
 }
 
@@ -452,6 +665,36 @@ func TestLsSrv6SIDUpdateTED_ReusesExistingNode(t *testing.T) {
 
 	assert.Same(t, existing, first.LocalNode)
 	assert.Equal(t, []*table.LsSrv6SID{first, second}, existing.SRv6SIDs)
+}
+
+func TestLsNodeAddSrv6SID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("re-advertisement of the same SID replaces the existing entry", func(t *testing.T) {
+		t.Parallel()
+
+		node := &table.LsNode{RouterID: testRouterID1}
+		first := &table.LsSrv6SID{Sids: []string{testSRv6SID1}}
+		node.AddSrv6SID(first)
+
+		second := &table.LsSrv6SID{Sids: []string{testSRv6SID1}}
+		node.AddSrv6SID(second)
+
+		assert.Equal(t, []*table.LsSrv6SID{second}, node.SRv6SIDs)
+	})
+
+	t.Run("entries with no Sids have no dedup key and are both appended", func(t *testing.T) {
+		t.Parallel()
+
+		node := &table.LsNode{RouterID: testRouterID1}
+		first := &table.LsSrv6SID{}
+		node.AddSrv6SID(first)
+
+		second := &table.LsSrv6SID{}
+		node.AddSrv6SID(second)
+
+		assert.Equal(t, []*table.LsSrv6SID{first, second}, node.SRv6SIDs, "entries with no Sids have no meaningful dedup key, so they must not collide")
+	})
 }
 
 func TestNewMetric(t *testing.T) {
@@ -633,6 +876,27 @@ func TestLsTEDAddressRouterIDIndex(t *testing.T) {
 	assert.Nil(t, nilTED.AddressRouterIDIndex())
 }
 
+func TestLsTEDAddressRouterIDIndex_ConflictIsAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	shared := netip.MustParsePrefix("192.0.2.0/30")
+
+	for range 20 {
+		ted := &table.LsTED{Nodes: map[string]*table.LsNode{}}
+
+		nodeX := table.NewLsNode(65000, "router-x")
+		nodeX.Prefixes = append(nodeX.Prefixes, &table.LsPrefix{LocalNode: nodeX, Prefix: shared})
+		ted.Nodes[nodeX.RouterID] = nodeX
+
+		nodeY := table.NewLsNode(65000, "router-y")
+		nodeY.Prefixes = append(nodeY.Prefixes, &table.LsPrefix{LocalNode: nodeY, Prefix: shared})
+		ted.Nodes[nodeY.RouterID] = nodeY
+
+		index := ted.AddressRouterIDIndex()
+		assert.Empty(t, index[shared.Addr()], "conflicting owners must never resolve to whichever node was visited last")
+	}
+}
+
 func TestLsTEDFindRouterIDByLoopback(t *testing.T) {
 	t.Parallel()
 
@@ -684,7 +948,7 @@ func TestLsTEDPrint(t *testing.T) {
 				RouterID: "R1",
 				Hostname: "router1",
 				Links: []*table.LsLink{
-					{RemoteNode: &table.LsNode{RouterID: "R2"}},
+					{Remote: table.LinkEndpoint{Node: &table.LsNode{RouterID: "R2"}}},
 				},
 			},
 		}}
@@ -703,10 +967,10 @@ func TestLsTEDPrint(t *testing.T) {
 				RouterID: "R1",
 				Links: []*table.LsLink{
 					{
-						RemoteNode: &table.LsNode{RouterID: "R2"},
-						Srv6EndXSID: &table.Srv6EndXSID{
+						Remote: table.LinkEndpoint{Node: &table.LsNode{RouterID: "R2"}},
+						Srv6EndXSIDs: []*table.Srv6EndXSID{{
 							Sids: []string{"fcbb:bb00:0100::"},
-						},
+						}},
 					},
 				},
 			},

--- a/test/helpers/wait.py
+++ b/test/helpers/wait.py
@@ -191,7 +191,7 @@ def wait_until_ted_has_links(
         for node in ted:
             local = node.get("routerId")
             for link in node.get("links", []):
-                remote = link.get("remoteRouterId")
+                remote = link.get("remote", {}).get("routerId")
                 if local and remote:
                     found.add(frozenset((local, remote)))
 

--- a/test/scenario/dynamic-path/README.md
+++ b/test/scenario/dynamic-path/README.md
@@ -1,54 +1,42 @@
 # Dynamic Path Scenario Tests
 
-This directory contains end-to-end scenario tests for SRv6 uSID dynamic path computation using Pola PCE, GoBGP, and Containerlab.
+End-to-end scenario tests for dynamic path computation using Pola PCE,
+GoBGP, and Containerlab.
 
-The tests verify:
+| Lab | Test class | Covers |
+| --- | --- | --- |
+| [`srv6-usid/`](./srv6-usid) | `TestDynamicPath` | SRv6 uSID dynamic path and loose source routing |
+| [`dual-stack/`](./dual-stack) | `TestDynamicPathDualStack` | Dual-stack TED and per-family SR-MPLS underlay selection |
 
-- PCEP session establishment
-- TED (Traffic Engineering Database) population
-- Dynamic SR Policy installation
-- SRv6 uSID segment list generation on the headend router
+Both labs verify PCEP session establishment, TED population, dynamic SR
+Policy installation, and the resulting segment list on the headend router.
 
-## Topology
+## SRv6 uSID Topology
 
 ![Topology](./topo.png)
 
-The topology consists of:
-
-- `pe01`
-  - Provider edge router
-- `pe02`
-  - Provider edge router
-  - PCEP PCC and SR Policy headend router
-- `p01` / `p02`
-  - Core routers
-- `pola`
-  - Pola PCE
-- `gobgp`
-  - BGP-LS speaker used to collect topology information
+- `pe01` / `pe02`: Provider edge routers
+- `pe02`: PCEP PCC and SR Policy headend
+- `p01` / `p02`: Core routers
+- `pola`: Pola PCE
+- `gobgp`: BGP-LS speaker
 
 ## Test Flow
 
-The topology is deployed once for the whole module, then every test case installs
-its own SR Policy on it. Each policy uses a distinct color and name, so the test
-cases stay independent of each other and of their execution order.
+Each lab is deployed once for the module. Each test then installs and verifies
+its own SR Policy.
 
 1. Deploy the Containerlab topology
-2. Wait for the PCEP session establishment
-3. Wait until all routers appear in the TED
-4. Wait until all expected links appear in the TED
+2. Wait for PCEP session establishment and TED population
+3. For each test:
+   - Install an SR Policy via `pola sr-policy add`
+   - Verify that it becomes `Up`
+   - Verify the generated segment list
 
-Then, per test case:
-
-1. Install an SR Policy via `pola sr-policy add`
-2. Verify that the SR Policy becomes `Up`
-3. Verify the generated SRv6 uSID segment list
-
-## Test Cases
+## SRv6 uSID Test Cases
 
 ### `test__srv6_usid_dynamic_path`
 
-Verifies normal dynamic path computation.
 Installs `DYNAMIC-POLICY` with color 100.
 
 Expected segment list:
@@ -76,7 +64,6 @@ srv6-usid/input/sr-policies/pe02-policy1.yaml
 
 ### `test__srv6_usid_loose_source_routing`
 
-Verifies loose source routing behavior with repeated waypoint traversal.
 Installs `LOOSE-SOURCE-ROUTING-POLICY` with color 200.
 
 Expected segment list:
@@ -103,3 +90,47 @@ Policy file:
 ```text
 srv6-usid/input/sr-policies/pe02-policy-loose-source-routing.yaml
 ```
+
+## Dual-Stack Topology
+
+```text
+                  +------+
+         +--------| p01  |--------+     IPv4 metric: cheap
+         |        | XRd  |        |     IPv6 metric: expensive
+         |        +------+        |
+     +------+                +------+
+     | pe01 |                | pe02 |
+     | XRd  |                | XRd  |
+     +------+                +------+
+         |        +------+        |
+         +--------| p02  |--------+     IPv4 metric: expensive
+                  | XRd  |              IPv6 metric: cheap
+                  +------+
+```
+
+Each PE-P link is dual-stack with independent IS-IS metrics, so the cheapest
+IPv4 and IPv6 paths differ.
+
+## Dual-Stack Test Cases
+
+### `test__dual_stack_links_expose_both_address_families`
+
+Verifies that dual-stack links expose both IPv4 and IPv6 addresses in the TED.
+
+### `test__pe02_ipv6_loopback_is_advertised_as_a_128_prefix`
+
+Verifies that `pe02` advertises its IPv6 loopback as a `/128` prefix.
+
+### `test__ipv4_underlay_computes_the_ipv4_cheap_path`
+
+Verifies that the IPv4 underlay selects the path via `p01`.
+
+### `test__ipv6_underlay_computes_the_ipv6_cheap_path`
+
+Verifies that the IPv6 underlay selects the path via `p02`.
+
+> [!NOTE]
+> This case is currently `xfail`. IOS-XR 24.4.1 cannot process a
+> PCE-initiated SR-MPLS policy with an IPv6 endpoint. The PCEP message is
+> correct on the wire; the PCC rejects it locally. See the `xfail` reason in
+> `test_dynamic_path.py` for details.

--- a/test/scenario/dynamic-path/README.md
+++ b/test/scenario/dynamic-path/README.md
@@ -100,7 +100,7 @@ srv6-usid/input/sr-policies/pe02-policy-loose-source-routing.yaml
          |        +------+        |
      +------+                +------+
      | pe01 |                | pe02 |
-     | XRd  |                | XRd  |
+     | XRd  |                | Junos|
      +------+                +------+
          |        +------+        |
          +--------| p02  |--------+     IPv4 metric: expensive
@@ -108,29 +108,42 @@ srv6-usid/input/sr-policies/pe02-policy-loose-source-routing.yaml
                   +------+
 ```
 
-Each PE-P link is dual-stack with independent IS-IS metrics, so the cheapest
-IPv4 and IPv6 paths differ.
+Each PE-P link is dual-stack, with independent IS-IS metrics for IPv4 and IPv6,
+so the preferred path differs by address family.
 
 ## Dual-Stack Test Cases
 
 ### `test__dual_stack_links_expose_both_address_families`
 
-Verifies that dual-stack links expose both IPv4 and IPv6 addresses in the TED.
+Dual-stack links expose both IPv4 and IPv6 addresses in the TED.
 
 ### `test__pe02_ipv6_loopback_is_advertised_as_a_128_prefix`
 
-Verifies that `pe02` advertises its IPv6 loopback as a `/128` prefix.
+`pe02` advertises its IPv6 loopback as a `/128` prefix.
 
-### `test__ipv4_underlay_computes_the_ipv4_cheap_path`
+### `test__pe02_ipv4_underlay_computes_the_ipv4_cheap_path`
 
-Verifies that the IPv4 underlay selects the path via `p01`.
+The IPv4 underlay selects the path via `p01`.
 
-### `test__ipv6_underlay_computes_the_ipv6_cheap_path`
+### `test__pe02_ipv6_underlay_computes_the_ipv6_cheap_path`
 
-Verifies that the IPv6 underlay selects the path via `p02`.
+The IPv6 underlay selects the path via `p02`.
 
 > [!NOTE]
-> This case is currently `xfail`. IOS-XR 24.4.1 cannot process a
-> PCE-initiated SR-MPLS policy with an IPv6 endpoint. The PCEP message is
-> correct on the wire; the PCC rejects it locally. See the `xfail` reason in
-> `test_dynamic_path.py` for details.
+> Currently `xfail`: Junos 25.2R1.9 `pccd` rejects the PCE-initiated SR-MPLS
+> policy because its SRPAG association object is IPv6-typed
+> (`PCError: IPv6 SRPAG received for non SRv6 LSP`). The PCInitiate message is
+> otherwise valid on the wire. See the `xfail` reason in `test_dynamic_path.py`.
+
+### `test__pe01_ipv4_underlay_computes_the_ipv4_cheap_path`
+
+The IPv4 underlay selects the path via `p01`.
+
+### `test__pe01_ipv6_underlay_computes_the_ipv6_cheap_path`
+
+The IPv6 underlay selects the path via `p02`.
+
+> [!NOTE]
+> Currently `xfail`: IOS-XR 24.4.1 rejects PCE-initiated SR-MPLS policies with
+> an IPv6 endpoint. The PCEP message is correct on the wire. See the `xfail`
+> reason in `test_dynamic_path.py`.

--- a/test/scenario/dynamic-path/dual-stack/input/gobgpd.yaml
+++ b/test/scenario/dynamic-path/dual-stack/input/gobgpd.yaml
@@ -1,0 +1,11 @@
+global:
+  config:
+    as: 65000
+    router-id: "10.255.2.255"
+neighbors:
+  - config:
+      peer-as: 65000
+      neighbor-address: "10.0.30.1"
+    afi-safis:
+      - config:
+          afi-safi-name: ls

--- a/test/scenario/dynamic-path/dual-stack/input/polad.yaml
+++ b/test/scenario/dynamic-path/dual-stack/input/polad.yaml
@@ -1,0 +1,18 @@
+global:
+  pcep:
+    address: "::"
+    port: 4189
+  grpcServer:
+    address: "127.0.0.1"
+    port: 50052
+  log:
+    path: "/var/log/pola/"
+    name: "polad.log"
+  ted:
+    enable: true
+    source: "gobgp"
+    asn: 65000
+  gobgp:
+    grpcClient:
+      address: "10.0.30.4"
+      port: 50051

--- a/test/scenario/dynamic-path/dual-stack/input/sr-policies/pe01-ipv4.yaml
+++ b/test/scenario/dynamic-path/dual-stack/input/sr-policies/pe01-ipv4.yaml
@@ -1,0 +1,13 @@
+asn: 65000
+srPolicy:
+  pcepSessionAddr: "10.0.30.1"
+  headendRouterID: "0000.0002.0001"
+  endpointRouterID: "0000.0002.0004"
+  endpointFamily: ipv4
+  name: "DUAL-STACK-IPV4-POLICY-PE01"
+  color: 401
+  candidatePath:
+    dynamic:
+      metric: igp
+      dataPlane: sr-mpls
+      underlayFamily: ipv4

--- a/test/scenario/dynamic-path/dual-stack/input/sr-policies/pe01-ipv6.yaml
+++ b/test/scenario/dynamic-path/dual-stack/input/sr-policies/pe01-ipv6.yaml
@@ -1,0 +1,13 @@
+asn: 65000
+srPolicy:
+  pcepSessionAddr: "10.0.30.1"
+  headendRouterID: "0000.0002.0001"
+  endpointRouterID: "0000.0002.0004"
+  endpointFamily: ipv6
+  name: "DUAL-STACK-IPV6-POLICY-PE01"
+  color: 601
+  candidatePath:
+    dynamic:
+      metric: igp
+      dataPlane: sr-mpls
+      underlayFamily: ipv6

--- a/test/scenario/dynamic-path/dual-stack/input/sr-policies/pe02-ipv4.yaml
+++ b/test/scenario/dynamic-path/dual-stack/input/sr-policies/pe02-ipv4.yaml
@@ -1,0 +1,13 @@
+asn: 65000
+srPolicy:
+  pcepSessionAddr: "10.0.30.2"
+  headendRouterID: "0000.0002.0004"
+  endpointRouterID: "0000.0002.0001"
+  endpointFamily: ipv4
+  name: "DUAL-STACK-IPV4-POLICY"
+  color: 400
+  candidatePath:
+    dynamic:
+      metric: igp
+      dataPlane: sr-mpls
+      underlayFamily: ipv4

--- a/test/scenario/dynamic-path/dual-stack/input/sr-policies/pe02-ipv6.yaml
+++ b/test/scenario/dynamic-path/dual-stack/input/sr-policies/pe02-ipv6.yaml
@@ -1,0 +1,13 @@
+asn: 65000
+srPolicy:
+  pcepSessionAddr: "10.0.30.2"
+  headendRouterID: "0000.0002.0004"
+  endpointRouterID: "0000.0002.0001"
+  endpointFamily: ipv6
+  name: "DUAL-STACK-IPV6-POLICY"
+  color: 600
+  candidatePath:
+    dynamic:
+      metric: igp
+      dataPlane: sr-mpls
+      underlayFamily: ipv6

--- a/test/scenario/dynamic-path/dual-stack/input/startup-configs/p01.cfg
+++ b/test/scenario/dynamic-path/dual-stack/input/startup-configs/p01.cfg
@@ -1,0 +1,96 @@
+hostname p01
+username admin
+ group root-lr
+ group cisco-support
+ secret admin@123
+!
+grpc
+ vrf MGMT
+ no-tls
+ address-family dual
+!
+vrf MGMT
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+!
+line default
+ transport input ssh
+!
+call-home
+ service active
+ contact smart-licensing
+ profile CiscoTAC-1
+  active
+  destination transport-method email disable
+  destination transport-method http
+ !
+!
+netconf-yang agent
+ ssh
+!
+interface Loopback0
+ ipv4 address 10.255.2.2 255.255.255.255
+ ipv6 address 2001:db8:200::2/128
+!
+interface GigabitEthernet0/0/0/0
+ description to:pe01
+ ipv4 address 10.0.20.2 255.255.255.252
+ ipv6 address 2001:db8:20:1::2/64
+!
+interface GigabitEthernet0/0/0/1
+ description to:pe02
+ ipv4 address 10.0.21.1 255.255.255.252
+ ipv6 address 2001:db8:20:2::1/64
+!
+router isis 1
+ is-type level-2-only
+ net 49.0000.0000.0002.0002.00
+ segment-routing global-block 16000 23999
+ address-family ipv4 unicast
+  metric-style wide
+  segment-routing mpls
+ !
+ address-family ipv6 unicast
+  metric-style wide
+  segment-routing mpls
+ !
+ interface Loopback0
+  passive
+  address-family ipv4 unicast
+   prefix-sid index 22
+  !
+  address-family ipv6 unicast
+   prefix-sid index 122
+  !
+ !
+ interface GigabitEthernet0/0/0/0
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv4 unicast
+   metric 10 level 2
+  !
+  address-family ipv6 unicast
+   metric 100 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/1
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv4 unicast
+   metric 10 level 2
+  !
+  address-family ipv6 unicast
+   metric 100 level 2
+  !
+ !
+!
+mpls oam
+!
+ssh server v2
+ssh server vrf MGMT
+ssh server netconf vrf MGMT
+end

--- a/test/scenario/dynamic-path/dual-stack/input/startup-configs/p02.cfg
+++ b/test/scenario/dynamic-path/dual-stack/input/startup-configs/p02.cfg
@@ -1,0 +1,96 @@
+hostname p02
+username admin
+ group root-lr
+ group cisco-support
+ secret admin@123
+!
+grpc
+ vrf MGMT
+ no-tls
+ address-family dual
+!
+vrf MGMT
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+!
+line default
+ transport input ssh
+!
+call-home
+ service active
+ contact smart-licensing
+ profile CiscoTAC-1
+  active
+  destination transport-method email disable
+  destination transport-method http
+ !
+!
+netconf-yang agent
+ ssh
+!
+interface Loopback0
+ ipv4 address 10.255.2.3 255.255.255.255
+ ipv6 address 2001:db8:200::3/128
+!
+interface GigabitEthernet0/0/0/0
+ description to:pe01
+ ipv4 address 10.0.22.2 255.255.255.252
+ ipv6 address 2001:db8:20:3::2/64
+!
+interface GigabitEthernet0/0/0/1
+ description to:pe02
+ ipv4 address 10.0.23.1 255.255.255.252
+ ipv6 address 2001:db8:20:4::1/64
+!
+router isis 1
+ is-type level-2-only
+ net 49.0000.0000.0002.0003.00
+ segment-routing global-block 16000 23999
+ address-family ipv4 unicast
+  metric-style wide
+  segment-routing mpls
+ !
+ address-family ipv6 unicast
+  metric-style wide
+  segment-routing mpls
+ !
+ interface Loopback0
+  passive
+  address-family ipv4 unicast
+   prefix-sid index 23
+  !
+  address-family ipv6 unicast
+   prefix-sid index 123
+  !
+ !
+ interface GigabitEthernet0/0/0/0
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv4 unicast
+   metric 100 level 2
+  !
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/1
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv4 unicast
+   metric 100 level 2
+  !
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+!
+mpls oam
+!
+ssh server v2
+ssh server vrf MGMT
+ssh server netconf vrf MGMT
+end

--- a/test/scenario/dynamic-path/dual-stack/input/startup-configs/pe01.cfg
+++ b/test/scenario/dynamic-path/dual-stack/input/startup-configs/pe01.cfg
@@ -111,6 +111,16 @@ router bgp 65000
 !
 mpls oam
 !
+segment-routing
+ traffic-eng
+  pcc
+   source-address ipv4 10.0.30.1
+   pce address ipv4 10.0.30.3
+   !
+   report-all
+  !
+ !
+!
 ssh server v2
 ssh server vrf MGMT
 ssh server netconf vrf MGMT

--- a/test/scenario/dynamic-path/dual-stack/input/startup-configs/pe01.cfg
+++ b/test/scenario/dynamic-path/dual-stack/input/startup-configs/pe01.cfg
@@ -1,0 +1,117 @@
+hostname pe01
+username admin
+ group root-lr
+ group cisco-support
+ secret admin@123
+!
+grpc
+ vrf MGMT
+ no-tls
+ address-family dual
+!
+vrf MGMT
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+!
+line default
+ transport input ssh
+!
+call-home
+ service active
+ contact smart-licensing
+ profile CiscoTAC-1
+  active
+  destination transport-method email disable
+  destination transport-method http
+ !
+!
+netconf-yang agent
+ ssh
+!
+interface Loopback0
+ ipv4 address 10.255.2.1 255.255.255.255
+!
+interface Loopback1
+ ipv6 address 2001:db8:200:1::1/128
+!
+interface GigabitEthernet0/0/0/0
+ description to:p01
+ ipv4 address 10.0.20.1 255.255.255.252
+ ipv6 address 2001:db8:20:1::1/64
+!
+interface GigabitEthernet0/0/0/1
+ description to:p02
+ ipv4 address 10.0.22.1 255.255.255.252
+ ipv6 address 2001:db8:20:3::1/64
+!
+interface GigabitEthernet0/0/0/2
+ description to:switch(bgp-ls)
+ ipv4 address 10.0.30.1 255.255.255.0
+!
+router isis 1
+ is-type level-2-only
+ net 49.0000.0000.0002.0001.00
+ distribute link-state level 2
+ segment-routing global-block 16000 23999
+ address-family ipv4 unicast
+  metric-style wide
+  segment-routing mpls
+ !
+ address-family ipv6 unicast
+  metric-style wide
+  segment-routing mpls
+ !
+ interface Loopback0
+  passive
+  address-family ipv4 unicast
+   prefix-sid index 21
+  !
+ !
+ interface Loopback1
+  passive
+  address-family ipv6 unicast
+   prefix-sid index 121
+  !
+ !
+ interface GigabitEthernet0/0/0/0
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv4 unicast
+   metric 10 level 2
+  !
+  address-family ipv6 unicast
+   metric 100 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/1
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv4 unicast
+   metric 100 level 2
+  !
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+!
+router bgp 65000
+ bgp router-id 10.255.2.1
+ address-family link-state link-state
+ !
+ neighbor 10.0.30.4
+  remote-as 65000
+  update-source GigabitEthernet0/0/0/2
+  address-family link-state link-state
+  !
+ !
+!
+mpls oam
+!
+ssh server v2
+ssh server vrf MGMT
+ssh server netconf vrf MGMT
+end

--- a/test/scenario/dynamic-path/dual-stack/input/startup-configs/pe02.cfg
+++ b/test/scenario/dynamic-path/dual-stack/input/startup-configs/pe02.cfg
@@ -1,115 +1,116 @@
-hostname pe02
-username admin
- group root-lr
- group cisco-support
- secret admin@123
-!
-grpc
- vrf MGMT
- no-tls
- address-family dual
-!
-vrf MGMT
- address-family ipv4 unicast
- !
- address-family ipv6 unicast
- !
-!
-line default
- transport input ssh
-!
-call-home
- service active
- contact smart-licensing
- profile CiscoTAC-1
-  active
-  destination transport-method email disable
-  destination transport-method http
- !
-!
-netconf-yang agent
- ssh
-!
-interface Loopback0
- ipv4 address 10.255.2.4 255.255.255.255
-!
-interface Loopback1
- ipv6 address 2001:db8:200:4::1/128
-!
-interface GigabitEthernet0/0/0/0
- description to:p01
- ipv4 address 10.0.21.2 255.255.255.252
- ipv6 address 2001:db8:20:2::2/64
-!
-interface GigabitEthernet0/0/0/1
- description to:p02
- ipv4 address 10.0.23.2 255.255.255.252
- ipv6 address 2001:db8:20:4::2/64
-!
-interface GigabitEthernet0/0/0/2
- description to:switch(pcep)
- ipv4 address 10.0.30.2 255.255.255.0
-!
-router isis 1
- is-type level-2-only
- net 49.0000.0000.0002.0004.00
- segment-routing global-block 16000 23999
- address-family ipv4 unicast
-  metric-style wide
-  segment-routing mpls
- !
- address-family ipv6 unicast
-  metric-style wide
-  segment-routing mpls
- !
- interface Loopback0
-  passive
-  address-family ipv4 unicast
-   prefix-sid index 24
-  !
- !
- interface Loopback1
-  passive
-  address-family ipv6 unicast
-   prefix-sid index 124
-  !
- !
- interface GigabitEthernet0/0/0/0
-  circuit-type level-2-only
-  point-to-point
-  hello-interval 1
-  address-family ipv4 unicast
-   metric 10 level 2
-  !
-  address-family ipv6 unicast
-   metric 100 level 2
-  !
- !
- interface GigabitEthernet0/0/0/1
-  circuit-type level-2-only
-  point-to-point
-  hello-interval 1
-  address-family ipv4 unicast
-   metric 100 level 2
-  !
-  address-family ipv6 unicast
-   metric 10 level 2
-  !
- !
-!
-mpls oam
-!
-segment-routing
- traffic-eng
-  pcc
-   source-address ipv4 10.0.30.2
-   pce address ipv4 10.0.30.3
-   !
-   report-all
-  !
- !
-!
-ssh server v2
-ssh server vrf MGMT
-ssh server netconf vrf MGMT
-end
+chassis {
+    network-services enhanced-ip;
+}
+
+interfaces {
+    ge-0/0/0 {
+        description "to:p01";
+        unit 0 {
+            family inet {
+                address 10.0.21.2/30;
+            }
+            family iso;
+            family inet6 {
+                address 2001:db8:20:2::2/64;
+            }
+            family mpls;
+        }
+    }
+    ge-0/0/1 {
+        description "to:p02";
+        unit 0 {
+            family inet {
+                address 10.0.23.2/30;
+            }
+            family iso;
+            family inet6 {
+                address 2001:db8:20:4::2/64;
+            }
+            family mpls;
+        }
+    }
+    ge-0/0/2 {
+        description "to:switch(pcep)";
+        unit 0 {
+            family inet {
+                address 10.0.30.2/24;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.255.2.4/32;
+            }
+            family iso {
+                address 49.0000.0000.0002.0004.00;
+            }
+            family inet6 {
+                address 2001:db8:200:4::1/128;
+            }
+        }
+    }
+}
+
+routing-options {
+    router-id 10.255.2.4;
+    autonomous-system 65000;
+}
+
+protocols {
+    isis {
+        level 1 disable;
+        level 2 {
+            wide-metrics-only;
+        }
+        topologies {
+            ipv6-unicast;
+        }
+        source-packet-routing {
+            srgb {
+                start-label 16000;
+                index-range 8000;
+            }
+            node-segment {
+                ipv4-index 24;
+                ipv6-index 124;
+            }
+        }
+        interface ge-0/0/0.0 {
+            point-to-point;
+            level 2 {
+                metric 10;
+                ipv6-unicast-metric 100;
+            }
+        }
+        interface ge-0/0/1.0 {
+            point-to-point;
+            level 2 {
+                metric 100;
+                ipv6-unicast-metric 10;
+            }
+        }
+        interface lo0.0 {
+            passive;
+        }
+    }
+    mpls {
+        lsp-external-controller pccd;
+        interface ge-0/0/0.0;
+        interface ge-0/0/1.0;
+    }
+    source-packet-routing {
+        lsp-external-controller pccd;
+        preserve-nexthop-hierarchy;
+    }
+    pcep {
+        pce POLA-PCE {
+            local-ipv4-address 10.0.30.2;
+            destination-ipv4-address 10.0.30.3;
+            pce-type active;
+            pce-type stateful;
+            lsp-provisioning;
+            spring-capability;
+        }
+    }
+}

--- a/test/scenario/dynamic-path/dual-stack/input/startup-configs/pe02.cfg
+++ b/test/scenario/dynamic-path/dual-stack/input/startup-configs/pe02.cfg
@@ -1,0 +1,115 @@
+hostname pe02
+username admin
+ group root-lr
+ group cisco-support
+ secret admin@123
+!
+grpc
+ vrf MGMT
+ no-tls
+ address-family dual
+!
+vrf MGMT
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+!
+line default
+ transport input ssh
+!
+call-home
+ service active
+ contact smart-licensing
+ profile CiscoTAC-1
+  active
+  destination transport-method email disable
+  destination transport-method http
+ !
+!
+netconf-yang agent
+ ssh
+!
+interface Loopback0
+ ipv4 address 10.255.2.4 255.255.255.255
+!
+interface Loopback1
+ ipv6 address 2001:db8:200:4::1/128
+!
+interface GigabitEthernet0/0/0/0
+ description to:p01
+ ipv4 address 10.0.21.2 255.255.255.252
+ ipv6 address 2001:db8:20:2::2/64
+!
+interface GigabitEthernet0/0/0/1
+ description to:p02
+ ipv4 address 10.0.23.2 255.255.255.252
+ ipv6 address 2001:db8:20:4::2/64
+!
+interface GigabitEthernet0/0/0/2
+ description to:switch(pcep)
+ ipv4 address 10.0.30.2 255.255.255.0
+!
+router isis 1
+ is-type level-2-only
+ net 49.0000.0000.0002.0004.00
+ segment-routing global-block 16000 23999
+ address-family ipv4 unicast
+  metric-style wide
+  segment-routing mpls
+ !
+ address-family ipv6 unicast
+  metric-style wide
+  segment-routing mpls
+ !
+ interface Loopback0
+  passive
+  address-family ipv4 unicast
+   prefix-sid index 24
+  !
+ !
+ interface Loopback1
+  passive
+  address-family ipv6 unicast
+   prefix-sid index 124
+  !
+ !
+ interface GigabitEthernet0/0/0/0
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv4 unicast
+   metric 10 level 2
+  !
+  address-family ipv6 unicast
+   metric 100 level 2
+  !
+ !
+ interface GigabitEthernet0/0/0/1
+  circuit-type level-2-only
+  point-to-point
+  hello-interval 1
+  address-family ipv4 unicast
+   metric 100 level 2
+  !
+  address-family ipv6 unicast
+   metric 10 level 2
+  !
+ !
+!
+mpls oam
+!
+segment-routing
+ traffic-eng
+  pcc
+   source-address ipv4 10.0.30.2
+   pce address ipv4 10.0.30.3
+   !
+   report-all
+  !
+ !
+!
+ssh server v2
+ssh server vrf MGMT
+ssh server netconf vrf MGMT
+end

--- a/test/scenario/dynamic-path/dual-stack/topo.clab.yaml
+++ b/test/scenario/dynamic-path/dual-stack/topo.clab.yaml
@@ -1,0 +1,74 @@
+name: dynamic-path-dual-stack
+topology:
+  kinds:
+    xrd:
+      image: ios-xr/xrd-control-plane:24.4.1
+    linux:
+      image: golang:1.26.5
+  nodes:
+    pe01:
+      kind: xrd
+      startup-config: input/startup-configs/pe01.cfg
+    pe02:
+      kind: xrd
+      startup-config: input/startup-configs/pe02.cfg
+    p01:
+      kind: xrd
+      startup-config: input/startup-configs/p01.cfg
+    p02:
+      kind: xrd
+      startup-config: input/startup-configs/p02.cfg
+    gobgp:
+      kind: linux
+      binds:
+        - ../../../bin/gobgpd:/bin/gobgpd
+        - ../../../bin/gobgp:/bin/gobgp
+        - input/gobgpd.yaml:/gobgpd.yaml
+      exec:
+        - apt update
+        - apt install -y iproute2 iputils-ping
+        - ip link set eth1 up
+        - ip addr add 10.0.30.4/24 dev eth1
+      cmd: /bin/gobgpd -f /gobgpd.yaml &
+    pola:
+      kind: linux
+      startup-delay: 10
+      binds:
+        - ../../../bin/polad:/bin/polad
+        - ../../../bin/pola:/bin/pola
+        - input/polad.yaml:/polad.yaml
+        - input/sr-policies/pe02-ipv4.yaml:/pe02-ipv4.yaml
+        - input/sr-policies/pe02-ipv6.yaml:/pe02-ipv6.yaml
+      exec:
+        - apt update
+        - apt install -y iproute2 iputils-ping
+        - ip link set eth1 up
+        - ip addr add 10.0.30.3/24 dev eth1
+      cmd: /bin/polad -f /polad.yaml &
+    switch:
+      kind: linux
+      image: wbitt/network-multitool:latest
+      exec:
+        - ip link add name br0 type bridge
+        - ip link set br0 up
+        - ip link set eth1 master br0
+        - ip link set eth1 up
+        - ip link set eth2 master br0
+        - ip link set eth2 up
+        - ip link set eth3 master br0
+        - ip link set eth3 up
+        - ip link set eth4 master br0
+        - ip link set eth4 up
+  links:
+    # dual-stack SR-MPLS domain: pe01 <-> pe02, via p01 (IPv4-cheap /
+    # IPv6-expensive) or p02 (IPv4-expensive / IPv6-cheap). Every PE-P link
+    # carries both address families, each with its own IS-IS metric.
+    - endpoints: ["pe01:Gi0-0-0-0", "p01:Gi0-0-0-0"]
+    - endpoints: ["pe01:Gi0-0-0-1", "p02:Gi0-0-0-0"]
+    - endpoints: ["pe02:Gi0-0-0-0", "p01:Gi0-0-0-1"]
+    - endpoints: ["pe02:Gi0-0-0-1", "p02:Gi0-0-0-1"]
+    # switch: pe01 sources BGP-LS, pe02 is the PCEP headend
+    - endpoints: ["pe01:Gi0-0-0-2", "switch:eth1"]
+    - endpoints: ["pe02:Gi0-0-0-2", "switch:eth2"]
+    - endpoints: ["pola:eth1", "switch:eth3"]
+    - endpoints: ["gobgp:eth1", "switch:eth4"]

--- a/test/scenario/dynamic-path/dual-stack/topo.clab.yaml
+++ b/test/scenario/dynamic-path/dual-stack/topo.clab.yaml
@@ -3,6 +3,8 @@ topology:
   kinds:
     xrd:
       image: ios-xr/xrd-control-plane:24.4.1
+    juniper_vjunosrouter:
+      image: vrnetlab/juniper_vjunos-router:25.2R1.9
     linux:
       image: golang:1.26.5
   nodes:
@@ -10,7 +12,7 @@ topology:
       kind: xrd
       startup-config: input/startup-configs/pe01.cfg
     pe02:
-      kind: xrd
+      kind: juniper_vjunosrouter
       startup-config: input/startup-configs/pe02.cfg
     p01:
       kind: xrd
@@ -37,6 +39,8 @@ topology:
         - ../../../bin/polad:/bin/polad
         - ../../../bin/pola:/bin/pola
         - input/polad.yaml:/polad.yaml
+        - input/sr-policies/pe01-ipv4.yaml:/pe01-ipv4.yaml
+        - input/sr-policies/pe01-ipv6.yaml:/pe01-ipv6.yaml
         - input/sr-policies/pe02-ipv4.yaml:/pe02-ipv4.yaml
         - input/sr-policies/pe02-ipv6.yaml:/pe02-ipv6.yaml
       exec:
@@ -60,15 +64,13 @@ topology:
         - ip link set eth4 master br0
         - ip link set eth4 up
   links:
-    # dual-stack SR-MPLS domain: pe01 <-> pe02, via p01 (IPv4-cheap /
-    # IPv6-expensive) or p02 (IPv4-expensive / IPv6-cheap). Every PE-P link
-    # carries both address families, each with its own IS-IS metric.
+    # Dual-stack SR-MPLS domain with separate IS-IS metrics for IPv4 and IPv6.
     - endpoints: ["pe01:Gi0-0-0-0", "p01:Gi0-0-0-0"]
     - endpoints: ["pe01:Gi0-0-0-1", "p02:Gi0-0-0-0"]
-    - endpoints: ["pe02:Gi0-0-0-0", "p01:Gi0-0-0-1"]
-    - endpoints: ["pe02:Gi0-0-0-1", "p02:Gi0-0-0-1"]
-    # switch: pe01 sources BGP-LS, pe02 is the PCEP headend
+    - endpoints: ["pe02:eth1", "p01:Gi0-0-0-1"]
+    - endpoints: ["pe02:eth2", "p02:Gi0-0-0-1"]
+    # switch
     - endpoints: ["pe01:Gi0-0-0-2", "switch:eth1"]
-    - endpoints: ["pe02:Gi0-0-0-2", "switch:eth2"]
+    - endpoints: ["pe02:eth3", "switch:eth2"]
     - endpoints: ["pola:eth1", "switch:eth3"]
     - endpoints: ["gobgp:eth1", "switch:eth4"]

--- a/test/scenario/dynamic-path/srv6-usid/input/sr-policies/pe02-policy-loose-source-routing.yaml
+++ b/test/scenario/dynamic-path/srv6-usid/input/sr-policies/pe02-policy-loose-source-routing.yaml
@@ -1,14 +1,15 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "fd00::2"
-  srcRouterID: "0000.0001.0002"
-  dstRouterID: "0000.0001.0001"
+  headendRouterID: "0000.0001.0002"
+  endpointRouterID: "0000.0001.0001"
   name: "LOOSE-SOURCE-ROUTING-POLICY"
   color: 200
-  type: dynamic
-  metric: igp
-  waypoints:
-    - routerID: "0000.0001.0003"
-    - routerID: "0000.0001.0004"
-    - routerID: "0000.0001.0003"
-      sid: "fcbb:bb00:1003::"
+  candidatePath:
+    dynamic:
+      metric: igp
+      waypoints:
+        - routerID: "0000.0001.0003"
+        - routerID: "0000.0001.0004"
+        - routerID: "0000.0001.0003"
+          sid: "fcbb:bb00:1003::"

--- a/test/scenario/dynamic-path/srv6-usid/input/sr-policies/pe02-policy1.yaml
+++ b/test/scenario/dynamic-path/srv6-usid/input/sr-policies/pe02-policy1.yaml
@@ -1,9 +1,10 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "fd00::2"
-  srcRouterID: "0000.0001.0002"
-  dstRouterID: "0000.0001.0001"
+  headendRouterID: "0000.0001.0002"
+  endpointRouterID: "0000.0001.0001"
   name: "DYNAMIC-POLICY"
   color: 100
-  type: dynamic
-  metric: igp
+  candidatePath:
+    dynamic:
+      metric: igp

--- a/test/scenario/dynamic-path/test_dynamic_path.py
+++ b/test/scenario/dynamic-path/test_dynamic_path.py
@@ -8,10 +8,12 @@ import re
 
 import pytest
 from helpers.wait import (
+    get_ted,
     run_command,
     wait_for_ssh,
     wait_until_command_success,
     wait_until_lsp_up,
+    wait_until_ssh_output_contains,
     wait_until_ted_has_links,
     wait_until_ted_has_routers,
 )
@@ -25,7 +27,8 @@ POLA = f"clab-{LAB}-pola"
 HEADEND = f"clab-{LAB}-pe02"
 GRPC_PORT = 50052
 
-pytestmark = pytest.mark.xdist_group(LAB)
+# Keep xdist_group on each class: pytest-xdist combines marks from the module
+# and class instead of letting the class-level mark override the module mark.
 
 ROUTER_IDS = [
     "0000.0001.0001",
@@ -40,6 +43,28 @@ LINKS = {
     frozenset(("0000.0001.0002", "0000.0001.0003")),
     frozenset(("0000.0001.0002", "0000.0001.0004")),
     frozenset(("0000.0001.0003", "0000.0001.0004")),
+}
+
+DUAL_STACK_LAB = "dynamic-path-dual-stack"
+DUAL_STACK_LAB_DIR = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "dual-stack",
+)
+DUAL_STACK_POLA = f"clab-{DUAL_STACK_LAB}-pola"
+DUAL_STACK_HEADEND = f"clab-{DUAL_STACK_LAB}-pe02"
+
+DUAL_STACK_ROUTER_IDS = [
+    "0000.0002.0001",  # pe01 (IPv4-only loopback identity)
+    "0000.0002.0002",  # p01 (dual-stack transit, IPv4-cheap / IPv6-expensive)
+    "0000.0002.0003",  # p02 (dual-stack transit, IPv4-expensive / IPv6-cheap)
+    "0000.0002.0004",  # pe02 (IPv4-only loopback identity, PCEP headend)
+]
+
+DUAL_STACK_LINKS = {
+    frozenset(("0000.0002.0001", "0000.0002.0002")),
+    frozenset(("0000.0002.0001", "0000.0002.0003")),
+    frozenset(("0000.0002.0002", "0000.0002.0004")),
+    frozenset(("0000.0002.0003", "0000.0002.0004")),
 }
 
 
@@ -68,6 +93,8 @@ class TestDynamicPath:
     - SR policy installation via Pola
     - Resulting SRv6 segment list on the router
     """
+
+    pytestmark = pytest.mark.xdist_group(LAB)
 
     def _assert_segments(self, policy_file, lsp_name, color, expected_segments):
         """Inject an SR policy and verify the SRv6 segment list it produces."""
@@ -129,4 +156,127 @@ class TestDynamicPath:
                 "fcbb:bb00:1003::",
                 "fcbb:bb00:1001::",
             ],
+        )
+
+
+@pytest.fixture(scope="module")
+def dual_stack_lab(clab_deploy_module):
+    """Deploy the dual-stack lab once and wait until the PCE holds the full TED."""
+
+    clab_deploy_module(DUAL_STACK_LAB_DIR)
+
+    print("Waiting for PCEP session")
+    wait_until_command_success(
+        f"docker exec {DUAL_STACK_POLA} /bin/pola session -p {GRPC_PORT} "
+        "| grep 'Session #0: 10.0.30.2'"
+    )
+
+    wait_until_ted_has_routers(DUAL_STACK_POLA, DUAL_STACK_ROUTER_IDS)
+    wait_until_ted_has_links(DUAL_STACK_POLA, DUAL_STACK_LINKS)
+
+
+class TestDynamicPathDualStack:
+    """Test dual-stack TED contents and underlay path selection."""
+
+    pytestmark = pytest.mark.xdist_group(DUAL_STACK_LAB)
+
+    def _add_policy(self, policy_file):
+        result = run_command(
+            f"docker exec {DUAL_STACK_POLA} "
+            f"/bin/pola sr-policy add -f {policy_file} -p {GRPC_PORT}"
+        )
+        assert "success" in result.stdout.lower(), (
+            f"failed to add {policy_file}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test__dual_stack_links_expose_both_address_families(self, dual_stack_lab):
+        """Verify that dual-stack links expose both IPv4 and IPv6 addresses in the TED."""
+
+        ted = get_ted(DUAL_STACK_POLA)
+
+        families_seen = set()
+        for node in ted:
+            for link in node.get("links", []):
+                local = link.get("local", {})
+                if "ipv4" in local:
+                    families_seen.add("ipv4")
+                if "ipv6" in local:
+                    families_seen.add("ipv6")
+
+        assert families_seen == {"ipv4", "ipv6"}, (
+            "expected both address families on dual-stack links, "
+            f"got {families_seen}\nfull TED: {ted}"
+        )
+
+    def test__pe02_ipv6_loopback_is_advertised_as_a_128_prefix(self, dual_stack_lab):
+        """Verify pe02 advertises its IPv6 loopback as a /128 prefix."""
+
+        ted = get_ted(DUAL_STACK_POLA)
+        nodes_by_router_id = {node.get("routerId"): node for node in ted}
+
+        prefixes = {
+            p.get("prefix")
+            for p in nodes_by_router_id["0000.0002.0004"].get("prefixes", [])
+        }
+        assert "2001:db8:200:4::1/128" in prefixes, (
+            f"pe02 did not advertise its IPv6 loopback as a /128 prefix\nfull TED: {ted}"
+        )
+
+    def test__ipv4_underlay_computes_the_ipv4_cheap_path(self, dual_stack_lab):
+        """Verify the IPv4-cheap path is selected for an IPv4 endpoint with IPv4 underlay."""
+
+        self._add_policy("/pe02-ipv4.yaml")
+
+        ssh_client = wait_for_ssh(DUAL_STACK_HEADEND)
+        try:
+            output = wait_until_ssh_output_contains(
+                ssh_client,
+                "show segment-routing traffic-eng policy color 400 endpoint ipv4 10.255.2.1",
+                "Operational: up",
+                timeout=180,
+            )
+        finally:
+            ssh_client.close()
+
+        assert "Path Type: SRMPLSv4" in output, output
+
+        sids = re.findall(r"SID\[\d+\]:\s*(\d+)", output)
+        assert sids == ["16022", "16021"], (
+            f"SR-ERO label stack mismatch (expected the path via p01).\n"
+            f"Expected: ['16022', '16021']\n"
+            f"Actual:   {sids}\n{output}"
+        )
+
+    @pytest.mark.xfail(
+        reason=(
+            "IOS-XR 24.4.1 cannot process PCE-initiated SR-MPLS policies "
+            "with IPv6 endpoints; it drops the request with "
+            "'pcinitiate: bad sock info'. The PCEP message is valid on the wire."
+        ),
+        strict=False,
+    )
+    def test__ipv6_underlay_computes_the_ipv6_cheap_path(self, dual_stack_lab):
+        """Verify the IPv6-cheap path is selected for an IPv6 endpoint with IPv6 underlay."""
+
+        self._add_policy("/pe02-ipv6.yaml")
+
+        ssh_client = wait_for_ssh(DUAL_STACK_HEADEND)
+        try:
+            output = wait_until_ssh_output_contains(
+                ssh_client,
+                "show segment-routing traffic-eng policy color 600 endpoint ipv6 2001:db8:200:1::1",
+                "Operational: up",
+                timeout=60,
+            )
+        finally:
+            ssh_client.close()
+
+        assert "Path Type: SRMPLSv4" in output, output
+
+        sids = re.findall(r"SID\[\d+\]:\s*(\d+)", output)
+        assert sids == ["16123", "16121"], (
+            f"SR-ERO label stack mismatch (expected the path via p02).\n"
+            f"Expected: ['16123', '16121']\n"
+            f"Actual:   {sids}\n{output}"
         )

--- a/test/scenario/dynamic-path/test_dynamic_path.py
+++ b/test/scenario/dynamic-path/test_dynamic_path.py
@@ -51,7 +51,8 @@ DUAL_STACK_LAB_DIR = os.path.join(
     "dual-stack",
 )
 DUAL_STACK_POLA = f"clab-{DUAL_STACK_LAB}-pola"
-DUAL_STACK_HEADEND = f"clab-{DUAL_STACK_LAB}-pe02"
+DUAL_STACK_PE01 = f"clab-{DUAL_STACK_LAB}-pe01"  # xrd headend
+DUAL_STACK_PE02 = f"clab-{DUAL_STACK_LAB}-pe02"  # Junos headend
 
 DUAL_STACK_ROUTER_IDS = [
     "0000.0002.0001",  # pe01 (IPv4-only loopback identity)
@@ -165,10 +166,14 @@ def dual_stack_lab(clab_deploy_module):
 
     clab_deploy_module(DUAL_STACK_LAB_DIR)
 
-    print("Waiting for PCEP session")
+    print("Waiting for PCEP sessions")
     wait_until_command_success(
         f"docker exec {DUAL_STACK_POLA} /bin/pola session -p {GRPC_PORT} "
-        "| grep 'Session #0: 10.0.30.2'"
+        "| grep '10.0.30.1'"
+    )
+    wait_until_command_success(
+        f"docker exec {DUAL_STACK_POLA} /bin/pola session -p {GRPC_PORT} "
+        "| grep '10.0.30.2'"
     )
 
     wait_until_ted_has_routers(DUAL_STACK_POLA, DUAL_STACK_ROUTER_IDS)
@@ -188,6 +193,45 @@ class TestDynamicPathDualStack:
         assert "success" in result.stdout.lower(), (
             f"failed to add {policy_file}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def _assert_xrd_segments(self, headend, command, expected_sids):
+        """Verify the SR-MPLS label stack reported by an xrd (IOS-XR) headend."""
+
+        ssh_client = wait_for_ssh(headend)
+        try:
+            output = wait_until_ssh_output_contains(
+                ssh_client, command, "Operational: up", timeout=180
+            )
+        finally:
+            ssh_client.close()
+
+        assert "Path Type: SRMPLSv4" in output, output
+
+        sids = re.findall(r"SID\[\d+\]:\s*(\d+)", output)
+        assert sids == expected_sids, (
+            f"SR-ERO label stack mismatch.\n"
+            f"Expected: {expected_sids}\n"
+            f"Actual:   {sids}\n{output}"
+        )
+
+    def _assert_junos_segments(self, lsp_name, expected_labels):
+        """Verify the SR-MPLS label stack reported by the Junos headend."""
+
+        ssh_client = wait_for_ssh(DUAL_STACK_PE02)
+        try:
+            lsp_output = wait_until_lsp_up(ssh_client, lsp_name)
+        finally:
+            ssh_client.close()
+
+        labels = re.findall(
+            r"SID type:\s*\d+-bit label,\s*Value:\s*(\d+)",
+            lsp_output,
+        )
+        assert labels == expected_labels, (
+            f"SR-ERO label stack mismatch.\n"
+            f"Expected: {expected_labels}\n"
+            f"Actual:   {labels}\n{lsp_output}"
         )
 
     def test__dual_stack_links_expose_both_address_families(self, dual_stack_lab):
@@ -223,60 +267,59 @@ class TestDynamicPathDualStack:
             f"pe02 did not advertise its IPv6 loopback as a /128 prefix\nfull TED: {ted}"
         )
 
-    def test__ipv4_underlay_computes_the_ipv4_cheap_path(self, dual_stack_lab):
-        """Verify the IPv4-cheap path is selected for an IPv4 endpoint with IPv4 underlay."""
+    def test__pe02_ipv4_underlay_computes_the_ipv4_cheap_path(self, dual_stack_lab):
+        """Verify pe02, as headend, selects the IPv4-cheap path via p01."""
 
         self._add_policy("/pe02-ipv4.yaml")
 
-        ssh_client = wait_for_ssh(DUAL_STACK_HEADEND)
-        try:
-            output = wait_until_ssh_output_contains(
-                ssh_client,
-                "show segment-routing traffic-eng policy color 400 endpoint ipv4 10.255.2.1",
-                "Operational: up",
-                timeout=180,
-            )
-        finally:
-            ssh_client.close()
-
-        assert "Path Type: SRMPLSv4" in output, output
-
-        sids = re.findall(r"SID\[\d+\]:\s*(\d+)", output)
-        assert sids == ["16022", "16021"], (
-            f"SR-ERO label stack mismatch (expected the path via p01).\n"
-            f"Expected: ['16022', '16021']\n"
-            f"Actual:   {sids}\n{output}"
+        self._assert_junos_segments(
+            "DUAL-STACK-IPV4-POLICY",
+            ["16022", "16021"],
         )
 
     @pytest.mark.xfail(
         reason=(
-            "IOS-XR 24.4.1 cannot process PCE-initiated SR-MPLS policies "
-            "with IPv6 endpoints; it drops the request with "
-            "'pcinitiate: bad sock info'. The PCEP message is valid on the wire."
+            "Junos 25.2R1.9 pccd rejects PCE-initiated SR-MPLS policies with "
+            "an IPv6-typed SRPAG association object: "
+            "'IPv6 SRPAG received for non SRv6 LSP'."
         ),
         strict=False,
     )
-    def test__ipv6_underlay_computes_the_ipv6_cheap_path(self, dual_stack_lab):
-        """Verify the IPv6-cheap path is selected for an IPv6 endpoint with IPv6 underlay."""
+    def test__pe02_ipv6_underlay_computes_the_ipv6_cheap_path(self, dual_stack_lab):
+        """Verify pe02, as headend, selects the IPv6-cheap path via p02."""
 
         self._add_policy("/pe02-ipv6.yaml")
 
-        ssh_client = wait_for_ssh(DUAL_STACK_HEADEND)
-        try:
-            output = wait_until_ssh_output_contains(
-                ssh_client,
-                "show segment-routing traffic-eng policy color 600 endpoint ipv6 2001:db8:200:1::1",
-                "Operational: up",
-                timeout=60,
-            )
-        finally:
-            ssh_client.close()
+        self._assert_junos_segments(
+            "DUAL-STACK-IPV6-POLICY",
+            ["16123", "16121"],
+        )
 
-        assert "Path Type: SRMPLSv4" in output, output
+    def test__pe01_ipv4_underlay_computes_the_ipv4_cheap_path(self, dual_stack_lab):
+        """Verify pe01, as headend, selects the IPv4-cheap path via p01."""
 
-        sids = re.findall(r"SID\[\d+\]:\s*(\d+)", output)
-        assert sids == ["16123", "16121"], (
-            f"SR-ERO label stack mismatch (expected the path via p02).\n"
-            f"Expected: ['16123', '16121']\n"
-            f"Actual:   {sids}\n{output}"
+        self._add_policy("/pe01-ipv4.yaml")
+
+        self._assert_xrd_segments(
+            DUAL_STACK_PE01,
+            "show segment-routing traffic-eng policy color 401 endpoint ipv4 10.255.2.4",
+            ["16022", "16024"],
+        )
+
+    @pytest.mark.xfail(
+        reason=(
+            "IOS-XR 24.4.1 rejects PCE-initiated SR-MPLS policies with IPv6 "
+            "endpoints, reporting 'pcinitiate: bad sock info'."
+        ),
+        strict=False,
+    )
+    def test__pe01_ipv6_underlay_computes_the_ipv6_cheap_path(self, dual_stack_lab):
+        """Verify pe01, as headend, selects the IPv6-cheap path via p02."""
+
+        self._add_policy("/pe01-ipv6.yaml")
+
+        self._assert_xrd_segments(
+            DUAL_STACK_PE01,
+            "show segment-routing traffic-eng policy color 601 endpoint ipv6 2001:db8:200:4::1",
+            ["16123", "16124"],
         )

--- a/test/scenario/explicit-path/sr-mpls/input/sr-policies/pe01-policy1.yaml
+++ b/test/scenario/explicit-path/sr-mpls/input/sr-policies/pe01-policy1.yaml
@@ -1,12 +1,14 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "10.0.255.1"
-  srcAddr: "10.255.0.1"
-  dstAddr: "10.255.0.2"
+  headend: "10.255.0.1"
+  endpoint: "10.255.0.2"
   name: pe01-policy1
   color: 1
-  segmentList:
-    - sid: "16002"
-      localAddr: "10.255.0.2"
-    - sid: "16003"
-      localAddr: "10.255.0.3"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "16002"
+          localAddr: "10.255.0.2"
+        - sid: "16003"
+          localAddr: "10.255.0.3"

--- a/test/scenario/explicit-path/sr-mpls/input/sr-policies/pe02-policy1.yaml
+++ b/test/scenario/explicit-path/sr-mpls/input/sr-policies/pe02-policy1.yaml
@@ -1,12 +1,14 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "10.0.255.2"
-  srcAddr: "10.255.0.2"
-  dstAddr: "10.255.0.1"
+  headend: "10.255.0.2"
+  endpoint: "10.255.0.1"
   name: pe02-policy1
   color: 1
-  segmentList:
-    - sid: "16001"
-      localAddr: "10.255.0.1"
-    - sid: "16003"
-      localAddr: "10.255.0.3"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "16001"
+          localAddr: "10.255.0.1"
+        - sid: "16003"
+          localAddr: "10.255.0.3"

--- a/test/scenario/explicit-path/sr-mpls/input/sr-policies/pe02-policy2.yaml
+++ b/test/scenario/explicit-path/sr-mpls/input/sr-policies/pe02-policy2.yaml
@@ -3,10 +3,12 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "10.0.255.2"
-  srcAddr: "10.255.0.2"
-  dstAddr: "10.255.0.1"
+  headend: "10.255.0.2"
+  endpoint: "10.255.0.1"
   name: pe02-policy2
   color: 2
-  segmentList:
-    - sid: "16001"
-    - sid: "16003"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "16001"
+        - sid: "16003"

--- a/test/scenario/explicit-path/sr-mpls/input/sr-policies/pe03-policy1.yaml
+++ b/test/scenario/explicit-path/sr-mpls/input/sr-policies/pe03-policy1.yaml
@@ -1,12 +1,14 @@
 asn: 65000
 srPolicy:
   pcepSessionAddr: "10.0.255.3"
-  srcAddr: "10.255.0.3"
-  dstAddr: "10.255.0.1"
+  headend: "10.255.0.3"
+  endpoint: "10.255.0.1"
   name: pe03-policy1
   color: 1
-  segmentList:
-    - sid: "16001"
-      localAddr: "10.255.0.1"
-    - sid: "16002"
-      localAddr: "10.255.0.2"
+  candidatePath:
+    explicit:
+      segmentList:
+        - sid: "16001"
+          localAddr: "10.255.0.1"
+        - sid: "16002"
+          localAddr: "10.255.0.2"

--- a/test/scenario/show-ted/sr-mpls/expected/ted-after-link-down.json
+++ b/test/scenario/show-ted/sr-mpls/expected/ted-after-link-down.json
@@ -34,9 +34,14 @@
         ],
         "links": [
             {
-                "localIp": "10.0.0.2",
-                "remoteIp": "10.0.0.1",
-                "remoteRouterId": "0000.0aff.0001",
+                "local": {
+                    "routerId": "0000.0aff.0002",
+                    "ipv4": "10.0.0.2"
+                },
+                "remote": {
+                    "routerId": "0000.0aff.0001",
+                    "ipv4": "10.0.0.1"
+                },
                 "metrics": [
                     {
                         "type": "igp",
@@ -47,7 +52,12 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 299776
+                "adjSids": [
+                    {
+                        "family": "unspecified",
+                        "sid": 299776
+                    }
+                ]
             }
         ],
         "srv6Sids": []

--- a/test/scenario/show-ted/sr-mpls/expected/ted.json
+++ b/test/scenario/show-ted/sr-mpls/expected/ted.json
@@ -16,9 +16,14 @@
         ],
         "links": [
             {
-                "localIp": "10.0.0.1",
-                "remoteIp": "10.0.0.2",
-                "remoteRouterId": "0000.0aff.0002",
+                "local": {
+                    "routerId": "0000.0aff.0001",
+                    "ipv4": "10.0.0.1"
+                },
+                "remote": {
+                    "routerId": "0000.0aff.0002",
+                    "ipv4": "10.0.0.2"
+                },
                 "metrics": [
                     {
                         "type": "igp",
@@ -29,7 +34,12 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 299776
+                "adjSids": [
+                    {
+                        "family": "unspecified",
+                        "sid": 299776
+                    }
+                ]
             }
         ],
         "srv6Sids": []
@@ -51,9 +61,14 @@
         ],
         "links": [
             {
-                "localIp": "10.0.0.2",
-                "remoteIp": "10.0.0.1",
-                "remoteRouterId": "0000.0aff.0001",
+                "local": {
+                    "routerId": "0000.0aff.0002",
+                    "ipv4": "10.0.0.2"
+                },
+                "remote": {
+                    "routerId": "0000.0aff.0001",
+                    "ipv4": "10.0.0.1"
+                },
                 "metrics": [
                     {
                         "type": "igp",
@@ -64,7 +79,12 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 299776
+                "adjSids": [
+                    {
+                        "family": "unspecified",
+                        "sid": 299776
+                    }
+                ]
             }
         ],
         "srv6Sids": []

--- a/test/scenario/show-ted/srv6-usid/expected/ted-after-link-down.json
+++ b/test/scenario/show-ted/srv6-usid/expected/ted-after-link-down.json
@@ -56,7 +56,14 @@
         ],
         "links": [
             {
-                "remoteRouterId": "0000.0aff.0001",
+                "local": {
+                    "routerId": "0000.0aff.0002",
+                    "interfaceId": 333
+                },
+                "remote": {
+                    "routerId": "0000.0aff.0001",
+                    "interfaceId": 333
+                },
                 "metrics": [
                     {
                         "type": "igp",
@@ -67,22 +74,24 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 0,
-                "srv6EndXSid": {
-                    "endpointBehavior": {
-                        "behavior": 57,
-                        "name": "UA"
-                    },
-                    "sids": [
-                        "fcbb:bb00:1002:e000::"
-                    ],
-                    "sidStructure": {
-                        "localBlock": 32,
-                        "localNode": 16,
-                        "localFunc": 16,
-                        "localArg": 64
+                "adjSids": [],
+                "srv6EndXSids": [
+                    {
+                        "endpointBehavior": {
+                            "behavior": 57,
+                            "name": "UA"
+                        },
+                        "sids": [
+                            "fcbb:bb00:1002:e000::"
+                        ],
+                        "sidStructure": {
+                            "localBlock": 32,
+                            "localNode": 16,
+                            "localFunc": 16,
+                            "localArg": 64
+                        }
                     }
-                }
+                ]
             }
         ],
         "srv6Sids": [

--- a/test/scenario/show-ted/srv6-usid/expected/ted.json
+++ b/test/scenario/show-ted/srv6-usid/expected/ted.json
@@ -18,7 +18,14 @@
         ],
         "links": [
             {
-                "remoteRouterId": "0000.0aff.0002",
+                "local": {
+                    "routerId": "0000.0aff.0001",
+                    "interfaceId": 333
+                },
+                "remote": {
+                    "routerId": "0000.0aff.0002",
+                    "interfaceId": 333
+                },
                 "metrics": [
                     {
                         "type": "igp",
@@ -29,22 +36,24 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 0,
-                "srv6EndXSid": {
-                    "endpointBehavior": {
-                        "behavior": 57,
-                        "name": "UA"
-                    },
-                    "sids": [
-                        "fcbb:bb00:1001:e000::"
-                    ],
-                    "sidStructure": {
-                        "localBlock": 32,
-                        "localNode": 16,
-                        "localFunc": 16,
-                        "localArg": 64
+                "adjSids": [],
+                "srv6EndXSids": [
+                    {
+                        "endpointBehavior": {
+                            "behavior": 57,
+                            "name": "UA"
+                        },
+                        "sids": [
+                            "fcbb:bb00:1001:e000::"
+                        ],
+                        "sidStructure": {
+                            "localBlock": 32,
+                            "localNode": 16,
+                            "localFunc": 16,
+                            "localArg": 64
+                        }
                     }
-                }
+                ]
             }
         ],
         "srv6Sids": [
@@ -86,7 +95,14 @@
         ],
         "links": [
             {
-                "remoteRouterId": "0000.0aff.0001",
+                "local": {
+                    "routerId": "0000.0aff.0002",
+                    "interfaceId": 333
+                },
+                "remote": {
+                    "routerId": "0000.0aff.0001",
+                    "interfaceId": 333
+                },
                 "metrics": [
                     {
                         "type": "igp",
@@ -97,22 +113,24 @@
                         "value": 10
                     }
                 ],
-                "adjSid": 0,
-                "srv6EndXSid": {
-                    "endpointBehavior": {
-                        "behavior": 57,
-                        "name": "UA"
-                    },
-                    "sids": [
-                        "fcbb:bb00:1002:e000::"
-                    ],
-                    "sidStructure": {
-                        "localBlock": 32,
-                        "localNode": 16,
-                        "localFunc": 16,
-                        "localArg": 64
+                "adjSids": [],
+                "srv6EndXSids": [
+                    {
+                        "endpointBehavior": {
+                            "behavior": 57,
+                            "name": "UA"
+                        },
+                        "sids": [
+                            "fcbb:bb00:1002:e000::"
+                        ],
+                        "sidStructure": {
+                            "localBlock": 32,
+                            "localNode": 16,
+                            "localFunc": 16,
+                            "localArg": 64
+                        }
                     }
-                }
+                ]
             }
         ],
         "srv6Sids": [


### PR DESCRIPTION
## Description
<!-- What does this PR change, and why is it needed? -->

This branch adds IPv6 underlay and dual-stack support to the Pola PCE.

It introduces the Plane model, dual-stack endpoint and underlay selection, an RFC 9256-based SR Policy model, and IPv6 SR-MPLS/SRv6 path computation support.

**Note:** The build is currently blocked by pending GoBGP API changes (`LsAttributeLinkAdjacencySID`, `GetMultiTopoId`, and `GetSrAdjacencySids`).
This PR will be merged after the corresponding GoBGP changes are implemented.

## Type of change
<!-- Check all that apply. -->
- [x] New feature
- [x] Bug fix
- [x] Refactoring
- [x] Documentation
- [ ] Build / CI

## How was this tested?
<!-- Commands run (e.g. `make test`, `make test-scenario`), and/or
example topologies verified.
-->

- Updated and extended unit tests in `pkg/cspf`, `pkg/table`, `cmd/pola/grpc`, and related packages.
- Added a dual-stack dynamic-path scenario under `test/scenario/dynamic-path/dual-stack/`.
- Updated show-ted scenario fixtures for the new TED and Plane model.
- `make test-scenario-parallel`
- `make ci` with a local GoBGP build containing the required API changes.

## Checklist

- [x] `make ci` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed

## Breaking Changes

1. **gRPC API** (`api/pola/v1/pola.proto`)

   * `SRPolicy` redesigned around `headend`, `endpoint`, and `CandidatePath`.
   * Removed `SRPolicyType` and `CreateSRPolicyRequest.disable_path_compute`.
   * `LsLink` redesigned with `LsLinkEndpoint` and repeated SID fields.
   * `Srv6EndXSID.endpoint_behavior` changed from `uint32` to `EndpointBehavior`.

2. **CLI YAML Input** (`pola sr-policy add`)

   * Renamed `srcAddr` / `dstAddr` to `headend` / `endpoint` equivalents.
   * Moved path settings under `candidatePath.dynamic` / `candidatePath.explicit`.
   * Added `endpointFamily`, `underlayFamily`, and `dataPlane`.

3. **CLI Output** (`pola sr-policy list`)

   * Renamed `SrcAddr` / `DstAddr` to `Headend` / `Endpoint`.
   * Updated JSON output to the new SR Policy model, with `preference` under `candidatePath` and `type` inferred from the candidate path.